### PR TITLE
Support for new DSN format (without secretKey) and remove the quiver dependency.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@
 #   Name/Organization <email address>
 
 Google Inc.
+Simon Lightfoot <simon@devangels.london>

--- a/lib/sentry.dart
+++ b/lib/sentry.dart
@@ -159,10 +159,9 @@ class SentryClient {
 
   /// Reports an [event] to Sentry.io.
   Future<SentryResponse> capture({@required Event event}) async {
-
     final DateTime now = _clock();
     String authHeader = 'Sentry sentry_version=6, sentry_client=$sentryClient, '
-      'sentry_timestamp=${now.millisecondsSinceEpoch}, sentry_key=$publicKey';
+        'sentry_timestamp=${now.millisecondsSinceEpoch}, sentry_key=$publicKey';
     if (secretKey != null) {
       authHeader += ', sentry_secret=$secretKey';
     }

--- a/lib/sentry.dart
+++ b/lib/sentry.dart
@@ -68,9 +68,8 @@ class SentryClient {
     uuidGenerator ??= _generateUuidV4WithoutDashes;
     compressPayload ??= true;
 
-    final ClockProvider clockProvider = clock is ClockProvider
-      ? clock
-      : clock.get;
+    final ClockProvider clockProvider =
+        clock is ClockProvider ? clock : clock.get;
 
     final Uri uri = Uri.parse(dsn);
     final List<String> userInfo = uri.userInfo.split(':');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,6 @@ environment:
 dependencies:
   http: ">=0.11.0 <2.0.0"
   meta: ">=1.0.0 <2.0.0"
-  quiver: ">=0.25.0 <2.0.0"
   stack_trace: ">=1.0.0 <2.0.0"
   usage: ">=3.0.0 <4.0.0"
 

--- a/test/sentry_test.dart
+++ b/test/sentry_test.dart
@@ -36,7 +36,8 @@ void main() {
 
     test('sends client auth header without secret', () async {
       final MockClient httpMock = new MockClient();
-      final ClockProvider fakeClockProvider = () => new DateTime.utc(2017, 1, 2);
+      final ClockProvider fakeClockProvider =
+          () => new DateTime.utc(2017, 1, 2);
 
       Map<String, String> headers;
 
@@ -64,7 +65,7 @@ void main() {
         ),
       );
 
-     try {
+      try {
         throw new ArgumentError('Test error');
       } catch (error, stackTrace) {
         final SentryResponse response = await client.captureException(
@@ -196,7 +197,8 @@ void main() {
 
     test('reads error message from the x-sentry-error header', () async {
       final MockClient httpMock = new MockClient();
-      final ClockProvider fakeClockProvider = () => new DateTime.utc(2017, 1, 2);
+      final ClockProvider fakeClockProvider =
+          () => new DateTime.utc(2017, 1, 2);
 
       httpMock.answerWith((Invocation invocation) async {
         if (invocation.memberName == #close) {
@@ -239,7 +241,8 @@ void main() {
 
     test('$Event userContext overrides client', () async {
       final MockClient httpMock = new MockClient();
-      final ClockProvider fakeClockProvider = () => new DateTime.utc(2017, 1, 2);
+      final ClockProvider fakeClockProvider =
+          () => new DateTime.utc(2017, 1, 2);
 
       String loggedUserId; // used to find out what user context was sent
       httpMock.answerWith((Invocation invocation) async {

--- a/test/sentry_test.dart
+++ b/test/sentry_test.dart
@@ -25,7 +25,8 @@ void main() {
 
     testCaptureException(bool compressPayload) async {
       final MockClient httpMock = new MockClient();
-      final ClockProvider fakeClockProvider = () => new DateTime.utc(2017, 1, 2);
+      final ClockProvider fakeClockProvider =
+          () => new DateTime.utc(2017, 1, 2);
 
       String postUri;
       Map<String, String> headers;
@@ -130,7 +131,7 @@ void main() {
 
     test('reads error message from the x-sentry-error header', () async {
       final MockClient httpMock = new MockClient();
-      final Clock fakeClock = new Clock.fixed(new DateTime(2017, 1, 2));
+      final ClockProvider fakeClockProvider = () => DateTime(2017, 1, 2);
 
       httpMock.answerWith((Invocation invocation) async {
         if (invocation.memberName == #close) {
@@ -147,7 +148,7 @@ void main() {
       final SentryClient client = new SentryClient(
         dsn: _testDsn,
         httpClient: httpMock,
-        clock: fakeClock,
+        clock: fakeClockProvider,
         uuidGenerator: () => 'X' * 32,
         compressPayload: false,
         environmentAttributes: const Event(
@@ -173,7 +174,7 @@ void main() {
 
     test('$Event userContext overrides client', () async {
       final MockClient httpMock = new MockClient();
-      final Clock fakeClock = new Clock.fixed(new DateTime(2017, 1, 2));
+      final ClockProvider fakeClockProvider = () => DateTime(2017, 1, 2);
 
       String loggedUserId; // used to find out what user context was sent
       httpMock.answerWith((Invocation invocation) async {
@@ -208,7 +209,7 @@ void main() {
       final SentryClient client = new SentryClient(
         dsn: _testDsn,
         httpClient: httpMock,
-        clock: fakeClock,
+        clock: fakeClockProvider,
         uuidGenerator: () => 'X' * 32,
         compressPayload: false,
         environmentAttributes: const Event(

--- a/test/sentry_test.dart
+++ b/test/sentry_test.dart
@@ -6,7 +6,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:http/http.dart';
-import 'package:quiver/time.dart';
 import 'package:sentry/sentry.dart';
 import 'package:test/test.dart';
 
@@ -26,7 +25,7 @@ void main() {
 
     testCaptureException(bool compressPayload) async {
       final MockClient httpMock = new MockClient();
-      final Clock fakeClock = new Clock.fixed(new DateTime.utc(2017, 1, 2));
+      final ClockProvider fakeClockProvider = () => new DateTime.utc(2017, 1, 2);
 
       String postUri;
       Map<String, String> headers;
@@ -47,7 +46,7 @@ void main() {
       final SentryClient client = new SentryClient(
         dsn: _testDsn,
         httpClient: httpMock,
-        clock: fakeClock,
+        clock: fakeClockProvider,
         uuidGenerator: () => 'X' * 32,
         compressPayload: compressPayload,
         environmentAttributes: const Event(
@@ -74,9 +73,7 @@ void main() {
         'Content-Type': 'application/json',
         'X-Sentry-Auth': 'Sentry sentry_version=6, '
             'sentry_client=${SentryClient.sentryClient}, '
-            'sentry_timestamp=${fakeClock
-            .now()
-            .millisecondsSinceEpoch}, '
+            'sentry_timestamp=${fakeClockProvider().millisecondsSinceEpoch}, '
             'sentry_key=public, '
             'sentry_secret=secret',
       };


### PR DESCRIPTION
I've updated the library to make the secretKey field optional so that it supports the new DSN format from Sentry.

I also noticed that Quiver is only used for Clock to hold a ticking DateTime for reporting. Looking at the use of it I see it can be replaced with a simple function typedef. This I feel is a better way to make the library for flexible and not have the extra dependency on the Quiver library.