### PR TITLE
add options.attachStacktrace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - feat: add missing protocol classes
 - fix: logger method and refactoring little things
 - fix: sentry protocol is v7
+- feat: add an attachStackTrace options
 
 ## 4.0.0-alpha.1
 

--- a/dart/example_web/web/main.dart
+++ b/dart/example_web/web/main.dart
@@ -92,9 +92,9 @@ void captureException() async {
 }
 
 Future<void> captureCompleteExampleEvent() async {
+  print('\nReporting a complete event example: ${sdkName}');
   final sentryId = await Sentry.captureEvent(event);
 
-  print('\nReporting a complete event example: ${sdkName}');
   print('Response SentryId: ${sentryId}');
 
   if (sentryId != SentryId.empty()) {

--- a/dart/lib/src/hub.dart
+++ b/dart/lib/src/hub.dart
@@ -54,7 +54,11 @@ class Hub {
   SentryId get lastEventId => _lastEventId;
 
   /// Captures the event.
-  Future<SentryId> captureEvent(SentryEvent event, {dynamic hint}) async {
+  Future<SentryId> captureEvent(
+    SentryEvent event, {
+    dynamic stackTrace,
+    dynamic hint,
+  }) async {
     var sentryId = SentryId.empty();
 
     if (!_isEnabled) {
@@ -73,6 +77,7 @@ class Hub {
         try {
           sentryId = await item.client.captureEvent(
             event,
+            stackTrace: stackTrace,
             scope: item.scope,
             hint: hint,
           );

--- a/dart/lib/src/hub_adapter.dart
+++ b/dart/lib/src/hub_adapter.dart
@@ -23,7 +23,11 @@ class HubAdapter implements Hub {
   void bindClient(SentryClient client) => Sentry.bindClient(client);
 
   @override
-  Future<SentryId> captureEvent(SentryEvent event, {dynamic hint}) =>
+  Future<SentryId> captureEvent(
+    SentryEvent event, {
+    dynamic stackTrace,
+    dynamic hint,
+  }) =>
       Sentry.captureEvent(event, hint: hint);
 
   @override

--- a/dart/lib/src/noop_hub.dart
+++ b/dart/lib/src/noop_hub.dart
@@ -17,7 +17,11 @@ class NoOpHub implements Hub {
   void bindClient(SentryClient client) {}
 
   @override
-  Future<SentryId> captureEvent(SentryEvent event, {dynamic hint}) =>
+  Future<SentryId> captureEvent(
+    SentryEvent event, {
+    dynamic stackTrace,
+    dynamic hint,
+  }) =>
       Future.value(SentryId.empty());
 
   @override

--- a/dart/lib/src/noop_sentry_client.dart
+++ b/dart/lib/src/noop_sentry_client.dart
@@ -16,6 +16,7 @@ class NoOpSentryClient implements SentryClient {
   @override
   Future<SentryId> captureEvent(
     SentryEvent event, {
+    dynamic stackTrace,
     Scope scope,
     dynamic hint,
   }) =>

--- a/dart/lib/src/protocol/sentry_event.dart
+++ b/dart/lib/src/protocol/sentry_event.dart
@@ -1,5 +1,3 @@
-import 'dart:isolate';
-
 import 'package:meta/meta.dart';
 
 import '../protocol.dart';
@@ -263,15 +261,14 @@ class SentryEvent {
       json['exception'] = {
         'values': [exception.toJson()].toList(growable: false)
       };
-    }
-
-    if (stackTrace != null) {
+    } else if (stackTrace != null) {
       json['threads'] = {
         'values': [
           {
-            'id': Isolate.current.debugName,
+            'id': 0,
             'stacktrace': stackTrace.toJson(),
             'crashed': true,
+            'name': 'Current Isolate',
           }
         ]
       };

--- a/dart/lib/src/protocol/sentry_event.dart
+++ b/dart/lib/src/protocol/sentry_event.dart
@@ -83,8 +83,8 @@ class SentryEvent {
   /// If this behavior is undesirable, consider using a custom formatted [message] instead.
   final dynamic throwable;
 
-  /// The stack trace corresponding to the thrown [exception] or attachedStackTrace
-  /// see [SentryOptions.attachStackTrace]
+  /// an optional attached StackTrace
+  /// used when event has no throwable or exception, see [SentryOptions.attachStackTrace]
   final SentryStackTrace stackTrace;
 
   /// an exception or error that occurred in a program

--- a/dart/lib/src/protocol/sentry_event.dart
+++ b/dart/lib/src/protocol/sentry_event.dart
@@ -1,3 +1,5 @@
+import 'dart:isolate';
+
 import 'package:meta/meta.dart';
 
 import '../protocol.dart';
@@ -83,10 +85,9 @@ class SentryEvent {
   /// If this behavior is undesirable, consider using a custom formatted [message] instead.
   final dynamic throwable;
 
-  /// The stack trace corresponding to the thrown [exception].
-  ///
-  /// Can be `null`, a [String], or a [StackTrace].
-  final dynamic stackTrace;
+  /// The stack trace corresponding to the thrown [exception] or attachedStackTrace
+  /// see [SentryOptions.attachStackTrace]
+  final SentryStackTrace stackTrace;
 
   /// an exception or error that occurred in a program
   /// TODO more doc
@@ -262,12 +263,15 @@ class SentryEvent {
       json['exception'] = {
         'values': [exception.toJson()].toList(growable: false)
       };
-    } else if (stackTrace is SentryStackTrace) {
+    }
+
+    if (stackTrace != null) {
       json['threads'] = {
         'values': [
           {
-            'id': 0,
-            'stacktrace': (stackTrace as SentryStackTrace).toJson(),
+            'id': Isolate.current.debugName,
+            'stacktrace': stackTrace.toJson(),
+            'crashed': true,
           }
         ]
       };

--- a/dart/lib/src/protocol/sentry_event.dart
+++ b/dart/lib/src/protocol/sentry_event.dart
@@ -263,7 +263,14 @@ class SentryEvent {
         'values': [exception.toJson()].toList(growable: false)
       };
     } else if (stackTrace is SentryStackTrace) {
-      json['stacktrace'] = (stackTrace as SentryStackTrace).toJson();
+      json['threads'] = {
+        'values': [
+          {
+            'id': 0,
+            'stacktrace': (stackTrace as SentryStackTrace).toJson(),
+          }
+        ]
+      };
     }
 
     if (level != null) {

--- a/dart/lib/src/protocol/sentry_event.dart
+++ b/dart/lib/src/protocol/sentry_event.dart
@@ -262,6 +262,8 @@ class SentryEvent {
       json['exception'] = {
         'values': [exception.toJson()].toList(growable: false)
       };
+    } else if (stackTrace is SentryStackTrace) {
+      json['stacktrace'] = (stackTrace as SentryStackTrace).toJson();
     }
 
     if (level != null) {

--- a/dart/lib/src/protocol/sentry_exception.dart
+++ b/dart/lib/src/protocol/sentry_exception.dart
@@ -14,7 +14,7 @@ class SentryException {
   final String module;
 
   /// An optional stack trace object
-  final SentryStackTrace stacktrace;
+  final SentryStackTrace stackTrace;
 
   /// An optional object describing the [Mechanism] that created this exception
   final Mechanism mechanism;
@@ -26,7 +26,7 @@ class SentryException {
     @required this.type,
     @required this.value,
     this.module,
-    this.stacktrace,
+    this.stackTrace,
     this.mechanism,
     this.threadId,
   });
@@ -46,8 +46,8 @@ class SentryException {
       json['module'] = module;
     }
 
-    if (stacktrace != null) {
-      json['stacktrace'] = stacktrace.toJson();
+    if (stackTrace != null) {
+      json['stacktrace'] = stackTrace.toJson();
     }
 
     if (mechanism != null) {

--- a/dart/lib/src/sentry.dart
+++ b/dart/lib/src/sentry.dart
@@ -59,9 +59,10 @@ class Sentry {
   /// Reports an [event] to Sentry.io.
   static Future<SentryId> captureEvent(
     SentryEvent event, {
+    dynamic stackTrace,
     dynamic hint,
   }) async =>
-      currentHub.captureEvent(event, hint: hint);
+      currentHub.captureEvent(event, stackTrace: stackTrace, hint: hint);
 
   /// Reports the [throwable] and optionally its [stackTrace] to Sentry.io.
   static Future<SentryId> captureException(

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -2,12 +2,12 @@ import 'dart:async';
 import 'dart:math';
 
 import 'package:meta/meta.dart';
-import 'package:sentry/src/sentry_stack_trace_factory.dart';
 
 import 'protocol.dart';
 import 'scope.dart';
 import 'sentry_exception_factory.dart';
 import 'sentry_options.dart';
+import 'sentry_stack_trace_factory.dart';
 import 'transport/http_transport.dart';
 import 'transport/noop_transport.dart';
 import 'version.dart';

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -101,7 +101,9 @@ class SentryClient {
       platform: event.platform ?? sdkPlatform,
     );
 
-    if (stackTrace != null && event.throwable == null) {
+    if (stackTrace != null &&
+        event.throwable == null &&
+        event.exception == null) {
       final frames = _stackTraceFactory.getStackFrames(stackTrace);
 
       if (frames != null && frames.isNotEmpty) {

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -138,14 +138,9 @@ class SentryClient {
       throwable: throwable,
       timestamp: _options.clock(),
     );
-    if (stackTrace != null) {
-      event = event.copyWith(
-        stackTrace: SentryStackTrace(
-          frames: _stackTraceFactory.getStackFrames(stackTrace),
-        ),
-      );
-    }
-    return captureEvent(event, scope: scope, hint: hint);
+
+    return captureEvent(event,
+        stackTrace: stackTrace, scope: scope, hint: hint);
   }
 
   /// Reports the [template]

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -129,7 +129,7 @@ class SentryClient {
     Scope scope,
     dynamic hint,
   }) {
-    var event = SentryEvent(
+    final event = SentryEvent(
       throwable: throwable,
       timestamp: _options.clock(),
     );

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -5,6 +5,7 @@ import 'protocol.dart';
 import 'scope.dart';
 import 'sentry_exception_factory.dart';
 import 'sentry_options.dart';
+import 'sentry_stack_trace_factory.dart';
 import 'transport/http_transport.dart';
 import 'transport/noop_transport.dart';
 import 'version.dart';
@@ -97,6 +98,15 @@ class SentryClient {
           .getSentryException(event.throwable, stackTrace: event.stackTrace);
 
       event = event.copyWith(exception: sentryException);
+    }
+
+    if (_options.attachStacktrace &&
+        event.throwable == null &&
+        event.exception == null) {
+      final frames =
+          SentryStackTraceFactory(_options).getStackFrames(StackTrace.current);
+
+      event = event.copyWith(stackTrace: SentryStackTrace(frames: frames));
     }
 
     return event;

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -114,10 +114,9 @@ class SentryClient {
           .getSentryException(event.throwable, stackTrace: stackTrace);
 
       event = event.copyWith(exception: sentryException);
-    } else if (stackTrace == null &&
-        _options.attachStackTrace &&
-        event.exception == null) {
-      final frames = _stackTraceFactory.getStackFrames(StackTrace.current);
+    } else if (_options.attachStackTrace && event.exception == null) {
+      stackTrace ??= StackTrace.current;
+      final frames = _stackTraceFactory.getStackFrames(stackTrace);
 
       if (frames != null && frames.isNotEmpty) {
         event = event.copyWith(stackTrace: SentryStackTrace(frames: frames));

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -111,9 +111,8 @@ class SentryClient {
           .getSentryException(event.throwable, stackTrace: event.stackTrace);
 
       event = event.copyWith(exception: sentryException);
-    }
-
-    if (_options.attachStackTrace &&
+    } else if (_options.attachStackTrace &&
+        event.stackTrace == null &&
         event.throwable == null &&
         event.exception == null) {
       final frames = _stackTraceFactory.getStackFrames(StackTrace.current);

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -118,7 +118,9 @@ class SentryClient {
         event.exception == null) {
       final frames = _stackTraceFactory.getStackFrames(StackTrace.current);
 
-      event = event.copyWith(stackTrace: SentryStackTrace(frames: frames));
+      if (frames != null && frames.isNotEmpty) {
+        event = event.copyWith(stackTrace: SentryStackTrace(frames: frames));
+      }
     }
 
     return event;

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -5,7 +5,6 @@ import 'protocol.dart';
 import 'scope.dart';
 import 'sentry_exception_factory.dart';
 import 'sentry_options.dart';
-import 'sentry_stack_trace_factory.dart';
 import 'transport/http_transport.dart';
 import 'transport/noop_transport.dart';
 import 'version.dart';
@@ -103,8 +102,8 @@ class SentryClient {
     if (_options.attachStackTrace &&
         event.throwable == null &&
         event.exception == null) {
-      final frames =
-          SentryStackTraceFactory(_options).getStackFrames(StackTrace.current);
+      final frames = _exceptionFactory.stacktraceFactory
+          .getStackFrames(StackTrace.current);
 
       event = event.copyWith(stackTrace: SentryStackTrace(frames: frames));
     }

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -107,7 +107,6 @@ class SentryClient {
       event = event.copyWith(exception: sentryException);
     } else if (_options.attachStackTrace &&
         event.stackTrace == null &&
-        event.throwable == null &&
         event.exception == null) {
       final frames = _stackTraceFactory.getStackFrames(StackTrace.current);
 

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -1,8 +1,6 @@
 import 'dart:async';
 import 'dart:math';
 
-import 'package:meta/meta.dart';
-
 import 'protocol.dart';
 import 'scope.dart';
 import 'sentry_exception_factory.dart';
@@ -18,11 +16,11 @@ class SentryClient {
 
   final Random _random;
 
-  final SentryExceptionFactory _exceptionFactory;
-
-  final SentryStackTraceFactory _stackTraceFactory;
-
   static final _sentryId = Future.value(SentryId.empty());
+
+  SentryExceptionFactory _exceptionFactory;
+
+  SentryStackTraceFactory _stackTraceFactory;
 
   /// Instantiates a client using [SentryOptions]
   factory SentryClient(SentryOptions options) {
@@ -34,22 +32,18 @@ class SentryClient {
       options.transport = HttpTransport(options);
     }
 
-    return SentryClient._(
-      options,
-      stackTraceFactory: SentryStackTraceFactory(options),
-    );
+    return SentryClient._(options);
   }
 
   /// Instantiates a client using [SentryOptions]
-  SentryClient._(
-    this._options, {
-    @required SentryStackTraceFactory stackTraceFactory,
-  })  : _stackTraceFactory = stackTraceFactory,
-        _exceptionFactory = SentryExceptionFactory(
-          options: _options,
-          stacktraceFactory: stackTraceFactory,
-        ),
-        _random = _options.sampleRate == null ? null : Random();
+  SentryClient._(this._options)
+      : _random = _options.sampleRate == null ? null : Random() {
+    _stackTraceFactory = SentryStackTraceFactory(_options);
+    _exceptionFactory = SentryExceptionFactory(
+      options: _options,
+      stacktraceFactory: _stackTraceFactory,
+    );
+  }
 
   /// Reports an [event] to Sentry.io.
   Future<SentryId> captureEvent(

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -101,20 +101,16 @@ class SentryClient {
       platform: event.platform ?? sdkPlatform,
     );
 
-    if (stackTrace != null &&
-        event.throwable == null &&
-        event.exception == null) {
-      final frames = _stackTraceFactory.getStackFrames(stackTrace);
+    if (event.exception != null) return event;
 
-      if (frames != null && frames.isNotEmpty) {
-        event = event.copyWith(stackTrace: SentryStackTrace(frames: frames));
-      }
-    } else if (event.throwable != null && event.exception == null) {
+    if (event.throwable != null) {
       final sentryException = _exceptionFactory
           .getSentryException(event.throwable, stackTrace: stackTrace);
 
-      event = event.copyWith(exception: sentryException);
-    } else if (_options.attachStackTrace && event.exception == null) {
+      return event.copyWith(exception: sentryException);
+    }
+
+    if (stackTrace != null || _options.attachStackTrace) {
       stackTrace ??= StackTrace.current;
       final frames = _stackTraceFactory.getStackFrames(stackTrace);
 

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -100,7 +100,7 @@ class SentryClient {
       event = event.copyWith(exception: sentryException);
     }
 
-    if (_options.attachStacktrace &&
+    if (_options.attachStackTrace &&
         event.throwable == null &&
         event.exception == null) {
       final frames =

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -112,7 +112,9 @@ class SentryClient {
           .getSentryException(event.throwable, stackTrace: stackTrace);
 
       event = event.copyWith(exception: sentryException);
-    } else if (_options.attachStackTrace && event.exception == null) {
+    } else if (stackTrace == null &&
+        _options.attachStackTrace &&
+        event.exception == null) {
       final frames = _stackTraceFactory.getStackFrames(StackTrace.current);
 
       if (frames != null && frames.isNotEmpty) {

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -49,6 +49,7 @@ class SentryClient {
   Future<SentryId> captureEvent(
     SentryEvent event, {
     Scope scope,
+    dynamic stackTrace,
     dynamic hint,
   }) async {
     event = _processEvent(event, eventProcessors: _options.eventProcessors);
@@ -62,6 +63,14 @@ class SentryClient {
       event = scope.applyToEvent(event, hint);
     } else {
       _options.logger(SentryLevel.debug, 'No scope is defined');
+    }
+
+    if (stackTrace != null) {
+      event = event.copyWith(
+        stackTrace: SentryStackTrace(
+          frames: _stackTraceFactory.getStackFrames(stackTrace),
+        ),
+      );
     }
 
     // dropped by scope event processors
@@ -125,11 +134,17 @@ class SentryClient {
     Scope scope,
     dynamic hint,
   }) {
-    final event = SentryEvent(
+    var event = SentryEvent(
       throwable: throwable,
-      stackTrace: stackTrace,
       timestamp: _options.clock(),
     );
+    if (stackTrace != null) {
+      event = event.copyWith(
+        stackTrace: SentryStackTrace(
+          frames: _stackTraceFactory.getStackFrames(stackTrace),
+        ),
+      );
+    }
     return captureEvent(event, scope: scope, hint: hint);
   }
 

--- a/dart/lib/src/sentry_exception_factory.dart
+++ b/dart/lib/src/sentry_exception_factory.dart
@@ -26,15 +26,20 @@ class SentryExceptionFactory {
 
   SentryException getSentryException(
     dynamic exception, {
-    SentryStackTrace stackTrace,
+    dynamic stackTrace,
     Mechanism mechanism,
   }) {
-    if (exception is Error) {
-      stackTrace ??= SentryStackTrace(
+    SentryStackTrace sentryStackTrace;
+    if (stackTrace != null) {
+      sentryStackTrace ??= SentryStackTrace(
+        frames: _stacktraceFactory.getStackFrames(stackTrace),
+      );
+    } else if (exception is Error) {
+      sentryStackTrace ??= SentryStackTrace(
         frames: _stacktraceFactory.getStackFrames(exception.stackTrace),
       );
     } else if (_options.attachStackTrace) {
-      stackTrace ??= SentryStackTrace(
+      sentryStackTrace ??= SentryStackTrace(
         frames: _stacktraceFactory.getStackFrames(StackTrace.current),
       );
     }
@@ -43,7 +48,7 @@ class SentryExceptionFactory {
       type: '${exception.runtimeType}',
       value: '$exception',
       mechanism: mechanism,
-      stacktrace: stackTrace,
+      stacktrace: sentryStackTrace,
     );
 
     return sentryException;

--- a/dart/lib/src/sentry_exception_factory.dart
+++ b/dart/lib/src/sentry_exception_factory.dart
@@ -31,15 +31,15 @@ class SentryExceptionFactory {
   }) {
     SentryStackTrace sentryStackTrace;
     if (stackTrace != null) {
-      sentryStackTrace ??= SentryStackTrace(
+      sentryStackTrace = SentryStackTrace(
         frames: _stacktraceFactory.getStackFrames(stackTrace),
       );
     } else if (exception is Error) {
-      sentryStackTrace ??= SentryStackTrace(
+      sentryStackTrace = SentryStackTrace(
         frames: _stacktraceFactory.getStackFrames(exception.stackTrace),
       );
     } else if (_options.attachStackTrace) {
-      sentryStackTrace ??= SentryStackTrace(
+      sentryStackTrace = SentryStackTrace(
         frames: _stacktraceFactory.getStackFrames(StackTrace.current),
       );
     }

--- a/dart/lib/src/sentry_exception_factory.dart
+++ b/dart/lib/src/sentry_exception_factory.dart
@@ -48,7 +48,7 @@ class SentryExceptionFactory {
       type: '${exception.runtimeType}',
       value: '$exception',
       mechanism: mechanism,
-      stacktrace: sentryStackTrace,
+      stackTrace: sentryStackTrace,
     );
 
     return sentryException;

--- a/dart/lib/src/sentry_exception_factory.dart
+++ b/dart/lib/src/sentry_exception_factory.dart
@@ -8,19 +8,20 @@ import 'sentry_stack_trace_factory.dart';
 class SentryExceptionFactory {
   final SentryOptions _options;
 
-  SentryStackTraceFactory _stacktraceFactory;
-
-  SentryStackTraceFactory get stacktraceFactory => _stacktraceFactory;
+  final SentryStackTraceFactory _stacktraceFactory;
 
   SentryExceptionFactory({
-    SentryStackTraceFactory stacktraceFactory,
+    @required SentryStackTraceFactory stacktraceFactory,
     @required SentryOptions options,
-  }) : _options = options {
+  })  : _options = options,
+        _stacktraceFactory = stacktraceFactory {
     if (_options == null) {
       throw ArgumentError('SentryOptions is required.');
     }
 
-    _stacktraceFactory = stacktraceFactory ?? SentryStackTraceFactory(_options);
+    if (_stacktraceFactory == null) {
+      throw ArgumentError('SentryStackTraceFactory is required.');
+    }
   }
 
   SentryException getSentryException(

--- a/dart/lib/src/sentry_exception_factory.dart
+++ b/dart/lib/src/sentry_exception_factory.dart
@@ -26,19 +26,16 @@ class SentryExceptionFactory {
 
   SentryException getSentryException(
     dynamic exception, {
-    dynamic stackTrace,
+    SentryStackTrace stackTrace,
     Mechanism mechanism,
   }) {
     if (exception is Error) {
-      stackTrace ??= exception.stackTrace;
+      stackTrace ??= SentryStackTrace(
+        frames: _stacktraceFactory.getStackFrames(exception.stackTrace),
+      );
     } else if (_options.attachStackTrace) {
-      stackTrace ??= StackTrace.current;
-    }
-
-    SentryStackTrace sentryStackTrace;
-    if (stackTrace != null) {
-      sentryStackTrace = SentryStackTrace(
-        frames: _stacktraceFactory.getStackFrames(stackTrace),
+      stackTrace ??= SentryStackTrace(
+        frames: _stacktraceFactory.getStackFrames(StackTrace.current),
       );
     }
 
@@ -46,7 +43,7 @@ class SentryExceptionFactory {
       type: '${exception.runtimeType}',
       value: '$exception',
       mechanism: mechanism,
-      stacktrace: sentryStackTrace,
+      stacktrace: stackTrace,
     );
 
     return sentryException;

--- a/dart/lib/src/sentry_exception_factory.dart
+++ b/dart/lib/src/sentry_exception_factory.dart
@@ -8,6 +8,8 @@ import 'sentry_stack_trace_factory.dart';
 class SentryExceptionFactory {
   SentryStackTraceFactory _stacktraceFactory;
 
+  SentryStackTraceFactory get stacktraceFactory => _stacktraceFactory;
+
   SentryExceptionFactory({
     SentryStackTraceFactory stacktraceFactory,
     @required SentryOptions options,

--- a/dart/lib/src/sentry_exception_factory.dart
+++ b/dart/lib/src/sentry_exception_factory.dart
@@ -34,7 +34,7 @@ class SentryExceptionFactory {
       sentryStackTrace = SentryStackTrace(
         frames: _stacktraceFactory.getStackFrames(stackTrace),
       );
-    } else if (exception is Error) {
+    } else if (exception is Error && exception.stackTrace != null) {
       sentryStackTrace = SentryStackTrace(
         frames: _stacktraceFactory.getStackFrames(exception.stackTrace),
       );

--- a/dart/lib/src/sentry_exception_factory.dart
+++ b/dart/lib/src/sentry_exception_factory.dart
@@ -6,6 +6,8 @@ import 'sentry_stack_trace_factory.dart';
 
 /// class to convert Dart Error and exception to SentryException
 class SentryExceptionFactory {
+  final SentryOptions _options;
+
   SentryStackTraceFactory _stacktraceFactory;
 
   SentryStackTraceFactory get stacktraceFactory => _stacktraceFactory;
@@ -13,12 +15,12 @@ class SentryExceptionFactory {
   SentryExceptionFactory({
     SentryStackTraceFactory stacktraceFactory,
     @required SentryOptions options,
-  }) {
-    if (options == null) {
+  }) : _options = options {
+    if (_options == null) {
       throw ArgumentError('SentryOptions is required.');
     }
 
-    _stacktraceFactory = stacktraceFactory ?? SentryStackTraceFactory(options);
+    _stacktraceFactory = stacktraceFactory ?? SentryStackTraceFactory(_options);
   }
 
   SentryException getSentryException(
@@ -28,13 +30,16 @@ class SentryExceptionFactory {
   }) {
     if (exception is Error) {
       stackTrace ??= exception.stackTrace;
-    } else {
+    } else if (_options.attachStackTrace) {
       stackTrace ??= StackTrace.current;
     }
 
-    final sentryStackTrace = SentryStackTrace(
-      frames: _stacktraceFactory.getStackFrames(stackTrace),
-    );
+    SentryStackTrace sentryStackTrace;
+    if (stackTrace != null) {
+      sentryStackTrace = SentryStackTrace(
+        frames: _stacktraceFactory.getStackFrames(stackTrace),
+      );
+    }
 
     final sentryException = SentryException(
       type: '${exception.runtimeType}',

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -164,6 +164,15 @@ class SentryOptions {
 
   bool _attachStackTrace = true;
 
+  /// When enabled, stack traces are automatically attached to all messages logged.
+  /// Stack traces are always attached to exceptions;
+  /// however, when this option is set, stack traces are also sent with messages.
+  /// This option, for instance, means that stack traces appear next to all log messages.
+  ///
+  /// This option is true` by default.
+  ///
+  /// Grouping in Sentry is different for events with stack traces and without.
+  /// As a result, you will get new groups as you enable or disable this flag for certain events.
   bool get attachStackTrace => _attachStackTrace;
 
   set attachStackTrace(bool attachStacktrace) {

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -162,6 +162,14 @@ class SentryOptions {
     _sdk = sdk ?? _sdk;
   }
 
+  bool _attachStacktrace = true;
+
+  bool get attachStacktrace => _attachStacktrace;
+
+  set attachStacktrace(bool attachStacktrace) {
+    _attachStacktrace = attachStacktrace ?? _attachStacktrace;
+  }
+
   // TODO: Scope observers, enableScopeSync
 
   // TODO: sendDefaultPii

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -162,12 +162,12 @@ class SentryOptions {
     _sdk = sdk ?? _sdk;
   }
 
-  bool _attachStacktrace = true;
+  bool _attachStackTrace = true;
 
-  bool get attachStacktrace => _attachStacktrace;
+  bool get attachStackTrace => _attachStackTrace;
 
-  set attachStacktrace(bool attachStacktrace) {
-    _attachStacktrace = attachStacktrace ?? _attachStacktrace;
+  set attachStackTrace(bool attachStacktrace) {
+    _attachStackTrace = attachStacktrace ?? _attachStackTrace;
   }
 
   // TODO: Scope observers, enableScopeSync

--- a/dart/lib/src/sentry_stack_trace_factory.dart
+++ b/dart/lib/src/sentry_stack_trace_factory.dart
@@ -36,8 +36,10 @@ class SentryStackTraceFactory {
 
     final frames = <SentryStackFrame>[];
     for (var t = 0; t < chain.traces.length; t += 1) {
-      final encodedFrames =
-          chain.traces[t].frames.map((f) => encodeStackTraceFrame(f));
+      final encodedFrames = chain.traces[t].frames
+          // we don't want to add our own frames
+          .where((frame) => frame.package != 'sentry')
+          .map((f) => encodeStackTraceFrame(f));
 
       frames.addAll(encodedFrames);
 
@@ -101,14 +103,14 @@ class SentryStackTraceFactory {
 
     if (_inAppIncludes != null) {
       for (final include in _inAppIncludes) {
-        if (frame.package != null && frame.package.startsWith(include)) {
+        if (frame.package != null && frame.package == include) {
           return true;
         }
       }
     }
     if (_inAppExcludes != null) {
       for (final exclude in _inAppExcludes) {
-        if (frame.package != null && frame.package.startsWith(exclude)) {
+        if (frame.package != null && frame.package == exclude) {
           return false;
         }
       }

--- a/dart/lib/src/sentry_stack_trace_factory.dart
+++ b/dart/lib/src/sentry_stack_trace_factory.dart
@@ -86,7 +86,9 @@ class SentryStackTraceFactory {
   /// "dart:" and "package:" imports are always relative and are OK to send in
   /// full.
   String _absolutePathForCrashReport(Frame frame) {
-    if (frame.uri.scheme != 'dart' && frame.uri.scheme != 'package') {
+    if (frame.uri.scheme != 'dart' &&
+        frame.uri.scheme != 'package' &&
+        frame.uri.pathSegments.isNotEmpty) {
       return frame.uri.pathSegments.last;
     }
 

--- a/dart/test/exception_factory_test.dart
+++ b/dart/test/exception_factory_test.dart
@@ -21,10 +21,7 @@ void main() {
         sentryException = exceptionFactory.getSentryException(
           err,
           mechanism: mechanism,
-          stackTrace: SentryStackTrace(
-            frames: SentryStackTraceFactory(SentryOptions())
-                .getStackFrames(stacktrace),
-          ),
+          stackTrace: stacktrace,
         );
       }
 
@@ -41,13 +38,11 @@ void main() {
           type: 'example',
           description: 'a mechanism',
         );
-        final stackTrace = SentryStackTrace(
-          frames: SentryStackTraceFactory(SentryOptions()).getStackFrames('''
+        final stackTrace = '''
 #0      baz (file:///pathto/test.dart:50:3)
 <asynchronous suspension>
 #1      bar (file:///pathto/test.dart:46:9)
-      '''),
-        );
+      ''';
         sentryException = exceptionFactory.getSentryException(
           err,
           mechanism: mechanism,

--- a/dart/test/exception_factory_test.dart
+++ b/dart/test/exception_factory_test.dart
@@ -1,10 +1,13 @@
 import 'package:sentry/sentry.dart';
 import 'package:sentry/src/sentry_exception_factory.dart';
+import 'package:sentry/src/sentry_stack_trace_factory.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('Exception factory', () {
-    final exceptionFactory = SentryExceptionFactory(options: SentryOptions());
+    final options = SentryOptions();
+    final exceptionFactory = SentryExceptionFactory(
+        options: options, stacktraceFactory: SentryStackTraceFactory(options));
 
     test('exceptionFactory.getSentryException', () {
       SentryException sentryException;
@@ -54,6 +57,19 @@ void main() {
   });
 
   test("options can't be null", () {
-    expect(() => SentryExceptionFactory(options: null), throwsArgumentError);
+    expect(
+        () => SentryExceptionFactory(
+              options: null,
+              stacktraceFactory: SentryStackTraceFactory(SentryOptions()),
+            ),
+        throwsArgumentError);
+  });
+
+  test("stacktraceFactory can't be null", () {
+    expect(
+      () => SentryExceptionFactory(
+          options: SentryOptions(), stacktraceFactory: null),
+      throwsArgumentError,
+    );
   });
 }

--- a/dart/test/exception_factory_test.dart
+++ b/dart/test/exception_factory_test.dart
@@ -21,7 +21,10 @@ void main() {
         sentryException = exceptionFactory.getSentryException(
           err,
           mechanism: mechanism,
-          stackTrace: stacktrace,
+          stackTrace: SentryStackTrace(
+            frames: SentryStackTraceFactory(SentryOptions())
+                .getStackFrames(stacktrace),
+          ),
         );
       }
 
@@ -38,14 +41,17 @@ void main() {
           type: 'example',
           description: 'a mechanism',
         );
-        sentryException = exceptionFactory.getSentryException(
-          err,
-          mechanism: mechanism,
-          stackTrace: '''
+        final stackTrace = SentryStackTrace(
+          frames: SentryStackTraceFactory(SentryOptions()).getStackFrames('''
 #0      baz (file:///pathto/test.dart:50:3)
 <asynchronous suspension>
 #1      bar (file:///pathto/test.dart:46:9)
-      ''',
+      '''),
+        );
+        sentryException = exceptionFactory.getSentryException(
+          err,
+          mechanism: mechanism,
+          stackTrace: stackTrace,
         );
       }
 

--- a/dart/test/exception_factory_test.dart
+++ b/dart/test/exception_factory_test.dart
@@ -26,7 +26,7 @@ void main() {
       }
 
       expect(sentryException.type, 'StateError');
-      expect(sentryException.stacktrace.frames, isNotEmpty);
+      expect(sentryException.stackTrace.frames, isNotEmpty);
     });
 
     test('should not override event.stacktrace', () {
@@ -51,9 +51,9 @@ void main() {
       }
 
       expect(sentryException.type, 'StateError');
-      expect(sentryException.stacktrace.frames.first.lineNo, 46);
-      expect(sentryException.stacktrace.frames.first.colNo, 9);
-      expect(sentryException.stacktrace.frames.first.fileName, 'test.dart');
+      expect(sentryException.stackTrace.frames.first.lineNo, 46);
+      expect(sentryException.stackTrace.frames.first.colNo, 9);
+      expect(sentryException.stackTrace.frames.first.fileName, 'test.dart');
     });
   });
 

--- a/dart/test/protocol/sentry_exception_test.dart
+++ b/dart/test/protocol/sentry_exception_test.dart
@@ -41,7 +41,7 @@ void main() {
       type: 'StateError',
       value: 'Bad state: error',
       module: 'example.module',
-      stacktrace: stacktrace,
+      stackTrace: stacktrace,
       mechanism: mechanism,
       threadId: 123456,
     );

--- a/dart/test/sentry_client_test.dart
+++ b/dart/test/sentry_client_test.dart
@@ -155,6 +155,40 @@ void main() {
       expect(capturedEvent.exception.stacktrace.frames.first.colNo, 9);
     });
 
+    test('should capture exception with Stackframe.current', () async {
+      try {
+        throw Exception('Error');
+      } catch (err) {
+        exception = err;
+      }
+
+      final client = SentryClient(options);
+      await client.captureException(exception);
+
+      final capturedEvent = (verify(
+        options.transport.send(captureAny),
+      ).captured.first) as SentryEvent;
+
+      expect(capturedEvent.exception.stacktrace, isNotNull);
+    });
+
+    test('should capture exception without Stackframe.current', () async {
+      try {
+        throw Exception('Error');
+      } catch (err) {
+        exception = err;
+      }
+
+      final client = SentryClient(options..attachStackTrace = false);
+      await client.captureException(exception);
+
+      final capturedEvent = (verify(
+        options.transport.send(captureAny),
+      ).captured.first) as SentryEvent;
+
+      expect(capturedEvent.exception.stacktrace, isNull);
+    });
+
     test('should not capture sentry frames exception', () async {
       try {
         throw Exception('Error');

--- a/dart/test/sentry_client_test.dart
+++ b/dart/test/sentry_client_test.dart
@@ -34,7 +34,7 @@ void main() {
     });
 
     test('should capture message without stacktrace', () async {
-      final client = SentryClient(options..attachStacktrace = false);
+      final client = SentryClient(options..attachStackTrace = false);
       await client.captureMessage('message', level: SentryLevel.error);
 
       final capturedEvent = (verify(

--- a/dart/test/sentry_event_test.dart
+++ b/dart/test/sentry_event_test.dart
@@ -192,7 +192,7 @@ void main() {
       final stacktrace =
           SentryStackTrace(frames: [SentryStackFrame(function: 'main')]);
       final serialized = SentryEvent(stackTrace: stacktrace).toJson();
-      expect(serialized['stacktrace'], isNotNull);
+      expect(serialized['threads']['values'].first['stacktrace'], isNotNull);
     });
 
     test('should not serialize event.stacktrace if event.exception is set', () {

--- a/dart/test/sentry_event_test.dart
+++ b/dart/test/sentry_event_test.dart
@@ -188,6 +188,29 @@ void main() {
       expect(serialized['exception'], null);
     });
 
+    test('should serialize stacktrace if SentryStacktrace', () {
+      final stacktrace =
+          SentryStackTrace(frames: [SentryStackFrame(function: 'main')]);
+      final serialized = SentryEvent(stackTrace: stacktrace).toJson();
+      expect(serialized['stacktrace'], isNotNull);
+    });
+
+    test('should not serialize event.stacktrace if event.exception is set', () {
+      final stacktrace =
+          SentryStackTrace(frames: [SentryStackFrame(function: 'main')]);
+      final serialized = SentryEvent(
+        exception: SentryException(value: 'Bad state', type: 'StateError'),
+        stackTrace: stacktrace,
+      ).toJson();
+      expect(serialized['stacktrace'], isNull);
+    });
+
+    test('should not serialize stacktrace if not SentryStacktrace', () {
+      final stacktrace = '#0      baz (file:///pathto/test.dart:50:3)';
+      final serialized = SentryEvent(stackTrace: stacktrace).toJson();
+      expect(serialized['stacktrace'], isNull);
+    });
+
     test('serializes to JSON with sentryException', () {
       var sentryException;
       try {

--- a/dart/test/sentry_event_test.dart
+++ b/dart/test/sentry_event_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:sentry/sentry.dart';
 import 'package:sentry/src/protocol/request.dart';
+import 'package:sentry/src/sentry_stack_trace_factory.dart';
 import 'package:sentry/src/utils.dart';
 import 'package:test/test.dart';
 
@@ -206,7 +207,10 @@ void main() {
     });
 
     test('should not serialize stacktrace if not SentryStacktrace', () {
-      final stacktrace = '#0      baz (file:///pathto/test.dart:50:3)';
+      final stacktrace = SentryStackTrace(
+        frames: SentryStackTraceFactory(SentryOptions())
+            .getStackFrames('#0      baz (file:///pathto/test.dart:50:3)'),
+      );
       final serialized = SentryEvent(stackTrace: stacktrace).toJson();
       expect(serialized['stacktrace'], isNull);
     });

--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -38,13 +38,12 @@ Future<void> main() async {
     print('Capture from runZonedGuarded $error');
     final event = SentryEvent(
       throwable: error,
-      stackTrace: stackTrace,
       // release is required on Web to match the source maps
       release: _release,
 
       // sdk: const Sdk(name: sdkName, version: sdkVersion),
     );
-    await _sentry.captureEvent(event);
+    await _sentry.captureEvent(event, stackTrace: stackTrace);
   });
 }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
- add `SentryOptions.attachStackTrace` to attach stacktrace on captureMessage and captureEvent ( true by default )
- filter 'package:sentry' frames

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://develop.sentry.dev/sdk/unified-api/

## :green_heart: How did you test it?
new tests to verify if stacktrace is correctly sended

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
