### PR TITLE
ref: Use Flutter linter rules

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,212 @@
-include: package:pedantic/analysis_options.yaml
+# From: https://github.com/flutter/flutter/blob/63381814285f247a63b113acd149187be8838a53/analysis_options.yaml
+#
+# Specify analysis options.
+#
+# Until there are meta linter rules, each desired lint must be explicitly enabled.
+# See: https://github.com/dart-lang/linter/issues/288
+#
+# For a list of lints, see: http://dart-lang.github.io/linter/lints/
+# See the configuration guide for more
+# https://github.com/dart-lang/sdk/tree/master/pkg/analyzer#configuring-the-analyzer
+#
+# There are other similar analysis options files in the flutter repos,
+# which should be kept in sync with this file:
+#
+#   - analysis_options.yaml (this file)
+#   - packages/flutter/lib/analysis_options_user.yaml
+#   - https://github.com/flutter/plugins/blob/master/analysis_options.yaml
+#   - https://github.com/flutter/engine/blob/master/analysis_options.yaml
+#
+# This file contains the analysis options used by Flutter tools, such as IntelliJ,
+# Android Studio, and the `flutter analyze` command.
+
+analyzer:
+  strong-mode:
+    implicit-casts: false
+    implicit-dynamic: false
+  errors:
+    # treat missing required parameters as a warning (not a hint)
+    missing_required_param: warning
+    # treat missing returns as a warning (not a hint)
+    missing_return: warning
+    # allow having TODOs in the code
+    todo: ignore
+    # allow self-reference to deprecated members (we do this because otherwise we have
+    # to annotate every member in every test, assert, etc, when we deprecate something)
+    deprecated_member_use_from_same_package: ignore
+    # Ignore analyzer hints for updating pubspecs when using Future or
+    # Stream and not importing dart:async
+    # Please see https://github.com/flutter/flutter/pull/24528 for details.
+    sdk_version_async_exported_from_core: ignore
+  exclude:
+    - "bin/cache/**"
+    # the following two are relative to the stocks example and the flutter package respectively
+    # see https://github.com/dart-lang/sdk/issues/28463
+    - "lib/i18n/messages_*.dart"
+    - "lib/src/http/**"
+
+linter:
+  rules:
+    # these rules are documented on and in the same order as
+    # the Dart Lint rules page to make maintenance easier
+    # https://github.com/dart-lang/linter/blob/master/example/all.yaml
+    - always_declare_return_types
+    - always_put_control_body_on_new_line
+    # - always_put_required_named_parameters_first # we prefer having parameters in the same order as fields https://github.com/flutter/flutter/issues/10219
+    - always_require_non_null_named_parameters
+    # - always_specify_types # sentry ignored
+    - annotate_overrides
+    # - avoid_annotating_with_dynamic # conflicts with always_specify_types
+    # - avoid_as # required for implicit-casts: true
+    - avoid_bool_literals_in_conditional_expressions
+    # - avoid_catches_without_on_clauses # we do this commonly
+    # - avoid_catching_errors # we do this commonly
+    - avoid_classes_with_only_static_members
+    # - avoid_double_and_int_checks # only useful when targeting JS runtime
+    - avoid_empty_else
+    - avoid_equals_and_hash_code_on_mutable_classes
+    - avoid_field_initializers_in_const_classes
+    - avoid_function_literals_in_foreach_calls
+    # - avoid_implementing_value_types # not yet tested
+    - avoid_init_to_null
+    # - avoid_js_rounded_ints # only useful when targeting JS runtime
+    - avoid_null_checks_in_equality_operators
+    # - avoid_positional_boolean_parameters # not yet tested
+    # - avoid_print # not yet tested
+    # - avoid_private_typedef_functions # we prefer having typedef (discussion in https://github.com/flutter/flutter/pull/16356)
+    # - avoid_redundant_argument_values # not yet tested
+    - avoid_relative_lib_imports
+    - avoid_renaming_method_parameters
+    - avoid_return_types_on_setters
+    # - avoid_returning_null # there are plenty of valid reasons to return null
+    # - avoid_returning_null_for_future # not yet tested
+    - avoid_returning_null_for_void
+    # - avoid_returning_this # there are plenty of valid reasons to return this
+    # - avoid_setters_without_getters # not yet tested
+    # - avoid_shadowing_type_parameters # not yet tested
+    - avoid_single_cascade_in_expression_statements
+    - avoid_slow_async_io
+    - avoid_types_as_parameter_names
+    # - avoid_types_on_closure_parameters # conflicts with always_specify_types
+    # - avoid_unnecessary_containers # not yet tested
+    - avoid_unused_constructor_parameters
+    - avoid_void_async
+    # - avoid_web_libraries_in_flutter # not yet tested
+    - await_only_futures
+    - camel_case_extensions
+    - camel_case_types
+    - cancel_subscriptions
+    # - cascade_invocations # not yet tested
+    # - close_sinks # not reliable enough
+    # - comment_references # blocked on https://github.com/flutter/flutter/issues/20765
+    # - constant_identifier_names # needs an opt-out https://github.com/dart-lang/linter/issues/204
+    - control_flow_in_finally
+    # - curly_braces_in_flow_control_structures # not yet tested
+    # - diagnostic_describe_all_properties # not yet tested
+    - directives_ordering
+    - empty_catches
+    - empty_constructor_bodies
+    - empty_statements
+    # - file_names # not yet tested
+    - flutter_style_todos
+    - hash_and_equals
+    - implementation_imports
+    # - invariant_booleans # too many false positives: https://github.com/dart-lang/linter/issues/811
+    - iterable_contains_unrelated_type
+    # - join_return_with_assignment # not yet tested
+    - library_names
+    - library_prefixes
+    # - lines_longer_than_80_chars # not yet tested
+    - list_remove_unrelated_type
+    # - literal_only_boolean_expressions # too many false positives: https://github.com/dart-lang/sdk/issues/34181
+    # - missing_whitespace_between_adjacent_strings # not yet tested
+    - no_adjacent_strings_in_list
+    - no_duplicate_case_values
+    # - no_logic_in_create_state # not yet tested
+    # - no_runtimeType_toString # not yet tested
+    - non_constant_identifier_names
+    # - null_closures  # not yet tested
+    # - omit_local_variable_types # opposite of always_specify_types
+    # - one_member_abstracts # too many false positives
+    # - only_throw_errors # https://github.com/flutter/flutter/issues/5792
+    - overridden_fields
+    - package_api_docs
+    - package_names
+    - package_prefixed_library_names
+    # - parameter_assignments # we do this commonly
+    - prefer_adjacent_string_concatenation
+    - prefer_asserts_in_initializer_lists
+    # - prefer_asserts_with_message # not yet tested
+    - prefer_collection_literals
+    - prefer_conditional_assignment
+    - prefer_const_constructors
+    - prefer_const_constructors_in_immutables
+    - prefer_const_declarations
+    - prefer_const_literals_to_create_immutables
+    # - prefer_constructors_over_static_methods # not yet tested
+    - prefer_contains
+    # - prefer_double_quotes # opposite of prefer_single_quotes
+    - prefer_equal_for_default_values
+    # - prefer_expression_function_bodies # conflicts with https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#consider-using--for-short-functions-and-methods
+    - prefer_final_fields
+    - prefer_final_in_for_each
+    - prefer_final_locals
+    - prefer_for_elements_to_map_fromIterable
+    - prefer_foreach
+    # - prefer_function_declarations_over_variables # not yet tested
+    - prefer_generic_function_type_aliases
+    - prefer_if_elements_to_conditional_expressions
+    - prefer_if_null_operators
+    - prefer_initializing_formals
+    - prefer_inlined_adds
+    # - prefer_int_literals # not yet tested
+    # - prefer_interpolation_to_compose_strings # not yet tested
+    - prefer_is_empty
+    - prefer_is_not_empty
+    - prefer_is_not_operator
+    - prefer_iterable_whereType
+    # - prefer_mixin # https://github.com/dart-lang/language/issues/32
+    # - prefer_null_aware_operators # disable until NNBD, see https://github.com/flutter/flutter/pull/32711#issuecomment-492930932
+    # - prefer_relative_imports # not yet tested
+    - prefer_single_quotes
+    - prefer_spread_collections
+    - prefer_typing_uninitialized_variables
+    - prefer_void_to_null
+    # - provide_deprecation_message # not yet tested
+    # - public_member_api_docs # enabled on a case-by-case basis; see e.g. packages/analysis_options.yaml
+    - recursive_getters
+    - slash_for_doc_comments
+    # - sort_child_properties_last # not yet tested
+    - sort_constructors_first
+    - sort_pub_dependencies
+    - sort_unnamed_constructors_first
+    - test_types_in_equals
+    - throw_in_finally
+    # - type_annotate_public_apis # subset of always_specify_types
+    - type_init_formals
+    # - unawaited_futures # too many false positives
+    # - unnecessary_await_in_return # not yet tested
+    - unnecessary_brace_in_string_interps
+    - unnecessary_const
+    # - unnecessary_final # conflicts with prefer_final_locals
+    - unnecessary_getters_setters
+    # - unnecessary_lambdas # has false positives: https://github.com/dart-lang/linter/issues/498
+    - unnecessary_new
+    - unnecessary_null_aware_assignments
+    - unnecessary_null_in_if_null_operators
+    - unnecessary_overrides
+    - unnecessary_parenthesis
+    - unnecessary_statements
+    - unnecessary_string_interpolations
+    - unnecessary_this
+    - unrelated_type_equality_checks
+    # - unsafe_html # not yet tested
+    - use_full_hex_values_for_flutter_colors
+    # - use_function_type_syntax_for_parameters # not yet tested
+    # - use_key_in_widget_constructors # not yet tested
+    - use_rethrow_when_possible
+    # - use_setters_to_change_properties # not yet tested
+    # - use_string_buffers # has false positives: https://github.com/dart-lang/sdk/issues/34182
+    # - use_to_and_as_if_applicable # has false positives, so we prefer to catch this by code-review
+    - valid_regexps
+    - void_checks

