### PR TITLE
Add a stackFrameFilter argument to SentryClient's capture

### DIFF
--- a/test/stack_trace_test.dart
+++ b/test/stack_trace_test.dart
@@ -74,5 +74,23 @@ void main() {
         },
       ]);
     });
+
+    test('allows changing the stack frame list before sending', () {
+      StackFrameFilter filter = (list) =>
+          list.where((f) => f['abs_path'] != 'secret.dart').toList();
+
+      expect(encodeStackTrace('''
+#0      baz (file:///pathto/test.dart:50:3)
+#1      bar (file:///pathto/secret.dart:46:9)
+      ''', stackFrameFilter: filter), [
+        {
+          'abs_path': 'test.dart',
+          'function': 'baz',
+          'lineno': 50,
+          'in_app': true,
+          'filename': 'test.dart'
+        },
+      ]);
+    });
   });
 }


### PR DESCRIPTION
This change allows filtering sensitive frames on the client or applying custom truncation logic.

I created this in reaction to this discussion: https://forum.sentry.io/t/issue-in-flutter-project-with-stackframe-display-limit-set-to-250/5014/2

Instead of adding complex truncation options that will likely depend on the frameworks you use anyways, I opted to provide a more general callback that could also be used for things like filtering specific frames. In the case of above discussion, we'd simply cut the list passed to us to only send the topmost 250 items.