### PR TITLE
Fix: Breadcrumb list is a plain list instead of a values list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,15 @@
 - Enhancement: add loadContextsIntegration tests
 - Fix: missing app's stack traces for Flutter errors
 - Enhancement: add isolateErrorIntegration and runZonedGuardedIntegration to default integrations in sentry-dart
+- Fix: Breadcrumb list is a plain list instead of a values list #201
+- Ref: Remove deprecated classes (Flutter Plugin for Android) and cleaning up #186
+- Fix: Handle immutable event lists and maps
+- Fix: NDK integration was being disabled by a typo
+- Fix: missing toList for debug meta #192
 
 ### Breaking changes
 
 - `Sentry.init` and `SentryFlutter.init` have an optional callback argument which runs the host app after Sentry initialization.
-- add loadContextsIntegration tests
-- Ref: add missing docs and move sentry web plugin to the inner src folder
-- Ref: Remove deprecated classes (Flutter Plugin for Android) and cleaning up #186
-- Fix: Handle immutable event lists and maps 
-- Fix: NDK integration was being disabled by a typo
-- Fix: missing toList for debug meta #192
 
 ## 4.0.0-alpha.2
 

--- a/dart/lib/src/protocol/sentry_event.dart
+++ b/dart/lib/src/protocol/sentry_event.dart
@@ -312,9 +312,8 @@ class SentryEvent {
     }
 
     if (breadcrumbs != null && breadcrumbs.isNotEmpty) {
-      json['breadcrumbs'] = <String, List<Map<String, dynamic>>>{
-        'values': breadcrumbs.map((b) => b.toJson()).toList(growable: false)
-      };
+      json['breadcrumbs'] =
+          breadcrumbs.map((b) => b.toJson()).toList(growable: false);
     }
 
     json['sdk'] = sdk?.toJson() ??

--- a/dart/test/sentry_event_test.dart
+++ b/dart/test/sentry_event_test.dart
@@ -149,14 +149,12 @@ void main() {
             'extras': {'foo': 'bar'}
           },
           'breadcrumbs': {
-            'values': [
-              {
-                'timestamp': '2019-01-01T00:00:00.000Z',
-                'message': 'test log',
-                'category': 'test',
-                'level': 'debug',
-              },
-            ]
+            {
+              'timestamp': '2019-01-01T00:00:00.000Z',
+              'message': 'test log',
+              'category': 'test',
+              'level': 'debug',
+            },
           },
           'request': {
             'url': request.url,


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Fix: Breadcrumb list is a plain list instead of a values list


## :bulb: Motivation and Context
Our protocol accepts a `values` list https://develop.sentry.dev/sdk/event-payloads/breadcrumbs/
but the Android SDK does reflection and does not support it yet, so it fails on parsing.
https://github.com/getsentry/sentry-java/blob/714d1a511b5e1ff5dcd2ba03711935486d852bef/sentry/src/main/java/io/sentry/SentryEvent.java#L108-L109

to fix this, we'd need to fix first on the Android SDK and do like:
https://github.com/getsentry/sentry-java/blob/714d1a511b5e1ff5dcd2ba03711935486d852bef/sentry/src/main/java/io/sentry/SentryEvent.java#L71-L74

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
