### PR TITLE
fix : stackTrace frames with 'package' uri.scheme are inApp by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## 4.0.0-alpha.3 (Next)
 
 - Development.
-- StackTrace factory : package are inApp by default 
-- add loadContextsIntegration tests
+- Fix: StackTrace frames with 'package' uri.scheme are inApp by default #185
+- Enhancement: add loadContextsIntegration tests
 
 ## 4.0.0-alpha.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 4.0.0-alpha.3 (Next)
 
 - Development.
+- StackTrace factory : package are inApp by default 
 - add loadContextsIntegration tests
 
 ## 4.0.0-alpha.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## vNext
 
-- Development.
 - Fix: StackTrace frames with 'package' uri.scheme are inApp by default #185
 - Enhancement: add loadContextsIntegration tests
 - StackTrace factory : package are inApp by default 

--- a/dart/lib/src/sentry_stack_trace_factory.dart
+++ b/dart/lib/src/sentry_stack_trace_factory.dart
@@ -130,7 +130,10 @@ class SentryStackTraceFactory {
       }
     }
 
-    if (frame.isCore) return false;
+    if (frame.isCore ||
+        (frame.uri.scheme == 'package' && frame.package == 'flutter')) {
+      return false;
+    }
 
     return true;
   }

--- a/dart/lib/src/sentry_stack_trace_factory.dart
+++ b/dart/lib/src/sentry_stack_trace_factory.dart
@@ -130,7 +130,7 @@ class SentryStackTraceFactory {
       }
     }
 
-    if (frame.isCore || frame.uri.scheme == 'package') return false;
+    if (frame.isCore) return false;
 
     return true;
   }

--- a/dart/test/stack_trace_test.dart
+++ b/dart/test/stack_trace_test.dart
@@ -69,10 +69,9 @@ void main() {
     test('flutter package is not inApp', () {
       final frame =
           Frame(Uri.parse('package:flutter/material.dart'), 1, 2, 'buzz');
-      final serializedFrame =
-          SentryStackTraceFactory(SentryOptions()..addInAppInclude('toolkit'))
-              .encodeStackTraceFrame(frame)
-              .toJson();
+      final serializedFrame = SentryStackTraceFactory(SentryOptions())
+          .encodeStackTraceFrame(frame)
+          .toJson();
       expect(serializedFrame['in_app'], false);
     });
 

--- a/dart/test/stack_trace_test.dart
+++ b/dart/test/stack_trace_test.dart
@@ -66,6 +66,16 @@ void main() {
       expect(serializedFrame['in_app'], true);
     });
 
+    test('flutter package is not inApp', () {
+      final frame =
+          Frame(Uri.parse('package:flutter/material.dart'), 1, 2, 'buzz');
+      final serializedFrame =
+          SentryStackTraceFactory(SentryOptions()..addInAppInclude('toolkit'))
+              .encodeStackTraceFrame(frame)
+              .toJson();
+      expect(serializedFrame['in_app'], false);
+    });
+
     test('apply inAppIncludes with precedence', () {
       final frame = Frame(Uri.parse('package:toolkit/baz.dart'), 1, 2, 'buzz');
       final serializedFrame = SentryStackTraceFactory(SentryOptions()

--- a/flutter/README.md
+++ b/flutter/README.md
@@ -33,12 +33,10 @@ Future<void> main() async {
   await SentryFlutter.init(
     (options) {
       options.dsn = 'https://example@sentry.io/add-your-dsn-here';
-      // For better groupping, change the 'example' below with your own App's package.
-      options.addInAppInclude('sentry_flutter_example');
     },
     () {
       // Init your App.
-      runApp(MyApp()),
+      runApp(MyApp());
     },
   );
 

--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -210,13 +210,6 @@ class CocoaExample extends StatelessWidget {
             await channel.invokeMethod<void>('crash');
           },
         ),
-        RaisedButton(
-          child: const Text('Crash swift'),
-          onPressed: () async {
-            const channel = MethodChannel('example.flutter.sentry.io');
-            await channel.invokeMethod<void>('crashSwift');
-          },
-        ),
       ],
     );
   }

