### PR TITLE
Fix: Breadcrumb data should accept serializable types and not only String values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Ref: execute before send callback
 - Feat: add lastEventId to the Sentry static API
 - Feat: addBreadcrumb on Static API
+- Fix: Breadcrumb data should accept serialziable types and not only String values
 
 # `package:sentry` changelog
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 - Ref: execute before send callback
 - Feat: add lastEventId to the Sentry static API
 - Feat: addBreadcrumb on Static API
-- Fix: Breadcrumb data should accept serialziable types and not only String values
+- Fix: Breadcrumb data should accept serializable types and not only String values
 
 # `package:sentry` changelog
 

--- a/dart/lib/src/protocol/breadcrumb.dart
+++ b/dart/lib/src/protocol/breadcrumb.dart
@@ -47,7 +47,7 @@ class Breadcrumb {
   /// See also:
   ///
   /// * https://docs.sentry.io/development/sdk-dev/event-payloads/breadcrumbs/#breadcrumb-types
-  final Map<String, String> data;
+  final Map<String, dynamic> data;
 
   /// Severity of the breadcrumb.
   ///
@@ -85,7 +85,7 @@ class Breadcrumb {
       json['category'] = category;
     }
     if (data != null && data.isNotEmpty) {
-      json['data'] = Map.of(data);
+      json['data'] = data;
     }
     if (level != null) {
       json['level'] = level.name;


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Fix: Breadcrumb data should accept serializable types and not only String values


## :bulb: Motivation and Context
https://develop.sentry.dev/sdk/event-payloads/breadcrumbs/
#129


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
