### PR TITLE
Ref: rename logger to SentryLogger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Enhancement: Add SentryWidgetsBindingObserver, an Integration that captures certain window and device events.
 - Ref: Only assign non-null option values in Android native integration in order preserve default values
 - Enhancement: Add 'attachThreads' in options. When enabled, threads are attached to all logged events for Android
+- Ref: Rename typedef `Logger` to `SentryLogger` to prevent name clashes with logging packages
 
 ## 4.0.0-beta.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Enhancement: Add SentryWidgetsBindingObserver, an Integration that captures certain window and device events.
 - Ref: Only assign non-null option values in Android native integration in order preserve default values
 - Enhancement: Add 'attachThreads' in options. When enabled, threads are attached to all logged events for Android
+
+### Breaking changes
+
 - Ref: Rename typedef `Logger` to `SentryLogger` to prevent name clashes with logging packages
 
 ## 4.0.0-beta.1

--- a/dart/lib/src/diagnostic_logger.dart
+++ b/dart/lib/src/diagnostic_logger.dart
@@ -2,7 +2,7 @@ import 'protocol.dart';
 import 'sentry_options.dart';
 
 class DiagnosticLogger {
-  final Logger _logger;
+  final SentryLogger _logger;
   final SentryOptions _options;
 
   DiagnosticLogger(this._logger, this._options);

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -60,12 +60,12 @@ class SentryOptions {
         : _maxBreadcrumbs;
   }
 
-  Logger _logger = noOpLogger;
+  SentryLogger _logger = noOpLogger;
 
   /// Logger interface to log useful debugging information if debug is enabled
-  Logger get logger => _logger;
+  SentryLogger get logger => _logger;
 
-  set logger(Logger logger) {
+  set logger(SentryLogger logger) {
     _logger = logger != null ? DiagnosticLogger(logger, this).log : _logger;
   }
 
@@ -252,7 +252,7 @@ typedef EventProcessor = FutureOr<SentryEvent> Function(SentryEvent event,
     {dynamic hint});
 
 /// Logger interface to log useful debugging information if debug is enabled
-typedef Logger = Function(SentryLevel level, String message);
+typedef SentryLogger = Function(SentryLevel level, String message);
 
 /// Used to provide timestamp for logging.
 typedef ClockProvider = DateTime Function();

--- a/dart/test/sentry_options_test.dart
+++ b/dart/test/sentry_options_test.dart
@@ -50,20 +50,20 @@ void main() {
     expect(200, options.maxBreadcrumbs);
   });
 
-  test('$Logger is NoOp by default', () {
+  test('$SentryLogger is NoOp by default', () {
     final options = SentryOptions();
 
     expect(noOpLogger, options.logger);
   });
 
-  test('$Logger is NoOp if null is set', () {
+  test('$SentryLogger is NoOp if null is set', () {
     final options = SentryOptions();
     options.logger = null;
 
     expect(noOpLogger, options.logger);
   });
 
-  test('$Logger sets a diagnostic logger', () {
+  test('$SentryLogger sets a diagnostic logger', () {
     final options = SentryOptions();
     options.logger = dartLogger;
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Renaming `Logger` to `SentryLogger` prevents name/import clashes with different logging packages.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See https://github.com/getsentry/sentry-dart/issues/218

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
