### PR TITLE
version 2.1.1; changelog update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ packages
 pubspec.lock
 .idea/libraries
 .idea/workspace.xml
+android/
+ios/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # package:sentry changelog
 
+## 2.1.1
+
+- Defensively copy internal maps event attributes to
+  avoid shared mutable state (https://github.com/flutter/sentry/commit/044e4c1f43c2d199ed206e5529e2a630c90e4434)
+
 ## 2.1.0
 
 - Support DNS format without secret key.

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -9,7 +9,7 @@
 library version;
 
 /// The SDK version reported to Sentry.io in the submitted events.
-const String sdkVersion = '2.1.0';
+const String sdkVersion = '2.1.1';
 
 /// The SDK name reported to Sentry.io in the submitted events.
 const String sdkName = 'dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sentry
-version: 2.1.0
+version: 2.1.1
 description: A pure Dart Sentry.io client.
 author: Flutter Authors <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/sentry


### PR DESCRIPTION
Prepare for publishing version 2.1.1, which includes the following change:

- Defensively copy internal maps event attributes to
  avoid shared mutable state (https://github.com/flutter/sentry/commit/044e4c1f43c2d199ed206e5529e2a630c90e4434)