### PR TITLE
Enha: Read sentry cocoa version at runtime

### DIFF
--- a/flutter/example/ios/Podfile.lock
+++ b/flutter/example/ios/Podfile.lock
@@ -2,15 +2,16 @@ PODS:
   - Flutter (1.0.0)
   - package_info (0.0.1):
     - Flutter
-  - Sentry (6.0.9):
-    - Sentry/Core (= 6.0.9)
-  - Sentry/Core (6.0.9)
+  - Sentry (6.0.10):
+    - Sentry/Core (= 6.0.10)
+  - Sentry/Core (6.0.10)
   - sentry_flutter (0.0.1):
     - Flutter
-    - Sentry (~> 6.0.9)
+    - Sentry (~> 6.0.10)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
+  - package_info (from `.symlinks/plugins/package_info/ios`)
   - sentry_flutter (from `.symlinks/plugins/sentry_flutter/ios`)
 
 SPEC REPOS:
@@ -20,15 +21,17 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
+  package_info:
+    :path: ".symlinks/plugins/package_info/ios"
   sentry_flutter:
     :path: ".symlinks/plugins/sentry_flutter/ios"
 
 SPEC CHECKSUMS:
   Flutter: 0e3d915762c693b495b44d77113d4970485de6ec
   package_info: 873975fc26034f0b863a300ad47e7f1ac6c7ec62
-  Sentry: 388c9dc093b2fd3a264466a5c5b21e25959610a9
-  sentry_flutter: 5526584667efa760b715a0356ca89cf369bfaddb
+  Sentry: 0a48d832ce921578a0c31c68272382fbef9a1726
+  sentry_flutter: e57e33f56d5791e4effa48e85e44505367686b27
 
 PODFILE CHECKSUM: a75497545d4391e2d394c3668e20cfb1c2bbd4aa
 
-COCOAPODS: 1.9.3
+COCOAPODS: 1.10.0

--- a/flutter/ios/Classes/SwiftSentryFlutterPlugin.swift
+++ b/flutter/ios/Classes/SwiftSentryFlutterPlugin.swift
@@ -39,7 +39,8 @@ public class SwiftSentryFlutterPlugin: NSObject, FlutterPlugin {
         infos["integrations"] = integrations
       }
 
-      infos["package"] = ["version": "\(Options().sdkInfo.version)", "sdk_name": "cocoapods:sentry-cocoa"]
+      let options = self.sentryOptions ?? Options()
+      infos["package"] = ["version": options.sdkInfo.version, "sdk_name": "cocoapods:sentry-cocoa"]
 
       result(infos)
     }

--- a/flutter/ios/Classes/SwiftSentryFlutterPlugin.swift
+++ b/flutter/ios/Classes/SwiftSentryFlutterPlugin.swift
@@ -39,8 +39,9 @@ public class SwiftSentryFlutterPlugin: NSObject, FlutterPlugin {
         infos["integrations"] = integrations
       }
 
-      let options = self.sentryOptions ?? Options()
-      infos["package"] = ["version": options.sdkInfo.version, "sdk_name": "cocoapods:sentry-cocoa"]
+      if let sentryOptions = self.sentryOptions {
+        infos["package"] = ["version": sentryOptions.sdkInfo.version, "sdk_name": "cocoapods:sentry-cocoa"]
+      }
 
       result(infos)
     }

--- a/flutter/ios/Classes/SwiftSentryFlutterPlugin.swift
+++ b/flutter/ios/Classes/SwiftSentryFlutterPlugin.swift
@@ -39,8 +39,7 @@ public class SwiftSentryFlutterPlugin: NSObject, FlutterPlugin {
         infos["integrations"] = integrations
       }
 
-      // TODO get the sdkVersion from SDK
-      infos["package"] = ["version": "6.0.9", "sdk_name": "cocoapods:sentry-cocoa"]
+      infos["package"] = ["version": "\(Options().sdkInfo.version)", "sdk_name": "cocoapods:sentry-cocoa"]
 
       result(infos)
     }

--- a/flutter/ios/sentry_flutter.podspec
+++ b/flutter/ios/sentry_flutter.podspec
@@ -11,7 +11,7 @@ Sentry SDK for Flutter with support to native through sentry-cocoa.
   s.source           = { :git => "https://github.com/getsentry/sentry-dart.git",
                          :tag => s.version.to_s }
   s.source_files = 'Classes/**/*'
-  s.dependency 'Sentry', '~> 6.0.9'
+  s.dependency 'Sentry', '~> 6.0.10'
   s.dependency 'Flutter'
   s.platform = :ios, '9.0'
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

- Read version info for cocoa SDK at runtime.
- Update iOS sample project to use current pod.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Prior, version info had to be updated in dart code along with updating cocoa sdk.

## :green_heart: How did you test it?

Ran the sample project and verified the correct version was read when recording events.

<img width="500" alt="Bildschirmfoto 2020-11-28 um 11 25 18" src="https://user-images.githubusercontent.com/3984453/100511099-c79c3980-316e-11eb-83db-df5c02f8a57c.png">

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
