### PR TITLE
Dart pkg: Remove Flutter from the heading

### DIFF
--- a/dart/README.md
+++ b/dart/README.md
@@ -5,12 +5,19 @@
   <br />
 </p>
 
-Sentry SDK for Dart and Flutter
+Sentry SDK for Dart
 ===========
 
 | package | build | pub | likes | popularity | pub points |
 | ------- | ------- | ------- | ------- | ------- | ------- |
 | sentry | [![build](https://github.com/getsentry/sentry-dart/workflows/sentry-dart/badge.svg?branch=main)](https://github.com/getsentry/sentry-dart/actions?query=workflow%3Asentry-dart) | [![pub package](https://img.shields.io/pub/v/sentry.svg)](https://pub.dev/packages/sentry) | [![likes](https://badges.bar/sentry/likes)](https://pub.dev/packages/sentry/score) | [![popularity](https://badges.bar/sentry/popularity)](https://pub.dev/packages/sentry/score) | [![pub points](https://badges.bar/sentry/pub%20points)](https://pub.dev/packages/sentry/score)
+
+Pure Dart SDK used by any Dart application like AngularDart, CLI and server. 
+
+#### Flutter
+
+For Flutter applications there's [`sentry_flutter`](https://pub.dev/packages/sentry_flutter) which builds on top of this package.
+That will give you native crash support (for Android and iOS), [release health](https://docs.sentry.io/product/releases/health/), offline caching and more.
 
 #### Versions
 
@@ -53,10 +60,6 @@ void aMethodThatMightFail() {
   throw null;
 }
 ```
-
-#### Flutter SDK Integration
-
-- Check out the [Flutter SDK](https://github.com/getsentry/sentry-dart/tree/main/flutter) with the Native integrations (Android/Apple).
 
 #### Resources
 

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -2,7 +2,7 @@ name: sentry
 version: 4.0.0-alpha.3
 description: >
   A crash reporting library for Dart that sends crash reports to Sentry.io.
-  This library supports Dart Native, and Flutter for mobile, web, and desktop.
+  This library supports Dart VM and Web. For Flutter consider sentry_flutter instead.
 homepage: https://github.com/getsentry/sentry-dart
 repository: https://github.com/getsentry/sentry-dart
 

--- a/flutter/README.md
+++ b/flutter/README.md
@@ -5,20 +5,15 @@
   <br />
 </p>
 
-Sentry SDK for Flutter and its Native integrations (Android/Apple)
+Sentry SDK for Flutter
 ===========
 
-| package | build |
-| ------- | ------- |
-| sentry_flutter | [![build](https://github.com/getsentry/sentry-dart/workflows/sentry-flutter/badge.svg?branch=main)](https://github.com/getsentry/sentry-dart/actions?query=workflow%3Asentry-flutter) |
+| package | build | pub | likes | popularity | pub points |
+| ------- | ------- | ------- | ------- | ------- | ------- |
+| sentry_flutter | [![build](https://github.com/getsentry/sentry-dart/workflows/sentry-flutter/badge.svg?branch=main)](https://github.com/getsentry/sentry-dart/actions?query=workflow%3Asentry-flutter) | [![pub package](https://img.shields.io/pub/v/sentry_flutter.svg)](https://pub.dev/packages/sentry_flutter) | [![likes](https://badges.bar/sentry_flutter/likes)](https://pub.dev/packages/sentry_flutter/score) | [![popularity](https://badges.bar/sentry_flutter/popularity)](https://pub.dev/packages/sentry_flutter/score) | [![pub points](https://badges.bar/sentry_flutter/pub%20points)](https://pub.dev/packages/sentry_flutter/score)
 
-#### Versions
-
-Versions `^4.0.0` are `Prereleases` and are under improvements/testing.
-
-Versions `^4.0.0` integrate our Native SDKs ([Android](https://github.com/getsentry/sentry-java) and [Apple](https://github.com/getsentry/sentry-cocoa)), so you are able to capture errors on Native code as well (Java/Kotlin/C/C++ for Android and Objective-C/Swift for Apple).
-
-The current stable version is the Dart SDK, [3.0.1](https://pub.dev/packages/sentry).
+This package includes support to native crashes through Sentry's native SDKs: ([Android](https://github.com/getsentry/sentry-java) and [iOS](https://github.com/getsentry/sentry-cocoa)).
+It will capture errors in the native layer, including (Java/Kotlin/C/C++ for Android and Objective-C/Swift for iOS).
 
 #### Usage
 


### PR DESCRIPTION
Feedback was that it's confusing why two packages.

Trying to be very clear this is the pure Dart SDK. And point folks to Flutter right at the top (given there are way more Flutter users than other Dart)