### PR TITLE
Bump: Sentry-cocoa to 6.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fix: Deprecated binaryMessenger (MethodChannel member) for Flutter Web
 * Ref: Make `WidgetsFlutterBinding.ensureInitialized();` the first thing the Sentry SDK calls.
+* Bump: Sentry-cocoa to 6.0.12
 
 # 4.0.1
 

--- a/flutter/example/ios/Podfile.lock
+++ b/flutter/example/ios/Podfile.lock
@@ -2,12 +2,12 @@ PODS:
   - Flutter (1.0.0)
   - package_info (0.0.1):
     - Flutter
-  - Sentry (6.0.10):
-    - Sentry/Core (= 6.0.10)
-  - Sentry/Core (6.0.10)
+  - Sentry (6.0.12):
+    - Sentry/Core (= 6.0.12)
+  - Sentry/Core (6.0.12)
   - sentry_flutter (0.0.1):
     - Flutter
-    - Sentry (~> 6.0.10)
+    - Sentry (~> 6.0.12)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
@@ -27,10 +27,10 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/sentry_flutter/ios"
 
 SPEC CHECKSUMS:
-  Flutter: 0e3d915762c693b495b44d77113d4970485de6ec
+  Flutter: 434fef37c0980e73bb6479ef766c45957d4b510c
   package_info: 873975fc26034f0b863a300ad47e7f1ac6c7ec62
-  Sentry: 0a48d832ce921578a0c31c68272382fbef9a1726
-  sentry_flutter: e57e33f56d5791e4effa48e85e44505367686b27
+  Sentry: 8ffcfe3416e0a58b90bb1ae319e8e8a13022a03e
+  sentry_flutter: c817164015701ab7297ace8343bc75f128a33305
 
 PODFILE CHECKSUM: a75497545d4391e2d394c3668e20cfb1c2bbd4aa
 

--- a/flutter/ios/sentry_flutter.podspec
+++ b/flutter/ios/sentry_flutter.podspec
@@ -11,7 +11,7 @@ Sentry SDK for Flutter with support to native through sentry-cocoa.
   s.source           = { :git => "https://github.com/getsentry/sentry-dart.git",
                          :tag => s.version.to_s }
   s.source_files = 'Classes/**/*'
-  s.dependency 'Sentry', '~> 6.0.10'
+  s.dependency 'Sentry', '~> 6.0.12'
   s.dependency 'Flutter'
   s.platform = :ios, '9.0'
 


### PR DESCRIPTION
## :scroll: Description
Bump: Sentry-cocoa to 6.0.12


## :bulb: Motivation and Context
Cocoa has made a few fixes
https://github.com/getsentry/sentry-cocoa/releases/tag/6.0.11
https://github.com/getsentry/sentry-cocoa/releases/tag/6.0.12


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
