### PR TITLE
Add 'transaction' and 'breadcrumbs' in event

### DIFF
--- a/lib/sentry.dart
+++ b/lib/sentry.dart
@@ -347,7 +347,7 @@ class Event {
   final dynamic stackTrace;
 
   /// The name of the transaction which generated this event,
-  /// for e.g., might be the route name: `"/users/<username>/"`.
+  /// for example, the route name: `"/users/<username>/"`.
   final String transaction;
 
   /// How important this event is.
@@ -367,7 +367,8 @@ class Event {
 
   /// List of breadcrumbs for this event.
   ///
-  /// see docs https://docs.sentry.io/enriching-error-data/breadcrumbs/?platform=javascript
+  /// See also:
+  /// * https://docs.sentry.io/enriching-error-data/breadcrumbs/?platform=javascript
   final List<Breadcrumb> breadcrumbs;
 
   /// Information about the current user.
@@ -536,20 +537,25 @@ class Breadcrumb {
   final Map<String, String> data;
   final SeverityLevel level;
 
-  /// default, http, or navigation.
-  /// see docs https://docs.sentry.io/development/sdk-dev/event-payloads/breadcrumbs/#breadcrumb-types
+  /// Describes what type of breadcrumb this is.
+  ///
+  /// Possible values: "default", "http", "navigation".
+  ///
+  /// See also:
+  ///
+  /// * https://docs.sentry.io/development/sdk-dev/event-payloads/breadcrumbs/#breadcrumb-types
   final String type;
 
-  /// Recording time
+  /// The time the breadcrumb was recorded.
   ///
-  /// note: serialized in  seconds
+  /// The value is submitted to Sentry with second precision.
   final DateTime timestamp;
   const Breadcrumb(this.message, this.timestamp,
       {this.category, this.data, this.level = SeverityLevel.info, this.type});
 
   Map<String, dynamic> toJson() {
     var json = <String, dynamic>{
-      'timestamp': timestamp.millisecondsSinceEpoch ~/ 1000,
+      'timestamp': formatDateAsIso8601WithSecondPrecision(timestamp),
     };
     if (message != null) {
       json['message'] = message;

--- a/lib/sentry.dart
+++ b/lib/sentry.dart
@@ -306,6 +306,7 @@ class Event {
     this.release,
     this.environment,
     this.message,
+    this.transaction,
     this.exception,
     this.stackTrace,
     this.level,
@@ -314,6 +315,7 @@ class Event {
     this.extra,
     this.fingerprint,
     this.userContext,
+    this.breadcrumbs,
   });
 
   /// The logger that logged the event.
@@ -344,6 +346,10 @@ class Event {
   /// Can be `null`, a [String], or a [StackTrace].
   final dynamic stackTrace;
 
+  /// The name of the transaction which generated this event,
+  /// for e.g., might be the route name: `"/users/<username>/"`.
+  final String transaction;
+
   /// How important this event is.
   final SeverityLevel level;
 
@@ -358,6 +364,11 @@ class Event {
   /// Sentry.io docs do not talk about restrictions on the values, other than
   /// they must be JSON-serializable.
   final Map<String, dynamic> extra;
+
+  /// List of breadcrumbs for this event.
+  ///
+  /// see docs https://docs.sentry.io/enriching-error-data/breadcrumbs/?platform=javascript
+  final List<Breadcrumb> breadcrumbs;
 
   /// Information about the current user.
   ///
@@ -401,6 +412,8 @@ class Event {
 
     if (message != null) json['message'] = message;
 
+    if (transaction != null) json['transaction'] = transaction;
+
     if (exception != null) {
       json['exception'] = [
         <String, dynamic>{
@@ -432,6 +445,12 @@ class Event {
 
     if (fingerprint != null && fingerprint.isNotEmpty)
       json['fingerprint'] = fingerprint;
+
+    if (breadcrumbs != null && breadcrumbs.isNotEmpty) {
+      json['breadcrumbs'] = <String, List<Map<String, dynamic>>>{
+        'values': breadcrumbs.map((b) => b.toJson()).toList(growable: false)
+      };
+    }
 
     return json;
   }
@@ -492,5 +511,61 @@ class User {
       "ip_address": ipAddress,
       "extras": extras,
     };
+  }
+}
+
+/// Structed data to describe more information pior to the event [captured][SentryClient.capture].
+///
+/// The outgoing JSON representation is:
+///
+/// ```
+/// {
+///   "timestamp": 1000
+///   "message": "message",
+///   "category": "category",
+///   "data": {"key": "value"},
+///   "level": "info",
+///   "type": "default"
+/// }
+/// ```
+/// See also:
+/// * https://docs.sentry.io/development/sdk-dev/event-payloads/breadcrumbs/
+class Breadcrumb {
+  final String message;
+  final String category;
+  final Map<String, String> data;
+  final SeverityLevel level;
+
+  /// default, http, or navigation.
+  /// see docs https://docs.sentry.io/development/sdk-dev/event-payloads/breadcrumbs/#breadcrumb-types
+  final String type;
+
+  /// Recording time
+  ///
+  /// note: serialized in  seconds
+  final DateTime timestamp;
+  const Breadcrumb(this.message, this.timestamp,
+      {this.category, this.data, this.level = SeverityLevel.info, this.type});
+
+  Map<String, dynamic> toJson() {
+    var json = <String, dynamic>{
+      'timestamp': timestamp.millisecondsSinceEpoch ~/ 1000,
+    };
+    if (message != null) {
+      json['message'] = message;
+    }
+    if (category != null) {
+      json['category'] = category;
+    }
+    if (data != null && data.isNotEmpty) {
+      json['data'] = Map.of(data);
+    }
+    if (level != null) {
+      json['level'] = level.name;
+    }
+    if (type != null) {
+      json['type'] = type;
+    }
+    return json;
   }
 }

--- a/test/sentry_test.dart
+++ b/test/sentry_test.dart
@@ -315,9 +315,16 @@ void main() {
           email: "email@email.com",
           ipAddress: "127.0.0.1",
           extras: {"foo": "bar"});
+
+      final breadcrumbs = [
+        Breadcrumb("test log", DateTime.fromMillisecondsSinceEpoch(1200 * 1000),
+            level: SeverityLevel.debug, category: "test"),
+      ];
+
       expect(
         new Event(
           message: 'test-message',
+          transaction: '/test/1',
           exception: new StateError('test-error'),
           level: SeverityLevel.debug,
           culprit: 'Professor Moriarty',
@@ -331,11 +338,13 @@ void main() {
           },
           fingerprint: <String>[Event.defaultFingerprint, 'foo'],
           userContext: user,
+          breadcrumbs: breadcrumbs,
         ).toJson(),
         <String, dynamic>{
           'platform': 'dart',
           'sdk': {'version': sdkVersion, 'name': 'dart'},
           'message': 'test-message',
+          'transaction': '/test/1',
           'exception': [
             {'type': 'StateError', 'value': 'Bad state: test-error'}
           ],
@@ -350,6 +359,16 @@ void main() {
             'email': 'email@email.com',
             'ip_address': '127.0.0.1',
             'extras': {'foo': 'bar'}
+          },
+          'breadcrumbs': {
+            'values': [
+              {
+                'timestamp': 1200,
+                'message': 'test log',
+                'category': 'test',
+                'level': 'debug',
+              },
+            ]
           },
         },
       );

--- a/test/sentry_test.dart
+++ b/test/sentry_test.dart
@@ -308,6 +308,22 @@ void main() {
   });
 
   group('$Event', () {
+    test('$Breadcrumb serializes', () {
+      expect(
+        Breadcrumb(
+          "example log",
+          DateTime.utc(2019),
+          level: SeverityLevel.debug,
+          category: "test",
+        ).toJson(),
+        <String, dynamic>{
+          'timestamp': '2019-01-01T00:00:00',
+          'message': 'example log',
+          'category': 'test',
+          'level': 'debug',
+        },
+      );
+    });
     test('serializes to JSON', () {
       final user = new User(
           id: "user_id",
@@ -317,7 +333,7 @@ void main() {
           extras: {"foo": "bar"});
 
       final breadcrumbs = [
-        Breadcrumb("test log", DateTime.fromMillisecondsSinceEpoch(1200 * 1000),
+        Breadcrumb("test log", DateTime.utc(2019),
             level: SeverityLevel.debug, category: "test"),
       ];
 
@@ -363,7 +379,7 @@ void main() {
           'breadcrumbs': {
             'values': [
               {
-                'timestamp': 1200,
+                'timestamp': '2019-01-01T00:00:00',
                 'message': 'test log',
                 'category': 'test',
                 'level': 'debug',


### PR DESCRIPTION
ref docs:
transaction: https://docs.sentry.io/development/sdk-dev/event-payloads/#optional-attributes
contexts: https://docs.sentry.io/development/sdk-dev/event-payloads/contexts/
breadcrumbs: https://docs.sentry.io/development/sdk-dev/event-payloads/breadcrumbs/

There is a related pr #40 when i create this pr. In my opinion, the `Event` class should know nothing about what the `contexts` have, so i did not create the wrapper class for the `os`,`device`,etc which it might contains. 
