### PR TITLE
Feat: add lastEventId to the Sentry static API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Ref: added Transport #123
 - Feat: apply sample rate
 - Ref: execute before send callback
+- Ref: add lastEventId to the Sentry static API
 
 # `package:sentry` changelog
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
 - Ref: added Transport #123
 - Feat: apply sample rate
 - Ref: execute before send callback
-- Ref: add lastEventId to the Sentry static API
+- Feat: add lastEventId to the Sentry static API
 
 # `package:sentry` changelog
 

--- a/dart/lib/src/hub.dart
+++ b/dart/lib/src/hub.dart
@@ -50,7 +50,7 @@ class Hub {
 
   SentryId _lastEventId = SentryId.empty();
 
-  /// Last event id recorded in the current scope
+  /// Last event id recorded by the Hub
   SentryId get lastEventId => _lastEventId;
 
   /// Captures the event.

--- a/dart/lib/src/sentry.dart
+++ b/dart/lib/src/sentry.dart
@@ -94,6 +94,9 @@ class Sentry {
   /// Check if the current Hub is enabled/active.
   static bool get isEnabled => currentHub.isEnabled;
 
+  /// Last event id recorded by the current Hub
+  static SentryId get lastEventId => currentHub.lastEventId;
+
   static bool _setDefaultConfiguration(SentryOptions options) {
     if (options.dsn == null) {
       throw ArgumentError.notNull(

--- a/dart/test/hub_test.dart
+++ b/dart/test/hub_test.dart
@@ -83,6 +83,18 @@ void main() {
         ),
       ).called(1);
     });
+
+    test('should save the lastEventId', () async {
+      final event = SentryEvent();
+      final eventId = event.eventId;
+      when(client.captureEvent(
+        event,
+        scope: anyNamed('scope'),
+        hint: anyNamed('hint'),
+      )).thenAnswer((_) => Future.value(event.eventId));
+      final returnedId = await hub.captureEvent(event);
+      expect(eventId.toString(), returnedId.toString());
+    });
   });
 
   group('Hub scope', () {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
Feat: add lastEventId to the Sentry static API


## :bulb: Motivation and Context
one wants to know the lastEventId and the Static API is the most convenient one to be called


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
