### PR TITLE
example complete event

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -18,10 +18,12 @@ Future<Null> main(List<String> rawArgs) async {
   final dsn = rawArgs.single;
   final client = SentryClient(dsn: dsn);
 
+  await captureCompleteExampleEvent(client);
+
   try {
     await foo();
   } catch (error, stackTrace) {
-    print('Reporting the following stack trace: ');
+    print('\nReporting the following stack trace: ');
     print(stackTrace);
     final response = await client.captureException(
       exception: error,
@@ -36,6 +38,91 @@ Future<Null> main(List<String> rawArgs) async {
   } finally {
     await client.close();
   }
+}
+
+Future<Null> captureCompleteExampleEvent(SentryClient client) async {
+  final event = Event(
+    loggerName: 'main',
+    serverName: 'server.dart',
+    release: '1.4.0-preview.1',
+    environment: 'Test',
+    message: 'This is an example Dart event.',
+    transaction: '/example/app',
+    level: SeverityLevel.warning,
+    tags: {'project-id':'7371'},
+    extra: {'company-name':'Dart Inc'},
+    fingerprint: ['example-dart'],
+    userContext: User(
+      id: '800',
+      username: 'first-user',
+      email: 'first@user.lan',
+      ipAddress: '127.0.0.1',
+      extras: {'first-sign-in':'2020-01-01'}),
+    breadcrumbs: [ Breadcrumb(
+      'UI Lifecycle',
+      DateTime.now().toUtc(),
+      category: 'ui.lifecycle',
+      type: 'navigation',
+      data: {
+        'screen':'MainActivity',
+        'state':'created'
+      },
+      level: SeverityLevel.info
+    )],
+    contexts: Contexts(
+      operatingSystem: OperatingSystem(
+        name: 'Android',
+        version: '5.0.2',
+        build: 'LRX22G.P900XXS0BPL2',
+        kernelVersion: 'Linux version 3.4.39-5726670 (dpi@SWHC3807) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Thu Dec 1 19:42:39 KST 2016',
+        rooted: false),
+      runtimes: [ Runtime(name: 'ART', version: '5') ],
+      app: App(
+        name: 'Example Dart App',
+        version: '1.42.0',
+        identifier: 'HGT-App-13',
+        build: '93785',
+        buildType: 'release',
+        deviceAppHash: '5afd3a6',
+        startTime: DateTime.now().toUtc()),
+      browser: Browser(name: 'Firefox', version: '42.0.1'),
+      device: Device(
+        name: 'SM-P900',
+        family: 'SM-P900',
+        model: 'SM-P900 (LRX22G)',
+        modelId: 'LRX22G',
+        arch: 'armeabi-v7a',
+        batteryLevel: 99,
+        orientation: Orientation.landscape,
+        manufacturer: 'samsung',
+        brand: 'samsung',
+        screenResolution: '2560x1600',
+        screenDensity: 2.1,
+        screenDpi: 320,
+        online: true,
+        charging: true,
+        lowMemory: true,
+        simulator: false,
+        memorySize: 1500,
+        freeMemory: 200,
+        usableMemory: 4294967296,
+        storageSize: 4294967296,
+        freeStorage: 2147483648,
+        externalStorageSize: 8589934592,
+        externalFreeStorage: 2863311530,
+        bootTime: DateTime.now().toUtc(),
+        timezone: 'America/Toronto',
+      )
+    ));
+
+    final response = await client.capture(event: event);
+
+    print('\nReporting a complete event example: ');
+    if (response.isSuccessful) {
+      print('SUCCESS\nid: ${response.eventId}');
+    } else {
+      print('FAILURE: ${response.error}');
+    }
 }
 
 Future<Null> foo() async {

--- a/example/main.dart
+++ b/example/main.dart
@@ -18,6 +18,7 @@ Future<Null> main(List<String> rawArgs) async {
   final dsn = rawArgs.single;
   final client = SentryClient(dsn: dsn);
 
+  // Sends a full Sentry event payload to show the different parts of the UI.
   await captureCompleteExampleEvent(client);
 
   try {
@@ -42,87 +43,83 @@ Future<Null> main(List<String> rawArgs) async {
 
 Future<Null> captureCompleteExampleEvent(SentryClient client) async {
   final event = Event(
-    loggerName: 'main',
-    serverName: 'server.dart',
-    release: '1.4.0-preview.1',
-    environment: 'Test',
-    message: 'This is an example Dart event.',
-    transaction: '/example/app',
-    level: SeverityLevel.warning,
-    tags: {'project-id':'7371'},
-    extra: {'company-name':'Dart Inc'},
-    fingerprint: ['example-dart'],
-    userContext: User(
-      id: '800',
-      username: 'first-user',
-      email: 'first@user.lan',
-      ipAddress: '127.0.0.1',
-      extras: {'first-sign-in':'2020-01-01'}),
-    breadcrumbs: [ Breadcrumb(
-      'UI Lifecycle',
-      DateTime.now().toUtc(),
-      category: 'ui.lifecycle',
-      type: 'navigation',
-      data: {
-        'screen':'MainActivity',
-        'state':'created'
-      },
-      level: SeverityLevel.info
-    )],
-    contexts: Contexts(
-      operatingSystem: OperatingSystem(
-        name: 'Android',
-        version: '5.0.2',
-        build: 'LRX22G.P900XXS0BPL2',
-        kernelVersion: 'Linux version 3.4.39-5726670 (dpi@SWHC3807) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Thu Dec 1 19:42:39 KST 2016',
-        rooted: false),
-      runtimes: [ Runtime(name: 'ART', version: '5') ],
-      app: App(
-        name: 'Example Dart App',
-        version: '1.42.0',
-        identifier: 'HGT-App-13',
-        build: '93785',
-        buildType: 'release',
-        deviceAppHash: '5afd3a6',
-        startTime: DateTime.now().toUtc()),
-      browser: Browser(name: 'Firefox', version: '42.0.1'),
-      device: Device(
-        name: 'SM-P900',
-        family: 'SM-P900',
-        model: 'SM-P900 (LRX22G)',
-        modelId: 'LRX22G',
-        arch: 'armeabi-v7a',
-        batteryLevel: 99,
-        orientation: Orientation.landscape,
-        manufacturer: 'samsung',
-        brand: 'samsung',
-        screenResolution: '2560x1600',
-        screenDensity: 2.1,
-        screenDpi: 320,
-        online: true,
-        charging: true,
-        lowMemory: true,
-        simulator: false,
-        memorySize: 1500,
-        freeMemory: 200,
-        usableMemory: 4294967296,
-        storageSize: 4294967296,
-        freeStorage: 2147483648,
-        externalStorageSize: 8589934592,
-        externalFreeStorage: 2863311530,
-        bootTime: DateTime.now().toUtc(),
-        timezone: 'America/Toronto',
-      )
-    ));
+      loggerName: 'main',
+      serverName: 'server.dart',
+      release: '1.4.0-preview.1',
+      environment: 'Test',
+      message: 'This is an example Dart event.',
+      transaction: '/example/app',
+      level: SeverityLevel.warning,
+      tags: {'project-id': '7371'},
+      extra: {'company-name': 'Dart Inc'},
+      fingerprint: ['example-dart'],
+      userContext: User(
+          id: '800',
+          username: 'first-user',
+          email: 'first@user.lan',
+          ipAddress: '127.0.0.1',
+          extras: {'first-sign-in': '2020-01-01'}),
+      breadcrumbs: [
+        Breadcrumb('UI Lifecycle', DateTime.now().toUtc(),
+            category: 'ui.lifecycle',
+            type: 'navigation',
+            data: {'screen': 'MainActivity', 'state': 'created'},
+            level: SeverityLevel.info)
+      ],
+      contexts: Contexts(
+          operatingSystem: OperatingSystem(
+              name: 'Android',
+              version: '5.0.2',
+              build: 'LRX22G.P900XXS0BPL2',
+              kernelVersion:
+                  'Linux version 3.4.39-5726670 (dpi@SWHC3807) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Thu Dec 1 19:42:39 KST 2016',
+              rooted: false),
+          runtimes: [Runtime(name: 'ART', version: '5')],
+          app: App(
+              name: 'Example Dart App',
+              version: '1.42.0',
+              identifier: 'HGT-App-13',
+              build: '93785',
+              buildType: 'release',
+              deviceAppHash: '5afd3a6',
+              startTime: DateTime.now().toUtc()),
+          browser: Browser(name: 'Firefox', version: '42.0.1'),
+          device: Device(
+            name: 'SM-P900',
+            family: 'SM-P900',
+            model: 'SM-P900 (LRX22G)',
+            modelId: 'LRX22G',
+            arch: 'armeabi-v7a',
+            batteryLevel: 99,
+            orientation: Orientation.landscape,
+            manufacturer: 'samsung',
+            brand: 'samsung',
+            screenResolution: '2560x1600',
+            screenDensity: 2.1,
+            screenDpi: 320,
+            online: true,
+            charging: true,
+            lowMemory: true,
+            simulator: false,
+            memorySize: 1500,
+            freeMemory: 200,
+            usableMemory: 4294967296,
+            storageSize: 4294967296,
+            freeStorage: 2147483648,
+            externalStorageSize: 8589934592,
+            externalFreeStorage: 2863311530,
+            bootTime: DateTime.now().toUtc(),
+            timezone: 'America/Toronto',
+          )));
 
-    final response = await client.capture(event: event);
+  final response = await client.capture(event: event);
 
-    print('\nReporting a complete event example: ');
-    if (response.isSuccessful) {
-      print('SUCCESS\nid: ${response.eventId}');
-    } else {
-      print('FAILURE: ${response.error}');
-    }
+  print('\nReporting a complete event example: ');
+  if (response.isSuccessful) {
+    print('SUCCESS\nid: ${response.eventId}');
+  } else {
+    print('FAILURE: ${response.error}');
+  }
 }
 
 Future<Null> foo() async {


### PR DESCRIPTION
The example now creates two events:

![image](https://user-images.githubusercontent.com/1633368/87479063-ce2f7780-c5f8-11ea-8653-f2e1e38f5c83.png)

One of which uses the complete Sentry event payload (except the exception which is featured in the second example):

![image](https://user-images.githubusercontent.com/1633368/87479001-b3f59980-c5f8-11ea-8ebe-6d1c6c5e6c9d.png)

The goal is to demonstrate how rich an event can be when using an integration which already collects a lot of that data from the device. Integrations will follow.