### PR TITLE
Docs: Put FlutterError.onError limitation in Readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Ref: Make `WidgetsFlutterBinding.ensureInitialized();` the first thing the Sentry SDK calls.
 * Bump: Sentry-cocoa to 6.0.12
 * Feat: Respect FlutterError silent flag #248
+* Documentation: Added FlutterError.onError limitations
 
 # 4.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 * Ref: Make `WidgetsFlutterBinding.ensureInitialized();` the first thing the Sentry SDK calls.
 * Bump: Sentry-cocoa to 6.0.12
 * Feat: Respect FlutterError silent flag #248
-* Documentation: Added FlutterError.onError limitations
 
 # 4.0.1
 

--- a/flutter/README.md
+++ b/flutter/README.md
@@ -79,6 +79,7 @@ For a more throughout example see the [example](example/lib/main.dart).
 
 - Flutter `split-debug-info` and `obfuscate` flag aren't supported on iOS yet, but only on Android, if this feature is enabled, Dart stack traces are not human readable
 - If you enable the `split-debug-info` feature, you must upload the Debug Symbols manually.
+- Layout related errors are only catched by [FlutterError.onError](https://api.flutter.dev/flutter/foundation/FlutterError/onError.html) in debug mode. In release mode they are removed by the Flutter framework. See [Flutter build modes](https://flutter.dev/docs/testing/build-modes). 
 
 ##### Uploading Debug Symbols (Android and iOS)
 
@@ -92,7 +93,7 @@ For a more throughout example see the [example](example/lib/main.dart).
 - Use a `try/catch` block.
 - Use a `catchError` block for `Futures`, examples on [dart.dev](https://dart.dev/guides/libraries/futures-error-handling).
 - The SDK already runs your `callback` on an error handler, e.g. using [runZonedGuarded](https://api.flutter.dev/flutter/dart-async/runZonedGuarded.html), events caught by the `runZonedGuarded` are captured automatically.
-- [Flutter-specific errors](https://api.flutter.dev/flutter/foundation/FlutterError/onError.html) (such as layout failures) are captured automatically.
+- [Flutter-specific errors](https://api.flutter.dev/flutter/foundation/FlutterError/onError.html) are captured automatically.
 - [Current Isolate errors](https://api.flutter.dev/flutter/dart-isolate/Isolate/addErrorListener.html) which is the equivalent of a main or UI thread, are captured automatically (Only for non-Web Apps).
 - For your own `Isolates`, add an [Error Listener](https://api.flutter.dev/flutter/dart-isolate/Isolate/addErrorListener.html) and call `Sentry.captureException`.
 

--- a/flutter/README.md
+++ b/flutter/README.md
@@ -79,7 +79,7 @@ For a more throughout example see the [example](example/lib/main.dart).
 
 - Flutter `split-debug-info` and `obfuscate` flag aren't supported on iOS yet, but only on Android, if this feature is enabled, Dart stack traces are not human readable
 - If you enable the `split-debug-info` feature, you must upload the Debug Symbols manually.
-- Layout related errors are only catched by [FlutterError.onError](https://api.flutter.dev/flutter/foundation/FlutterError/onError.html) in debug mode. In release mode they are removed by the Flutter framework. See [Flutter build modes](https://flutter.dev/docs/testing/build-modes). 
+- Layout related errors are only caught by [FlutterError.onError](https://api.flutter.dev/flutter/foundation/FlutterError/onError.html) in debug mode. In release mode, they are removed by the Flutter framework. See [Flutter build modes](https://flutter.dev/docs/testing/build-modes). 
 
 ##### Uploading Debug Symbols (Android and iOS)
 


### PR DESCRIPTION
## :scroll: Description
I've added https://github.com/getsentry/sentry-dart/blob/main/flutter/lib/src/default_integrations.dart#L13 to the readme.


## :bulb: Motivation and Context
This change makes it more clear, that layout related error won't be catched in release mode. Previously a user would probably assume, that Sentry would catch these errors


## :green_heart: How did you test it?
Just docs, so no code changes


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps


#skip-changelog


