### PR TITLE
fix: sentry protocol is v7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - feat: add contexts to scope
 - fix: logger method and refactoring little things
+- fix: sentry protocol is v7
 
 ## 4.0.0-alpha.1
 

--- a/dart/lib/src/transport/http_transport.dart
+++ b/dart/lib/src/transport/http_transport.dart
@@ -69,7 +69,7 @@ class HttpTransport implements Transport {
     } else {
       _options.logger(
         SentryLevel.debug,
-        'Event ${event.eventId} was sent suceffully.',
+        'Event ${event.eventId} was sent successfully.',
       );
     }
 
@@ -103,11 +103,12 @@ class _CredentialBuilder {
       : _authHeader = authHeader,
         _clock = clock;
 
-  factory _CredentialBuilder(Dsn dsn, String clientId, ClockProvider clock) {
+  factory _CredentialBuilder(
+      Dsn dsn, String sdkIdentifier, ClockProvider clock) {
     final authHeader = _buildAuthHeader(
       publicKey: dsn.publicKey,
       secretKey: dsn.secretKey,
-      clientId: clientId,
+      sdkIdentifier: sdkIdentifier,
     );
 
     return _CredentialBuilder._(authHeader, clock);
@@ -116,9 +117,9 @@ class _CredentialBuilder {
   static String _buildAuthHeader({
     String publicKey,
     String secretKey,
-    String clientId,
+    String sdkIdentifier,
   }) {
-    var header = 'Sentry sentry_version=6, sentry_client=$clientId, '
+    var header = 'Sentry sentry_version=7, sentry_client=$sdkIdentifier, '
         'sentry_key=$publicKey';
 
     if (secretKey != null) {

--- a/dart/lib/src/utils.dart
+++ b/dart/lib/src/utils.dart
@@ -16,4 +16,4 @@ String formatDateAsIso8601WithSecondPrecision(DateTime date) {
 }
 
 /// helper to detect a browser context
-const isWeb = identical(1.0, 1);
+const isWeb = identical(0, 0.0);

--- a/dart/test/sentry_options_test.dart
+++ b/dart/test/sentry_options_test.dart
@@ -1,6 +1,5 @@
 import 'package:http/http.dart';
 import 'package:sentry/sentry.dart';
-import 'package:sentry/src/diagnostic_logger.dart';
 import 'package:sentry/src/noop_client.dart';
 import 'package:test/test.dart';
 

--- a/dart/test/test_utils.dart
+++ b/dart/test/test_utils.dart
@@ -27,7 +27,7 @@ void testHeaders(
 }) {
   final expectedHeaders = <String, String>{
     'Content-Type': 'application/json',
-    'X-Sentry-Auth': 'Sentry sentry_version=6, '
+    'X-Sentry-Auth': 'Sentry sentry_version=7, '
         'sentry_client=$sdkName/$sdkVersion, '
         'sentry_key=public, '
   };


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
fix: sentry protocol is v7


## :bulb: Motivation and Context
headers were already meeting protocol v7 but it was still sending v6

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
