### PR TITLE
ref: rename capture to captureEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 5.0.0
 
 - BREAKING CHANGE: Fixed context screenDpi is of type int #58
+- BREAKING CHANGE: Renamed capture method to captureEvent #64
 
 ## 4.0.0
 

--- a/example/main.dart
+++ b/example/main.dart
@@ -112,7 +112,7 @@ Future<Null> captureCompleteExampleEvent(SentryClient client) async {
             timezone: 'America/Toronto',
           )));
 
-  final response = await client.capture(event: event);
+  final response = await client.captureEvent(event: event);
 
   print('\nReporting a complete event example: ');
   if (response.isSuccessful) {

--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -139,7 +139,7 @@ abstract class SentryClient {
   }
 
   /// Reports an [event] to Sentry.io.
-  Future<SentryResponse> capture({
+  Future<SentryResponse> captureEvent({
     @required Event event,
     StackFrameFilter stackFrameFilter,
   }) async {
@@ -206,7 +206,7 @@ abstract class SentryClient {
       exception: exception,
       stackTrace: stackTrace,
     );
-    return capture(event: event);
+    return captureEvent(event: event);
   }
 
   Future<Null> close() async {
@@ -1054,7 +1054,7 @@ class User {
   }
 }
 
-/// Structed data to describe more information pior to the event [captured][SentryClient.capture].
+/// Structed data to describe more information pior to the event [captured][SentryClient.captureEvent].
 ///
 /// The outgoing JSON representation is:
 ///

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -360,9 +360,9 @@ void runTest({Codec<List<int>, List<int>> gzip, bool isWeb = false}) {
           exception: error,
           stackTrace: stackTrace,
           userContext: eventUserContext);
-      await client.capture(event: eventWithoutContext);
+      await client.captureEvent(event: eventWithoutContext);
       expect(loggedUserId, clientUserContext.id);
-      await client.capture(event: eventWithContext);
+      await client.captureEvent(event: eventWithContext);
       expect(loggedUserId, eventUserContext.id);
     }
 


### PR DESCRIPTION
To stay more in line with the other SDKs (Java is also getting renamed now on v2.0):

`capture` gets renamed to `captureEvent`.

We're not overloading these `capture` methods by parameter type but in fact we name them:

`captureException`
`captureEvent`
`captureMessage`

Coming up there'll be `captureTransaction`, `captureSession` etc.