### PR TITLE
Stay on v4 which was not yet published.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,9 @@
 # package:sentry changelog
 
-## 5.0.0
-
-- BREAKING CHANGE: Fixed context screenDpi is of type int #58
-
 ## 4.0.0
 
 - BREAKING CHANGE: Fixed context screenDensity is of type double #53
+- BREAKING CHANGE: Fixed context screenDpi is of type int #58
 
 ## 3.0.1
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -9,7 +9,7 @@
 library version;
 
 /// The SDK version reported to Sentry.io in the submitted events.
-const String sdkVersion = '5.0.0';
+const String sdkVersion = '4.0.0';
 
 /// The SDK name reported to Sentry.io in the submitted events.
 const String sdkName = 'dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sentry
-version: 5.0.0
+version: 4.0.0
 description: >
   A crash reporting library for for Dart that sends crash reports to Sentry.io.
   This library supports Dart VM, and Flutter for mobile, web, and desktop.


### PR DESCRIPTION
Rolling back to version 4 which is unpublished and not tagged yet:

Since [pub.dev only has version 3.0.1](https://pub.dev/packages/sentry), and that's also the [latest release and tag](https://github.com/flutter/sentry/releases/tag/3.0.1).