--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -40,48 +40,61 @@ class _MyAppState extends State<MyApp> {
     return MaterialApp(
       home: Scaffold(
         appBar: AppBar(title: const Text('Sentry Flutter Example')),
-        body: Column(
-          children: [
-            const Center(child: Text('Trigger an action:\n')),
-            RaisedButton(
-              child: const Text('Dart: try catch'),
-              onPressed: () => tryCatch(),
-            ),
-            RaisedButton(
-              child: const Text('Dart: throw null'),
-              // Warning : not captured if a debugger is attached
-              // https://github.com/flutter/flutter/issues/48972
-              onPressed: () => throw null,
-            ),
-            RaisedButton(
-              child: const Text('Dart: assert'),
-              onPressed: () {
-                // Only relevant in debug builds
+        body: SingleChildScrollView(
+          child: Column(
+            children: [
+              const Center(child: Text('Trigger an action:\n')),
+              RaisedButton(
+                child: const Text('Dart: try catch'),
+                onPressed: () => tryCatch(),
+              ),
+              RaisedButton(
+                child: const Text('Flutter error : Scaffold.of()'),
+                onPressed: () => Scaffold.of(context).showSnackBar(SnackBar(
+                  content: Text(''),
+                )),
+              ),
+              RaisedButton(
+                child: const Text('Dart: throw null'),
                 // Warning : not captured if a debugger is attached
                 // https://github.com/flutter/flutter/issues/48972
-                assert(false, 'assert failure');
-              },
-            ),
-            RaisedButton(
-                child: const Text('Dart: async throws'),
-                onPressed: () async => asyncThrows().catchError(handleError)),
-            RaisedButton(
-              child: const Text('Dart: Fail in microtask.'),
-              onPressed: () async => {
-                await Future.microtask(
-                  () => throw StateError('Failure in a microtask'),
-                ).catchError(handleError)
-              },
-            ),
-            RaisedButton(
-              child: const Text('Dart: Fail in compute'),
-              onPressed: () async =>
-                  {await compute(loop, 10).catchError(handleError)},
-            ),
-            if (UniversalPlatform.isIOS) const CocoaExample(),
-            if (UniversalPlatform.isAndroid) const AndroidExample(),
-            if (UniversalPlatform.isWeb) const WebExample(),
-          ],
+                onPressed: () => throw null,
+              ),
+              RaisedButton(
+                child: const Text('Dart: assert'),
+                onPressed: () {
+                  // Only relevant in debug builds
+                  // Warning : not captured if a debugger is attached
+                  // https://github.com/flutter/flutter/issues/48972
+                  assert(false, 'assert failure');
+                },
+              ),
+              RaisedButton(
+                  child: const Text('Dart: async throws'),
+                  onPressed: () async => asyncThrows().catchError(handleError)),
+              RaisedButton(
+                child: const Text('Dart: Fail in microtask.'),
+                onPressed: () async => {
+                  await Future.microtask(
+                    () => throw StateError('Failure in a microtask'),
+                  ).catchError(handleError)
+                },
+              ),
+              RaisedButton(
+                child: const Text('Dart: Fail in compute'),
+                onPressed: () async =>
+                    {await compute(loop, 10).catchError(handleError)},
+              ),
+              RaisedButton(
+                child: const Text('Dart: Fail in compute'),
+                onPressed: () async =>
+                    {await compute(loop, 10).catchError(handleError)},
+              ),
+              if (UniversalPlatform.isIOS) const CocoaExample(),
+              if (UniversalPlatform.isAndroid) const AndroidExample(),
+              if (UniversalPlatform.isWeb) const WebExample(),
+            ],
+          ),
         ),
       ),
     );
@@ -195,6 +208,13 @@ class CocoaExample extends StatelessWidget {
           onPressed: () async {
             const channel = MethodChannel('example.flutter.sentry.io');
             await channel.invokeMethod<void>('crash');
+          },
+        ),
+        RaisedButton(
+          child: const Text('Crash swift'),
+          onPressed: () async {
+            const channel = MethodChannel('example.flutter.sentry.io');
+            await channel.invokeMethod<void>('crashSwift');
           },
         ),
       ],

--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -16,8 +16,6 @@ Future<void> main() async {
   await SentryFlutter.init(
     (options) {
       options.dsn = _exampleDsn;
-      // Change the 'sentry_flutter_example' below with your own package.
-      options.addInAppInclude('sentry_flutter_example');
     },
     () {
       // Init your App.


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
change the logic behind the stackTraceFactory to not consider all package as !inApp

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
remove the need to add the application own package to the `inAppIncludes`

## :green_heart: How did you test it?
new Unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
