### PR TITLE
Fix: Pana Flutter upper bound deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # vNext
 
 * Bump: sentry-android to v4.0.0
+* Fix: Pana Flutter upper bound deprecation
 
 # 4.0.4
 

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/getsentry/sentry-dart
 
 environment:
   sdk: ">=2.8.0 <3.0.0"
-  flutter: ">=1.17.0 <2.0.0"
+  flutter: ">=1.17.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## :scroll: Description
Pana Flutter upper bound deprecation


## :bulb: Motivation and Context
Package validation found the following potential issue:
* The Flutter constraint should not have an upper bound.
  In your pubspec.yaml the constraint is currently `>=1.17.0 <2.0.0`.

  You can replace that with just the lower bound: `>=1.17.0`.

  See https://dart.dev/go/flutter-upper-bound-deprecation


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
