### PR TITLE
Fix: Deprecated binaryMessenger (MethodChannel member) for Flutter Web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # vNext
 
+* Fix: Deprecated binaryMessenger (MethodChannel member) for Flutter Web
+
 # 4.0.1
 
 * Ref: Changed category of Flutter lifecycle tracking [#240](https://github.com/getsentry/sentry-dart/issues/240)

--- a/flutter/lib/src/sentry_flutter_web.dart
+++ b/flutter/lib/src/sentry_flutter_web.dart
@@ -9,7 +9,7 @@ class SentryFlutterWeb {
     final channel = MethodChannel(
       'sentry_flutter',
       const StandardMethodCodec(),
-      registrar.messenger,
+      registrar,
     );
 
     final pluginInstance = SentryFlutterWeb();


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
Deprecated binaryMessenger (MethodChannel member) for Flutter Web


## :bulb: Motivation and Context
lint (pana) was complaining and failing CI


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
