### PR TITLE
Fix the pubspec Dart Sdk constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - chore: new analysis options rules
 - Ref: rename the `throwable` argument name to `exception` in `captureEvents(...)`
 - Ref : remove dsn from Transport public Api
+- update the Dart sdk constraint
 
 # `package:sentry` changelog
 

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -6,7 +6,7 @@ description: >
 homepage: https://github.com/getsentry/sentry-dart
 
 environment:
-  sdk: ^2.0.0
+  sdk: ">=2.0.0 <3.0.0"
 
 dependencies:
   http: ^0.12.0

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://docs.sentry.io/platforms/flutter/
 repository: https://github.com/getsentry/sentry-dart
 
 environment:
-  sdk: ^2.7.0
+  sdk: ">=2.0.0 <3.0.0"
   flutter: ^1.17.0
 
 dependencies:
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  sentry:
+  sentry: #^4.0.0 uncomment before publishing
     path: ../dart
 
 dev_dependencies:


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
```
Package validation found the following error:
* ^ version constraints aren't allowed for SDK constraints since older versions of pub don't support them.
```

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
