### PR TITLE
Use caret and adjust min version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@
 - BREAKING CHANGE: Fixed context screenDensity is of type double #53
 - BREAKING CHANGE: Fixed context screenDpi is of type int #58
 - BREAKING CHANGE: Renamed capture method to captureEvent #64
+- BREAKING CHANGE: `package:http` min version bumped to 0.12.0 #104
+- BREAKING CHANGE: replace the `package:usage` by `package:uuid` #94
 - By default no logger it set #63
 - Added missing Contexts to Event.copyWith() #62 
 - remove the `package:args` dependency #94
-- replace the `package:usage` by `package:uuid` #94
 - move the `package:pedantic` to dev depencies #94
 - Added GH Action Changelog verifier #95
 - new Dart code file structure #96 

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -6,16 +6,16 @@ description: >
 homepage: https://github.com/getsentry/sentry-dart
 
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: ^2.0.0
 
 dependencies:
-  http: ">=0.11.0 <2.0.0"
-  meta: ">=1.0.0 <2.0.0"
-  stack_trace: ">=1.0.0 <2.0.0"
-  uuid: "^2.2.2"
+  http: ^0.12.0
+  meta: ^1.0.0
+  stack_trace: ^1.0.0
+  uuid: ^2.0.0
 
 dev_dependencies:
-  mockito: ">=2.0.0 <4.0.0"
-  pedantic: ">=1.8.0 <2.0.0"
-  test: ">=0.12.0 <2.0.0"
-  yaml: ">=2.1.0 <3.0.0"
+  mockito: ^4.1.2
+  pedantic: ^1.9.2
+  test: ^1.15.4
+  yaml: ^2.2.1

--- a/flutter/example/pubspec.lock
+++ b/flutter/example/pubspec.lock
@@ -43,6 +43,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.15.0-nullsafety.3"
+  convert:
+    dependency: transitive
+    description:
+      name: convert
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.1"
+  crypto:
+    dependency: transitive
+    description:
+      name: crypto
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.5"
   fake_async:
     dependency: transitive
     description:
@@ -110,10 +124,10 @@ packages:
   sentry:
     dependency: transitive
     description:
-      name: sentry
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.0.1"
+      path: "../../dart"
+      relative: true
+    source: path
+    version: "4.0.0"
   sentry_flutter:
     dependency: "direct main"
     description:
@@ -182,13 +196,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.3"
-  usage:
+  uuid:
     dependency: transitive
     description:
-      name: usage
+      name: uuid
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.4.2"
+    version: "2.2.2"
   vector_math:
     dependency: transitive
     description:

--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -43,6 +43,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.15.0-nullsafety.3"
+  convert:
+    dependency: transitive
+    description:
+      name: convert
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.1"
+  crypto:
+    dependency: transitive
+    description:
+      name: crypto
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.5"
   fake_async:
     dependency: transitive
     description:
@@ -110,10 +124,10 @@ packages:
   sentry:
     dependency: "direct main"
     description:
-      name: sentry
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.0.1"
+      path: "../dart"
+      relative: true
+    source: path
+    version: "4.0.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -168,13 +182,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0-nullsafety.3"
-  usage:
+  uuid:
     dependency: transitive
     description:
-      name: usage
+      name: uuid
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.4.2"
+    version: "2.2.2"
   vector_math:
     dependency: transitive
     description:
@@ -183,5 +197,5 @@ packages:
     source: hosted
     version: "2.1.0-nullsafety.3"
 sdks:
-  dart: ">=2.10.0-110 <=2.11.0-161.0.dev"
+  dart: ">=2.10.0-110 <2.11.0"
   flutter: ">=1.17.0 <2.0.0"

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -5,15 +5,15 @@ homepage: https://docs.sentry.io/platforms/flutter/
 repository: https://github.com/getsentry/sentry-dart
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
-  flutter: ">=1.17.0 <2.0.0"
+  sdk: ^2.7.0
+  flutter: ^1.17.0
 
 dependencies:
   flutter:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  sentry: #3.0.1
+  sentry:
     path: ../dart
 
 dev_dependencies:


### PR DESCRIPTION
Since we require Dart 2 or higher, we can use the caret notation to define dependency version requirements.

Whenever possible I used `^`: https://dart.dev/tools/pub/dependencies#caret-syntax

Goal: Keep dependencies on the lowest possibly version to allow apps bump if/when they need and not because they've added `sentry`. Dev dependencies can be on the latest version:

Breaking `http` bumped to 0.12 for the nullability requirements

Dev dependencies bumped to the latest version.

`uuid` lowered to 2.0.0 (nothing on the changelog or in API compatibility says we need anything higher).
