### PR TITLE
add a Message type to add a logEntry to Event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - BREAKING CHANGE: Renamed capture method to captureEvent #64
 - BREAKING CHANGE: `package:http` min version bumped to 0.12.0 #104
 - BREAKING CHANGE: replace the `package:usage` by `package:uuid` #94
+- BREAKING CHANGE: `Event.message` must now be an instance of `Message`
 - By default no logger it set #63
 - Added missing Contexts to Event.copyWith() #62 
 - remove the `package:args` dependency #94

--- a/dart/example/main.dart
+++ b/dart/example/main.dart
@@ -47,7 +47,7 @@ Future<void> captureCompleteExampleEvent(SentryClient client) async {
       serverName: 'server.dart',
       release: '1.4.0-preview.1',
       environment: 'Test',
-      message: 'This is an example Dart event.',
+      message: Message(formatted: 'This is an example Dart event.'),
       transaction: '/example/app',
       level: SeverityLevel.warning,
       tags: const <String, String>{'project-id': '7371'},

--- a/dart/lib/src/protocol.dart
+++ b/dart/lib/src/protocol.dart
@@ -6,6 +6,7 @@ export 'protocol/device.dart';
 export 'protocol/dsn.dart';
 export 'protocol/event.dart';
 export 'protocol/level.dart';
+export 'protocol/message.dart';
 export 'protocol/package.dart';
 export 'protocol/runtime.dart';
 export 'protocol/sdk.dart';

--- a/dart/lib/src/protocol/event.dart
+++ b/dart/lib/src/protocol/event.dart
@@ -49,7 +49,7 @@ class Event {
   /// Event message.
   ///
   /// Generally an event either contains a [message] or an [exception].
-  final String message;
+  final Message message;
 
   /// An object that was thrown.
   ///
@@ -121,7 +121,7 @@ class Event {
     String serverName,
     String release,
     String environment,
-    String message,
+    Message message,
     String transaction,
     dynamic exception,
     dynamic stackTrace,
@@ -179,7 +179,7 @@ class Event {
     }
 
     if (message != null) {
-      json['message'] = message;
+      json['message'] = message.toJson();
     }
 
     if (transaction != null) {

--- a/dart/lib/src/protocol/message.dart
+++ b/dart/lib/src/protocol/message.dart
@@ -1,3 +1,11 @@
+/// The Message Interface carries a log message that describes an event or error.
+/// Optionally, it can carry a format string and structured parameters. This can help to group similar messages into the same issue.
+/// example of a serialized message : {
+///   "message": {
+///     "message": "My raw message with interpreted strings like %s",
+///     "params": ["this"]
+///   }
+/// }
 class Message {
   /// The fully formatted message. If missing, Sentry will try to interpolate the message.
   final String formatted;
@@ -18,21 +26,4 @@ class Message {
       'params': params,
     };
   }
-
-  @override
-  String toString() {
-    return 'Message{formatted: $formatted, message: $message, params: $params}';
-  }
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is Message &&
-          runtimeType == other.runtimeType &&
-          formatted == other.formatted &&
-          message == other.message &&
-          params == other.params;
-
-  @override
-  int get hashCode => formatted.hashCode ^ message.hashCode ^ params.hashCode;
 }

--- a/dart/lib/src/protocol/message.dart
+++ b/dart/lib/src/protocol/message.dart
@@ -1,0 +1,38 @@
+class Message {
+  /// The fully formatted message. If missing, Sentry will try to interpolate the message.
+  final String formatted;
+
+  /// The raw message string (uninterpolated).
+  /// example : "My raw message with interpreted strings like %s",
+  final String message;
+
+  /// A list of formatting parameters, preferably strings. Non-strings will be coerced to strings.
+  final List<dynamic> params;
+
+  Message({this.formatted, this.message, this.params});
+
+  Map<String, dynamic> toJson() {
+    return {
+      'formatted': formatted,
+      'message': message,
+      'params': params,
+    };
+  }
+
+  @override
+  String toString() {
+    return 'Message{formatted: $formatted, message: $message, params: $params}';
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Message &&
+          runtimeType == other.runtimeType &&
+          formatted == other.formatted &&
+          message == other.message &&
+          params == other.params;
+
+  @override
+  int get hashCode => formatted.hashCode ^ message.hashCode ^ params.hashCode;
+}

--- a/dart/test/event_test.dart
+++ b/dart/test/event_test.dart
@@ -57,7 +57,11 @@ void main() {
 
       expect(
         Event(
-          message: 'test-message',
+          message: Message(
+            formatted: 'test-message 1 2',
+            message: 'test-message %d %d',
+            params: ['1', '2'],
+          ),
           transaction: '/test/1',
           exception: StateError('test-error'),
           level: SeverityLevel.debug,
@@ -77,7 +81,11 @@ void main() {
         <String, dynamic>{
           'platform': 'dart',
           'sdk': {'version': sdkVersion, 'name': 'sentry.dart'},
-          'message': 'test-message',
+          'message': {
+            'formatted': 'test-message 1 2',
+            'message': 'test-message %d %d',
+            'params': ['1', '2']
+          },
           'transaction': '/test/1',
           'exception': [
             {'type': 'StateError', 'value': 'Bad state: test-error'}


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Add a new Message class

## :bulb: Motivation and Context
The Message Interface carries a log message that describes an event or error. Optionally, it can carry a format string and structured parameters. This can help to group similar messages into the same issue. cf. https://develop.sentry.dev/sdk/event-payloads/message/

fix #100 

## :green_heart: How did you test it?

I updated the existing tests to verify all the message properties are correctly serialized

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
