### PR TITLE
Fix: Flutter Configurations should be able to mutate the SentryFlutterOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+- Fix: Flutter Configurations should be able to mutate the SentryFlutterOptions
+
 ## 4.0.0-beta.1
 
 - Fix: StackTrace frames with 'package' uri.scheme are inApp by default #185

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -16,12 +16,16 @@ import 'version.dart';
 // this injected PlatformChecker allows to test this behavior
 import 'web_platform_checker.dart' if (dart.library.io) 'platform_checker.dart';
 
+/// Configuration options callback
+typedef FlutterOptionsConfiguration = FutureOr<void> Function(
+    SentryFlutterOptions);
+
 /// Sentry Flutter SDK main entry point
 mixin SentryFlutter {
   static const _channel = MethodChannel('sentry_flutter');
 
   static Future<void> init(
-    OptionsConfiguration optionsConfiguration, {
+    FlutterOptionsConfiguration optionsConfiguration, {
     AppRunner appRunner,
     PackageLoader packageLoader = _loadPackageInfo,
     iOSPlatformChecker isIOSChecker = isIOS,

--- a/flutter/test/sentry_flutter_util.dart
+++ b/flutter/test/sentry_flutter_util.dart
@@ -13,7 +13,7 @@ FutureOr<void> Function(SentryOptions) getConfigurationTester({
   bool isWeb = false,
   bool isAndroid = false,
 }) =>
-    (SentryOptions options) async {
+    (options) async {
       options.dsn = fakeDsn;
 
       expect(kDebugMode, options.debug);


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Fix: Flutter Configurations should be able to mutate the SentryFlutterOptions


## :bulb: Motivation and Context
it's not possible to mutate the FlutterSentryOptions but only the base class fields

@ueman thanks for the finding.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
