### PR TITLE
Fix: NPE check before initing the SentryWidgetsBindingObserver

### DIFF
--- a/flutter/lib/src/default_integrations.dart
+++ b/flutter/lib/src/default_integrations.dart
@@ -199,11 +199,21 @@ class WidgetsBindingIntegration extends Integration<SentryFlutterOptions> {
     if (instance != null) {
       instance.addObserver(_observer);
       options.sdk.addIntegration('widgetsBindingIntegration');
+    } else {
+      options.logger(
+        SentryLevel.error,
+        'widgetsBindingIntegration failed to be installed',
+      );
     }
   }
 
   @override
-  void close() => WidgetsBinding.instance.removeObserver(_observer);
+  void close() {
+    final instance = WidgetsBinding.instance;
+    if (instance != null) {
+      instance.removeObserver(_observer);
+    }
+  }
 }
 
 /// Loads the Android Image list for stack trace symbolication

--- a/flutter/lib/src/default_integrations.dart
+++ b/flutter/lib/src/default_integrations.dart
@@ -194,9 +194,12 @@ class WidgetsBindingIntegration extends Integration<SentryFlutterOptions> {
 
     // We don't need to call `WidgetsFlutterBinding.ensureInitialized()`
     // because `FlutterSentry.init` already calls it.
-    WidgetsBinding.instance.addObserver(_observer);
-
-    options.sdk.addIntegration('widgetsBindingIntegration');
+    // If the instance is not created, we skip it to keep going.
+    final instance = WidgetsBinding.instance;
+    if (instance != null) {
+      instance.addObserver(_observer);
+      options.sdk.addIntegration('widgetsBindingIntegration');
+    }
   }
 
   @override

--- a/flutter/test/not_initialized_widgets_binding_test.dart
+++ b/flutter/test/not_initialized_widgets_binding_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+import 'package:sentry_flutter/src/sentry_flutter_options.dart';
+
+import 'mocks.dart';
+
+/// Tests that require `WidgetsFlutterBinding.ensureInitialized();` not
+/// being called at all.
+void main() {
+  Fixture fixture;
+
+  setUp(() {
+    fixture = Fixture();
+  });
+
+  test('widgetsBindingIntegration does not add integration', () async {
+    final integration = WidgetsBindingIntegration();
+
+    await integration(fixture.hub, fixture.options);
+
+    expect(false,
+        fixture.options.sdk.integrations.contains('widgetsBindingIntegration'));
+  });
+}
+
+class Fixture {
+  final hub = MockHub();
+  final options = SentryFlutterOptions();
+}


### PR DESCRIPTION
## :scroll: Description
Fix: NPE check before initing the SentryWidgetsBindingObserver


## :bulb: Motivation and Context
If `WidgetsFlutterBinding.ensureInitialized()` fails somehow, this would prevent the SDK to keep initing.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
