### PR TITLE
Ref: Sentry init with null and empty DSN and close method

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG.md merge=union

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 - Ref: SentryId generates UUID #119
 - Ref: Event now is SentryEvent and added GPU #121
 - Feat: before breadcrumb and scope ref. #122
-- Ref: Sentry init with null and empty DSN and close method
+- Ref: Sentry init with null and empty DSN and close method #126
 - Ref: Hint is passed across Sentry static class, Hub and Client #124
 - Ref: Remove stackFrameFilter in favor of beforeSendCallback #125
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Ref: SentryId generates UUID #119
 - Ref: Event now is SentryEvent and added GPU #121
 - Feat: before breadcrumb and scope ref. #122
+- Ref: Sentry init with null and empty DSN and close method
 
 # `package:sentry` changelog
 

--- a/dart/lib/src/client.dart
+++ b/dart/lib/src/client.dart
@@ -184,7 +184,7 @@ abstract class SentryClient {
     return captureEvent(event, scope: scope);
   }
 
-  Future<void> close() async {
+  void close() {
     options.httpClient?.close();
   }
 

--- a/dart/lib/src/sentry.dart
+++ b/dart/lib/src/sentry.dart
@@ -37,7 +37,10 @@ class Sentry {
       );
     }
 
-    _setDefaultConfiguration(options);
+    // if there's an empty DSN, SDK is disabled
+    if (!_setDefaultConfiguration(options)) {
+      return;
+    }
 
     final hub = currentHub;
     _hub = Hub(options);
@@ -72,17 +75,29 @@ class Sentry {
   }
 
   /// Close the client SDK
-  static Future<void> close() async => currentHub.close();
+  static void close() {
+    final hub = currentHub;
+    _hub = NoOpHub();
+    return hub.close();
+  }
 
   /// Check if the current Hub is enabled/active.
   static bool get isEnabled => currentHub.isEnabled;
 
-  static void _setDefaultConfiguration(SentryOptions options) {
-    // TODO: check DSN nullability and empty
+  static bool _setDefaultConfiguration(SentryOptions options) {
+    if (options.dsn == null) {
+      throw ArgumentError.notNull(
+          'DSN is required. Use empty string to disable SDK.');
+    }
+    if (options.dsn.isEmpty) {
+      close();
+      return false;
+    }
 
     if (options.debug && options.logger == noOpLogger) {
       options.logger = dartLogger;
     }
+    return true;
   }
 
   /// client injector only use for testing

--- a/dart/test/sentry_test.dart
+++ b/dart/test/sentry_test.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 import 'mocks.dart';
 
 void main() {
-  group('Sentry static entry', () {
+  group('Sentry capture methods', () {
     SentryClient client;
 
     Exception anException;
@@ -17,9 +17,12 @@ void main() {
       client = MockSentryClient();
       Sentry.initClient(client);
     });
+    tearDown(() {
+      Sentry.close();
+    });
 
-    test('should capture the event', () {
-      Sentry.captureEvent(fakeEvent);
+    test('should capture the event', () async {
+      await Sentry.captureEvent(fakeEvent);
       verify(
         client.captureEvent(
           fakeEvent,
@@ -53,6 +56,32 @@ void main() {
           scope: anyNamed('scope'),
         ),
       ).called(1);
+    });
+  });
+  group('Sentry is enabled or closed', () {
+    test('null DSN', () {
+      expect(
+        () => Sentry.init((options) => options.dsn = null),
+        throwsArgumentError,
+      );
+      expect(Sentry.isEnabled, false);
+    });
+
+    test('empty DSN', () {
+      Sentry.init((options) => options.dsn = '');
+      expect(Sentry.isEnabled, false);
+    });
+
+    test('empty DSN', () {
+      Sentry.init((options) => options.dsn = fakeDsn);
+
+      Sentry.initClient(MockSentryClient());
+
+      expect(Sentry.isEnabled, true);
+
+      Sentry.close();
+
+      expect(Sentry.isEnabled, false);
     });
   });
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [X] Refactoring


## :scroll: Description
Ref: Sentry init with null and empty DSN and close method #126


## :bulb: Motivation and Context
One should be able to pass an empty DSN and disable the SDK, also to close the SDK if needed


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
