### PR TITLE
Fix: Android NDK version (Sample only)

### DIFF
--- a/flutter/example/android/app/build.gradle
+++ b/flutter/example/android/app/build.gradle
@@ -66,7 +66,7 @@ android {
 
     // TODO: we need to fix CI as the version 21.1 (default) is not installed by default on
     // GH Actions.
-    ndkVersion "22.0.7026061"
+    ndkVersion "21.3.6528147" // ubuntu requires 21.3.6528147
 
     externalNativeBuild {
         cmake {


### PR DESCRIPTION
## :scroll: Description
Fix: Android NDK version (Sample only)


## :bulb: Motivation and Context
No version of NDK matched the requested version 22.0.7026061. Versions available locally: 21.3.6528147

I hope mac/win also has this version otherwise we'd need to install NDK versions manually, again :(


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
