### PR TITLE
feat: before breadcrumb and scope ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Ref: Hub passes the Scope to SentryClient
 - Feat: sentry options #116
 - Ref: SentryId generates UUID
+- Feat: before breadcrumb and scope ref.
 
 # `package:sentry` changelog
 

--- a/dart/lib/src/scope.dart
+++ b/dart/lib/src/scope.dart
@@ -53,7 +53,7 @@ class Scope {
 
   Map<String, dynamic> get extra => Map.unmodifiable(_extra);
 
-  // TODO: EventProcessors, Contexts, BeforeBreadcrumbCallback, Breadcrumb Hint, clone
+  // TODO: Contexts
 
   /// Scope's event processor list
   final List<EventProcessor> _eventProcessors = [];

--- a/dart/test/scope_test.dart
+++ b/dart/test/scope_test.dart
@@ -214,7 +214,7 @@ class Fixture {
     return Scope(options);
   }
 
-  Event processor(Event event, dynamic hint) => null;
+  SentryEvent processor(SentryEvent event, dynamic hint) => null;
 
   Breadcrumb beforeBreadcrumbCallback(Breadcrumb breadcrumb, dynamic hint) =>
       null;

--- a/dart/test/scope_test.dart
+++ b/dart/test/scope_test.dart
@@ -168,6 +168,8 @@ void main() {
     sut.setTag('test', 'test');
     sut.setExtra('test', 'test');
 
+    sut.addEventProcessor(fixture.processor);
+
     sut.clear();
 
     expect(sut.breadcrumbs.length, 0);
@@ -183,6 +185,8 @@ void main() {
     expect(sut.tags.length, 0);
 
     expect(sut.extra.length, 0);
+
+    expect(sut.eventProcessors.length, 0);
   });
 
   test('clones', () {

--- a/dart/test/scope_test.dart
+++ b/dart/test/scope_test.dart
@@ -48,6 +48,25 @@ void main() {
     expect(sut.breadcrumbs.last, breadcrumb);
   });
 
+  test('Executes and drops $Breadcrumb', () {
+    final sut = fixture.getSut(
+      beforeBreadcrumbCallback: fixture.beforeBreadcrumbCallback,
+    );
+
+    final breadcrumb = Breadcrumb('test log', DateTime.utc(2019));
+    sut.addBreadcrumb(breadcrumb);
+
+    expect(sut.breadcrumbs.length, 0);
+  });
+
+  test('adds $EventProcessor', () {
+    final sut = fixture.getSut();
+
+    sut.addEventProcessor(fixture.processor);
+
+    expect(sut.eventProcessors.last, fixture.processor);
+  });
+
   test('respects max $Breadcrumb', () {
     final maxBreadcrumbs = 2;
     final sut = fixture.getSut(maxBreadcrumbs: maxBreadcrumbs);
@@ -175,13 +194,24 @@ void main() {
     expect(sut.tags, clone.tags);
     expect(sut.breadcrumbs, clone.breadcrumbs);
     expect(ListEquality().equals(sut.fingerprint, clone.fingerprint), true);
+    expect(ListEquality().equals(sut.eventProcessors, clone.eventProcessors),
+        true);
   });
 }
 
 class Fixture {
-  Scope getSut({int maxBreadcrumbs = 100}) {
+  Scope getSut({
+    int maxBreadcrumbs = 100,
+    BeforeBreadcrumbCallback beforeBreadcrumbCallback,
+  }) {
     final options = SentryOptions();
     options.maxBreadcrumbs = maxBreadcrumbs;
+    options.beforeBreadcrumbCallback = beforeBreadcrumbCallback;
     return Scope(options);
   }
+
+  Event processor(Event event, dynamic hint) => null;
+
+  Breadcrumb beforeBreadcrumbCallback(Breadcrumb breadcrumb, dynamic hint) =>
+      null;
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [X] New feature
- [ ] Enhancement
- [X] Refactoring


## :scroll: Description
feat: before breadcrumb and scope ref


## :bulb: Motivation and Context
One should be able to filter breadcrumbs on before breadcrumb callback and also add event processors to the scope


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
Contexts is still missing