### PR TITLE
Add sdk info

### DIFF
--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -309,6 +309,7 @@ class Event {
     this.userContext,
     this.contexts,
     this.breadcrumbs,
+    this.sdk,
   });
 
   /// The logger that logged the event.
@@ -391,6 +392,8 @@ class Event {
   ///     var supplemented = [Event.defaultFingerprint, 'foo'];
   final List<String> fingerprint;
 
+  final Sdk sdk;
+
   Event copyWith({
     String loggerName,
     String serverName,
@@ -407,6 +410,7 @@ class Event {
     List<String> fingerprint,
     User userContext,
     List<Breadcrumb> breadcrumbs,
+    Sdk sdk,
   }) =>
       Event(
         loggerName: loggerName ?? this.loggerName,
@@ -424,6 +428,7 @@ class Event {
         fingerprint: fingerprint ?? this.fingerprint,
         userContext: userContext ?? this.userContext,
         breadcrumbs: breadcrumbs ?? this.breadcrumbs,
+        sdk: sdk ?? this.sdk,
       );
 
   /// Serializes this event to JSON.
@@ -431,10 +436,6 @@ class Event {
       {StackFrameFilter stackFrameFilter, String origin}) {
     final json = <String, dynamic>{
       'platform': sdkPlatform,
-      'sdk': {
-        'version': sdkVersion,
-        'name': sdkName,
-      },
     };
 
     if (loggerName != null) {
@@ -516,6 +517,12 @@ class Event {
         'values': breadcrumbs.map((b) => b.toJson()).toList(growable: false)
       };
     }
+
+    json['sdk'] = sdk?.toJson() ??
+        {
+          'name': sdkName,
+          'version': sdkVersion,
+        };
 
     return json;
   }
@@ -1147,6 +1154,96 @@ class Breadcrumb {
       json['type'] = type;
     }
     return json;
+  }
+}
+
+/// Describes the SDK that is submitting events to Sentry.
+///
+/// https://develop.sentry.dev/sdk/event-payloads/sdk/
+///
+/// SDK's maintained by Sentry take the following format:
+/// sentry.lang and for specializations: sentry.lang.specialization
+///
+/// Examples: sentry.dart, sentry.dart.browser, sentry.dart.flutter
+///
+/// It can also contain the packages bundled and integrations enabled.
+///
+/// ```
+/// "sdk": {
+///   "name": "sentry.dart.flutter",
+///   "version": "5.0.0",
+///   "integrations": [
+///     "tracing"
+///   ],
+///   "packages": [
+///     {
+///       "name": "git:https://github.com/getsentry/sentry-cocoa.git",
+///       "version": "5.1.0"
+///     },
+///     {
+///       "name": "maven:io.sentry.android",
+///       "version": "2.2.0"
+///     }
+///   ]
+/// }
+/// ```
+@immutable
+class Sdk {
+  /// The name of the SDK.
+  final String name;
+
+  /// The version of the SDK.
+  final String version;
+
+  /// A list of integrations enabled in the SDK that created the [Event].
+  final List<String> integrations;
+
+  /// A list of packages that compose this SDK.
+  final List<Package> packages;
+
+  /// Creates an [Sdk] object which represents the SDK that created an [Event].
+  const Sdk(
+      {@required this.name,
+      @required this.version,
+      this.integrations,
+      this.packages})
+      : assert(name != null || version != null);
+
+  /// Produces a [Map] that can be serialized to JSON.
+  Map<String, dynamic> toJson() {
+    final json = <String, dynamic>{};
+    json['name'] = name;
+    json['version'] = version;
+    if (packages != null && packages.isNotEmpty) {
+      json['packages'] =
+          packages.map((p) => p.toJson()).toList(growable: false);
+    }
+    if (integrations != null && integrations.isNotEmpty) {
+      json['integrations'] = integrations;
+    }
+    return json;
+  }
+}
+
+/// A [Package] part of the [Sdk].
+@immutable
+class Package {
+  /// The name of the SDK.
+  final String name;
+
+  /// The version of the SDK.
+  final String version;
+
+  /// Creates an [Package] object that is part of the [Sdk].
+  const Package(this.name, this.version)
+      : assert(name != null && version != null);
+
+  /// Produces a [Map] that can be serialized to JSON.
+  Map<String, dynamic> toJson() {
+    return {
+      'name': name,
+      'version': version,
+    };
   }
 }
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -11,8 +11,8 @@ library version;
 /// The SDK version reported to Sentry.io in the submitted events.
 const String sdkVersion = '5.0.0';
 
-/// The SDK name reported to Sentry.io in the submitted events.
-const String sdkName = 'dart';
+/// The default SDK name reported to Sentry.io in the submitted events.
+const String sdkName = 'sentry.dart';
 
 /// The name of the SDK platform reported to Sentry.io in the submitted events.
 ///

--- a/test/event_test.dart
+++ b/test/event_test.dart
@@ -23,6 +23,25 @@ void main() {
         },
       );
     });
+    test('$Sdk serializes', () {
+      final event = Event(
+          sdk: Sdk(
+              name: 'sentry.dart.flutter',
+              version: '4.3.2',
+              integrations: <String>['integration'],
+              packages: <Package>[Package('npm:@sentry/javascript', '1.3.4')]));
+      expect(event.toJson(), <String, dynamic>{
+        'platform': 'dart',
+        'sdk': {
+          'name': 'sentry.dart.flutter',
+          'version': '4.3.2',
+          'packages': [
+            {'name': 'npm:@sentry/javascript', 'version': '1.3.4'}
+          ],
+          'integrations': ['integration'],
+        },
+      });
+    });
     test('serializes to JSON', () {
       final user = User(
           id: 'user_id',
@@ -57,7 +76,7 @@ void main() {
         ).toJson(),
         <String, dynamic>{
           'platform': 'dart',
-          'sdk': {'version': sdkVersion, 'name': 'dart'},
+          'sdk': {'version': sdkVersion, 'name': 'sentry.dart'},
           'message': 'test-message',
           'transaction': '/test/1',
           'exception': [

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -135,7 +135,7 @@ void testCaptureException(
       'timestamp': '2017-01-02T00:00:00',
       'logger': 'SentryClient',
       'platform': 'javascript',
-      'sdk': {'version': sdkVersion, 'name': 'dart'},
+      'sdk': {'version': sdkVersion, 'name': 'sentry.dart'},
       'server_name': 'test.server.com',
       'release': '1.2.3',
       'environment': 'staging',
@@ -156,7 +156,7 @@ void testCaptureException(
       'exception': [
         {'type': 'ArgumentError', 'value': 'Invalid argument(s): Test error'}
       ],
-      'sdk': {'version': sdkVersion, 'name': 'dart'},
+      'sdk': {'version': sdkVersion, 'name': 'sentry.dart'},
       'logger': 'SentryClient',
       'server_name': 'test.server.com',
       'release': '1.2.3',


### PR DESCRIPTION
This field is expected to be used internally (follow up PRs will use it).

We'll need to break the client apart, part of it will become the _transport_. It'll be also easier to test in this case.
So we can test the event once it goes through the client (call `beforeSend` on it for example) and then sends it to the transport which sends to Sentry in the background.

Inside the client (through options) it'll be possible to add the correct sdk name. If it's running in flutter, it'd become `sentry.dart.flutter`. When we add the native SDKs underneath, there'll be cached envelopes on disk with different values there.
We'll be adding to `packages` all SDKs involved (i.e: `maven:io.sentry.android`, `pub.dev:sentry` etc).

To avoid bringing flutter dependencies it'l make sense to create a package on top of `sentry`.