### PR TITLE
Refactoring: Init Flutter first + documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # vNext
 
+* Ref: Make `WidgetsFlutterBinding.ensureInitialized();` the first thing the Sentry SDK calls.
+
 # 4.0.1
 
 * Ref: Changed category of Flutter lifecycle tracking [#240](https://github.com/getsentry/sentry-dart/issues/240)

--- a/flutter/lib/src/default_integrations.dart
+++ b/flutter/lib/src/default_integrations.dart
@@ -12,7 +12,7 @@ import 'widgets_binding_observer.dart';
 ///
 /// Remarks:
 ///   - Most UI and layout related errors (such as
-///     [these](https://flutter.dev/docs/testing/errors)) are AssertionErrors
+///     [these](https://flutter.dev/docs/testing/common-errors)) are AssertionErrors
 ///     and are stripped in release mode. See [Flutter build modes](https://flutter.dev/docs/testing/build-modes).
 ///     So they only get caught in debug mode.
 class FlutterErrorIntegration extends Integration<SentryFlutterOptions> {

--- a/flutter/lib/src/default_integrations.dart
+++ b/flutter/lib/src/default_integrations.dart
@@ -8,7 +8,13 @@ import 'package:sentry/sentry.dart';
 import 'sentry_flutter_options.dart';
 import 'widgets_binding_observer.dart';
 
-/// integration that capture errors on the FlutterError handler
+/// Integration that capture errors on the [FlutterError.onError] handler.
+///
+/// Remarks:
+///   - Most UI and layout related errors (such as
+///     [these](https://flutter.dev/docs/testing/errors)) are AssertionErrors
+///     and are stripped in release mode. See [Flutter build modes](https://flutter.dev/docs/testing/build-modes).
+///     So they only get caught in debug mode.
 class FlutterErrorIntegration extends Integration<SentryFlutterOptions> {
   @override
   void call(Hub hub, SentryFlutterOptions options) {
@@ -16,7 +22,9 @@ class FlutterErrorIntegration extends Integration<SentryFlutterOptions> {
 
     FlutterError.onError = (FlutterErrorDetails errorDetails) async {
       options.logger(
-          SentryLevel.debug, 'Capture from onError ${errorDetails.exception}');
+        SentryLevel.debug,
+        'Capture from onError ${errorDetails.exception}',
+      );
 
       // FlutterError doesn't crash the App.
       final mechanism = Mechanism(type: 'FlutterError', handled: true);

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -34,6 +34,11 @@ mixin SentryFlutter {
     if (optionsConfiguration == null) {
       throw ArgumentError('OptionsConfiguration is required.');
     }
+
+    // It is necessary to initialize Flutter method channels so that
+    // our plugin can call into the native code.
+    WidgetsFlutterBinding.ensureInitialized();
+
     final flutterOptions = SentryFlutterOptions();
     // first step is to install the native integration and set default values,
     // so we are able to capture future errors.
@@ -58,10 +63,6 @@ mixin SentryFlutter {
   static Future<void> _initDefaultValues(
     SentryFlutterOptions options,
   ) async {
-    // it is necessary to initialize Flutter method channels so that
-    // our plugin can call into the native code.
-    WidgetsFlutterBinding.ensureInitialized();
-
     options.debug = kDebugMode;
 
     // web still uses a http transport for Web which is set by default


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
`WidgetsFlutterBinding.ensureInitialized();` should be the first thing, the SDK calls. This prevents all kinds of mistakes which could result from default integrations assuming it was already caught. (For example PlatoformChannels and so on).
Previously it was called after the default integrations were added.

I've also improved the documentation of the `FlutterErrorIntegration` regarding UI and layout errors.
This should also set the users expections regarding catching [these](https://flutter.dev/docs/testing/common-errors) errors
 in release mode.


## :bulb: Motivation and Context
See 
- https://github.com/getsentry/sentry-dart/issues/243
- https://github.com/flutter/flutter/issues/72598


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
