### PR TITLE
Sample: Bump Android Sample NdkVersion

### DIFF
--- a/flutter/example/android/app/build.gradle
+++ b/flutter/example/android/app/build.gradle
@@ -66,7 +66,7 @@ android {
 
     // TODO: we need to fix CI as the version 21.1 (default) is not installed by default on
     // GH Actions.
-    ndkVersion "21.3.6528147"
+    ndkVersion "22.0.7026061"
 
     externalNativeBuild {
         cmake {


### PR DESCRIPTION
## :scroll: Description
Sample: Bump Android Sample NdkVersion


## :bulb: Motivation and Context
GH upgraded its ubuntu and windows images and its NDK installed versions.
CI is not happy: No version of NDK matched the requested version 21.3.6528147. Versions available locally: 22.0.7026061, 22.0.7026061

## :green_heart: How did you test it?
hopefully this PR passes

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
