### PR TITLE
Change SDK name based on platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - move the `package:pedantic` to dev depencies #94
 - Added GH Action Changelog verifier #95
 - new Dart code file structure #96 
+- Base the sdk name on the platform (`sentry.dart` for io & flutter, `sentry.dart.browser` in a browser context) #103 
 
 # `package:sentry` changelog
 

--- a/dart/lib/src/browser_client.dart
+++ b/dart/lib/src/browser_client.dart
@@ -95,6 +95,7 @@ class SentryBrowserClient extends SentryClient {
           dsn: dsn,
           platform: platform,
           origin: origin,
+          sdk: Sdk(name: browserSdkName, version: sdkVersion),
         );
 
   @override

--- a/dart/lib/src/io_client.dart
+++ b/dart/lib/src/io_client.dart
@@ -98,6 +98,7 @@ class SentryIOClient extends SentryClient {
           dsn: dsn,
           platform: platform,
           origin: origin,
+          sdk: Sdk(name: sdkName, version: sdkVersion),
         );
 
   /// Whether to compress payloads sent to Sentry.io.
@@ -109,7 +110,7 @@ class SentryIOClient extends SentryClient {
 
     // NOTE(lejard_h) overriding user agent on VM and Flutter not sure why
     // for web it use browser user agent
-    headers['User-Agent'] = SentryClient.sentryClient;
+    headers['User-Agent'] = clientId /* SentryClient.sentryClient*/;
 
     return headers;
   }

--- a/dart/lib/src/io_client.dart
+++ b/dart/lib/src/io_client.dart
@@ -110,7 +110,7 @@ class SentryIOClient extends SentryClient {
 
     // NOTE(lejard_h) overriding user agent on VM and Flutter not sure why
     // for web it use browser user agent
-    headers['User-Agent'] = clientId /* SentryClient.sentryClient*/;
+    headers['User-Agent'] = clientId;
 
     return headers;
   }

--- a/dart/lib/src/protocol/sdk.dart
+++ b/dart/lib/src/protocol/sdk.dart
@@ -54,6 +54,8 @@ class Sdk {
   /// A list of packages that compose this SDK.
   final List<Package> packages;
 
+  String get identifier => '${name}/${version}';
+
   /// Produces a [Map] that can be serialized to JSON.
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};

--- a/dart/lib/src/version.dart
+++ b/dart/lib/src/version.dart
@@ -14,6 +14,9 @@ const String sdkVersion = '4.0.0';
 /// The default SDK name reported to Sentry.io in the submitted events.
 const String sdkName = 'sentry.dart';
 
+/// The SDK name for web projects reported to Sentry.io in the submitted events.
+const String browserSdkName = 'sentry.dart.browser';
+
 /// The name of the SDK platform reported to Sentry.io in the submitted events.
 ///
 /// Used for IO version.

--- a/dart/test/test_utils.dart
+++ b/dart/test/test_utils.dart
@@ -27,7 +27,7 @@ void testHeaders(
   final expectedHeaders = <String, String>{
     'Content-Type': 'application/json',
     'X-Sentry-Auth': 'Sentry sentry_version=6, '
-        'sentry_client=${SentryClient.sentryClient}, '
+        'sentry_client=$sdkName/$sdkVersion, '
         'sentry_timestamp=${fakeClockProvider().millisecondsSinceEpoch}, '
         'sentry_key=public'
   };

--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -39,8 +39,9 @@ Future<void> main() async {
       stackTrace: stackTrace,
       // release is required on Web to match the source maps
       release: _release,
+      sdk: _sentry.sdk,
     );
-    await _sentry.capture(event: event);
+    await _sentry.captureEvent(event: event);
   });
 }
 

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -13,7 +13,8 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  sentry: ^3.0.1
+  sentry: #3.0.1
+    path: ../dart
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
define the sdk name based on platform on which it's used


## :bulb: Motivation and Context

give more precise information about events


## :green_heart: How did you test it?



## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps

Define the `sentry.dart.flutter` sdk name when sentry is used from a Flutter app
