### PR TITLE
Add a stackFrameFilter argument to SentryClient's capture

### DIFF
--- a/lib/sentry.dart
+++ b/lib/sentry.dart
@@ -164,10 +164,8 @@ class SentryClient {
       '${dsnUri.scheme}://${dsnUri.host}/api/$projectId/store/';
 
   /// Reports an [event] to Sentry.io.
-  Future<SentryResponse> capture({
-    @required Event event,
-    StackFrameFilter stackFrameFilter
-  }) async {
+  Future<SentryResponse> capture(
+      {@required Event event, StackFrameFilter stackFrameFilter}) async {
     final DateTime now = _clock();
     String authHeader = 'Sentry sentry_version=6, sentry_client=$sentryClient, '
         'sentry_timestamp=${now.millisecondsSinceEpoch}, sentry_key=$publicKey';
@@ -195,7 +193,8 @@ class SentryClient {
     if (userContext != null) {
       mergeAttributes({'user': userContext.toJson()}, into: data);
     }
-    mergeAttributes(event.toJson(stackFrameFilter: stackFrameFilter), into: data);
+    mergeAttributes(event.toJson(stackFrameFilter: stackFrameFilter),
+        into: data);
 
     List<int> body = utf8.encode(json.encode(data));
     if (compressPayload) {
@@ -413,7 +412,8 @@ class Event {
 
     if (stackTrace != null) {
       json['stacktrace'] = <String, dynamic>{
-        'frames': encodeStackTrace(stackTrace, stackFrameFilter: stackFrameFilter),
+        'frames':
+            encodeStackTrace(stackTrace, stackFrameFilter: stackFrameFilter),
       };
     }
 

--- a/lib/src/stack_trace.dart
+++ b/lib/src/stack_trace.dart
@@ -6,8 +6,8 @@ import 'package:stack_trace/stack_trace.dart';
 
 /// Used to filter or modify stack frames before sending stack trace. The stack
 /// frames are in the Sentry.io format.
-typedef StackFrameFilter =
-  List<Map<String,dynamic>> Function(List<Map<String,dynamic>>);
+typedef StackFrameFilter = List<Map<String, dynamic>> Function(
+    List<Map<String, dynamic>>);
 
 /// Sentry.io JSON encoding of a stack frame for the asynchronous suspension,
 /// which is the gap between asynchronous calls.
@@ -32,9 +32,7 @@ List<Map<String, dynamic>> encodeStackTrace(dynamic stackTrace,
   }
 
   final jsonFrames = frames.reversed.toList();
-  return stackFrameFilter != null
-      ? stackFrameFilter(jsonFrames)
-      : jsonFrames;
+  return stackFrameFilter != null ? stackFrameFilter(jsonFrames) : jsonFrames;
 }
 
 Map<String, dynamic> encodeStackTraceFrame(Frame frame) {

--- a/lib/src/stack_trace.dart
+++ b/lib/src/stack_trace.dart
@@ -4,7 +4,8 @@
 
 import 'package:stack_trace/stack_trace.dart';
 
-/// Used to filter or modify stack frames before sending stack trace.
+/// Used to filter or modify stack frames before sending stack trace. The stack
+/// frames are in the Sentry.io format.
 typedef StackFrameFilter =
   List<Map<String,dynamic>> Function(List<Map<String,dynamic>>);
 

--- a/test/stack_trace_test.dart
+++ b/test/stack_trace_test.dart
@@ -76,8 +76,8 @@ void main() {
     });
 
     test('allows changing the stack frame list before sending', () {
-      StackFrameFilter filter = (list) =>
-          list.where((f) => f['abs_path'] != 'secret.dart').toList();
+      StackFrameFilter filter =
+          (list) => list.where((f) => f['abs_path'] != 'secret.dart').toList();
 
       expect(encodeStackTrace('''
 #0      baz (file:///pathto/test.dart:50:3)

--- a/test/stack_trace_test.dart
+++ b/test/stack_trace_test.dart
@@ -74,5 +74,23 @@ void main() {
         },
       ]);
     });
+
+    test('allows changing the stack frame list before sending', () {
+      StackFrameFilter filter = (list) =>
+          list.where((f) => f['abs_path'] != 'secret.dart').toList();
+
+      expect(encodeStackTrace('''
+#0      baz (file:///pathto/test.dart:50:3)
+#1      bar (file:///pathto/secret.dart:46:9)
+      ''', stackFrameFilter: filter), [
+        {
+          'abs_path': 'test.dart',
+          'function': 'baz',
+          'lineno': 50,
+          'in_app': true,
+          'filename': 'test.dart'
+        },
+      ]);
+    });
   });
 }


### PR DESCRIPTION
Attempt no 2, description copied:

This change allows filtering sensitive frames on the client or applying custom truncation logic.

I created this in reaction to this discussion: https://forum.sentry.io/t/issue-in-flutter-project-with-stackframe-display-limit-set-to-250/5014/2

Instead of adding complex truncation options that will likely depend on the frameworks you use anyways, I opted to provide a more general callback that could also be used for things like filtering specific frames. In the case of above discussion, we'd simply cut the list passed to us to only send the topmost 250 items.