### PR TITLE
ref: remove default logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 5.0.0
 
 - BREAKING CHANGE: Fixed context screenDpi is of type int #58
+- By default no logger it set #63
 
 ## 4.0.0
 

--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -46,9 +46,6 @@ abstract class SentryClient {
   /// Sentry.io client identifier for _this_ client.
   static const String sentryClient = '$sdkName/$sdkVersion';
 
-  /// The default logger name used if no other value is supplied.
-  static const String defaultLoggerName = 'SentryClient';
-
   @protected
   final Client httpClient;
 
@@ -155,8 +152,7 @@ abstract class SentryClient {
     final data = <String, dynamic>{
       'project': projectId,
       'event_id': _uuidGenerator(),
-      'timestamp': formatDateAsIso8601WithSecondPrecision(now),
-      'logger': defaultLoggerName,
+      'timestamp': formatDateAsIso8601WithSecondPrecision(now)
     };
 
     if (environmentAttributes != null) {

--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -152,7 +152,7 @@ abstract class SentryClient {
     final data = <String, dynamic>{
       'project': projectId,
       'event_id': _uuidGenerator(),
-      'timestamp': formatDateAsIso8601WithSecondPrecision(now)
+      'timestamp': formatDateAsIso8601WithSecondPrecision(now),
     };
 
     if (environmentAttributes != null) {

--- a/lib/src/browser.dart
+++ b/lib/src/browser.dart
@@ -20,8 +20,7 @@ class SentryBrowserClient extends SentryClient {
   /// [environmentAttributes] contain event attributes that do not change over
   /// the course of a program's lifecycle. These attributes will be added to
   /// all events captured via this client. The following attributes often fall
-  /// under this category: [Event.loggerName], [Event.serverName],
-  /// [Event.release], [Event.environment].
+  /// under this category: [Event.serverName], [Event.release], [Event.environment].
   ///
   /// If [httpClient] is provided, it is used instead of the default client to
   /// make HTTP calls to Sentry.io. This is useful in tests.

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -22,8 +22,7 @@ class SentryIOClient extends SentryClient {
   /// [environmentAttributes] contain event attributes that do not change over
   /// the course of a program's lifecycle. These attributes will be added to
   /// all events captured via this client. The following attributes often fall
-  /// under this category: [Event.loggerName], [Event.serverName],
-  /// [Event.release], [Event.environment].
+  /// under this category: [Event.serverName], [Event.release], [Event.environment].
   ///
   /// If [compressPayload] is `true` the outgoing HTTP payloads are compressed
   /// using gzip. Otherwise, the payloads are sent in plain UTF8-encoded JSON

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -133,7 +133,6 @@ void testCaptureException(
       'project': '1',
       'event_id': 'X' * 32,
       'timestamp': '2017-01-02T00:00:00',
-      'logger': 'SentryClient',
       'platform': 'javascript',
       'sdk': {'version': sdkVersion, 'name': 'dart'},
       'server_name': 'test.server.com',
@@ -157,7 +156,6 @@ void testCaptureException(
         {'type': 'ArgumentError', 'value': 'Invalid argument(s): Test error'}
       ],
       'sdk': {'version': sdkVersion, 'name': 'dart'},
-      'logger': 'SentryClient',
       'server_name': 'test.server.com',
       'release': '1.2.3',
       'environment': 'staging',


### PR DESCRIPTION
`logger` isn't really a required value. And having a constant value there isn't really very valuable.

This field is usually used when integrating with a logging library, and depending on the logger (aka: category, tag) that creates the record, it takes ends up on that name.

Since this is a "breaking change", fitting in the 5.0 release