### PR TITLE
Fix: Dart Flutter min version

### DIFF
--- a/dart/example_web/pubspec.yaml
+++ b/dart/example_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: sentry_dart_web_example
 description: An absolute bare-bones web app.
 
 environment:
-  sdk: ^2.0.0
+  sdk: ^2.8.0
 
 dependencies:
   sentry:

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -6,7 +6,7 @@ description: >
 homepage: https://github.com/getsentry/sentry-dart
 
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: ">=2.8.0 <3.0.0"
 
 dependencies:
   http: ^0.12.0

--- a/flutter/example/pubspec.yaml
+++ b/flutter/example/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.1.2+3
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.8.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://docs.sentry.io/platforms/flutter/
 repository: https://github.com/getsentry/sentry-dart
 
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: ">=2.8.0 <3.0.0"
   flutter: ^1.17.0
 
 dependencies:


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Fix: Dart Flutter min version


## :bulb: Motivation and Context
To avoid such errors on runtime and because Flutter is such a new technology for mobile, people always to be up to date.
`runZonedGuarded` requires Dart 2.8, so Flutter must be 1.17 as well.
We'd like to avoid using deprecated methods as well.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
