### PR TITLE
Fix: Envelope length should be based on the UTF8 array instead of String length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # vNext
 
 * Ref: Changed category of Flutter lifecycle tracking [#240](https://github.com/getsentry/sentry-dart/issues/240)
+* Fix: Envelope length should be based on the UTF8 array instead of String length
 
 # 4.0.0
 

--- a/flutter/lib/src/file_system_transport.dart
+++ b/flutter/lib/src/file_system_transport.dart
@@ -19,11 +19,12 @@ class FileSystemTransport implements Transport {
     final eventMap = event.toJson();
 
     final eventString = jsonEncode(eventMap);
+    final eventUtf8 = utf8.encode(eventString);
 
     final itemHeaderMap = {
       'content_type': 'application/json',
       'type': 'event',
-      'length': eventString.length,
+      'length': eventUtf8.length,
     };
 
     final headerString = jsonEncode(headerMap);

--- a/flutter/test/file_system_transport_test.dart
+++ b/flutter/test/file_system_transport_test.dart
@@ -51,7 +51,7 @@ void main() {
 
     final transport = fixture.getSut(_channel);
 
-    final event = SentryEvent();
+    final event = SentryEvent(message: Message('hi I am a special char ◤'));
     await transport.send(event);
 
     final envelopeList = arguments as List;
@@ -72,10 +72,11 @@ void main() {
     final itemHeaderMap = jsonDecode(itemHeader) as Map<String, dynamic>;
 
     final eventString = jsonEncode(event.toJson());
+    final eventUtf = utf8.encode(eventString);
 
     expect('application/json', itemHeaderMap['content_type']);
     expect('event', itemHeaderMap['type']);
-    expect(eventString.length, itemHeaderMap['length']);
+    expect(eventUtf.length, itemHeaderMap['length']);
 
     expect(item, eventString);
   });


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Fix: Envelope length should be based on the UTF8 array instead of String length


## :bulb: Motivation and Context
#242


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
