### PR TITLE
CI: macos-latest targets only iOS

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -30,6 +30,7 @@ jobs:
             sdk: dev
           - os: macos-latest
             sdk: beta
+
     steps:
         - uses: cedx/setup-dart@v2
           with:

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -30,6 +30,9 @@ jobs:
             sdk: dev
           - os: macos-latest
             sdk: beta
+          # macos-latest is taking hours due to limited resources
+          - os: macos-latest
+            sdk: dev
 
     steps:
         - uses: cedx/setup-dart@v2

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -26,6 +26,12 @@ jobs:
           # No web on stable yet
           - channel: stable
             target: web
+          # macos-latest is taking hours due to limited resources
+          - os: macos-latest
+            target: android
+          - os: macos-latest
+            target: web
+
     steps:
         - uses: actions/checkout@v2
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
CI: macos-latest targets only iOS


## :bulb: Motivation and Context
CI is taking too long because of limited resources, let's focus the macos-latest only for iOS builds.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
