### PR TITLE
fix pod-lint

### DIFF
--- a/flutter/ios/Classes/SwiftSentryFlutterPlugin.swift
+++ b/flutter/ios/Classes/SwiftSentryFlutterPlugin.swift
@@ -19,7 +19,7 @@ public class SwiftSentryFlutterPlugin: NSObject, FlutterPlugin {
         if let dsn = resource.object(forKey: "SentryDsn") {
           SentrySDK.start { options in
               options.dsn = dsn as? String
-              options.debug = resource["SentryDebug"] as? NSNumber ?? 0
+              options.debug = resource["SentryDebug"] as? Bool == true
               options.attachStacktrace = true
           }
         }

--- a/flutter/ios/sentry_flutter.podspec
+++ b/flutter/ios/sentry_flutter.podspec
@@ -6,12 +6,12 @@ Pod::Spec.new do |s|
 Sentry SDK for Flutter with support to native through sentry-cocoa.
                        DESC
   s.homepage         = 'https://sentry.io'
-  s.license          = { :type => 'MIT', :file => '../LICENSE' }
+  s.license          = { :type => 'MIT', :file => '../../LICENSE' }
   s.authors          = "Sentry"
   s.source           = { :git => "https://github.com/getsentry/sentry-flutter.git",
                          :tag => s.version.to_s }
   s.source_files = 'Classes/**/*'
-  s.dependency 'Sentry', '~> 6.0.0-alpha.0'
+  s.dependency 'Sentry', '~> 6.0.1'
   s.dependency 'Flutter'
   s.platform = :ios, '9.0'
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1633368/95102142-037fc900-0701-11eb-8f8e-c79ec0f1f5a1.png)

Bumped sentry-cocoa in the process, fixed the new type of `debug` which is finally `Bool`