### PR TITLE
Ref: Remove stackFrameFilter in favor of beforeSendCallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 - Ref: SentryId generates UUID #119
 - Ref: Event now is SentryEvent and added GPU #121
 - Feat: before breadcrumb and scope ref. #122
-- Feat: Remove stackFrameFilter in favor of beforeSendCallback
+- Ref: Remove stackFrameFilter in favor of beforeSendCallback
 
 # `package:sentry` changelog
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Ref: SentryId generates UUID #119
 - Ref: Event now is SentryEvent and added GPU #121
 - Feat: before breadcrumb and scope ref. #122
+- Feat: Remove stackFrameFilter in favor of beforeSendCallback
 
 # `package:sentry` changelog
 

--- a/dart/lib/src/client.dart
+++ b/dart/lib/src/client.dart
@@ -8,7 +8,6 @@ import 'client_stub.dart'
     if (dart.library.html) 'browser_client.dart'
     if (dart.library.io) 'io_client.dart';
 import 'protocol.dart';
-import 'stack_trace.dart';
 import 'utils.dart';
 import 'version.dart';
 
@@ -97,7 +96,6 @@ abstract class SentryClient {
   /// Reports an [event] to Sentry.io.
   Future<SentryId> captureEvent(
     SentryEvent event, {
-    StackFrameFilter stackFrameFilter,
     Scope scope,
   }) async {
     final now = options.clock();
@@ -127,7 +125,6 @@ abstract class SentryClient {
 
     mergeAttributes(
       event.toJson(
-        stackFrameFilter: stackFrameFilter,
         origin: origin,
       ),
       into: data,

--- a/dart/lib/src/noop_client.dart
+++ b/dart/lib/src/noop_client.dart
@@ -34,11 +34,15 @@ class NoOpSentryClient implements SentryClient {
   Map<String, String> buildHeaders(String authHeader) => {};
 
   @override
-  Future<SentryId> captureEvent(SentryEvent event, {stackFrameFilter, scope}) =>
+  Future<SentryId> captureEvent(SentryEvent event, {Scope scope}) =>
       Future.value(SentryId.empty());
 
   @override
-  Future<SentryId> captureException(throwable, {stackTrace, scope}) =>
+  Future<SentryId> captureException(
+    throwable, {
+    dynamic stackTrace,
+    Scope scope,
+  }) =>
       Future.value(SentryId.empty());
 
   @override

--- a/dart/lib/src/noop_client.dart
+++ b/dart/lib/src/noop_client.dart
@@ -4,7 +4,6 @@ import 'client.dart';
 import 'protocol.dart';
 import 'scope.dart';
 import 'sentry_options.dart';
-import 'stack_trace.dart';
 
 class NoOpSentryClient implements SentryClient {
   NoOpSentryClient._();

--- a/dart/lib/src/protocol/sentry_event.dart
+++ b/dart/lib/src/protocol/sentry_event.dart
@@ -193,8 +193,7 @@ class SentryEvent {
       );
 
   /// Serializes this event to JSON.
-  Map<String, dynamic> toJson(
-      {StackFrameFilter stackFrameFilter, String origin}) {
+  Map<String, dynamic> toJson({String origin}) {
     final json = <String, dynamic>{};
 
     if (eventId != null) {
@@ -254,7 +253,6 @@ class SentryEvent {
         json['stacktrace'] = <String, dynamic>{
           'frames': encodeStackTrace(
             exception.stackTrace,
-            stackFrameFilter: stackFrameFilter,
             origin: origin,
           ),
         };
@@ -265,7 +263,6 @@ class SentryEvent {
       json['stacktrace'] = <String, dynamic>{
         'frames': encodeStackTrace(
           stackTrace,
-          stackFrameFilter: stackFrameFilter,
           origin: origin,
         ),
       };

--- a/dart/lib/src/stack_trace.dart
+++ b/dart/lib/src/stack_trace.dart
@@ -4,16 +4,6 @@
 
 import 'package:stack_trace/stack_trace.dart';
 
-/// Used to filter or modify stack frames before sending the stack trace.
-///
-/// The input stack frames are in the Sentry.io JSON format. The output
-/// stack frames must follow the same format.
-///
-/// Detailed documentation about the stack trace format is on Sentry.io's
-/// web-site: https://docs.sentry.io/development/sdk-dev/overview/.
-typedef StackFrameFilter = List<Map<String, dynamic>> Function(
-    List<Map<String, dynamic>>);
-
 /// Sentry.io JSON encoding of a stack frame for the asynchronous suspension,
 /// which is the gap between asynchronous calls.
 const Map<String, dynamic> asynchronousGapFrameJson = <String, dynamic>{
@@ -25,7 +15,6 @@ const Map<String, dynamic> asynchronousGapFrameJson = <String, dynamic>{
 /// [stackTrace] must be [String] or [StackTrace].
 List<Map<String, dynamic>> encodeStackTrace(
   dynamic stackTrace, {
-  StackFrameFilter stackFrameFilter,
   String origin,
 }) {
   assert(stackTrace is String || stackTrace is StackTrace);
@@ -47,8 +36,7 @@ List<Map<String, dynamic>> encodeStackTrace(
     }
   }
 
-  final jsonFrames = frames.reversed.toList();
-  return stackFrameFilter != null ? stackFrameFilter(jsonFrames) : jsonFrames;
+  return frames.reversed.toList();
 }
 
 Map<String, dynamic> encodeStackTraceFrame(Frame frame, {String origin}) {

--- a/dart/test/event_test.dart
+++ b/dart/test/event_test.dart
@@ -131,7 +131,6 @@ void main() {
                     'stacktrace': {
                       'frames': encodeStackTrace(
                         error.stackTrace,
-                        stackFrameFilter: null,
                         origin: null,
                       )
                     }

--- a/dart/test/hub_test.dart
+++ b/dart/test/hub_test.dart
@@ -57,7 +57,6 @@ void main() {
               client.captureEvent(
                 fakeEvent,
                 scope: captureAnyNamed('scope'),
-                stackFrameFilter: null,
               ),
             ).captured.first,
             Scope(options),
@@ -112,7 +111,6 @@ void main() {
             client.captureEvent(
               fakeEvent,
               scope: captureAnyNamed('scope'),
-              stackFrameFilter: null,
             ),
           ).captured.first,
           Scope(SentryOptions(dsn: fakeDsn))
@@ -145,7 +143,6 @@ void main() {
         client2.captureEvent(
           fakeEvent,
           scope: anyNamed('scope'),
-          stackFrameFilter: null,
         ),
       ).called(1);
     });

--- a/dart/test/sentry_test.dart
+++ b/dart/test/sentry_test.dart
@@ -24,7 +24,6 @@ void main() {
         client.captureEvent(
           fakeEvent,
           scope: anyNamed('scope'),
-          stackFrameFilter: null,
         ),
       ).called(1);
     });

--- a/dart/test/stack_trace_test.dart
+++ b/dart/test/stack_trace_test.dart
@@ -79,24 +79,25 @@ void main() {
       ]);
     });
 
-    test('allows changing the stack frame list before sending', () {
-      // ignore: omit_local_variable_types
-      final StackFrameFilter filter =
-          (list) => list.where((f) => f['abs_path'] != 'secret.dart').toList();
+// TODO: use beforeSend to filter stack frames
+//     test('allows changing the stack frame list before sending', () {
+//       // ignore: omit_local_variable_types
+//       final StackFrameFilter filter =
+//           (list) => list.where((f) => f['abs_path'] != 'secret.dart').toList();
 
-      expect(encodeStackTrace('''
-#0      baz (file:///pathto/test.dart:50:3)
-#1      bar (file:///pathto/secret.dart:46:9)
-      ''', stackFrameFilter: filter), [
-        {
-          'abs_path': 'test.dart',
-          'function': 'baz',
-          'lineno': 50,
-          'colno': 3,
-          'in_app': true,
-          'filename': 'test.dart'
-        },
-      ]);
-    });
+//       expect(encodeStackTrace('''
+// #0      baz (file:///pathto/test.dart:50:3)
+// #1      bar (file:///pathto/secret.dart:46:9)
+//       ''', stackFrameFilter: filter), [
+//         {
+//           'abs_path': 'test.dart',
+//           'function': 'baz',
+//           'lineno': 50,
+//           'colno': 3,
+//           'in_app': true,
+//           'filename': 'test.dart'
+//         },
+//       ]);
+//     });
   });
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [X] Refactoring


## :scroll: Description
Ref: Remove stackFrameFilter in favor of beforeSendCallback


## :bulb: Motivation and Context
we have the beforeSendCallback to filter the whole event and not only the stack trace frames, so stackFrameFilter is not really necessary


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
fix the stackFrameFilter test using the beforeSendCallback after #123 which applies the prepareEvent and run callbacks