### PR TITLE
release 1.0.0 - the last Dart 1 compatible major version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,14 @@
 
 [![Build Status](https://travis-ci.org/flutter/sentry.svg?branch=master)](https://travis-ci.org/flutter/sentry)
 
-**WARNING: experimental code**
-
 Use this library in your Dart programs (Flutter, command-line and (TBD) AngularDart) to report errors thrown by your
 program to https://sentry.io error tracking service.
+
+## Versions
+
+>=0.0.0 and <2.0.0 is the range of versions compatible with Dart 1.
+
+>=2.0.0 and <3.0.0 is the range of versions compatible with Dart 2.
 
 ## Usage
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -9,7 +9,7 @@
 library version;
 
 /// The SDK version reported to Sentry.io in the submitted events.
-const String sdkVersion = '0.0.6';
+const String sdkVersion = '1.0.0';
 
 /// The SDK name reported to Sentry.io in the submitted events.
 const String sdkName = 'dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sentry
-version: 0.0.6
+version: 1.0.0
 description: A pure Dart Sentry.io client.
 author: Flutter Authors <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/sentry


### PR DESCRIPTION
I propose that we submit this first. Then https://github.com/flutter/sentry/pull/9 will go next.

/cc @pulyaevskiy @xster 