### PR TITLE
support dsn that use non-regular port or contains prefix path 

### DIFF
--- a/lib/sentry.dart
+++ b/lib/sentry.dart
@@ -169,7 +169,7 @@ class SentryClient {
     var pathLength = dsnUri.pathSegments.length;
     var apiPath;
     if (pathLength > 1) {
-      // some paths would present before the projectID in the dsnUri 
+      // some paths would present before the projectID in the dsnUri
       apiPath =
           (dsnUri.pathSegments.sublist(0, pathLength - 1) + ['api']).join('/');
     } else {

--- a/lib/sentry.dart
+++ b/lib/sentry.dart
@@ -161,13 +161,13 @@ class SentryClient {
 
   @visibleForTesting
   String get postUri {
-    var port = dsnUri.hasPort &&
+    String port = dsnUri.hasPort &&
             ((dsnUri.scheme == 'http' && dsnUri.port != 80) ||
                 (dsnUri.scheme == 'https' && dsnUri.port != 443))
         ? ':${dsnUri.port}'
         : '';
-    var pathLength = dsnUri.pathSegments.length;
-    var apiPath;
+    int pathLength = dsnUri.pathSegments.length;
+    String apiPath;
     if (pathLength > 1) {
       // some paths would present before the projectID in the dsnUri
       apiPath =

--- a/lib/sentry.dart
+++ b/lib/sentry.dart
@@ -160,8 +160,23 @@ class SentryClient {
   User userContext;
 
   @visibleForTesting
-  String get postUri =>
-      '${dsnUri.scheme}://${dsnUri.host}/api/$projectId/store/';
+  String get postUri {
+    var port = dsnUri.hasPort &&
+            ((dsnUri.scheme == 'http' && dsnUri.port != 80) ||
+                (dsnUri.scheme == 'https' && dsnUri.port != 443))
+        ? ':${dsnUri.port}'
+        : '';
+    var pathLength = dsnUri.pathSegments.length;
+    var apiPath;
+    if (pathLength > 1) {
+      // some paths would present before the projectID in the dsnUri 
+      apiPath =
+          (dsnUri.pathSegments.sublist(0, pathLength - 1) + ['api']).join('/');
+    } else {
+      apiPath = 'api';
+    }
+    return '${dsnUri.scheme}://${dsnUri.host}${port}/$apiPath/$projectId/store/';
+  }
 
   /// Reports an [event] to Sentry.io.
   Future<SentryResponse> capture(

--- a/test/sentry_test.dart
+++ b/test/sentry_test.dart
@@ -11,8 +11,10 @@ import 'package:test/test.dart';
 
 const String _testDsn = 'https://public:secret@sentry.example.com/1';
 const String _testDsnWithoutSecret = 'https://public@sentry.example.com/1';
-const String _testDsnWithPath = 'https://public:secret@sentry.example.com/path/1';
-const String _testDsnWithPort = 'https://public:secret@sentry.example.com:8888/1';
+const String _testDsnWithPath =
+    'https://public:secret@sentry.example.com/path/1';
+const String _testDsnWithPort =
+    'https://public:secret@sentry.example.com:8888/1';
 void main() {
   group('$SentryClient', () {
     test('can parse DSN', () async {

--- a/test/sentry_test.dart
+++ b/test/sentry_test.dart
@@ -11,7 +11,8 @@ import 'package:test/test.dart';
 
 const String _testDsn = 'https://public:secret@sentry.example.com/1';
 const String _testDsnWithoutSecret = 'https://public@sentry.example.com/1';
-
+const String _testDsnWithPath = 'https://public:secret@sentry.example.com/path/1';
+const String _testDsnWithPort = 'https://public:secret@sentry.example.com:8888/1';
 void main() {
   group('$SentryClient', () {
     test('can parse DSN', () async {
@@ -34,6 +35,24 @@ void main() {
       await client.close();
     });
 
+    test('can parse DSN with path', () async {
+      final SentryClient client = new SentryClient(dsn: _testDsnWithPath);
+      expect(client.dsnUri, Uri.parse(_testDsnWithPath));
+      expect(client.postUri, 'https://sentry.example.com/path/api/1/store/');
+      expect(client.publicKey, 'public');
+      expect(client.secretKey, 'secret');
+      expect(client.projectId, '1');
+      await client.close();
+    });
+    test('can parse DSN with port', () async {
+      final SentryClient client = new SentryClient(dsn: _testDsnWithPort);
+      expect(client.dsnUri, Uri.parse(_testDsnWithPort));
+      expect(client.postUri, 'https://sentry.example.com:8888/api/1/store/');
+      expect(client.publicKey, 'public');
+      expect(client.secretKey, 'secret');
+      expect(client.projectId, '1');
+      await client.close();
+    });
     test('sends client auth header without secret', () async {
       final MockClient httpMock = new MockClient();
       final ClockProvider fakeClockProvider =


### PR DESCRIPTION
This PR will modify the `postUri` value in `SentryClient`.

Added two test cases :
```
const String _testDsnWithPath = 'https://public:secret@sentry.example.com/path/1';
const String _testDsnWithPort = 'https://public:secret@sentry.example.com:8888/1';
```
