### PR TITLE
fix: Mark session as `errored` in iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # vNext
 
+* fix: Mark session as `errored` in iOS #270
 * Fix: Pass auto session tracking interval to iOS
 * Fix: Deprecated binaryMessenger (MethodChannel member) for Flutter Web
 * Ref: Make `WidgetsFlutterBinding.ensureInitialized();` the first thing the Sentry SDK calls.

--- a/flutter/example/ios/Podfile.lock
+++ b/flutter/example/ios/Podfile.lock
@@ -2,12 +2,12 @@ PODS:
   - Flutter (1.0.0)
   - package_info (0.0.1):
     - Flutter
-  - Sentry (6.0.12):
-    - Sentry/Core (= 6.0.12)
-  - Sentry/Core (6.0.12)
+  - Sentry (6.1.3):
+    - Sentry/Core (= 6.1.3)
+  - Sentry/Core (6.1.3)
   - sentry_flutter (0.0.1):
     - Flutter
-    - Sentry (~> 6.0.12)
+    - Sentry (~> 6.1.3)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
@@ -27,11 +27,11 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/sentry_flutter/ios"
 
 SPEC CHECKSUMS:
-  Flutter: 434fef37c0980e73bb6479ef766c45957d4b510c
+  Flutter: 0e3d915762c693b495b44d77113d4970485de6ec
   package_info: 873975fc26034f0b863a300ad47e7f1ac6c7ec62
-  Sentry: 8ffcfe3416e0a58b90bb1ae319e8e8a13022a03e
-  sentry_flutter: c817164015701ab7297ace8343bc75f128a33305
+  Sentry: 5b741b3c932fa293c28ba6a6f510b72bd63c9993
+  sentry_flutter: 4c31236a9842dd37526007230bd7fba651c23cd6
 
 PODFILE CHECKSUM: a75497545d4391e2d394c3668e20cfb1c2bbd4aa
 
-COCOAPODS: 1.10.0
+COCOAPODS: 1.10.1

--- a/flutter/ios/Classes/SwiftSentryFlutterPlugin.swift
+++ b/flutter/ios/Classes/SwiftSentryFlutterPlugin.swift
@@ -194,7 +194,7 @@ public class SwiftSentryFlutterPlugin: NSObject, FlutterPlugin {
 
     do {
       let envelope = try parseJsonEnvelope(event)
-      SentrySDK.currentHub().getClient()?.capture(envelope: envelope)
+      SentrySDK.currentHub().capture(envelope: envelope)
       result("")
     } catch {
       print("Cannot parse the envelope json !")

--- a/flutter/ios/sentry_flutter.podspec
+++ b/flutter/ios/sentry_flutter.podspec
@@ -11,7 +11,7 @@ Sentry SDK for Flutter with support to native through sentry-cocoa.
   s.source           = { :git => "https://github.com/getsentry/sentry-dart.git",
                          :tag => s.version.to_s }
   s.source_files = 'Classes/**/*'
-  s.dependency 'Sentry', '~> 6.0.12'
+  s.dependency 'Sentry', '~> 6.1.3'
   s.dependency 'Flutter'
   s.platform = :ios, '9.0'
 


### PR DESCRIPTION


## :scroll: Description
Update sentry-cocoa to 6.1.3, which contains the fix
https://github.com/getsentry/sentry-cocoa/pull/906 for this issue.


## :bulb: Motivation and Context
Fixes GH-268


## :green_heart: How did you test it?
With an emulator.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
