### PR TITLE
fix: Pass auto session tracking interval to iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # vNext
 
+* Fix: Pass auto session tracking interval to iOS
 * Fix: Deprecated binaryMessenger (MethodChannel member) for Flutter Web
 * Ref: Make `WidgetsFlutterBinding.ensureInitialized();` the first thing the Sentry SDK calls.
 * Bump: Sentry-cocoa to 6.0.12

--- a/flutter/ios/Classes/SwiftSentryFlutterPlugin.swift
+++ b/flutter/ios/Classes/SwiftSentryFlutterPlugin.swift
@@ -119,7 +119,7 @@ public class SwiftSentryFlutterPlugin: NSObject, FlutterPlugin {
       options.logLevel = logLevelFrom(diagnosticLevel: diagnosticLevel)
     }
 
-    if let sessionTrackingIntervalMillis = arguments["sessionTrackingIntervalMillis"] as? UInt {
+    if let sessionTrackingIntervalMillis = arguments["autoSessionTrackingIntervalMillis"] as? UInt {
       options.sessionTrackingIntervalMillis = sessionTrackingIntervalMillis
     }
 
@@ -194,7 +194,6 @@ public class SwiftSentryFlutterPlugin: NSObject, FlutterPlugin {
 
     do {
       let envelope = try parseJsonEnvelope(event)
-
       SentrySDK.currentHub().getClient()?.capture(envelope: envelope)
       result("")
     } catch {


### PR DESCRIPTION


## :scroll: Description
In SwiftSentryFlutterPlugin we look for sessionTrackingIntervalMillis in
the arguments. Instead, it must be autoSessionTrackingIntervalMillis, see https://github.com/getsentry/sentry-dart/blob/8406d676d4839606b89665ed65a99dcdb3910a98/flutter/lib/src/sentry_flutter_options.dart#L35.


## :bulb: Motivation and Context
We want to be able to change the `autoSessionTrackingIntervalMillis ` in iOS.


## :green_heart: How did you test it?
With an emulator.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
