### PR TITLE
Fixed "Culprit" recording in Sentry

### DIFF
--- a/lib/src/stack_trace.dart
+++ b/lib/src/stack_trace.dart
@@ -24,7 +24,7 @@ List<Map<String, dynamic>> encodeStackTrace(dynamic stackTrace) {
     frames.addAll(chain.traces[t].frames.map(encodeStackTraceFrame));
     if (t < chain.traces.length - 1) frames.add(asynchronousGapFrameJson);
   }
-  return frames;
+  return frames.reversed.toList();
 }
 
 Map<String, dynamic> encodeStackTraceFrame(Frame frame) {

--- a/test/sentry_test.dart
+++ b/test/sentry_test.dart
@@ -93,7 +93,8 @@ void main() {
       expect(stacktrace['frames'], const isInstanceOf<List>());
       expect(stacktrace['frames'], isNotEmpty);
 
-      final Map<String, dynamic> topFrame = (stacktrace['frames'] as Iterable<dynamic>).last;
+      final Map<String, dynamic> topFrame =
+          (stacktrace['frames'] as Iterable<dynamic>).last;
       expect(topFrame.keys,
           <String>['abs_path', 'function', 'lineno', 'in_app', 'filename']);
       expect(topFrame['abs_path'], 'sentry_test.dart');

--- a/test/sentry_test.dart
+++ b/test/sentry_test.dart
@@ -93,7 +93,7 @@ void main() {
       expect(stacktrace['frames'], const isInstanceOf<List>());
       expect(stacktrace['frames'], isNotEmpty);
 
-      final Map<String, dynamic> topFrame = stacktrace['frames'].first;
+      final Map<String, dynamic> topFrame = (stacktrace['frames'] as Iterable<dynamic>).last;
       expect(topFrame.keys,
           <String>['abs_path', 'function', 'lineno', 'in_app', 'filename']);
       expect(topFrame['abs_path'], 'sentry_test.dart');

--- a/test/stack_trace_test.dart
+++ b/test/stack_trace_test.dart
@@ -34,18 +34,18 @@ void main() {
       '''), [
         {
           'abs_path': 'test.dart',
-          'function': 'baz',
-          'lineno': 50,
+          'function': 'bar',
+          'lineno': 46,
           'in_app': true,
           'filename': 'test.dart'
         },
         {
           'abs_path': 'test.dart',
-          'function': 'bar',
-          'lineno': 46,
+          'function': 'baz',
+          'lineno': 50,
           'in_app': true,
           'filename': 'test.dart'
-        }
+        },
       ]);
     });
 
@@ -57,8 +57,8 @@ void main() {
       '''), [
         {
           'abs_path': 'test.dart',
-          'function': 'baz',
-          'lineno': 50,
+          'function': 'bar',
+          'lineno': 46,
           'in_app': true,
           'filename': 'test.dart'
         },
@@ -67,11 +67,11 @@ void main() {
         },
         {
           'abs_path': 'test.dart',
-          'function': 'bar',
-          'lineno': 46,
+          'function': 'baz',
+          'lineno': 50,
           'in_app': true,
           'filename': 'test.dart'
-        }
+        },
       ]);
     });
   });


### PR DESCRIPTION
Fix stack-trace frame ordering. In order for `Culprit` to be logged correctly it should have the latest frame at the top.