### PR TITLE
Use integer type for screenDpi

### DIFF
--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -662,7 +662,7 @@ class Device {
   final double screenDensity;
 
   /// A decimal value reflecting the DPI (dots-per-inch) density.
-  final String screenDpi;
+  final int screenDpi;
 
   /// Whether the device was online or not.
   final bool online;


### PR DESCRIPTION
The sentry API expect the value of screenDpi to be an unsigned integer and not a string.

![afbeelding](https://user-images.githubusercontent.com/7236283/84369645-73f55e00-abd7-11ea-96e3-f1723963f08d.png)
