### PR TITLE
CI: Fix CI when running tests on chrome platform that hangs if using coverage

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -39,11 +39,12 @@ jobs:
           with:
             release-channel: ${{ matrix.sdk }}
         - uses: actions/checkout@v2
-        # consider -p "chrome,vm" and --coverage=coverage
+        # coverage with 'chrome' platform hangs the build
         - name: Test (VM and browser)
           run: |
             pub get
-            pub run test -p "chrome,vm" --coverage=coverage
+            pub run test -p chrome
+            pub run test -p vm --coverage=coverage
             pub run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --packages=.packages --report-on=lib
 
         - uses: codecov/codecov-action@v1


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
CI: Fix CI when running tests on chrome platform that hangs if using coverage


## :bulb: Motivation and Context
command hangs and CI consequentially never finishes.
I could reproduce this locally as well, only happens if coverage is enabled and running on chrome platform as well.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
wait for help
https://github.com/dart-lang/tools/issues/471