### PR TITLE
Fix: Scope processors should be awaited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Ref: Only assign non-null option values in Android native integration in order preserve default values
 * Enhancement: Add 'attachThreads' in options. When enabled, threads are attached to all logged events for Android
 * Ref: Rename typedef `Logger` to `SentryLogger` to prevent name clashes with logging packages
+* Fix: Scope Event processors should be awaited
 
 ## Breaking changes
 

--- a/dart/lib/src/scope.dart
+++ b/dart/lib/src/scope.dart
@@ -164,7 +164,7 @@ class Scope {
   /// Removes an extra from the Scope
   void removeExtra(String key) => _extra.remove(key);
 
-  SentryEvent applyToEvent(SentryEvent event, dynamic hint) {
+  Future<SentryEvent> applyToEvent(SentryEvent event, dynamic hint) async {
     event = event.copyWith(
       transaction: event.transaction ?? transaction,
       user: event.user ?? user,
@@ -190,7 +190,7 @@ class Scope {
 
     for (final processor in _eventProcessors) {
       try {
-        event = processor(event, hint: hint);
+        event = await processor(event, hint: hint);
       } catch (err) {
         _options.logger(
           SentryLevel.error,

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -63,7 +63,7 @@ class SentryClient {
     event = _prepareEvent(event, stackTrace: stackTrace);
 
     if (scope != null) {
-      event = scope.applyToEvent(event, hint);
+      event = await scope.applyToEvent(event, hint);
     } else {
       _options.logger(SentryLevel.debug, 'No scope is defined');
     }

--- a/dart/test/scope_test.dart
+++ b/dart/test/scope_test.dart
@@ -253,7 +253,7 @@ void main() {
 
     final breadcrumb = Breadcrumb(message: 'Authenticated');
 
-    test('apply context to event', () {
+    test('apply context to event', () async {
       final event = SentryEvent(
         tags: const {'etag': '987'},
         extra: const {'e-infos': 'abc'},
@@ -271,7 +271,7 @@ void main() {
           (event, {hint}) => event..tags.addAll({'page-locale': 'en-us'}),
         );
 
-      final updatedEvent = scope.applyToEvent(event, null);
+      final updatedEvent = await scope.applyToEvent(event, null);
 
       expect(updatedEvent.user, scopeUser);
       expect(updatedEvent.transaction, '/example/app');
@@ -286,7 +286,7 @@ void main() {
     });
 
     test('should not apply the scope properties when event already has it ',
-        () {
+        () async {
       final eventUser = User(id: '123');
       final eventBreadcrumb = Breadcrumb(message: 'event-breadcrumb');
 
@@ -302,7 +302,7 @@ void main() {
         ..addBreadcrumb(breadcrumb)
         ..transaction = '/example/app';
 
-      final updatedEvent = scope.applyToEvent(event, null);
+      final updatedEvent = await scope.applyToEvent(event, null);
 
       expect(updatedEvent.user, eventUser);
       expect(updatedEvent.transaction, '/event/transaction');
@@ -312,7 +312,7 @@ void main() {
 
     test(
         'should not apply the scope.contexts values if the event already has it',
-        () {
+        () async {
       final event = SentryEvent(
         contexts: Contexts(
           device: Device(name: 'event-device'),
@@ -349,7 +349,7 @@ void main() {
           OperatingSystem(name: 'context-os'),
         );
 
-      final updatedEvent = scope.applyToEvent(event, null);
+      final updatedEvent = await scope.applyToEvent(event, null);
 
       expect(updatedEvent.contexts[Device.type].name, 'event-device');
       expect(updatedEvent.contexts[App.type].name, 'event-app');
@@ -360,7 +360,7 @@ void main() {
       expect(updatedEvent.contexts[OperatingSystem.type].name, 'event-os');
     });
 
-    test('should apply the scope.contexts values ', () {
+    test('should apply the scope.contexts values ', () async {
       final event = SentryEvent();
       final scope = Scope(SentryOptions())
         ..setContexts(Device.type, Device(name: 'context-device'))
@@ -374,7 +374,7 @@ void main() {
         ..setContexts('version', 9)
         ..setContexts('location', {'city': 'London'});
 
-      final updatedEvent = scope.applyToEvent(event, null);
+      final updatedEvent = await scope.applyToEvent(event, null);
 
       expect(updatedEvent.contexts[Device.type].name, 'context-device');
       expect(updatedEvent.contexts[App.type].name, 'context-app');
@@ -390,11 +390,11 @@ void main() {
       expect(updatedEvent.contexts['location'], {'city': 'London'});
     });
 
-    test('should apply the scope level', () {
+    test('should apply the scope level', () async {
       final event = SentryEvent(level: SentryLevel.warning);
       final scope = Scope(SentryOptions())..level = SentryLevel.error;
 
-      final updatedEvent = scope.applyToEvent(event, null);
+      final updatedEvent = await scope.applyToEvent(event, null);
 
       expect(updatedEvent.level, SentryLevel.error);
     });


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Fix: Scope processors should be awaited


## :bulb: Motivation and Context
If an `async` event processor was added to the Scope, it' not be waiting for the Future to be completed.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
