### PR TITLE
Fix: package usage as git dependency

### DIFF
--- a/dart/example_web/pubspec.yaml
+++ b/dart/example_web/pubspec.yaml
@@ -7,10 +7,13 @@ environment:
   sdk: ^2.8.0
 
 dependencies:
-  sentry:
-    path: ../
+  sentry: any
 
 dev_dependencies:
   build_runner: ^1.10.0
   build_web_compilers: ^2.13.0
   pedantic: ^1.9.0
+
+dependency_overrides:
+  sentry:
+    path: ../

--- a/flutter/example/pubspec.yaml
+++ b/flutter/example/pubspec.yaml
@@ -10,11 +10,14 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  sentry_flutter: any
+  universal_platform: ^0.1.3
 
+dependency_overrides:
+  sentry:
+    path: ../../dart
   sentry_flutter:
     path: ../
-
-  universal_platform: ^0.1.3
 
 flutter:
   uses-material-design: true

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -13,10 +13,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  sentry: #">=4.0.0-beta.2 <4.1.0"
-    # TODO: we need the specific version for publishing it, but the relative path for development.
-    # Figure out how to do it via Craft for releases.
-    path: ../dart
+  sentry: ">=4.0.0-beta.2 <4.1.0"
   package_info: ^0.4.0
 
 dev_dependencies:
@@ -26,6 +23,10 @@ dev_dependencies:
   test: ^1.15.7
   yaml: ^2.2.1 # needed for version match (code and pubspec)
   pedantic: ^1.9.2
+
+dependency_overrides:
+  sentry:
+    path: ../dart
 
 flutter:
   plugin:


### PR DESCRIPTION
Using the development path in the dependency section prevents the package from being used as git dependency. A better approach is to add the custom path to dependency_overrides - this way a consumer can also override the sentry dependency.

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
By using `dependency_overrides` it is possible to consume the package directly from git(hub) to test latest changes on different branches:
```yaml
dependency_overrides:
  sentry:
    git:
      url: https://github.com/getsentry/sentry-dart.git
      ref: main
      path: dart
  sentry_flutter:
    git:
      url: https://github.com/getsentry/sentry-dart.git
      ref: main
      path: flutter
```
Without using `dependency_overrides` for the local development override this is not possible as the path `../dart` can not be resolved to a local dependency.

Not sure how this ties into build scripts/actions.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See description

## :green_heart: How did you test it?
I added the snippet to my projects.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
