### PR TITLE
fix: dart ci no coverage

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -36,12 +36,6 @@ jobs:
             release-channel: ${{ matrix.sdk }}
         - uses: actions/checkout@v2
         - run: pub get
-        - name: Test on Dart VM and collect code coverage
-          uses: stelynx/dart-full-coverage@v1.0.3
-          with:
-            package: sentry
-            path: dart # seems the action does a cd {BLA} and ignores the workdir we set
-        - uses: codecov/codecov-action@v1
         - name: Test on Chrome
           run: pub run test -p chrome test/*
         - run: dartanalyzer --fatal-warnings ./

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -11,8 +11,9 @@ jobs:
   build:
     name: Build ${{matrix.sdk}} on ${{matrix.os}}
     runs-on: ${{ matrix.os }}
-    env:
-      working-directory: ./dart
+    defaults:
+      env:
+        working-directory: ./dart
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -12,8 +12,7 @@ jobs:
     name: Build ${{matrix.sdk}} on ${{matrix.os}}
     runs-on: ${{ matrix.os }}
     defaults:
-      env:
-        working-directory: ./dart
+      working-directory: ./dart
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -11,6 +11,8 @@ jobs:
   build:
     name: Build ${{matrix.sdk}} on ${{matrix.os}}
     runs-on: ${{ matrix.os }}
+    env:
+      working-directory: ./dart
     strategy:
       fail-fast: false
       matrix:
@@ -32,24 +34,16 @@ jobs:
           with:
             release-channel: ${{ matrix.sdk }}
         - uses: actions/checkout@v2
-        - run: |
-            cd dart
-            pub get
+        - run: pub get
         - name: Test on Dart VM and collect code coverage
-          run: |
-            cd dart
-            pub run test_coverage
+          uses: stelynx/dart-full-coverage@v1.0.3
+          with:
+            package: sentry
         - uses: codecov/codecov-action@v1
         - name: Test on Chrome
-          run:  |
-            cd dart
-            pub run test -p vm test/*
-        - run:  |
-            cd dart
-            dartanalyzer --fatal-warnings ./
-        - run:  |
-            cd dart
-            dartfmt -n --set-exit-if-changed ./
+          run: pub run test -p chrome test/*
+        - run: dartanalyzer --fatal-warnings ./
+        - run: dartfmt -n --set-exit-if-changed ./
   package-analysis:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -40,6 +40,7 @@ jobs:
           uses: stelynx/dart-full-coverage@v1.0.3
           with:
             package: sentry
+            path: dart # seems the action does a cd {BLA} and ignores the workdir we set
         - uses: codecov/codecov-action@v1
         - name: Test on Chrome
           run: pub run test -p chrome test/*

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -12,7 +12,8 @@ jobs:
     name: Build ${{matrix.sdk}} on ${{matrix.os}}
     runs-on: ${{ matrix.os }}
     defaults:
-      working-directory: ./dart
+      run:
+        working-directory: ./dart
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Disabling coverage until we figure out the hang, ideally with an action such as: https://github.com/marketplace/actions/dart-full-coverage

See #110 