### PR TITLE
Fix: missing app's stack traces for Flutter errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ android/
 ios/
 build/
 .cxx/
+.vscode/
 
 
 .test_coverage.dart

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # `package:sentry` and `package:sentry_flutter` changelog
 
-## 4.0.0-alpha.3 (Next)
+## vNext
 
-- Development.
+- Fix: missing app's stack traces for Flutter errors
 
 ## 4.0.0-alpha.2
 

--- a/dart/lib/src/hub_adapter.dart
+++ b/dart/lib/src/hub_adapter.dart
@@ -28,7 +28,11 @@ class HubAdapter implements Hub {
     dynamic stackTrace,
     dynamic hint,
   }) =>
-      Sentry.captureEvent(event, hint: hint);
+      Sentry.captureEvent(
+        event,
+        stackTrace: stackTrace,
+        hint: hint,
+      );
 
   @override
   Future<SentryId> captureException(


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Fix: missing app's stack traces for Flutter errors


## :bulb: Motivation and Context
`FlutterError.onError` errors were not showing app's stack traces.


## :green_heart: How did you test it?
running it

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
TODO: write tests for HubAdapter