### PR TITLE
Fix: missing toList for debug meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix: missing app's stack traces for Flutter errors
 - add loadContextsIntegration tests
 - Ref: Remove deprecated classes (Flutter Plugin for Android) and cleaning up #186
+- Fix: missing toList for debug meta #192
 
 ## 4.0.0-alpha.2
 

--- a/dart/lib/src/protocol/debug_meta.dart
+++ b/dart/lib/src/protocol/debug_meta.dart
@@ -20,7 +20,7 @@ class DebugMeta {
     }
 
     if (_images != null && _images.isNotEmpty) {
-      json['images'] = _images.map((e) => e.toJson());
+      json['images'] = _images.map((e) => e.toJson()).toList(growable: false);
     }
 
     return json;

--- a/dart/lib/src/protocol/sentry_stack_trace.dart
+++ b/dart/lib/src/protocol/sentry_stack_trace.dart
@@ -28,7 +28,8 @@ class SentryStackTrace {
     final json = <String, dynamic>{};
 
     if (_frames != null && _frames.isNotEmpty) {
-      json['frames'] = _frames.map((frame) => frame.toJson()).toList(growable: false);
+      json['frames'] =
+          _frames.map((frame) => frame.toJson()).toList(growable: false);
     }
 
     if (_registers != null && _registers.isNotEmpty ?? false) {

--- a/dart/lib/src/protocol/sentry_stack_trace.dart
+++ b/dart/lib/src/protocol/sentry_stack_trace.dart
@@ -28,7 +28,7 @@ class SentryStackTrace {
     final json = <String, dynamic>{};
 
     if (_frames != null && _frames.isNotEmpty) {
-      json['frames'] = _frames.map((frame) => frame.toJson()).toList();
+      json['frames'] = _frames.map((frame) => frame.toJson()).toList(growable: false);
     }
 
     if (_registers != null && _registers.isNotEmpty ?? false) {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Fix: missing toList for debug meta


## :bulb: Motivation and Context
`toJson` was throwing as the image list was supposed to be a List.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
Write test