### PR TITLE
CI: Fix ktlint

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -137,8 +137,9 @@ jobs:
         with:
           java-version: '8'
       - run: |
-          brew install ktlint
-          ktlint --reporter=checkstyle,output=build/ktlint-report.xml || true
+          curl -sSLO https://github.com/pinterest/ktlint/releases/download/0.40.0/ktlint
+          chmod a+x ktlint
+          ./ktlint --reporter=checkstyle,output=build/ktlint-report.xml || true
       - uses: yutailang0119/action-ktlint@v1
         with:
           xml_path: build/ktlint-report.xml

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -37,7 +37,7 @@ jobs:
 
         - uses: actions/setup-java@v1
           with:
-              java-version: '8'
+            java-version: '8'
 
         - uses: subosito/flutter-action@v1
           with:
@@ -133,6 +133,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: '8'
       - run: |
           brew install ktlint
           ktlint --reporter=checkstyle,output=build/ktlint-report.xml || true


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
CI: Fix ktlint


## :bulb: Motivation and Context
When `ktlint` is installed via `brew`, it triggers errors because of `openjdk`, so instead of using its own jdk dependency, we download it via curl and use `setup-java`


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