--- a/example/main.dart
+++ b/example/main.dart
@@ -8,7 +8,7 @@ import 'dart:io';
 import 'package:sentry/sentry.dart';
 
 /// Sends a test exception report to Sentry.io using this Dart client.
-Future<Null> main(List<String> rawArgs) async {
+Future<void> main(List<String> rawArgs) async {
   if (rawArgs.length != 1) {
     stderr.writeln(
         'Expected exactly one argument, which is the DSN issued by Sentry.io to your project.');
@@ -41,7 +41,7 @@ Future<Null> main(List<String> rawArgs) async {
   }
 }
 
-Future<Null> captureCompleteExampleEvent(SentryClient client) async {
+Future<void> captureCompleteExampleEvent(SentryClient client) async {
   final event = Event(
       loggerName: 'main',
       serverName: 'server.dart',
@@ -50,15 +50,15 @@ Future<Null> captureCompleteExampleEvent(SentryClient client) async {
       message: 'This is an example Dart event.',
       transaction: '/example/app',
       level: SeverityLevel.warning,
-      tags: {'project-id': '7371'},
-      extra: {'company-name': 'Dart Inc'},
-      fingerprint: ['example-dart'],
-      userContext: User(
+      tags: const <String, String>{'project-id': '7371'},
+      extra: const <String, String>{'company-name': 'Dart Inc'},
+      fingerprint: const <String>['example-dart'],
+      userContext: const User(
           id: '800',
           username: 'first-user',
           email: 'first@user.lan',
           ipAddress: '127.0.0.1',
-          extras: {'first-sign-in': '2020-01-01'}),
+          extras: <String, String>{'first-sign-in': '2020-01-01'}),
       breadcrumbs: [
         Breadcrumb('UI Lifecycle', DateTime.now().toUtc(),
             category: 'ui.lifecycle',
@@ -67,14 +67,14 @@ Future<Null> captureCompleteExampleEvent(SentryClient client) async {
             level: SeverityLevel.info)
       ],
       contexts: Contexts(
-          operatingSystem: OperatingSystem(
+          operatingSystem: const OperatingSystem(
               name: 'Android',
               version: '5.0.2',
               build: 'LRX22G.P900XXS0BPL2',
               kernelVersion:
                   'Linux version 3.4.39-5726670 (dpi@SWHC3807) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Thu Dec 1 19:42:39 KST 2016',
               rooted: false),
-          runtimes: [Runtime(name: 'ART', version: '5')],
+          runtimes: [const Runtime(name: 'ART', version: '5')],
           app: App(
               name: 'Example Dart App',
               version: '1.42.0',
@@ -83,7 +83,7 @@ Future<Null> captureCompleteExampleEvent(SentryClient client) async {
               buildType: 'release',
               deviceAppHash: '5afd3a6',
               startTime: DateTime.now().toUtc()),
-          browser: Browser(name: 'Firefox', version: '42.0.1'),
+          browser: const Browser(name: 'Firefox', version: '42.0.1'),
           device: Device(
             name: 'SM-P900',
             family: 'SM-P900',
@@ -122,14 +122,14 @@ Future<Null> captureCompleteExampleEvent(SentryClient client) async {
   }
 }
 
-Future<Null> foo() async {
+Future<void> foo() async {
   await bar();
 }
 
-Future<Null> bar() async {
+Future<void> bar() async {
   await baz();
 }
 
-Future<Null> baz() async {
+Future<void> baz() async {
   throw StateError('This is a test error');
 }

--- a/lib/browser_client.dart
+++ b/lib/browser_client.dart
@@ -3,5 +3,5 @@
 // found in the LICENSE file.
 
 export 'src/base.dart';
-export 'src/version.dart';
 export 'src/browser.dart';
+export 'src/version.dart';

--- a/lib/io_client.dart
+++ b/lib/io_client.dart
@@ -3,5 +3,5 @@
 // found in the LICENSE file.
 
 export 'src/base.dart';
-export 'src/version.dart';
 export 'src/io.dart';
+export 'src/version.dart';

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -13,9 +13,6 @@ import 'version.dart';
 
 /// Logs crash reports and events to the Sentry.io service.
 class SentryIOClient extends SentryClient {
-  /// Whether to compress payloads sent to Sentry.io.
-  final bool compressPayload;
-
   /// Instantiates a client using [dsn] issued to your project by Sentry.io as
   /// the endpoint for submitting events.
   ///
@@ -82,6 +79,9 @@ class SentryIOClient extends SentryClient {
           platform: platform,
           origin: origin,
         );
+
+  /// Whether to compress payloads sent to Sentry.io.
+  final bool compressPayload;
 
   @override
   Map<String, String> buildHeaders(String authHeader) {

--- a/lib/src/stack_trace.dart
+++ b/lib/src/stack_trace.dart
@@ -33,7 +33,7 @@ List<Map<String, dynamic>> encodeStackTrace(
 
   final chain = stackTrace is StackTrace
       ? Chain.forTrace(stackTrace)
-      : Chain.parse(stackTrace);
+      : Chain.parse(stackTrace as String);
 
   final frames = <Map<String, dynamic>>[];
   for (var t = 0; t < chain.traces.length; t += 1) {
@@ -42,7 +42,9 @@ List<Map<String, dynamic>> encodeStackTrace(
 
     frames.addAll(encodedFrames);
 
-    if (t < chain.traces.length - 1) frames.add(asynchronousGapFrameJson);
+    if (t < chain.traces.length - 1) {
+      frames.add(asynchronousGapFrameJson);
+    }
   }
 
   final jsonFrames = frames.reversed.toList();

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -19,7 +19,8 @@ void mergeAttributes(Map<String, dynamic> attributes,
         // of 'value' will expose 'value' to be mutated by further merges.
         into[name] = targetValue = <String, dynamic>{};
       }
-      mergeAttributes(value, into: targetValue);
+      mergeAttributes(value as Map<String, dynamic>,
+          into: targetValue as Map<String, dynamic>);
     } else {
       into[name] = value;
     }

--- a/test/contexts_test.dart
+++ b/test/contexts_test.dart
@@ -36,13 +36,13 @@ void main() {
         bootTime: testBootTime,
         timezone: 'Australia/Melbourne',
       );
-      final testOS = OperatingSystem(name: 'testOS');
+      const testOS = OperatingSystem(name: 'testOS');
       final testRuntimes = [
-        Runtime(name: 'testRT1', version: '1.0'),
-        Runtime(name: 'testRT2', version: '2.3.1'),
+        const Runtime(name: 'testRT1', version: '1.0'),
+        const Runtime(name: 'testRT2', version: '2.3.1'),
       ];
-      final testApp = App(version: '1.2.3');
-      final testBrowser = Browser(version: '12.3.4');
+      const testApp = App(version: '1.2.3');
+      const testBrowser = Browser(version: '12.3.4');
 
       final contexts = Contexts(
         device: testDevice,

--- a/test/event_test.dart
+++ b/test/event_test.dart
@@ -24,7 +24,7 @@ void main() {
       );
     });
     test('$Sdk serializes', () {
-      final event = Event(
+      const event = Event(
           sdk: Sdk(
               name: 'sentry.dart.flutter',
               version: '4.3.2',
@@ -43,12 +43,12 @@ void main() {
       });
     });
     test('serializes to JSON', () {
-      final user = User(
+      const user = User(
           id: 'user_id',
           username: 'username',
           email: 'email@email.com',
           ipAddress: '127.0.0.1',
-          extras: {'foo': 'bar'});
+          extras: <String, String>{'foo': 'bar'});
 
       final breadcrumbs = [
         Breadcrumb('test log', DateTime.utc(2019),
@@ -62,15 +62,15 @@ void main() {
           exception: StateError('test-error'),
           level: SeverityLevel.debug,
           culprit: 'Professor Moriarty',
-          tags: <String, String>{
+          tags: const <String, String>{
             'a': 'b',
             'c': 'd',
           },
-          extra: <String, dynamic>{
+          extra: const <String, dynamic>{
             'e': 'f',
             'g': 2,
           },
-          fingerprint: <String>[Event.defaultFingerprint, 'foo'],
+          fingerprint: const <String>[Event.defaultFingerprint, 'foo'],
           userContext: user,
           breadcrumbs: breadcrumbs,
         ).toJson(),

--- a/test/stack_trace_test.dart
+++ b/test/stack_trace_test.dart
@@ -80,8 +80,7 @@ void main() {
     });
 
     test('allows changing the stack frame list before sending', () {
-      // ignore: omit_local_variable_types
-      StackFrameFilter filter =
+      final StackFrameFilter filter =
           (list) => list.where((f) => f['abs_path'] != 'secret.dart').toList();
 
       expect(encodeStackTrace('''


### PR DESCRIPTION
Following up with [@yjbanov's suggestion to use Flutter's rules in this repo](https://github.com/flutter/sentry/pull/52#pullrequestreview-405410644):

Bringing the `analysis_options.yaml` from the flutter/flutter repo. The commit hash is at the top of the file for reference. 

The [issue discussed here](https://github.com/flutter/sentry/pull/52#discussion_r407118547) was solved on Dart 2.9.0 so I could remove the `// ignore`.

One modification to the rules was dropping `always_specify_types`, with a comment: `ignored sentry`.

Please let me know if you're not OK with that. I hope we can discuss if the goal is to align 100% with the Flutter rules or another reason to add it.

My take on it, after having the "should we use or not `var`" discussion already back in 2008 (in C#), I've never looked back into declaring types to the left hand side of the assignment operator. But I'm new to the ecosystem and it's possible I'm missing something.

- Adding @zoechi as a reviewer for visibility, since he's helping Sentry out with Flutter. Thank you @zoechi !