### PR TITLE
To support flutter test which require quiver ^0.24.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://github.com/flutter/sentry
 dependencies:
   http: ">=0.11.3+13 <2.0.0"
   meta: ">=1.0.5 <2.0.0"
-  quiver: ">=0.25.0 <2.0.0"
+  quiver: ">=0.24.0 <2.0.0"
   stack_trace: ">=1.7.3 <2.0.0"
   usage: ">=3.1.1 <4.0.0"
 


### PR DESCRIPTION
```
Upgrading Flutter from /Users/mbikyaw/flutter/flutter...
Already up-to-date.

Upgrading engine...
Already up-to-date.

Flutter • channel alpha • https://github.com/flutter/flutter.git
Framework • revision 1c372c6803 (4 days ago) • 2017-08-31 15:54:45 -0700
Engine • revision f9e00a7c72
Tools • Dart 1.25.0-dev.11.0

Running "flutter packages upgrade" in sugar-mobile...
Incompatible version constraints on quiver:
- flutter_test 0.0.12 depends on version ^0.24.0
- sentry 0.0.1 depends on version >=0.25.0 <2.0.0
pub upgrade failed (1)
```