### PR TITLE
Refactoring: Dart Nullsafety

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -20,7 +20,7 @@ jobs:
         # TODO: cedx/setup-dart@v2 doesn't work on Windows (doesn't add pub to the PATH?)
         # os: [ubuntu-latest, windows-latest, macos-latest]
         os: [ubuntu-latest, macos-latest]
-        sdk: [beta, dev, stable]
+        sdk: [beta, dev]
         exclude:
           # Bad state: Could not run tests with Observatory enabled. Try setting a different port with --port option.
           - os: ubuntu-latest
@@ -61,7 +61,7 @@ jobs:
     steps:
       - uses: cedx/setup-dart@v2
         with:
-          release-channel: stable
+          release-channel: beta
       - uses: actions/checkout@v2
       - run: |
           dart pub get

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         target: ['ios', 'android', 'web']
-        channel: ['stable', 'beta']
+        channel: ['beta']
         exclude:
           - os: ubuntu-latest
             target: ios

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # vNext
 
 * Refactoring: Migrate Sentry Dart to null safety
+
 # 4.0.5
 
 * Bump: sentry-android to v4.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # vNext
 
+* Refactoring: Migrate Sentry Dart to null safety
 * Bump: sentry-android to v4.0.0
 * Fix: Pana Flutter upper bound deprecation
 

--- a/dart/example/main.dart
+++ b/dart/example/main.dart
@@ -85,7 +85,7 @@ Future<void> runApp() async {
 
     print('Capture exception result : SentryId : $sentryId');
   } finally {
-    await Sentry.close();
+    Sentry.close();
   }
 }
 

--- a/dart/lib/src/diagnostic_logger.dart
+++ b/dart/lib/src/diagnostic_logger.dart
@@ -5,7 +5,7 @@ class DiagnosticLogger {
   final SentryLogger _logger;
   final SentryOptions _options;
 
-  DiagnosticLogger(this._logger, this._options) : assert(_logger != null);
+  DiagnosticLogger(this._logger, this._options);
 
   void log(SentryLevel level, String message) {
     if (_isEnabled(level)) {

--- a/dart/lib/src/diagnostic_logger.dart
+++ b/dart/lib/src/diagnostic_logger.dart
@@ -5,7 +5,7 @@ class DiagnosticLogger {
   final SentryLogger _logger;
   final SentryOptions _options;
 
-  DiagnosticLogger(this._logger, this._options);
+  DiagnosticLogger(this._logger, this._options) : assert(_logger != null);
 
   void log(SentryLevel level, String message) {
     if (_isEnabled(level)) {

--- a/dart/lib/src/http_client/sentry_http_client.dart
+++ b/dart/lib/src/http_client/sentry_http_client.dart
@@ -46,7 +46,7 @@ import '../../sentry.dart';
 // For example with Darts Stopwatch:
 // https://api.dart.dev/stable/2.10.4/dart-core/Stopwatch-class.html
 class SentryHttpClient extends BaseClient {
-  SentryHttpClient({Client/*?*/ client, Hub/*?*/ hub})
+  SentryHttpClient({Client? client, Hub? hub})
       : _hub = hub ?? HubAdapter(),
         _client = client ?? Client();
 

--- a/dart/lib/src/http_client/sentry_http_client.dart
+++ b/dart/lib/src/http_client/sentry_http_client.dart
@@ -46,13 +46,12 @@ import '../../sentry.dart';
 // For example with Darts Stopwatch:
 // https://api.dart.dev/stable/2.10.4/dart-core/Stopwatch-class.html
 class SentryHttpClient extends BaseClient {
-  SentryHttpClient({Client client, Hub hub}) {
-    _hub = hub ?? HubAdapter();
-    _client = client ?? Client();
-  }
+  SentryHttpClient({Client/*?*/ client, Hub/*?*/ hub})
+      : _hub = hub ?? HubAdapter(),
+        _client = client ?? Client();
 
-  Client _client;
-  Hub _hub;
+  final Client _client;
+  final Hub _hub;
 
   @override
   Future<StreamedResponse> send(BaseRequest request) async {

--- a/dart/lib/src/hub.dart
+++ b/dart/lib/src/hub.dart
@@ -129,7 +129,7 @@ class Hub {
   /// Captures the message.
   Future<SentryId> captureMessage(
     String? message, {
-    SentryLevel? level = SentryLevel.info,
+    SentryLevel? level,
     String? template,
     List<dynamic>? params,
     dynamic hint,

--- a/dart/lib/src/hub.dart
+++ b/dart/lib/src/hub.dart
@@ -129,7 +129,7 @@ class Hub {
   /// Captures the message.
   Future<SentryId> captureMessage(
     String? message, {
-    SentryLevel level,
+    SentryLevel level = SentryLevel.info,
     String? template,
     List<dynamic>? params,
     dynamic hint,

--- a/dart/lib/src/hub.dart
+++ b/dart/lib/src/hub.dart
@@ -17,8 +17,9 @@ class Hub {
 
   final ListQueue<_StackItem> _stack = ListQueue();
 
-  /// if stack is empty, it throws IterableElementError.noElement()
-  _StackItem? _peek() => _stack.isNotEmpty ? _stack.first : null;
+  // peek can never return null since Stack can be created only with an item and
+  // pop does not drop the last item.
+  _StackItem _peek() => _stack.first;
 
   final SentryOptions _options;
 
@@ -64,27 +65,21 @@ class Hub {
       );
     } else {
       final item = _peek();
-      if (item != null) {
-        try {
-          sentryId = await item.client.captureEvent(
-            event,
-            stackTrace: stackTrace,
-            scope: item.scope,
-            hint: hint,
-          );
-        } catch (err) {
-          _options.logger(
-            SentryLevel.error,
-            'Error while capturing event with id: ${event.eventId.toString()}',
-          );
-        } finally {
-          _lastEventId = sentryId;
-        }
-      } else {
-        _options.logger(
-          SentryLevel.fatal,
-          'Stack peek was null when captureEvent',
+
+      try {
+        sentryId = await item.client.captureEvent(
+          event,
+          stackTrace: stackTrace,
+          scope: item.scope,
+          hint: hint,
         );
+      } catch (err) {
+        _options.logger(
+          SentryLevel.error,
+          'Error while capturing event with id: ${event.eventId.toString()}',
+        );
+      } finally {
+        _lastEventId = sentryId;
       }
     }
     return sentryId;
@@ -110,27 +105,21 @@ class Hub {
       );
     } else {
       final item = _peek();
-      if (item != null) {
-        try {
-          sentryId = await item.client.captureException(
-            throwable,
-            stackTrace: stackTrace,
-            scope: item.scope,
-            hint: hint,
-          );
-        } catch (err) {
-          _options.logger(
-            SentryLevel.error,
-            'Error while capturing exception : $throwable',
-          );
-        } finally {
-          _lastEventId = sentryId;
-        }
-      } else {
-        _options.logger(
-          SentryLevel.fatal,
-          'Stack peek was null when captureException',
+
+      try {
+        sentryId = await item.client.captureException(
+          throwable,
+          stackTrace: stackTrace,
+          scope: item.scope,
+          hint: hint,
         );
+      } catch (err) {
+        _options.logger(
+          SentryLevel.error,
+          'Error while capturing exception : $throwable',
+        );
+      } finally {
+        _lastEventId = sentryId;
       }
     }
 
@@ -159,29 +148,23 @@ class Hub {
       );
     } else {
       final item = _peek();
-      if (item != null) {
-        try {
-          sentryId = await item.client.captureMessage(
-            message,
-            level: level,
-            template: template,
-            params: params,
-            scope: item.scope,
-            hint: hint,
-          );
-        } catch (err) {
-          _options.logger(
-            SentryLevel.error,
-            'Error while capturing message with id: $message',
-          );
-        } finally {
-          _lastEventId = sentryId;
-        }
-      } else {
-        _options.logger(
-          SentryLevel.fatal,
-          'Stack peek was null when captureMessage',
+
+      try {
+        sentryId = await item.client.captureMessage(
+          message,
+          level: level,
+          template: template,
+          params: params,
+          scope: item.scope,
+          hint: hint,
         );
+      } catch (err) {
+        _options.logger(
+          SentryLevel.error,
+          'Error while capturing message with id: $message',
+        );
+      } finally {
+        _lastEventId = sentryId;
       }
     }
     return sentryId;
@@ -196,14 +179,7 @@ class Hub {
       );
     } else {
       final item = _peek();
-      if (item != null) {
-        item.scope.addBreadcrumb(crumb, hint: hint);
-      } else {
-        _options.logger(
-          SentryLevel.fatal,
-          'Stack peek was null when addBreadcrumb',
-        );
-      }
+      item.scope.addBreadcrumb(crumb, hint: hint);
     }
   }
 
@@ -214,15 +190,8 @@ class Hub {
           "Instance is disabled and this 'bindClient' call is a no-op.");
     } else {
       final item = _peek();
-      if (item != null) {
-        _options.logger(SentryLevel.debug, 'New client bound to scope.');
-        item.client = client;
-      } else {
-        _options.logger(
-          SentryLevel.fatal,
-          'Stack peek was null when bindClient',
-        );
-      }
+      _options.logger(SentryLevel.debug, 'New client bound to scope.');
+      item.client = client;
     }
   }
 
@@ -252,21 +221,15 @@ class Hub {
       }
 
       final item = _peek();
-      if (item != null) {
-        try {
-          item.client.close();
-        } catch (err) {
-          _options.logger(
-            SentryLevel.error,
-            'Error while closing the Hub.',
-          );
-        }
-      } else {
+      try {
+        item.client.close();
+      } catch (err) {
         _options.logger(
-          SentryLevel.fatal,
-          'Stack peek was NULL when closing Hub',
+          SentryLevel.error,
+          'Error while closing the Hub.',
         );
       }
+
       _isEnabled = false;
     }
   }
@@ -280,19 +243,13 @@ class Hub {
       );
     } else {
       final item = _peek();
-      if (item != null) {
-        try {
-          callback(item.scope);
-        } catch (err) {
-          _options.logger(
-            SentryLevel.error,
-            "Error in the 'configureScope' callback.",
-          );
-        }
-      } else {
+
+      try {
+        callback(item.scope);
+      } catch (err) {
         _options.logger(
-          SentryLevel.fatal,
-          'Stack peek was NULL when configureScope',
+          SentryLevel.error,
+          "Error in the 'configureScope' callback.",
         );
       }
     }

--- a/dart/lib/src/hub.dart
+++ b/dart/lib/src/hub.dart
@@ -24,6 +24,7 @@ class Hub {
   final SentryOptions _options;
 
   factory Hub(SentryOptions options) {
+    assert(options != null, 'SentryOptions is required.');
     _validateOptions(options);
 
     return Hub._(options);
@@ -35,10 +36,6 @@ class Hub {
   }
 
   static void _validateOptions(SentryOptions options) {
-    if (options == null) {
-      throw ArgumentError('SentryOptions is required.');
-    }
-
     if (options.dsn?.isNotEmpty != true) {
       throw ArgumentError('DSN is required.');
     }

--- a/dart/lib/src/hub.dart
+++ b/dart/lib/src/hub.dart
@@ -219,7 +219,7 @@ class Hub {
   }
 
   /// Binds a different client to the hub
-  void bindClient(SentryClient client) {
+  void bindClient(SentryClient? client) {
     if (!_isEnabled) {
       _options.logger(SentryLevel.warning,
           "Instance is disabled and this 'bindClient' call is a no-op.");

--- a/dart/lib/src/hub.dart
+++ b/dart/lib/src/hub.dart
@@ -98,9 +98,9 @@ class Hub {
 
   /// Captures the exception
   Future<SentryId> captureException(
-    dynamic /*?*/ throwable, {
-    dynamic /*?*/ stackTrace,
-    dynamic /*?*/ hint,
+    dynamic throwable, {
+    dynamic stackTrace,
+    dynamic hint,
   }) async {
     var sentryId = SentryId.empty();
 

--- a/dart/lib/src/hub.dart
+++ b/dart/lib/src/hub.dart
@@ -35,7 +35,7 @@ class Hub {
   }
 
   static void _validateOptions(SentryOptions options) {
-    if (options.dsn.isEmpty) {
+    if (options.dsn == null) {
       throw ArgumentError('DSN is required.');
     }
   }
@@ -52,7 +52,7 @@ class Hub {
 
   /// Captures the event.
   Future<SentryId> captureEvent(
-    SentryEvent? event, {
+    SentryEvent event, {
     dynamic stackTrace,
     dynamic hint,
   }) async {
@@ -62,11 +62,6 @@ class Hub {
       _options.logger(
         SentryLevel.warning,
         "Instance is disabled and this 'captureEvent' call is a no-op.",
-      );
-    } else if (event == null) {
-      _options.logger(
-        SentryLevel.warning,
-        'captureEvent called with null parameter.',
       );
     } else {
       final item = _peek();
@@ -194,16 +189,11 @@ class Hub {
   }
 
   /// Adds a breacrumb to the current Scope
-  void addBreadcrumb(Breadcrumb? crumb, {dynamic hint}) {
+  void addBreadcrumb(Breadcrumb crumb, {dynamic hint}) {
     if (!_isEnabled) {
       _options.logger(
         SentryLevel.warning,
         "Instance is disabled and this 'addBreadcrumb' call is a no-op.",
-      );
-    } else if (crumb == null) {
-      _options.logger(
-        SentryLevel.warning,
-        'addBreadcrumb called with null parameter.',
       );
     } else {
       final item = _peek();
@@ -219,20 +209,15 @@ class Hub {
   }
 
   /// Binds a different client to the hub
-  void bindClient(SentryClient? client) {
+  void bindClient(SentryClient client) {
     if (!_isEnabled) {
       _options.logger(SentryLevel.warning,
           "Instance is disabled and this 'bindClient' call is a no-op.");
     } else {
       final item = _peek();
       if (item != null) {
-        if (client != null) {
-          _options.logger(SentryLevel.debug, 'New client bound to scope.');
-          item.client = client;
-        } else {
-          _options.logger(SentryLevel.debug, 'NoOp client bound to scope.');
-          item.client = NoOpSentryClient();
-        }
+        _options.logger(SentryLevel.debug, 'New client bound to scope.');
+        item.client = client;
       } else {
         _options.logger(
           SentryLevel.fatal,

--- a/dart/lib/src/hub.dart
+++ b/dart/lib/src/hub.dart
@@ -53,7 +53,7 @@ class Hub {
 
   /// Captures the event.
   Future<SentryId> captureEvent(
-    SentryEvent event, {
+    SentryEvent /*?*/ event, {
     dynamic stackTrace,
     dynamic hint,
   }) async {
@@ -99,9 +99,9 @@ class Hub {
 
   /// Captures the exception
   Future<SentryId> captureException(
-    dynamic throwable, {
-    dynamic stackTrace,
-    dynamic hint,
+    dynamic /*?*/ throwable, {
+    dynamic /*?*/ stackTrace,
+    dynamic /*?*/ hint,
   }) async {
     var sentryId = SentryId.empty();
 
@@ -146,7 +146,7 @@ class Hub {
 
   /// Captures the message.
   Future<SentryId> captureMessage(
-    String message, {
+    String /*?*/ message, {
     SentryLevel level = SentryLevel.info,
     String template,
     List<dynamic> params,
@@ -195,7 +195,7 @@ class Hub {
   }
 
   /// Adds a breacrumb to the current Scope
-  void addBreadcrumb(Breadcrumb crumb, {dynamic hint}) {
+  void addBreadcrumb(Breadcrumb /*?*/ crumb, {dynamic hint}) {
     if (!_isEnabled) {
       _options.logger(
         SentryLevel.warning,

--- a/dart/lib/src/hub.dart
+++ b/dart/lib/src/hub.dart
@@ -19,12 +19,11 @@ class Hub {
   final ListQueue<_StackItem> _stack = ListQueue();
 
   /// if stack is empty, it throws IterableElementError.noElement()
-  _StackItem _peek() => _stack.isNotEmpty ? _stack.first : null;
+  _StackItem? _peek() => _stack.isNotEmpty ? _stack.first : null;
 
   final SentryOptions _options;
 
   factory Hub(SentryOptions options) {
-    assert(options != null, 'SentryOptions is required.');
     _validateOptions(options);
 
     return Hub._(options);
@@ -36,7 +35,7 @@ class Hub {
   }
 
   static void _validateOptions(SentryOptions options) {
-    if (options.dsn?.isNotEmpty != true) {
+    if (options.dsn.isEmpty) {
       throw ArgumentError('DSN is required.');
     }
   }
@@ -53,7 +52,7 @@ class Hub {
 
   /// Captures the event.
   Future<SentryId> captureEvent(
-    SentryEvent /*?*/ event, {
+    SentryEvent? event, {
     dynamic stackTrace,
     dynamic hint,
   }) async {
@@ -146,10 +145,10 @@ class Hub {
 
   /// Captures the message.
   Future<SentryId> captureMessage(
-    String /*?*/ message, {
-    SentryLevel level = SentryLevel.info,
-    String template,
-    List<dynamic> params,
+    String? message, {
+    SentryLevel? level = SentryLevel.info,
+    String? template,
+    List<dynamic>? params,
     dynamic hint,
   }) async {
     var sentryId = SentryId.empty();
@@ -195,7 +194,7 @@ class Hub {
   }
 
   /// Adds a breacrumb to the current Scope
-  void addBreadcrumb(Breadcrumb /*?*/ crumb, {dynamic hint}) {
+  void addBreadcrumb(Breadcrumb? crumb, {dynamic hint}) {
     if (!_isEnabled) {
       _options.logger(
         SentryLevel.warning,

--- a/dart/lib/src/hub.dart
+++ b/dart/lib/src/hub.dart
@@ -129,7 +129,7 @@ class Hub {
   /// Captures the message.
   Future<SentryId> captureMessage(
     String? message, {
-    SentryLevel level = SentryLevel.info,
+    SentryLevel? level = SentryLevel.info,
     String? template,
     List<dynamic>? params,
     dynamic hint,

--- a/dart/lib/src/hub.dart
+++ b/dart/lib/src/hub.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:collection';
 
-import 'noop_sentry_client.dart';
 import 'protocol.dart';
 import 'scope.dart';
 import 'sentry_client.dart';

--- a/dart/lib/src/hub.dart
+++ b/dart/lib/src/hub.dart
@@ -146,7 +146,7 @@ class Hub {
   /// Captures the message.
   Future<SentryId> captureMessage(
     String? message, {
-    SentryLevel? level = SentryLevel.info,
+    SentryLevel level = SentryLevel.info,
     String? template,
     List<dynamic>? params,
     dynamic hint,

--- a/dart/lib/src/hub_adapter.dart
+++ b/dart/lib/src/hub_adapter.dart
@@ -49,7 +49,7 @@ class HubAdapter implements Hub {
   @override
   Future<SentryId> captureMessage(
     String? message, {
-    SentryLevel? level = SentryLevel.info,
+    SentryLevel? level,
     String? template,
     List? params,
     dynamic hint,

--- a/dart/lib/src/hub_adapter.dart
+++ b/dart/lib/src/hub_adapter.dart
@@ -16,7 +16,7 @@ class HubAdapter implements Hub {
   }
 
   @override
-  void addBreadcrumb(Breadcrumb crumb, {dynamic hint}) =>
+  void addBreadcrumb(Breadcrumb? crumb, {dynamic hint}) =>
       Sentry.addBreadcrumb(crumb, hint: hint);
 
   @override
@@ -24,7 +24,7 @@ class HubAdapter implements Hub {
 
   @override
   Future<SentryId> captureEvent(
-    SentryEvent event, {
+    SentryEvent? event, {
     dynamic stackTrace,
     dynamic hint,
   }) =>
@@ -48,10 +48,10 @@ class HubAdapter implements Hub {
 
   @override
   Future<SentryId> captureMessage(
-    String message, {
-    SentryLevel level = SentryLevel.info,
-    String template,
-    List params,
+    String? message, {
+    SentryLevel? level = SentryLevel.info,
+    String? template,
+    List? params,
     dynamic hint,
   }) =>
       Sentry.captureMessage(

--- a/dart/lib/src/hub_adapter.dart
+++ b/dart/lib/src/hub_adapter.dart
@@ -49,7 +49,7 @@ class HubAdapter implements Hub {
   @override
   Future<SentryId> captureMessage(
     String? message, {
-    SentryLevel level = SentryLevel.info,
+    SentryLevel? level = SentryLevel.info,
     String? template,
     List? params,
     dynamic hint,

--- a/dart/lib/src/hub_adapter.dart
+++ b/dart/lib/src/hub_adapter.dart
@@ -49,7 +49,7 @@ class HubAdapter implements Hub {
   @override
   Future<SentryId> captureMessage(
     String? message, {
-    SentryLevel level,
+    SentryLevel level = SentryLevel.info,
     String? template,
     List? params,
     dynamic hint,

--- a/dart/lib/src/hub_adapter.dart
+++ b/dart/lib/src/hub_adapter.dart
@@ -20,7 +20,7 @@ class HubAdapter implements Hub {
       Sentry.addBreadcrumb(crumb, hint: hint);
 
   @override
-  void bindClient(SentryClient client) => Sentry.bindClient(client);
+  void bindClient(SentryClient? client) => Sentry.bindClient(client);
 
   @override
   Future<SentryId> captureEvent(

--- a/dart/lib/src/hub_adapter.dart
+++ b/dart/lib/src/hub_adapter.dart
@@ -49,7 +49,7 @@ class HubAdapter implements Hub {
   @override
   Future<SentryId> captureMessage(
     String? message, {
-    SentryLevel? level = SentryLevel.info,
+    SentryLevel level = SentryLevel.info,
     String? template,
     List? params,
     dynamic hint,

--- a/dart/lib/src/hub_adapter.dart
+++ b/dart/lib/src/hub_adapter.dart
@@ -16,15 +16,15 @@ class HubAdapter implements Hub {
   }
 
   @override
-  void addBreadcrumb(Breadcrumb? crumb, {dynamic hint}) =>
+  void addBreadcrumb(Breadcrumb crumb, {dynamic hint}) =>
       Sentry.addBreadcrumb(crumb, hint: hint);
 
   @override
-  void bindClient(SentryClient? client) => Sentry.bindClient(client);
+  void bindClient(SentryClient client) => Sentry.bindClient(client);
 
   @override
   Future<SentryId> captureEvent(
-    SentryEvent? event, {
+    SentryEvent event, {
     dynamic stackTrace,
     dynamic hint,
   }) =>

--- a/dart/lib/src/isolate_error_integration.dart
+++ b/dart/lib/src/isolate_error_integration.dart
@@ -37,7 +37,6 @@ RawReceivePort _createPort(Hub hub, SentryOptions options) {
 }
 
 /// Parse and raise an event out of the Isolate error.
-@internal
 @visibleForTesting
 Future<void> handleIsolateError(
   Hub hub,

--- a/dart/lib/src/isolate_error_integration.dart
+++ b/dart/lib/src/isolate_error_integration.dart
@@ -37,6 +37,7 @@ RawReceivePort _createPort(Hub hub, SentryOptions options) {
 }
 
 /// Parse and raise an event out of the Isolate error.
+@internal
 @visibleForTesting
 Future<void> handleIsolateError(
   Hub hub,

--- a/dart/lib/src/isolate_error_integration.dart
+++ b/dart/lib/src/isolate_error_integration.dart
@@ -10,7 +10,7 @@ import 'sentry_options.dart';
 import 'throwable_mechanism.dart';
 
 class IsolateErrorIntegration extends Integration {
-  RawReceivePort _receivePort;
+  late RawReceivePort _receivePort;
 
   @override
   FutureOr<void> call(Hub hub, SentryOptions options) async {

--- a/dart/lib/src/noop_client.dart
+++ b/dart/lib/src/noop_client.dart
@@ -24,38 +24,38 @@ class NoOpClient implements Client {
   @override
   Future<Response> delete(
     Uri url, {
-    Map<String, String> headers,
-    Object body,
-    Encoding encoding,
+    Map<String, String>? headers,
+    Object? body,
+    Encoding? encoding,
   }) =>
       _response;
 
   @override
-  Future<Response> get(url, {Map<String, String> headers}) => _response;
+  Future<Response> get(url, {Map<String, String>? headers}) => _response;
 
   @override
-  Future<Response> head(url, {Map<String, String> headers}) => _response;
+  Future<Response> head(url, {Map<String, String>? headers}) => _response;
 
   @override
   Future<Response> patch(url,
-          {Map<String, String> headers, body, Encoding encoding}) =>
+          {Map<String, String>? headers, body, Encoding? encoding}) =>
       _response;
 
   @override
   Future<Response> post(url,
-          {Map<String, String> headers, body, Encoding encoding}) =>
+          {Map<String, String>? headers, body, Encoding? encoding}) =>
       _response;
 
   @override
   Future<Response> put(url,
-          {Map<String, String> headers, body, Encoding encoding}) =>
+          {Map<String, String>? headers, body, Encoding? encoding}) =>
       _response;
 
   @override
-  Future<String> read(url, {Map<String, String> headers}) => _string;
+  Future<String> read(url, {Map<String, String>? headers}) => _string;
 
   @override
-  Future<Uint8List> readBytes(url, {Map<String, String> headers}) => _intList;
+  Future<Uint8List> readBytes(url, {Map<String, String>? headers}) => _intList;
 
   @override
   Future<StreamedResponse> send(BaseRequest request) => _streamedResponse;

--- a/dart/lib/src/noop_client.dart
+++ b/dart/lib/src/noop_client.dart
@@ -22,7 +22,13 @@ class NoOpClient implements Client {
   void close() {}
 
   @override
-  Future<Response> delete(url, {Map<String, String> headers}) => _response;
+  Future<Response> delete(
+    Uri url, {
+    Map<String, String> headers,
+    Object body,
+    Encoding encoding,
+  }) =>
+      _response;
 
   @override
   Future<Response> get(url, {Map<String, String> headers}) => _response;

--- a/dart/lib/src/noop_hub.dart
+++ b/dart/lib/src/noop_hub.dart
@@ -18,7 +18,7 @@ class NoOpHub implements Hub {
 
   @override
   Future<SentryId> captureEvent(
-    SentryEvent event, {
+    SentryEvent? event, {
     dynamic stackTrace,
     dynamic hint,
   }) =>
@@ -34,10 +34,10 @@ class NoOpHub implements Hub {
 
   @override
   Future<SentryId> captureMessage(
-    String message, {
-    SentryLevel level = SentryLevel.info,
-    String template,
-    List params,
+    String? message, {
+    SentryLevel? level = SentryLevel.info,
+    String? template,
+    List? params,
     dynamic hint,
   }) =>
       Future.value(SentryId.empty());
@@ -58,5 +58,5 @@ class NoOpHub implements Hub {
   SentryId get lastEventId => SentryId.empty();
 
   @override
-  void addBreadcrumb(Breadcrumb crumb, {dynamic hint}) {}
+  void addBreadcrumb(Breadcrumb? crumb, {dynamic hint}) {}
 }

--- a/dart/lib/src/noop_hub.dart
+++ b/dart/lib/src/noop_hub.dart
@@ -14,7 +14,7 @@ class NoOpHub implements Hub {
   }
 
   @override
-  void bindClient(SentryClient client) {}
+  void bindClient(SentryClient? client) {}
 
   @override
   Future<SentryId> captureEvent(

--- a/dart/lib/src/noop_hub.dart
+++ b/dart/lib/src/noop_hub.dart
@@ -58,5 +58,5 @@ class NoOpHub implements Hub {
   SentryId get lastEventId => SentryId.empty();
 
   @override
-  void addBreadcrumb(Breadcrumb? crumb, {dynamic hint}) {}
+  void addBreadcrumb(Breadcrumb crumb, {dynamic hint}) {}
 }

--- a/dart/lib/src/noop_hub.dart
+++ b/dart/lib/src/noop_hub.dart
@@ -14,11 +14,11 @@ class NoOpHub implements Hub {
   }
 
   @override
-  void bindClient(SentryClient? client) {}
+  void bindClient(SentryClient client) {}
 
   @override
   Future<SentryId> captureEvent(
-    SentryEvent? event, {
+    SentryEvent event, {
     dynamic stackTrace,
     dynamic hint,
   }) =>

--- a/dart/lib/src/noop_sentry_client.dart
+++ b/dart/lib/src/noop_sentry_client.dart
@@ -17,7 +17,7 @@ class NoOpSentryClient implements SentryClient {
   Future<SentryId> captureEvent(
     SentryEvent event, {
     dynamic stackTrace,
-    Scope scope,
+    Scope? scope,
     dynamic hint,
   }) =>
       Future.value(SentryId.empty());
@@ -26,18 +26,18 @@ class NoOpSentryClient implements SentryClient {
   Future<SentryId> captureException(
     dynamic exception, {
     dynamic stackTrace,
-    Scope scope,
+    Scope? scope,
     dynamic hint,
   }) =>
       Future.value(SentryId.empty());
 
   @override
   Future<SentryId> captureMessage(
-    String message, {
-    SentryLevel level = SentryLevel.info,
-    String template,
-    List<dynamic> params,
-    Scope scope,
+    String? message, {
+    SentryLevel? level = SentryLevel.info,
+    String? template,
+    List<dynamic>? params,
+    Scope? scope,
     dynamic hint,
   }) =>
       Future.value(SentryId.empty());

--- a/dart/lib/src/platform_checker.dart
+++ b/dart/lib/src/platform_checker.dart
@@ -4,17 +4,17 @@ class PlatformChecker {
   const PlatformChecker();
 
   /// Check if running in release/production environment
-  bool/*!*/ isReleaseMode() {
+  bool isReleaseMode() {
     return const bool.fromEnvironment('dart.vm.product', defaultValue: false);
   }
 
   /// Check if running in debug environment
-  bool/*!*/ isDebugMode() {
+  bool isDebugMode() {
     return !isReleaseMode() && !isProfileMode();
   }
 
   /// Check if running in profile environment
-  bool/*!*/ isProfileMode() {
+  bool isProfileMode() {
     return const bool.fromEnvironment('dart.vm.profile', defaultValue: false);
   }
 }

--- a/dart/lib/src/platform_checker.dart
+++ b/dart/lib/src/platform_checker.dart
@@ -4,17 +4,17 @@ class PlatformChecker {
   const PlatformChecker();
 
   /// Check if running in release/production environment
-  bool isReleaseMode() {
+  bool/*!*/ isReleaseMode() {
     return const bool.fromEnvironment('dart.vm.product', defaultValue: false);
   }
 
   /// Check if running in debug environment
-  bool isDebugMode() {
+  bool/*!*/ isDebugMode() {
     return !isReleaseMode() && !isProfileMode();
   }
 
   /// Check if running in profile environment
-  bool isProfileMode() {
+  bool/*!*/ isProfileMode() {
     return const bool.fromEnvironment('dart.vm.profile', defaultValue: false);
   }
 }

--- a/dart/lib/src/protocol/app.dart
+++ b/dart/lib/src/protocol/app.dart
@@ -53,26 +53,26 @@ class App {
 
   /// Produces a [Map] that can be serialized to JSON.
   Map<String, dynamic> toJson() {
-    final json = <String, String?>{};
+    final json = <String, String>{};
 
     if (name != null) {
-      json['app_name'] = name;
+      json['app_name'] = name!;
     }
 
     if (version != null) {
-      json['app_version'] = version;
+      json['app_version'] = version!;
     }
 
     if (identifier != null) {
-      json['app_identifier'] = identifier;
+      json['app_identifier'] = identifier!;
     }
 
     if (build != null) {
-      json['app_build'] = build;
+      json['app_build'] = build!;
     }
 
     if (buildType != null) {
-      json['build_type'] = buildType;
+      json['build_type'] = buildType!;
     }
 
     if (startTime != null) {
@@ -80,7 +80,7 @@ class App {
     }
 
     if (deviceAppHash != null) {
-      json['device_app_hash'] = deviceAppHash;
+      json['device_app_hash'] = deviceAppHash!;
     }
 
     return json;

--- a/dart/lib/src/protocol/app.dart
+++ b/dart/lib/src/protocol/app.dart
@@ -31,29 +31,29 @@ class App {
       );
 
   /// Human readable application name, as it appears on the platform.
-  final String name;
+  final String? name;
 
   /// Human readable application version, as it appears on the platform.
-  final String version;
+  final String? version;
 
   /// Version-independent application identifier, often a dotted bundle ID.
-  final String identifier;
+  final String? identifier;
 
   /// Internal build identifier, as it appears on the platform.
-  final String build;
+  final String? build;
 
   /// String identifying the kind of build, e.g. `testflight`.
-  final String buildType;
+  final String? buildType;
 
   /// When the application was started by the user.
-  final DateTime startTime;
+  final DateTime? startTime;
 
   /// Application specific device identifier.
-  final String deviceAppHash;
+  final String? deviceAppHash;
 
   /// Produces a [Map] that can be serialized to JSON.
   Map<String, dynamic> toJson() {
-    final json = <String, String>{};
+    final json = <String, String?>{};
 
     if (name != null) {
       json['app_name'] = name;
@@ -76,7 +76,7 @@ class App {
     }
 
     if (startTime != null) {
-      json['app_start_time'] = startTime.toIso8601String();
+      json['app_start_time'] = startTime!.toIso8601String();
     }
 
     if (deviceAppHash != null) {
@@ -97,13 +97,13 @@ class App {
       );
 
   App copyWith({
-    String name,
-    String version,
-    String identifier,
-    String build,
-    String buildType,
-    DateTime startTime,
-    String deviceAppHash,
+    String? name,
+    String? version,
+    String? identifier,
+    String? build,
+    String? buildType,
+    DateTime? startTime,
+    String? deviceAppHash,
   }) =>
       App(
         name: name ?? this.name,

--- a/dart/lib/src/protocol/breadcrumb.dart
+++ b/dart/lib/src/protocol/breadcrumb.dart
@@ -24,7 +24,7 @@ class Breadcrumb {
   /// Creates a breadcrumb that can be attached to an [Event].
   Breadcrumb({
     this.message,
-    DateTime timestamp,
+    DateTime? timestamp,
     this.category,
     this.data,
     this.level = SentryLevel.info,
@@ -34,12 +34,12 @@ class Breadcrumb {
   /// Describes the breadcrumb.
   ///
   /// This field is optional and may be set to null.
-  final String message;
+  final String? message;
 
   /// A dot-separated string describing the source of the breadcrumb, e.g. "ui.click".
   ///
   /// This field is optional and may be set to null.
-  final String category;
+  final String? category;
 
   /// Data associated with the breadcrumb.
   ///
@@ -50,7 +50,7 @@ class Breadcrumb {
   /// See also:
   ///
   /// * https://docs.sentry.io/development/sdk-dev/event-payloads/breadcrumbs/#breadcrumb-types
-  final Map<String, dynamic> data;
+  final Map<String, dynamic>? data;
 
   /// Severity of the breadcrumb.
   ///
@@ -66,7 +66,7 @@ class Breadcrumb {
   /// See also:
   ///
   /// * https://docs.sentry.io/development/sdk-dev/event-payloads/breadcrumbs/#breadcrumb-types
-  final String type;
+  final String? type;
 
   /// The time the breadcrumb was recorded.
   ///
@@ -87,7 +87,7 @@ class Breadcrumb {
     if (category != null) {
       json['category'] = category;
     }
-    if (data != null && data.isNotEmpty) {
+    if (data != null && data!.isNotEmpty) {
       json['data'] = data;
     }
     if (level != null) {
@@ -100,12 +100,12 @@ class Breadcrumb {
   }
 
   Breadcrumb copyWith({
-    String message,
-    String category,
-    Map<String, dynamic> data,
-    SentryLevel level,
-    String type,
-    DateTime timestamp,
+    String? message,
+    String? category,
+    Map<String, dynamic>? data,
+    SentryLevel? level,
+    String? type,
+    DateTime? timestamp,
   }) =>
       Breadcrumb(
         message: message ?? this.message,

--- a/dart/lib/src/protocol/breadcrumb.dart
+++ b/dart/lib/src/protocol/breadcrumb.dart
@@ -26,10 +26,11 @@ class Breadcrumb {
     this.message,
     DateTime? timestamp,
     this.category,
-    this.data,
+    Map<String, dynamic>? data,
     this.level = SentryLevel.info,
     this.type,
-  }) : timestamp = timestamp ?? getUtcDateTime();
+  })  : timestamp = timestamp ?? getUtcDateTime(),
+        data = data ?? <String, dynamic>{};
 
   /// Describes the breadcrumb.
   ///
@@ -50,12 +51,12 @@ class Breadcrumb {
   /// See also:
   ///
   /// * https://docs.sentry.io/development/sdk-dev/event-payloads/breadcrumbs/#breadcrumb-types
-  final Map<String, dynamic>? data;
+  final Map<String, dynamic> data;
 
   /// Severity of the breadcrumb.
   ///
   /// This field is optional and may be set to null.
-  final SentryLevel level;
+  final SentryLevel? level;
 
   /// Describes what type of breadcrumb this is.
   ///
@@ -87,11 +88,12 @@ class Breadcrumb {
     if (category != null) {
       json['category'] = category;
     }
-    if (data?.isNotEmpty ?? false) {
+    if (data.isNotEmpty) {
       json['data'] = data;
     }
-
-    json['level'] = level.name;
+    if (level != null) {
+      json['level'] = level!.name;
+    }
 
     if (type != null) {
       json['type'] = type;

--- a/dart/lib/src/protocol/breadcrumb.dart
+++ b/dart/lib/src/protocol/breadcrumb.dart
@@ -87,7 +87,7 @@ class Breadcrumb {
     if (category != null) {
       json['category'] = category;
     }
-    if (data != null && data!.isNotEmpty) {
+    if (data?.isNotEmpty ?? false) {
       json['data'] = data;
     }
 

--- a/dart/lib/src/protocol/breadcrumb.dart
+++ b/dart/lib/src/protocol/breadcrumb.dart
@@ -90,9 +90,9 @@ class Breadcrumb {
     if (data != null && data!.isNotEmpty) {
       json['data'] = data;
     }
-    if (level != null) {
-      json['level'] = level.name;
-    }
+
+    json['level'] = level.name;
+
     if (type != null) {
       json['type'] = type;
     }

--- a/dart/lib/src/protocol/breadcrumb.dart
+++ b/dart/lib/src/protocol/breadcrumb.dart
@@ -26,11 +26,10 @@ class Breadcrumb {
     this.message,
     DateTime? timestamp,
     this.category,
-    Map<String, dynamic>? data,
+    this.data,
     this.level = SentryLevel.info,
     this.type,
-  })  : timestamp = timestamp ?? getUtcDateTime(),
-        data = data ?? <String, dynamic>{};
+  }) : timestamp = timestamp ?? getUtcDateTime();
 
   /// Describes the breadcrumb.
   ///
@@ -51,7 +50,7 @@ class Breadcrumb {
   /// See also:
   ///
   /// * https://docs.sentry.io/development/sdk-dev/event-payloads/breadcrumbs/#breadcrumb-types
-  final Map<String, dynamic> data;
+  final Map<String, dynamic>? data;
 
   /// Severity of the breadcrumb.
   ///
@@ -88,7 +87,7 @@ class Breadcrumb {
     if (category != null) {
       json['category'] = category;
     }
-    if (data.isNotEmpty) {
+    if (data?.isNotEmpty ?? false) {
       json['data'] = data;
     }
     if (level != null) {

--- a/dart/lib/src/protocol/breadcrumb.dart
+++ b/dart/lib/src/protocol/breadcrumb.dart
@@ -81,6 +81,7 @@ class Breadcrumb {
     final json = <String, dynamic>{
       'timestamp': formatDateAsIso8601WithMillisPrecision(timestamp),
     };
+
     if (message != null) {
       json['message'] = message;
     }

--- a/dart/lib/src/protocol/breadcrumb.dart
+++ b/dart/lib/src/protocol/breadcrumb.dart
@@ -27,7 +27,7 @@ class Breadcrumb {
     DateTime? timestamp,
     this.category,
     this.data,
-    SentryLevel level,
+    SentryLevel? level,
     this.type,
   })  : timestamp = timestamp ?? getUtcDateTime(),
         level = level ?? SentryLevel.info;

--- a/dart/lib/src/protocol/browser.dart
+++ b/dart/lib/src/protocol/browser.dart
@@ -17,10 +17,10 @@ class Browser {
       );
 
   /// Human readable application name, as it appears on the platform.
-  final String name;
+  final String? name;
 
   /// Human readable application version, as it appears on the platform.
-  final String version;
+  final String? version;
 
   /// Produces a [Map] that can be serialized to JSON.
   Map<String, dynamic> toJson() {
@@ -40,8 +40,8 @@ class Browser {
   Browser clone() => Browser(name: name, version: version);
 
   Browser copyWith({
-    String name,
-    String version,
+    String? name,
+    String? version,
   }) =>
       Browser(
         name: name ?? this.name,

--- a/dart/lib/src/protocol/contexts.dart
+++ b/dart/lib/src/protocol/contexts.dart
@@ -10,12 +10,12 @@ import '../protocol.dart';
 /// See also: https://develop.sentry.dev/sdk/event-payloads/contexts/.
 class Contexts extends MapView<String, dynamic> {
   Contexts({
-    Device device,
-    OperatingSystem operatingSystem,
-    List<SentryRuntime> runtimes,
-    App app,
-    Browser browser,
-    Gpu gpu,
+    Device? device,
+    OperatingSystem? operatingSystem,
+    List<SentryRuntime>? runtimes,
+    App? app,
+    Browser? browser,
+    Gpu? gpu,
   }) : super({
           Device.type: device,
           OperatingSystem.type: operatingSystem,
@@ -60,17 +60,17 @@ class Contexts extends MapView<String, dynamic> {
   }
 
   /// This describes the device that caused the event.
-  Device/*?*/ get device => this[Device.type];
+  Device? get device => this[Device.type];
 
-  set device(Device device) => this[Device.type] = device;
+  set device(Device? device) => this[Device.type] = device;
 
   /// Describes the operating system on which the event was created.
   ///
   /// In web contexts, this is the operating system of the browse
   /// (normally pulled from the User-Agent string).
-  OperatingSystem/*?*/ get operatingSystem => this[OperatingSystem.type];
+  OperatingSystem? get operatingSystem => this[OperatingSystem.type];
 
-  set operatingSystem(OperatingSystem operatingSystem) =>
+  set operatingSystem(OperatingSystem? operatingSystem) =>
       this[OperatingSystem.type] = operatingSystem;
 
   /// Describes an immutable list of runtimes in more detail
@@ -89,23 +89,23 @@ class Contexts extends MapView<String, dynamic> {
   ///
   /// As opposed to the runtime, this is the actual application that was
   /// running and carries metadata about the current session.
-  App/*?*/ get app => this[App.type];
+  App? get app => this[App.type];
 
-  set app(App app) => this[App.type] = app;
+  set app(App? app) => this[App.type] = app;
 
   /// Carries information about the browser or user agent for web-related
   /// errors.
   ///
   /// This can either be the browser this event ocurred in, or the user
   /// agent of a web request that triggered the event.
-  Browser/*?*/ get browser => this[Browser.type];
+  Browser? get browser => this[Browser.type];
 
-  set browser(Browser browser) => this[Browser.type] = browser;
+  set browser(Browser? browser) => this[Browser.type] = browser;
 
   /// GPU context describes the GPU of the device.
-  Gpu/*?*/ get gpu => this[Gpu.type];
+  Gpu? get gpu => this[Gpu.type];
 
-  set gpu(Gpu gpu) => this[Gpu.type] = gpu;
+  set gpu(Gpu? gpu) => this[Gpu.type] = gpu;
 
   /// Produces a [Map] that can be serialized to JSON.
   Map<String, dynamic> toJson() {
@@ -116,35 +116,35 @@ class Contexts extends MapView<String, dynamic> {
       switch (key) {
         case Device.type:
           Map<String, dynamic> deviceMap;
-          if (device != null && (deviceMap = device.toJson()).isNotEmpty) {
+          if (device != null && (deviceMap = device!.toJson()).isNotEmpty) {
             json[Device.type] = deviceMap;
           }
           break;
         case OperatingSystem.type:
           Map<String, dynamic> osMap;
           if (operatingSystem != null &&
-              (osMap = operatingSystem.toJson()).isNotEmpty) {
+              (osMap = operatingSystem!.toJson()).isNotEmpty) {
             json[OperatingSystem.type] = osMap;
           }
           break;
 
         case App.type:
           Map<String, dynamic> appMap;
-          if (app != null && (appMap = app.toJson()).isNotEmpty) {
+          if (app != null && (appMap = app!.toJson()).isNotEmpty) {
             json[App.type] = appMap;
           }
           break;
 
         case Browser.type:
           Map<String, dynamic> browserMap;
-          if (browser != null && (browserMap = browser.toJson()).isNotEmpty) {
+          if (browser != null && (browserMap = browser!.toJson()).isNotEmpty) {
             json[Browser.type] = browserMap;
           }
           break;
 
         case Gpu.type:
           Map<String, dynamic> gpuMap;
-          if (gpu != null && (gpuMap = gpu.toJson()).isNotEmpty) {
+          if (gpu != null && (gpuMap = gpu!.toJson()).isNotEmpty) {
             json[Gpu.type] = gpuMap;
           }
           break;
@@ -165,7 +165,7 @@ class Contexts extends MapView<String, dynamic> {
                 Map<String, dynamic> runtimeMap;
                 if (runtime != null &&
                     (runtimeMap = runtime.toJson()).isNotEmpty) {
-                  var key = runtime.key ?? runtime.name.toLowerCase();
+                  var key = runtime.key ?? runtime.name!.toLowerCase();
 
                   if (json.containsKey(key)) {
                     var k = 0;
@@ -209,12 +209,12 @@ class Contexts extends MapView<String, dynamic> {
   }
 
   Contexts copyWith({
-    Device device,
-    OperatingSystem operatingSystem,
-    List<SentryRuntime> runtimes,
-    App app,
-    Browser browser,
-    Gpu gpu,
+    Device? device,
+    OperatingSystem? operatingSystem,
+    List<SentryRuntime>? runtimes,
+    App? app,
+    Browser? browser,
+    Gpu? gpu,
   }) =>
       Contexts(
         device: device ?? this.device,

--- a/dart/lib/src/protocol/contexts.dart
+++ b/dart/lib/src/protocol/contexts.dart
@@ -115,36 +115,35 @@ class Contexts extends MapView<String, dynamic> {
       if (value == null) return;
       switch (key) {
         case Device.type:
-          Map<String, dynamic> deviceMap;
-          if (device != null && (deviceMap = device!.toJson()).isNotEmpty) {
+          final deviceMap = device?.toJson();
+          if (deviceMap?.isNotEmpty ?? false) {
             json[Device.type] = deviceMap;
           }
           break;
         case OperatingSystem.type:
-          Map<String, dynamic> osMap;
-          if (operatingSystem != null &&
-              (osMap = operatingSystem!.toJson()).isNotEmpty) {
+          final osMap = operatingSystem?.toJson();
+          if (osMap?.isNotEmpty ?? false) {
             json[OperatingSystem.type] = osMap;
           }
           break;
 
         case App.type:
-          Map<String, dynamic> appMap;
-          if (app != null && (appMap = app!.toJson()).isNotEmpty) {
+          final appMap = app?.toJson();
+          if (appMap?.isNotEmpty ?? false) {
             json[App.type] = appMap;
           }
           break;
 
         case Browser.type:
-          Map<String, dynamic> browserMap;
-          if (browser != null && (browserMap = browser!.toJson()).isNotEmpty) {
+          final browserMap = browser?.toJson();
+          if (browserMap?.isNotEmpty ?? false) {
             json[Browser.type] = browserMap;
           }
           break;
 
         case Gpu.type:
-          Map<String, dynamic> gpuMap;
-          if (gpu != null && (gpuMap = gpu!.toJson()).isNotEmpty) {
+          final gpuMap = gpu?.toJson();
+          if (gpuMap?.isNotEmpty ?? false) {
             json[Gpu.type] = gpuMap;
           }
           break;

--- a/dart/lib/src/protocol/contexts.dart
+++ b/dart/lib/src/protocol/contexts.dart
@@ -28,27 +28,22 @@ class Contexts extends MapView<String, dynamic> {
   factory Contexts.fromJson(Map<String, dynamic> data) {
     final contexts = Contexts(
       device: data[Device.type] != null
-          ? Device.fromJson(Map<String, dynamic>.from(data[Device.type]))
+          ? Device.fromJson(Map.from(data[Device.type]))
           : null,
       operatingSystem: data[OperatingSystem.type] != null
-          ? OperatingSystem.fromJson(
-              Map<String, dynamic>.from(data[OperatingSystem.type]))
+          ? OperatingSystem.fromJson(Map.from(data[OperatingSystem.type]))
           : null,
       app: data[App.type] != null
-          ? App.fromJson(Map<String, dynamic>.from(data[App.type]))
+          ? App.fromJson(Map.from(data[App.type]))
           : null,
       browser: data[Browser.type] != null
-          ? Browser.fromJson(Map<String, dynamic>.from(data[Browser.type]))
+          ? Browser.fromJson(Map.from(data[Browser.type]))
           : null,
       gpu: data[Gpu.type] != null
-          ? Gpu.fromJson(Map<String, dynamic>.from(data[Gpu.type]))
+          ? Gpu.fromJson(Map.from(data[Gpu.type]))
           : null,
       runtimes: data[SentryRuntime.type] != null
-          ? [
-              SentryRuntime.fromJson(
-                Map<String, dynamic>.from(data[SentryRuntime.type]),
-              ),
-            ]
+          ? [SentryRuntime.fromJson(Map.from(data[SentryRuntime.type]))]
           : null,
     );
 

--- a/dart/lib/src/protocol/contexts.dart
+++ b/dart/lib/src/protocol/contexts.dart
@@ -77,7 +77,7 @@ class Contexts extends MapView<String, dynamic> {
   /// (for instance if you have a Flutter application running
   /// on top of Android).
   List<SentryRuntime> get runtimes =>
-      List.unmodifiable(this[SentryRuntime.listType]);
+      List.unmodifiable(this[SentryRuntime.listType] ?? []);
 
   void addRuntime(SentryRuntime runtime) =>
       this[SentryRuntime.listType].add(runtime);
@@ -150,33 +150,29 @@ class Contexts extends MapView<String, dynamic> {
           break;
 
         case SentryRuntime.listType:
-          if (runtimes != null) {
-            if (runtimes.length == 1) {
-              final runtime = runtimes[0];
-              Map<String, dynamic> runtimeMap;
-              if (runtime != null &&
-                  (runtimeMap = runtime.toJson()).isNotEmpty) {
-                final key = runtime.key ?? SentryRuntime.type;
+          if (runtimes.length == 1) {
+            final runtime = runtimes[0];
+            final runtimeMap = runtime.toJson();
+            if (runtimeMap.isNotEmpty) {
+              final key = runtime.key ?? SentryRuntime.type;
 
-                json[key] = runtimeMap;
-              }
-            } else if (runtimes.length > 1) {
-              for (final runtime in runtimes) {
-                Map<String, dynamic> runtimeMap;
-                if (runtime != null &&
-                    (runtimeMap = runtime.toJson()).isNotEmpty) {
-                  var key = runtime.key ?? runtime.name!.toLowerCase();
+              json[key] = runtimeMap;
+            }
+          } else if (runtimes.length > 1) {
+            for (final runtime in runtimes) {
+              final runtimeMap = runtime.toJson();
+              if (runtimeMap.isNotEmpty) {
+                var key = runtime.key ?? runtime.name!.toLowerCase();
 
-                  if (json.containsKey(key)) {
-                    var k = 0;
-                    while (json.containsKey(key)) {
-                      key = '$key$k';
-                      k++;
-                    }
+                if (json.containsKey(key)) {
+                  var k = 0;
+                  while (json.containsKey(key)) {
+                    key = '$key$k';
+                    k++;
                   }
-                  json[key] = runtimeMap
-                    ..addAll(<String, String>{'type': SentryRuntime.type});
                 }
+                json[key] = runtimeMap
+                  ..addAll(<String, String>{'type': SentryRuntime.type});
               }
             }
           }

--- a/dart/lib/src/protocol/contexts.dart
+++ b/dart/lib/src/protocol/contexts.dart
@@ -60,7 +60,7 @@ class Contexts extends MapView<String, dynamic> {
   }
 
   /// This describes the device that caused the event.
-  Device get device => this[Device.type];
+  Device/*?*/ get device => this[Device.type];
 
   set device(Device device) => this[Device.type] = device;
 
@@ -68,7 +68,7 @@ class Contexts extends MapView<String, dynamic> {
   ///
   /// In web contexts, this is the operating system of the browse
   /// (normally pulled from the User-Agent string).
-  OperatingSystem get operatingSystem => this[OperatingSystem.type];
+  OperatingSystem/*?*/ get operatingSystem => this[OperatingSystem.type];
 
   set operatingSystem(OperatingSystem operatingSystem) =>
       this[OperatingSystem.type] = operatingSystem;
@@ -89,7 +89,7 @@ class Contexts extends MapView<String, dynamic> {
   ///
   /// As opposed to the runtime, this is the actual application that was
   /// running and carries metadata about the current session.
-  App get app => this[App.type];
+  App/*?*/ get app => this[App.type];
 
   set app(App app) => this[App.type] = app;
 
@@ -98,12 +98,12 @@ class Contexts extends MapView<String, dynamic> {
   ///
   /// This can either be the browser this event ocurred in, or the user
   /// agent of a web request that triggered the event.
-  Browser get browser => this[Browser.type];
+  Browser/*?*/ get browser => this[Browser.type];
 
   set browser(Browser browser) => this[Browser.type] = browser;
 
   /// GPU context describes the GPU of the device.
-  Gpu get gpu => this[Gpu.type];
+  Gpu/*?*/ get gpu => this[Gpu.type];
 
   set gpu(Gpu gpu) => this[Gpu.type] = gpu;
 

--- a/dart/lib/src/protocol/debug_image.dart
+++ b/dart/lib/src/protocol/debug_image.dart
@@ -11,32 +11,32 @@ import 'package:meta/meta.dart';
 /// more details : https://develop.sentry.dev/sdk/event-payloads/debugmeta/
 @immutable
 class DebugImage {
-  final String uuid;
+  final String? uuid;
 
   /// Required. Type of the debug image. Must be "macho".
-  final String type;
+  final String? type;
 
   /// Required. Identifier of the dynamic library or executable. It is the value of the LC_UUID load command in the Mach header, formatted as UUID.
-  final String debugId;
+  final String? debugId;
 
   /// Required. Memory address, at which the image is mounted in the virtual address space of the process.
   /// Should be a string in hex representation prefixed with "0x".
-  final String imageAddr;
+  final String? imageAddr;
 
   /// Required. The size of the image in virtual memory. If missing, Sentry will assume that the image spans up to the next image, which might lead to invalid stack traces.
-  final int imageSize;
+  final int? imageSize;
 
   /// OptionalName or absolute path to the dSYM file containing debug information for this image. This value might be required to retrieve debug files from certain symbol servers.
-  final String debugFile;
+  final String? debugFile;
 
   /// Optional. The absolute path to the dynamic library or executable. This helps to locate the file if it is missing on Sentry.
-  final String codeFile;
+  final String? codeFile;
 
   /// Optional Architecture of the module. If missing, this will be backfilled by Sentry.
-  final String arch;
+  final String? arch;
 
   /// Optional. Identifier of the dynamic library or executable. It is the value of the LC_UUID load command in the Mach header, formatted as UUID. Can be empty for Mach images, as it is equivalent to the debug identifier.
-  final String codeId;
+  final String? codeId;
 
   const DebugImage({
     this.type,
@@ -93,15 +93,15 @@ class DebugImage {
   }
 
   DebugImage copyWith({
-    String uuid,
-    String type,
-    String debugId,
-    String debugFile,
-    String codeFile,
-    String imageAddr,
-    int imageSize,
-    String arch,
-    String codeId,
+    String? uuid,
+    String? type,
+    String? debugId,
+    String? debugFile,
+    String? codeFile,
+    String? imageAddr,
+    int? imageSize,
+    String? arch,
+    String? codeId,
   }) =>
       DebugImage(
         uuid: uuid ?? this.uuid,

--- a/dart/lib/src/protocol/debug_image.dart
+++ b/dart/lib/src/protocol/debug_image.dart
@@ -14,7 +14,7 @@ class DebugImage {
   final String? uuid;
 
   /// Required. Type of the debug image. Must be "macho".
-  final String? type;
+  final String type;
 
   /// Required. Identifier of the dynamic library or executable. It is the value of the LC_UUID load command in the Mach header, formatted as UUID.
   final String? debugId;
@@ -39,7 +39,7 @@ class DebugImage {
   final String? codeId;
 
   const DebugImage({
-    this.type,
+    required this.type,
     this.imageAddr,
     this.debugId,
     this.debugFile,
@@ -57,9 +57,7 @@ class DebugImage {
       json['uuid'] = uuid;
     }
 
-    if (type != null) {
-      json['type'] = type;
-    }
+    json['type'] = type;
 
     if (debugId != null) {
       json['debug_id'] = debugId;

--- a/dart/lib/src/protocol/debug_meta.dart
+++ b/dart/lib/src/protocol/debug_meta.dart
@@ -22,8 +22,8 @@ class DebugMeta {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
 
-    Map<String, dynamic> sdkInfo;
-    if (sdk != null && (sdkInfo = sdk!.toJson()).isNotEmpty) {
+    final sdkInfo = sdk?.toJson();
+    if (sdkInfo?.isNotEmpty ?? false) {
       json['sdk_info'] = sdkInfo;
     }
 

--- a/dart/lib/src/protocol/debug_meta.dart
+++ b/dart/lib/src/protocol/debug_meta.dart
@@ -8,16 +8,15 @@ class DebugMeta {
   /// An object describing the system SDK.
   final SdkInfo? sdk;
 
-  final List<DebugImage> _images;
+  final List<DebugImage>? _images;
 
   /// The immutable list of debug images contains all dynamic libraries loaded
   /// into the process and their memory addresses.
   /// Instruction addresses in the Stack Trace are mapped into the list of debug
   /// images in order to retrieve debug files for symbolication.
-  List<DebugImage> get images => List.unmodifiable(_images);
+  List<DebugImage> get images => List.unmodifiable(_images ?? const []);
 
-  DebugMeta({this.sdk, List<DebugImage>? images})
-      : _images = List.from(images ?? []);
+  DebugMeta({this.sdk, List<DebugImage>? images}) : _images = images;
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -27,8 +26,8 @@ class DebugMeta {
       json['sdk_info'] = sdkInfo;
     }
 
-    if (_images.isNotEmpty) {
-      json['images'] = _images
+    if (_images?.isNotEmpty ?? false) {
+      json['images'] = _images!
           .map((e) => e.toJson())
           .where((element) => element.isNotEmpty)
           .toList(growable: false);

--- a/dart/lib/src/protocol/debug_meta.dart
+++ b/dart/lib/src/protocol/debug_meta.dart
@@ -6,29 +6,29 @@ import '../protocol.dart';
 @immutable
 class DebugMeta {
   /// An object describing the system SDK.
-  final SdkInfo sdk;
+  final SdkInfo? sdk;
 
-  final List<DebugImage> _images;
+  final List<DebugImage>? _images;
 
   /// The immutable list of debug images contains all dynamic libraries loaded
   /// into the process and their memory addresses.
   /// Instruction addresses in the Stack Trace are mapped into the list of debug
   /// images in order to retrieve debug files for symbolication.
-  List<DebugImage> get images => List.unmodifiable(_images);
+  List<DebugImage> get images => List.unmodifiable(_images!);
 
-  DebugMeta({this.sdk, List<DebugImage> images})
+  DebugMeta({this.sdk, List<DebugImage>? images})
       : _images = images != null ? List.from(images) : null;
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
 
     Map<String, dynamic> sdkInfo;
-    if (sdk != null && (sdkInfo = sdk.toJson()).isNotEmpty) {
+    if (sdk != null && (sdkInfo = sdk!.toJson()).isNotEmpty) {
       json['sdk_info'] = sdkInfo;
     }
 
-    if (_images != null && _images.isNotEmpty) {
-      json['images'] = _images
+    if (_images != null && _images!.isNotEmpty) {
+      json['images'] = _images!
           .map((e) => e.toJson())
           .where((element) => element.isNotEmpty)
           .toList(growable: false);
@@ -38,8 +38,8 @@ class DebugMeta {
   }
 
   DebugMeta copyWith({
-    SdkInfo sdk,
-    List<DebugImage> images,
+    SdkInfo? sdk,
+    List<DebugImage>? images,
   }) =>
       DebugMeta(
         sdk: sdk ?? this.sdk,

--- a/dart/lib/src/protocol/debug_meta.dart
+++ b/dart/lib/src/protocol/debug_meta.dart
@@ -8,16 +8,16 @@ class DebugMeta {
   /// An object describing the system SDK.
   final SdkInfo? sdk;
 
-  final List<DebugImage>? _images;
+  final List<DebugImage> _images;
 
   /// The immutable list of debug images contains all dynamic libraries loaded
   /// into the process and their memory addresses.
   /// Instruction addresses in the Stack Trace are mapped into the list of debug
   /// images in order to retrieve debug files for symbolication.
-  List<DebugImage> get images => List.unmodifiable(_images!);
+  List<DebugImage> get images => List.unmodifiable(_images);
 
   DebugMeta({this.sdk, List<DebugImage>? images})
-      : _images = images != null ? List.from(images) : null;
+      : _images = List.from(images ?? []);
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -27,8 +27,8 @@ class DebugMeta {
       json['sdk_info'] = sdkInfo;
     }
 
-    if (_images != null && _images!.isNotEmpty) {
-      json['images'] = _images!
+    if (_images.isNotEmpty) {
+      json['images'] = _images
           .map((e) => e.toJson())
           .where((element) => element.isNotEmpty)
           .toList(growable: false);

--- a/dart/lib/src/protocol/device.dart
+++ b/dart/lib/src/protocol/device.dart
@@ -35,7 +35,8 @@ class Device {
     this.bootTime,
     this.timezone,
   }) : assert(
-            batteryLevel == null || (batteryLevel >= 0 && batteryLevel <= 100));
+          batteryLevel == null || (batteryLevel >= 0 && batteryLevel <= 100),
+        );
 
   factory Device.fromJson(Map<String, dynamic> data) => Device(
         name: data['name'],

--- a/dart/lib/src/protocol/device.dart
+++ b/dart/lib/src/protocol/device.dart
@@ -68,92 +68,92 @@ class Device {
       );
 
   /// The name of the device. This is typically a hostname.
-  final String name;
+  final String? name;
 
   /// The family of the device.
   ///
   /// This is normally the common part of model names across generations.
   /// For instance `iPhone` would be a reasonable family,
   /// so would be `Samsung Galaxy`.
-  final String family;
+  final String? family;
 
   /// The model name. This for instance can be `Samsung Galaxy S3`.
-  final String model;
+  final String? model;
 
   /// An internal hardware revision to identify the device exactly.
-  final String modelId;
+  final String? modelId;
 
   /// The CPU architecture.
-  final String arch;
+  final String? arch;
 
   /// If the device has a battery, this can be an floating point value
   /// defining the battery level (in the range 0-100).
-  final double batteryLevel;
+  final double? batteryLevel;
 
   /// Defines the orientation of a device.
-  final Orientation orientation;
+  final Orientation? orientation;
 
   /// The manufacturer of the device.
-  final String manufacturer;
+  final String? manufacturer;
 
   /// The brand of the device.
-  final String brand;
+  final String? brand;
 
   /// The screen resolution. (e.g.: `800x600`, `3040x1444`).
-  final String screenResolution;
+  final String? screenResolution;
 
   /// A floating point denoting the screen density.
-  final double screenDensity;
+  final double? screenDensity;
 
   /// A decimal value reflecting the DPI (dots-per-inch) density.
-  final int screenDpi;
+  final int? screenDpi;
 
   /// Whether the device was online or not.
-  final bool online;
+  final bool? online;
 
   /// Whether the device was charging or not.
-  final bool charging;
+  final bool? charging;
 
   /// Whether the device was low on memory.
-  final bool lowMemory;
+  final bool? lowMemory;
 
   /// A flag indicating whether this device is a simulator or an actual device.
-  final bool simulator;
+  final bool? simulator;
 
   /// Total system memory available in bytes.
-  final int memorySize;
+  final int? memorySize;
 
   /// Free system memory in bytes.
-  final int freeMemory;
+  final int? freeMemory;
 
   /// Memory usable for the app in bytes.
-  final int usableMemory;
+  final int? usableMemory;
 
   /// Total device storage in bytes.
-  final int storageSize;
+  final int? storageSize;
 
   /// Free device storage in bytes.
-  final int freeStorage;
+  final int? freeStorage;
 
   /// Total size of an attached external storage in bytes
   /// (e.g.: android SDK card).
-  final int externalStorageSize;
+  final int? externalStorageSize;
 
   /// Free size of an attached external storage in bytes
   /// (e.g.: android SDK card).
-  final int externalFreeStorage;
+  final int? externalFreeStorage;
 
   /// When the system was booted
-  final DateTime bootTime;
+  final DateTime? bootTime;
 
   /// The timezone of the device, e.g.: `Europe/Vienna`.
-  final String timezone;
+  final String? timezone;
 
   /// Produces a [Map] that can be serialized to JSON.
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
 
-    String orientation;
+    String? orientation;
 
     switch (this.orientation) {
       case Orientation.portrait:
@@ -161,6 +161,9 @@ class Device {
         break;
       case Orientation.landscape:
         orientation = 'landscape';
+        break;
+      case null:
+        orientation = null;
         break;
     }
 
@@ -257,7 +260,7 @@ class Device {
     }
 
     if (bootTime != null) {
-      json['boot_time'] = bootTime.toIso8601String();
+      json['boot_time'] = bootTime!.toIso8601String();
     }
 
     if (timezone != null) {
@@ -296,31 +299,31 @@ class Device {
       );
 
   Device copyWith({
-    String name,
-    String family,
-    String model,
-    String modelId,
-    String arch,
-    double batteryLevel,
-    Orientation orientation,
-    String manufacturer,
-    String brand,
-    String screenResolution,
-    double screenDensity,
-    int screenDpi,
-    bool online,
-    bool charging,
-    bool lowMemory,
-    bool simulator,
-    int memorySize,
-    int freeMemory,
-    int usableMemory,
-    int storageSize,
-    int freeStorage,
-    int externalStorageSize,
-    int externalFreeStorage,
-    DateTime bootTime,
-    String timezone,
+    String? name,
+    String? family,
+    String? model,
+    String? modelId,
+    String? arch,
+    double? batteryLevel,
+    Orientation? orientation,
+    String? manufacturer,
+    String? brand,
+    String? screenResolution,
+    double? screenDensity,
+    int? screenDpi,
+    bool? online,
+    bool? charging,
+    bool? lowMemory,
+    bool? simulator,
+    int? memorySize,
+    int? freeMemory,
+    int? usableMemory,
+    int? storageSize,
+    int? freeStorage,
+    int? externalStorageSize,
+    int? externalFreeStorage,
+    DateTime? bootTime,
+    String? timezone,
   }) =>
       Device(
         name: name ?? this.name,

--- a/dart/lib/src/protocol/dsn.dart
+++ b/dart/lib/src/protocol/dsn.dart
@@ -24,7 +24,7 @@ class Dsn {
   /// The DSN URI.
   final Uri uri;
 
-  String get postUri {
+  Uri get postUri {
     final port = uri.hasPort &&
             ((uri.scheme == 'http' && uri.port != 80) ||
                 (uri.scheme == 'https' && uri.port != 443))
@@ -41,7 +41,9 @@ class Dsn {
     } else {
       apiPath = 'api';
     }
-    return '${uri.scheme}://${uri.host}$port/$apiPath/$projectId/store/';
+    return Uri.parse(
+      '${uri.scheme}://${uri.host}$port/$apiPath/$projectId/store/',
+    );
   }
 
   /// Parses a DSN String to a Dsn object

--- a/dart/lib/src/protocol/dsn.dart
+++ b/dart/lib/src/protocol/dsn.dart
@@ -4,8 +4,8 @@ import 'package:meta/meta.dart';
 @immutable
 class Dsn {
   const Dsn({
-    @required this.publicKey,
-    @required this.projectId,
+    required this.publicKey,
+    required this.projectId,
     this.uri,
     this.secretKey,
   });
@@ -14,7 +14,7 @@ class Dsn {
   final String publicKey;
 
   /// The Sentry.io secret key for the project.
-  final String secretKey;
+  final String? secretKey;
 
   /// The ID issued by Sentry.io to your project.
   ///
@@ -22,27 +22,27 @@ class Dsn {
   final String projectId;
 
   /// The DSN URI.
-  final Uri uri;
+  final Uri? uri;
 
   Uri get postUri {
-    final port = uri.hasPort &&
-            ((uri.scheme == 'http' && uri.port != 80) ||
-                (uri.scheme == 'https' && uri.port != 443))
-        ? ':${uri.port}'
+    final port = uri!.hasPort &&
+            ((uri!.scheme == 'http' && uri!.port != 80) ||
+                (uri!.scheme == 'https' && uri!.port != 443))
+        ? ':${uri!.port}'
         : '';
 
-    final pathLength = uri.pathSegments.length;
+    final pathLength = uri!.pathSegments.length;
 
     String apiPath;
     if (pathLength > 1) {
       // some paths would present before the projectID in the uri
       apiPath =
-          (uri.pathSegments.sublist(0, pathLength - 1) + ['api']).join('/');
+          (uri!.pathSegments.sublist(0, pathLength - 1) + ['api']).join('/');
     } else {
       apiPath = 'api';
     }
     return Uri.parse(
-      '${uri.scheme}://${uri.host}$port/$apiPath/$projectId/store/',
+      '${uri!.scheme}://${uri!.host}$port/$apiPath/$projectId/store/',
     );
   }
 

--- a/dart/lib/src/protocol/dsn.dart
+++ b/dart/lib/src/protocol/dsn.dart
@@ -32,18 +32,18 @@ class Dsn {
         ? ':${uriCopy.port}'
         : '';
 
-    final pathLength = uri!.pathSegments.length;
+    final pathLength = uriCopy.pathSegments.length;
 
     String apiPath;
     if (pathLength > 1) {
       // some paths would present before the projectID in the uri
       apiPath =
-          (uri!.pathSegments.sublist(0, pathLength - 1) + ['api']).join('/');
+          (uriCopy.pathSegments.sublist(0, pathLength - 1) + ['api']).join('/');
     } else {
       apiPath = 'api';
     }
     return Uri.parse(
-      '${uri!.scheme}://${uri!.host}$port/$apiPath/$projectId/store/',
+      '${uriCopy.scheme}://${uriCopy.host}$port/$apiPath/$projectId/store/',
     );
   }
 

--- a/dart/lib/src/protocol/dsn.dart
+++ b/dart/lib/src/protocol/dsn.dart
@@ -25,10 +25,11 @@ class Dsn {
   final Uri? uri;
 
   Uri get postUri {
-    final port = uri!.hasPort &&
-            ((uri!.scheme == 'http' && uri!.port != 80) ||
-                (uri!.scheme == 'https' && uri!.port != 443))
-        ? ':${uri!.port}'
+    final uriCopy = uri!;
+    final port = uriCopy.hasPort &&
+            ((uriCopy.scheme == 'http' && uriCopy.port != 80) ||
+                (uriCopy.scheme == 'https' && uriCopy.port != 443))
+        ? ':${uriCopy.port}'
         : '';
 
     final pathLength = uri!.pathSegments.length;

--- a/dart/lib/src/protocol/gpu.dart
+++ b/dart/lib/src/protocol/gpu.dart
@@ -18,31 +18,31 @@ class Gpu {
   static const type = 'gpu';
 
   /// The name of the graphics device.
-  final String name;
+  final String? name;
 
   /// The PCI identifier of the graphics device.
-  final int id;
+  final int? id;
 
   /// The PCI vendor identifier of the graphics device.
-  final int vendorId;
+  final int? vendorId;
 
   /// The vendor name as reported by the graphics device.
-  final String vendorName;
+  final String? vendorName;
 
   /// The total GPU memory available in Megabytes.
-  final int memorySize;
+  final int? memorySize;
 
   /// The device low-level API type.
-  final String apiType;
+  final String? apiType;
 
   /// Whether the GPU has multi-threaded rendering or not.
-  final bool multiThreadedRendering;
+  final bool? multiThreadedRendering;
 
   /// The Version of the graphics device.
-  final String version;
+  final String? version;
 
   /// The Non-Power-Of-Two-Support support.
-  final String npotSupport;
+  final String? npotSupport;
 
   const Gpu({
     this.name,
@@ -124,15 +124,15 @@ class Gpu {
   }
 
   Gpu copyWith({
-    String name,
-    int id,
-    int vendorId,
-    String vendorName,
-    int memorySize,
-    String apiType,
-    bool multiThreadedRendering,
-    String version,
-    String npotSupport,
+    String? name,
+    int? id,
+    int? vendorId,
+    String? vendorName,
+    int? memorySize,
+    String? apiType,
+    bool? multiThreadedRendering,
+    String? version,
+    String? npotSupport,
   }) =>
       Gpu(
         name: name ?? this.name,

--- a/dart/lib/src/protocol/mechanism.dart
+++ b/dart/lib/src/protocol/mechanism.dart
@@ -23,7 +23,7 @@ class Mechanism {
   /// Optional flag indicating whether the exception has been handled by the user (e.g. via try..catch)
   final bool? handled;
 
-  final Map<String, dynamic>? _meta;
+  final Map<String, dynamic> _meta;
 
   /// Optional information from the operating system or runtime on the exception mechanism
   /// The mechanism meta data usually carries error codes reported by
@@ -32,12 +32,12 @@ class Mechanism {
   /// descriptions for well known error codes, as it will be filled out by
   /// Sentry. For proprietary or vendor-specific error codes,
   /// adding these values will give additional information to the user.
-  Map<String, dynamic> get meta => Map.unmodifiable(_meta!);
+  Map<String, dynamic> get meta => Map.unmodifiable(_meta);
 
-  final Map<String, dynamic>? _data;
+  final Map<String, dynamic> _data;
 
   /// Arbitrary extra data that might help the user understand the error thrown by this mechanism
-  Map<String, dynamic> get data => Map.unmodifiable(_data!);
+  Map<String, dynamic> get data => Map.unmodifiable(_data);
 
   /// An optional flag indicating that this error is synthetic.
   /// Synthetic errors are errors that carry little meaning by themselves.
@@ -52,8 +52,8 @@ class Mechanism {
     this.synthetic,
     Map<String, dynamic>? meta,
     Map<String, dynamic>? data,
-  })  : _meta = meta != null ? Map.from(meta) : null,
-        _data = data != null ? Map.from(data) : null;
+  })  : _meta = Map.from(meta ?? {}),
+        _data = Map.from(data ?? {});
 
   Mechanism copyWith({
     String? type,
@@ -91,11 +91,11 @@ class Mechanism {
       json['handled'] = handled;
     }
 
-    if (_meta != null && _meta!.isNotEmpty) {
+    if (_meta.isNotEmpty) {
       json['meta'] = _meta;
     }
 
-    if (_data != null && _data!.isNotEmpty) {
+    if (_data.isNotEmpty) {
       json['data'] = _data;
     }
 

--- a/dart/lib/src/protocol/mechanism.dart
+++ b/dart/lib/src/protocol/mechanism.dart
@@ -77,9 +77,7 @@ class Mechanism {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
 
-    if (type != null) {
-      json['type'] = type;
-    }
+    json['type'] = type;
 
     if (description != null) {
       json['description'] = description;

--- a/dart/lib/src/protocol/mechanism.dart
+++ b/dart/lib/src/protocol/mechanism.dart
@@ -15,15 +15,15 @@ class Mechanism {
   final String type;
 
   /// Optional human readable description of the error mechanism and a possible hint on how to solve this error
-  final String description;
+  final String? description;
 
   /// Optional fully qualified URL to an online help resource, possible interpolated with error parameters
-  final String helpLink;
+  final String? helpLink;
 
   /// Optional flag indicating whether the exception has been handled by the user (e.g. via try..catch)
-  final bool handled;
+  final bool? handled;
 
-  final Map<String, dynamic> _meta;
+  final Map<String, dynamic>? _meta;
 
   /// Optional information from the operating system or runtime on the exception mechanism
   /// The mechanism meta data usually carries error codes reported by
@@ -32,37 +32,37 @@ class Mechanism {
   /// descriptions for well known error codes, as it will be filled out by
   /// Sentry. For proprietary or vendor-specific error codes,
   /// adding these values will give additional information to the user.
-  Map<String, dynamic> get meta => Map.unmodifiable(_meta);
+  Map<String, dynamic> get meta => Map.unmodifiable(_meta!);
 
-  final Map<String, dynamic> _data;
+  final Map<String, dynamic>? _data;
 
   /// Arbitrary extra data that might help the user understand the error thrown by this mechanism
-  Map<String, dynamic> get data => Map.unmodifiable(_data);
+  Map<String, dynamic> get data => Map.unmodifiable(_data!);
 
   /// An optional flag indicating that this error is synthetic.
   /// Synthetic errors are errors that carry little meaning by themselves.
   /// This may be because they are created at a central place (like a crash handler), and are all called the same: Error, Segfault etc. When the flag is set, Sentry will then try to use other information (top in-app frame function) rather than exception type and value in the UI for the primary event display. This flag should be set for all "segfaults" for instance as every single error group would look very similar otherwise.
-  final bool synthetic;
+  final bool? synthetic;
 
   Mechanism({
-    @required this.type,
+    required this.type,
     this.description,
     this.helpLink,
     this.handled,
     this.synthetic,
-    Map<String, dynamic> meta,
-    Map<String, dynamic> data,
+    Map<String, dynamic>? meta,
+    Map<String, dynamic>? data,
   })  : _meta = meta != null ? Map.from(meta) : null,
         _data = data != null ? Map.from(data) : null;
 
   Mechanism copyWith({
-    String type,
-    String description,
-    String helpLink,
-    bool handled,
-    Map<String, dynamic> meta,
-    Map<String, dynamic> data,
-    bool synthetic,
+    String? type,
+    String? description,
+    String? helpLink,
+    bool? handled,
+    Map<String, dynamic>? meta,
+    Map<String, dynamic>? data,
+    bool? synthetic,
   }) =>
       Mechanism(
         type: type ?? this.type,
@@ -93,11 +93,11 @@ class Mechanism {
       json['handled'] = handled;
     }
 
-    if (_meta != null && _meta.isNotEmpty) {
+    if (_meta != null && _meta!.isNotEmpty) {
       json['meta'] = _meta;
     }
 
-    if (_data != null && _data.isNotEmpty) {
+    if (_data != null && _data!.isNotEmpty) {
       json['data'] = _data;
     }
 

--- a/dart/lib/src/protocol/mechanism.dart
+++ b/dart/lib/src/protocol/mechanism.dart
@@ -52,8 +52,8 @@ class Mechanism {
     this.synthetic,
     Map<String, dynamic>? meta,
     Map<String, dynamic>? data,
-  })  : _meta = meta,
-        _data = data;
+  })  : _meta = meta != null ? Map.from(meta) : null,
+        _data = data != null ? Map.from(data) : null;
 
   Mechanism copyWith({
     String? type,

--- a/dart/lib/src/protocol/mechanism.dart
+++ b/dart/lib/src/protocol/mechanism.dart
@@ -23,7 +23,7 @@ class Mechanism {
   /// Optional flag indicating whether the exception has been handled by the user (e.g. via try..catch)
   final bool? handled;
 
-  final Map<String, dynamic> _meta;
+  final Map<String, dynamic>? _meta;
 
   /// Optional information from the operating system or runtime on the exception mechanism
   /// The mechanism meta data usually carries error codes reported by
@@ -32,12 +32,12 @@ class Mechanism {
   /// descriptions for well known error codes, as it will be filled out by
   /// Sentry. For proprietary or vendor-specific error codes,
   /// adding these values will give additional information to the user.
-  Map<String, dynamic> get meta => Map.unmodifiable(_meta);
+  Map<String, dynamic> get meta => Map.unmodifiable(_meta ?? const {});
 
-  final Map<String, dynamic> _data;
+  final Map<String, dynamic>? _data;
 
   /// Arbitrary extra data that might help the user understand the error thrown by this mechanism
-  Map<String, dynamic> get data => Map.unmodifiable(_data);
+  Map<String, dynamic> get data => Map.unmodifiable(_data ?? const {});
 
   /// An optional flag indicating that this error is synthetic.
   /// Synthetic errors are errors that carry little meaning by themselves.
@@ -52,8 +52,8 @@ class Mechanism {
     this.synthetic,
     Map<String, dynamic>? meta,
     Map<String, dynamic>? data,
-  })  : _meta = Map.from(meta ?? {}),
-        _data = Map.from(data ?? {});
+  })  : _meta = meta,
+        _data = data;
 
   Mechanism copyWith({
     String? type,
@@ -91,11 +91,11 @@ class Mechanism {
       json['handled'] = handled;
     }
 
-    if (_meta.isNotEmpty) {
+    if (_meta?.isNotEmpty ?? false) {
       json['meta'] = _meta;
     }
 
-    if (_data.isNotEmpty) {
+    if (_data?.isNotEmpty ?? false) {
       json['data'] = _data;
     }
 

--- a/dart/lib/src/protocol/message.dart
+++ b/dart/lib/src/protocol/message.dart
@@ -11,14 +11,14 @@ import 'package:meta/meta.dart';
 @immutable
 class Message {
   /// The fully formatted message. If missing, Sentry will try to interpolate the message.
-  final String formatted;
+  final String? formatted;
 
   /// The raw message string (uninterpolated).
   /// example : "My raw message with interpreted strings like %s",
-  final String template;
+  final String? template;
 
   /// A list of formatting parameters, preferably strings. Non-strings will be coerced to strings.
-  final List<dynamic> params;
+  final List<dynamic>? params;
 
   const Message(this.formatted, {this.template, this.params});
 
@@ -33,7 +33,7 @@ class Message {
       json['message'] = template;
     }
 
-    if (params != null && params.isNotEmpty) {
+    if (params != null && params!.isNotEmpty) {
       json['params'] = params;
     }
 
@@ -41,9 +41,9 @@ class Message {
   }
 
   Message copyWith({
-    String formatted,
-    String template,
-    List<dynamic> params,
+    String? formatted,
+    String? template,
+    List<dynamic>? params,
   }) =>
       Message(
         formatted ?? this.formatted,

--- a/dart/lib/src/protocol/message.dart
+++ b/dart/lib/src/protocol/message.dart
@@ -11,7 +11,7 @@ import 'package:meta/meta.dart';
 @immutable
 class Message {
   /// The fully formatted message. If missing, Sentry will try to interpolate the message.
-  final String? formatted;
+  final String formatted;
 
   /// The raw message string (uninterpolated).
   /// example : "My raw message with interpreted strings like %s",
@@ -25,9 +25,7 @@ class Message {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
 
-    if (formatted != null) {
-      json['formatted'] = formatted;
-    }
+    json['formatted'] = formatted;
 
     if (template != null) {
       json['message'] = template;

--- a/dart/lib/src/protocol/message.dart
+++ b/dart/lib/src/protocol/message.dart
@@ -33,7 +33,7 @@ class Message {
       json['message'] = template;
     }
 
-    if (params != null && params!.isNotEmpty) {
+    if (params?.isNotEmpty ?? false) {
       json['params'] = params;
     }
 

--- a/dart/lib/src/protocol/operating_system.dart
+++ b/dart/lib/src/protocol/operating_system.dart
@@ -28,27 +28,27 @@ class OperatingSystem {
       );
 
   /// The name of the operating system.
-  final String name;
+  final String? name;
 
   /// The version of the operating system.
-  final String version;
+  final String? version;
 
   /// The internal build revision of the operating system.
-  final String build;
+  final String? build;
 
   /// An independent kernel version string.
   ///
   /// This is typically the entire output of the `uname` syscall.
-  final String kernelVersion;
+  final String? kernelVersion;
 
   /// A flag indicating whether the OS has been jailbroken or rooted.
-  final bool rooted;
+  final bool? rooted;
 
   /// An unprocessed description string obtained by the operating system.
   ///
   /// For some well-known runtimes, Sentry will attempt to parse name and
   /// version from this string, if they are not explicitly given.
-  final String rawDescription;
+  final String? rawDescription;
 
   /// Produces a [Map] that can be serialized to JSON.
   Map<String, dynamic> toJson() {
@@ -91,12 +91,12 @@ class OperatingSystem {
       );
 
   OperatingSystem copyWith({
-    String name,
-    String version,
-    String build,
-    String kernelVersion,
-    bool rooted,
-    String rawDescription,
+    String? name,
+    String? version,
+    String? build,
+    String? kernelVersion,
+    bool? rooted,
+    String? rawDescription,
   }) =>
       OperatingSystem(
         name: name ?? this.name,

--- a/dart/lib/src/protocol/request.dart
+++ b/dart/lib/src/protocol/request.dart
@@ -37,25 +37,23 @@ class Request {
     return _data;
   }
 
-  final Map<String, String>? _headers;
+  final Map<String, String> _headers;
 
   /// An immutable dictionary of submitted headers.
   /// If a header appears multiple times it,
   /// needs to be merged according to the HTTP standard for header merging.
   /// Header names are treated case-insensitively by Sentry.
-  Map<String, String>? get headers =>
-      _headers != null ? Map.unmodifiable(_headers!) : null;
+  Map<String, String> get headers => Map.unmodifiable(_headers);
 
-  final Map<String, String>? _env;
+  final Map<String, String> _env;
 
   /// An immutable dictionary containing environment information passed from the server.
   /// This is where information such as CGI/WSGI/Rack keys go that are not HTTP headers.
-  Map<String, String>? get env => _env != null ? Map.unmodifiable(_env!) : null;
+  Map<String, String> get env => Map.unmodifiable(_env);
 
-  final Map<String, String>? _other;
+  final Map<String, String> _other;
 
-  Map<String, String>? get other =>
-      _other != null ? Map.unmodifiable(_other!) : null;
+  Map<String, String> get other => Map.unmodifiable(_other);
 
   Request({
     this.url,
@@ -67,9 +65,9 @@ class Request {
     Map<String, String>? env,
     Map<String, String>? other,
   })  : _data = data,
-        _headers = headers != null ? Map.from(headers) : null,
-        _env = env != null ? Map.from(env) : null,
-        _other = other != null ? Map.from(other) : null;
+        _headers = Map.from(headers ?? {}),
+        _env = Map.from(env ?? {}),
+        _other = Map.from(other ?? {});
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -94,15 +92,15 @@ class Request {
       json['cookies'] = cookies;
     }
 
-    if (headers != null && headers!.isNotEmpty) {
+    if (headers.isNotEmpty) {
       json['headers'] = headers;
     }
 
-    if (env != null && env!.isNotEmpty) {
+    if (env.isNotEmpty) {
       json['env'] = env;
     }
 
-    if (other != null && other!.isNotEmpty) {
+    if (other.isNotEmpty) {
       json['other'] = other;
     }
 

--- a/dart/lib/src/protocol/request.dart
+++ b/dart/lib/src/protocol/request.dart
@@ -65,9 +65,9 @@ class Request {
     Map<String, String>? env,
     Map<String, String>? other,
   })  : _data = data,
-        _headers = headers,
-        _env = env,
-        _other = other;
+        _headers = headers != null ? Map.from(headers) : null,
+        _env = env != null ? Map.from(env) : null,
+        _other = other != null ? Map.from(other) : null;
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};

--- a/dart/lib/src/protocol/request.dart
+++ b/dart/lib/src/protocol/request.dart
@@ -8,19 +8,19 @@ class Request {
   ///The URL of the request if available.
   ///The query string can be declared either as part of the url,
   ///or separately in queryString.
-  final String url;
+  final String? url;
 
   ///The HTTP method of the request.
-  final String method;
+  final String? method;
 
   /// The query string component of the URL.
   ///
   /// If the query string is not declared and part of the url parameter,
   /// Sentry moves it to the query string.
-  final String queryString;
+  final String? queryString;
 
   /// The cookie values as string.
-  final String cookies;
+  final String? cookies;
 
   final dynamic _data;
 
@@ -37,25 +37,25 @@ class Request {
     return _data;
   }
 
-  final Map<String, String> _headers;
+  final Map<String, String>? _headers;
 
   /// An immutable dictionary of submitted headers.
   /// If a header appears multiple times it,
   /// needs to be merged according to the HTTP standard for header merging.
   /// Header names are treated case-insensitively by Sentry.
-  Map<String, String> get headers =>
-      _headers != null ? Map.unmodifiable(_headers) : null;
+  Map<String, String>? get headers =>
+      _headers != null ? Map.unmodifiable(_headers!) : null;
 
-  final Map<String, String> _env;
+  final Map<String, String>? _env;
 
   /// An immutable dictionary containing environment information passed from the server.
   /// This is where information such as CGI/WSGI/Rack keys go that are not HTTP headers.
-  Map<String, String> get env => _env != null ? Map.unmodifiable(_env) : null;
+  Map<String, String>? get env => _env != null ? Map.unmodifiable(_env!) : null;
 
-  final Map<String, String> _other;
+  final Map<String, String>? _other;
 
-  Map<String, String> get other =>
-      _other != null ? Map.unmodifiable(_other) : null;
+  Map<String, String>? get other =>
+      _other != null ? Map.unmodifiable(_other!) : null;
 
   Request({
     this.url,
@@ -63,9 +63,9 @@ class Request {
     this.queryString,
     this.cookies,
     dynamic data,
-    Map<String, String> headers,
-    Map<String, String> env,
-    Map<String, String> other,
+    Map<String, String>? headers,
+    Map<String, String>? env,
+    Map<String, String>? other,
   })  : _data = data,
         _headers = headers != null ? Map.from(headers) : null,
         _env = env != null ? Map.from(env) : null,
@@ -94,15 +94,15 @@ class Request {
       json['cookies'] = cookies;
     }
 
-    if (headers != null && headers.isNotEmpty) {
+    if (headers != null && headers!.isNotEmpty) {
       json['headers'] = headers;
     }
 
-    if (env != null && env.isNotEmpty) {
+    if (env != null && env!.isNotEmpty) {
       json['env'] = env;
     }
 
-    if (other != null && other.isNotEmpty) {
+    if (other != null && other!.isNotEmpty) {
       json['other'] = other;
     }
 
@@ -110,14 +110,14 @@ class Request {
   }
 
   Request copyWith({
-    String url,
-    String method,
-    String queryString,
-    String cookies,
+    String? url,
+    String? method,
+    String? queryString,
+    String? cookies,
     dynamic data,
-    Map<String, String> headers,
-    Map<String, String> env,
-    Map<String, String> other,
+    Map<String, String>? headers,
+    Map<String, String>? env,
+    Map<String, String>? other,
   }) =>
       Request(
         url: url ?? this.url,

--- a/dart/lib/src/protocol/request.dart
+++ b/dart/lib/src/protocol/request.dart
@@ -37,23 +37,23 @@ class Request {
     return _data;
   }
 
-  final Map<String, String> _headers;
+  final Map<String, String>? _headers;
 
   /// An immutable dictionary of submitted headers.
   /// If a header appears multiple times it,
   /// needs to be merged according to the HTTP standard for header merging.
   /// Header names are treated case-insensitively by Sentry.
-  Map<String, String> get headers => Map.unmodifiable(_headers);
+  Map<String, String> get headers => Map.unmodifiable(_headers ?? const {});
 
-  final Map<String, String> _env;
+  final Map<String, String>? _env;
 
   /// An immutable dictionary containing environment information passed from the server.
   /// This is where information such as CGI/WSGI/Rack keys go that are not HTTP headers.
-  Map<String, String> get env => Map.unmodifiable(_env);
+  Map<String, String> get env => Map.unmodifiable(_env ?? const {});
 
-  final Map<String, String> _other;
+  final Map<String, String>? _other;
 
-  Map<String, String> get other => Map.unmodifiable(_other);
+  Map<String, String> get other => Map.unmodifiable(_other ?? const {});
 
   Request({
     this.url,
@@ -65,9 +65,9 @@ class Request {
     Map<String, String>? env,
     Map<String, String>? other,
   })  : _data = data,
-        _headers = Map.from(headers ?? {}),
-        _env = Map.from(env ?? {}),
-        _other = Map.from(other ?? {});
+        _headers = headers,
+        _env = env,
+        _other = other;
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};

--- a/dart/lib/src/protocol/sdk_info.dart
+++ b/dart/lib/src/protocol/sdk_info.dart
@@ -3,10 +3,10 @@ import 'package:meta/meta.dart';
 /// An object describing the system SDK.
 @immutable
 class SdkInfo {
-  final String sdkName;
-  final int versionMajor;
-  final int versionMinor;
-  final int versionPatchlevel;
+  final String? sdkName;
+  final int? versionMajor;
+  final int? versionMinor;
+  final int? versionPatchlevel;
 
   const SdkInfo({
     this.sdkName,
@@ -37,10 +37,10 @@ class SdkInfo {
   }
 
   SdkInfo copyWith({
-    String sdkName,
-    int versionMajor,
-    int versionMinor,
-    int versionPatchlevel,
+    String? sdkName,
+    int? versionMajor,
+    int? versionMinor,
+    int? versionPatchlevel,
   }) =>
       SdkInfo(
         sdkName: sdkName ?? this.sdkName,

--- a/dart/lib/src/protocol/sdk_version.dart
+++ b/dart/lib/src/protocol/sdk_version.dart
@@ -40,7 +40,7 @@ class SdkVersion {
     required this.version,
     List<String>? integrations,
     List<SentryPackage>? packages,
-  })  : assert(name != null || version != null),
+  })  :
         // List.from prevents from having immutable lists
         _integrations = integrations != null ? List.from(integrations) : [],
         _packages = packages != null ? List.from(packages) : [];
@@ -66,20 +66,17 @@ class SdkVersion {
   /// Produces a [Map] that can be serialized to JSON.
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
-    if (name != null) {
-      json['name'] = name;
-    }
 
-    if (version != null) {
-      json['version'] = version;
-    }
+    json['name'] = name;
 
-    if (packages != null && packages.isNotEmpty) {
+    json['version'] = version;
+
+    if (packages.isNotEmpty) {
       json['packages'] =
           packages.map((p) => p.toJson()).toList(growable: false);
     }
 
-    if (integrations != null && integrations.isNotEmpty) {
+    if (integrations.isNotEmpty) {
       json['integrations'] = integrations;
     }
     return json;

--- a/dart/lib/src/protocol/sdk_version.dart
+++ b/dart/lib/src/protocol/sdk_version.dart
@@ -42,8 +42,8 @@ class SdkVersion {
     List<SentryPackage>? packages,
   })  :
         // List.from prevents from having immutable lists
-        _integrations = integrations != null ? List.from(integrations) : [],
-        _packages = packages != null ? List.from(packages) : [];
+        _integrations = List.from(integrations ?? []),
+        _packages = List.from(packages ?? []);
 
   /// The name of the SDK.
   final String name;
@@ -93,11 +93,12 @@ class SdkVersion {
     _integrations.add(integration);
   }
 
-  SdkVersion copyWith(
-          {String? name,
-          String? version,
-          List<String>? integrations,
-          List<SentryPackage>? packages}) =>
+  SdkVersion copyWith({
+    String? name,
+    String? version,
+    List<String>? integrations,
+    List<SentryPackage>? packages,
+  }) =>
       SdkVersion(
         name: name ?? this.name,
         version: version ?? this.version,

--- a/dart/lib/src/protocol/sdk_version.dart
+++ b/dart/lib/src/protocol/sdk_version.dart
@@ -36,10 +36,10 @@ import 'sentry_package.dart';
 class SdkVersion {
   /// Creates an [SdkVersion] object which represents the SDK that created an [Event].
   SdkVersion({
-    @required this.name,
-    @required this.version,
-    List<String> integrations,
-    List<SentryPackage> packages,
+    required this.name,
+    required this.version,
+    List<String>? integrations,
+    List<SentryPackage>? packages,
   })  : assert(name != null || version != null),
         // List.from prevents from having immutable lists
         _integrations = integrations != null ? List.from(integrations) : [],
@@ -97,10 +97,10 @@ class SdkVersion {
   }
 
   SdkVersion copyWith(
-          {String name,
-          String version,
-          List<String> integrations,
-          List<SentryPackage> packages}) =>
+          {String? name,
+          String? version,
+          List<String>? integrations,
+          List<SentryPackage>? packages}) =>
       SdkVersion(
         name: name ?? this.name,
         version: version ?? this.version,

--- a/dart/lib/src/protocol/sentry_event.dart
+++ b/dart/lib/src/protocol/sentry_event.dart
@@ -37,10 +37,10 @@ class SentryEvent {
         timestamp = timestamp ?? getUtcDateTime(),
         contexts = contexts ?? Contexts(),
         modules = modules != null ? Map.from(modules) : null,
-        tags = Map.from(tags ?? {}),
-        extra = Map.from(extra ?? {}),
-        fingerprint = List.from(fingerprint ?? []),
-        breadcrumbs = List.from(breadcrumbs ?? []);
+        tags = tags != null ? Map.from(tags) : null,
+        extra = extra != null ? Map.from(extra) : null,
+        fingerprint = fingerprint != null ? List.from(fingerprint) : null,
+        breadcrumbs = breadcrumbs != null ? List.from(breadcrumbs) : null;
 
   /// Refers to the default fingerprinting algorithm.
   ///
@@ -106,19 +106,19 @@ class SentryEvent {
   final String? culprit;
 
   /// Name/value pairs that events can be searched by.
-  final Map<String, String> tags;
+  final Map<String, String>? tags;
 
   /// Arbitrary name/value pairs attached to the event.
   ///
   /// Sentry.io docs do not talk about restrictions on the values, other than
   /// they must be JSON-serializable.
-  final Map<String, dynamic> extra;
+  final Map<String, dynamic>? extra;
 
   /// List of breadcrumbs for this event.
   ///
   /// See also:
   /// * https://docs.sentry.io/enriching-error-data/breadcrumbs/?platform=javascript
-  final List<Breadcrumb> breadcrumbs;
+  final List<Breadcrumb>? breadcrumbs;
 
   /// Information about the current user.
   ///
@@ -145,7 +145,7 @@ class SentryEvent {
   ///     var custom = ['foo', 'bar', 'baz'];
   ///     // A fingerprint that supplements the default one with value 'foo':
   ///     var supplemented = [SentryEvent.defaultFingerprint, 'foo'];
-  final List<String> fingerprint;
+  final List<String>? fingerprint;
 
   /// The SDK Interface describes the Sentry SDK and its configuration used to capture and transmit an event.
   final SdkVersion? sdk;
@@ -287,11 +287,11 @@ class SentryEvent {
       json['culprit'] = culprit;
     }
 
-    if (tags.isNotEmpty) {
+    if (tags?.isNotEmpty ?? false) {
       json['tags'] = tags;
     }
 
-    if (extra.isNotEmpty) {
+    if (extra?.isNotEmpty ?? false) {
       json['extra'] = extra;
     }
 
@@ -305,13 +305,13 @@ class SentryEvent {
       json['user'] = userMap;
     }
 
-    if (fingerprint.isNotEmpty) {
+    if (fingerprint?.isNotEmpty ?? false) {
       json['fingerprint'] = fingerprint;
     }
 
-    if (breadcrumbs.isNotEmpty) {
+    if (breadcrumbs?.isNotEmpty ?? false) {
       json['breadcrumbs'] =
-          breadcrumbs.map((b) => b.toJson()).toList(growable: false);
+          breadcrumbs?.map((b) => b.toJson()).toList(growable: false);
     }
 
     final sdkMap = sdk?.toJson();

--- a/dart/lib/src/protocol/sentry_event.dart
+++ b/dart/lib/src/protocol/sentry_event.dart
@@ -219,13 +219,9 @@ class SentryEvent {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
 
-    if (eventId != null) {
-      json['event_id'] = eventId.toString();
-    }
+    json['event_id'] = eventId.toString();
 
-    if (timestamp != null) {
-      json['timestamp'] = formatDateAsIso8601WithMillisPrecision(timestamp);
-    }
+    json['timestamp'] = formatDateAsIso8601WithMillisPrecision(timestamp);
 
     if (platform != null) {
       json['platform'] = platform;
@@ -264,14 +260,13 @@ class SentryEvent {
       json['transaction'] = transaction;
     }
 
-    Map<String, dynamic> exceptionMap;
-    Map<String, dynamic> stackTraceMap;
-    if (exception != null && (exceptionMap = exception!.toJson()).isNotEmpty) {
+    final exceptionMap = exception?.toJson();
+    final stackTraceMap = stackTrace?.toJson();
+    if (exceptionMap?.isNotEmpty ?? false) {
       json['exception'] = {
         'values': [exceptionMap].toList(growable: false)
       };
-    } else if (stackTrace != null &&
-        (stackTraceMap = stackTrace!.toJson()).isNotEmpty) {
+    } else if (stackTraceMap?.isNotEmpty ?? false) {
       json['threads'] = {
         'values': [
           {
@@ -292,45 +287,45 @@ class SentryEvent {
       json['culprit'] = culprit;
     }
 
-    if (tags != null && tags!.isNotEmpty) {
+    if (tags?.isNotEmpty ?? false) {
       json['tags'] = tags;
     }
 
-    if (extra != null && extra!.isNotEmpty) {
+    if (extra?.isNotEmpty ?? false) {
       json['extra'] = extra;
     }
 
-    Map<String, dynamic> contextsMap;
-    if (contexts != null && (contextsMap = contexts.toJson()).isNotEmpty) {
+    final contextsMap = contexts.toJson();
+    if (contextsMap.isNotEmpty) {
       json['contexts'] = contextsMap;
     }
 
-    Map<String, dynamic> userMap;
-    if (user != null && (userMap = user!.toJson()).isNotEmpty) {
+    final userMap = user?.toJson();
+    if (userMap?.isNotEmpty ?? false) {
       json['user'] = userMap;
     }
 
-    if (fingerprint != null && fingerprint!.isNotEmpty) {
+    if (fingerprint?.isNotEmpty ?? false) {
       json['fingerprint'] = fingerprint;
     }
 
-    if (breadcrumbs != null && breadcrumbs!.isNotEmpty) {
+    if (breadcrumbs?.isNotEmpty ?? false) {
       json['breadcrumbs'] =
           breadcrumbs!.map((b) => b.toJson()).toList(growable: false);
     }
 
-    Map<String, dynamic> sdkMap;
-    if (sdk != null && (sdkMap = sdk!.toJson()).isNotEmpty) {
+    final sdkMap = sdk?.toJson();
+    if (sdkMap?.isNotEmpty ?? false) {
       json['sdk'] = sdkMap;
     }
 
-    Map<String, dynamic> requestMap;
-    if (request != null && (requestMap = request!.toJson()).isNotEmpty) {
+    final requestMap = request?.toJson();
+    if (requestMap?.isNotEmpty ?? false) {
       json['request'] = requestMap;
     }
 
-    Map<String, dynamic> debugMetaMap;
-    if (debugMeta != null && (debugMetaMap = debugMeta!.toJson()).isNotEmpty) {
+    final debugMetaMap = debugMeta?.toJson();
+    if (debugMetaMap?.isNotEmpty ?? false) {
       json['debug_meta'] = debugMetaMap;
     }
 

--- a/dart/lib/src/protocol/sentry_event.dart
+++ b/dart/lib/src/protocol/sentry_event.dart
@@ -8,13 +8,13 @@ import '../utils.dart';
 class SentryEvent {
   /// Creates an event.
   SentryEvent({
-    SentryId eventId,
-    DateTime timestamp,
-    Map<String, String> modules,
-    Map<String, String> tags,
-    Map<String, dynamic> extra,
-    List<String> fingerprint,
-    List<Breadcrumb> breadcrumbs,
+    SentryId? eventId,
+    DateTime? timestamp,
+    Map<String, String>? modules,
+    Map<String, String>? tags,
+    Map<String, dynamic>? extra,
+    List<String>? fingerprint,
+    List<Breadcrumb>? breadcrumbs,
     this.sdk,
     this.platform,
     this.logger,
@@ -30,7 +30,7 @@ class SentryEvent {
     this.level,
     this.culprit,
     this.user,
-    Contexts contexts,
+    Contexts? contexts,
     this.request,
     this.debugMeta,
   })  : eventId = eventId ?? SentryId.newId(),
@@ -55,30 +55,30 @@ class SentryEvent {
   final DateTime timestamp;
 
   /// A string representing the platform the SDK is submitting from. This will be used by the Sentry interface to customize various components in the interface.
-  final String platform;
+  final String? platform;
 
   /// The logger that logged the event.
-  final String logger;
+  final String? logger;
 
   /// Identifies the server that logged this event.
-  final String serverName;
+  final String? serverName;
 
   /// The version of the application that logged the event.
-  final String release;
+  final String? release;
 
   /// The distribution of the application.
-  final String dist;
+  final String? dist;
 
   /// The environment that logged the event, e.g. "production", "staging".
-  final String environment;
+  final String? environment;
 
   /// A list of relevant modules and their versions.
-  final Map<String, String> modules;
+  final Map<String, String>? modules;
 
   /// Event message.
   ///
   /// Generally an event either contains a [message] or an [exception].
-  final Message message;
+  final Message? message;
 
   /// An object that was thrown.
   ///
@@ -89,42 +89,42 @@ class SentryEvent {
 
   /// an optional attached StackTrace
   /// used when event has no throwable or exception, see [SentryOptions.attachStacktrace]
-  final SentryStackTrace stackTrace;
+  final SentryStackTrace? stackTrace;
 
   /// an exception or error that occurred in a program
   /// TODO more doc
-  final SentryException exception;
+  final SentryException? exception;
 
   /// The name of the transaction which generated this event,
   /// for example, the route name: `"/users/<username>/"`.
-  final String transaction;
+  final String? transaction;
 
   /// How important this event is.
-  final SentryLevel level;
+  final SentryLevel? level;
 
   /// What caused this event to be logged.
-  final String culprit;
+  final String? culprit;
 
   /// Name/value pairs that events can be searched by.
-  final Map<String, String> tags;
+  final Map<String, String>? tags;
 
   /// Arbitrary name/value pairs attached to the event.
   ///
   /// Sentry.io docs do not talk about restrictions on the values, other than
   /// they must be JSON-serializable.
-  final Map<String, dynamic> extra;
+  final Map<String, dynamic>? extra;
 
   /// List of breadcrumbs for this event.
   ///
   /// See also:
   /// * https://docs.sentry.io/enriching-error-data/breadcrumbs/?platform=javascript
-  final List<Breadcrumb> breadcrumbs;
+  final List<Breadcrumb>? breadcrumbs;
 
   /// Information about the current user.
   ///
   /// The value in this field overrides the user context
   /// set in [Scope.user] for this logged event.
-  final User user;
+  final User? user;
 
   /// The context interfaces provide additional context data.
   /// Typically this is data related to the current user,
@@ -145,45 +145,45 @@ class SentryEvent {
   ///     var custom = ['foo', 'bar', 'baz'];
   ///     // A fingerprint that supplements the default one with value 'foo':
   ///     var supplemented = [SentryEvent.defaultFingerprint, 'foo'];
-  final List<String> fingerprint;
+  final List<String>? fingerprint;
 
   /// The SDK Interface describes the Sentry SDK and its configuration used to capture and transmit an event.
-  final SdkVersion sdk;
+  final SdkVersion? sdk;
 
   ///  contains information on a HTTP request related to the event.
   ///  In client, this can be an outgoing request, or the request that rendered the current web page.
   ///  On server, this could be the incoming web request that is being handled
-  final Request request;
+  final Request? request;
 
   /// The debug meta interface carries debug information for processing errors and crash reports.
-  final DebugMeta debugMeta;
+  final DebugMeta? debugMeta;
 
   SentryEvent copyWith({
-    SentryId eventId,
-    DateTime timestamp,
-    String platform,
-    String logger,
-    String serverName,
-    String release,
-    String dist,
-    String environment,
-    Map<String, String> modules,
-    Message message,
-    String transaction,
+    SentryId? eventId,
+    DateTime? timestamp,
+    String? platform,
+    String? logger,
+    String? serverName,
+    String? release,
+    String? dist,
+    String? environment,
+    Map<String, String>? modules,
+    Message? message,
+    String? transaction,
     dynamic throwable,
-    SentryException exception,
+    SentryException? exception,
     dynamic stackTrace,
-    SentryLevel level,
-    String culprit,
-    Map<String, String> tags,
-    Map<String, dynamic> extra,
-    List<String> fingerprint,
-    User user,
-    Contexts contexts,
-    List<Breadcrumb> breadcrumbs,
-    SdkVersion sdk,
-    Request request,
-    DebugMeta debugMeta,
+    SentryLevel? level,
+    String? culprit,
+    Map<String, String>? tags,
+    Map<String, dynamic>? extra,
+    List<String>? fingerprint,
+    User? user,
+    Contexts? contexts,
+    List<Breadcrumb>? breadcrumbs,
+    SdkVersion? sdk,
+    Request? request,
+    DebugMeta? debugMeta,
   }) =>
       SentryEvent(
         eventId: eventId ?? this.eventId,
@@ -251,12 +251,12 @@ class SentryEvent {
       json['environment'] = environment;
     }
 
-    if (modules != null && modules.isNotEmpty) {
+    if (modules != null && modules!.isNotEmpty) {
       json['modules'] = modules;
     }
 
     Map<String, dynamic> messageMap;
-    if (message != null && (messageMap = message.toJson()).isNotEmpty) {
+    if (message != null && (messageMap = message!.toJson()).isNotEmpty) {
       json['message'] = messageMap;
     }
 
@@ -266,12 +266,12 @@ class SentryEvent {
 
     Map<String, dynamic> exceptionMap;
     Map<String, dynamic> stackTraceMap;
-    if (exception != null && (exceptionMap = exception.toJson()).isNotEmpty) {
+    if (exception != null && (exceptionMap = exception!.toJson()).isNotEmpty) {
       json['exception'] = {
         'values': [exceptionMap].toList(growable: false)
       };
     } else if (stackTrace != null &&
-        (stackTraceMap = stackTrace.toJson()).isNotEmpty) {
+        (stackTraceMap = stackTrace!.toJson()).isNotEmpty) {
       json['threads'] = {
         'values': [
           {
@@ -285,18 +285,18 @@ class SentryEvent {
     }
 
     if (level != null) {
-      json['level'] = level.name;
+      json['level'] = level!.name;
     }
 
     if (culprit != null) {
       json['culprit'] = culprit;
     }
 
-    if (tags != null && tags.isNotEmpty) {
+    if (tags != null && tags!.isNotEmpty) {
       json['tags'] = tags;
     }
 
-    if (extra != null && extra.isNotEmpty) {
+    if (extra != null && extra!.isNotEmpty) {
       json['extra'] = extra;
     }
 
@@ -306,31 +306,31 @@ class SentryEvent {
     }
 
     Map<String, dynamic> userMap;
-    if (user != null && (userMap = user.toJson()).isNotEmpty) {
+    if (user != null && (userMap = user!.toJson()).isNotEmpty) {
       json['user'] = userMap;
     }
 
-    if (fingerprint != null && fingerprint.isNotEmpty) {
+    if (fingerprint != null && fingerprint!.isNotEmpty) {
       json['fingerprint'] = fingerprint;
     }
 
-    if (breadcrumbs != null && breadcrumbs.isNotEmpty) {
+    if (breadcrumbs != null && breadcrumbs!.isNotEmpty) {
       json['breadcrumbs'] =
-          breadcrumbs.map((b) => b.toJson()).toList(growable: false);
+          breadcrumbs!.map((b) => b.toJson()).toList(growable: false);
     }
 
     Map<String, dynamic> sdkMap;
-    if (sdk != null && (sdkMap = sdk.toJson()).isNotEmpty) {
+    if (sdk != null && (sdkMap = sdk!.toJson()).isNotEmpty) {
       json['sdk'] = sdkMap;
     }
 
     Map<String, dynamic> requestMap;
-    if (request != null && (requestMap = request.toJson()).isNotEmpty) {
+    if (request != null && (requestMap = request!.toJson()).isNotEmpty) {
       json['request'] = requestMap;
     }
 
     Map<String, dynamic> debugMetaMap;
-    if (debugMeta != null && (debugMetaMap = debugMeta.toJson()).isNotEmpty) {
+    if (debugMeta != null && (debugMetaMap = debugMeta!.toJson()).isNotEmpty) {
       json['debug_meta'] = debugMetaMap;
     }
 

--- a/dart/lib/src/protocol/sentry_event.dart
+++ b/dart/lib/src/protocol/sentry_event.dart
@@ -37,10 +37,10 @@ class SentryEvent {
         timestamp = timestamp ?? getUtcDateTime(),
         contexts = contexts ?? Contexts(),
         modules = modules != null ? Map.from(modules) : null,
-        tags = tags != null ? Map.from(tags) : null,
-        extra = extra != null ? Map.from(extra) : null,
-        fingerprint = fingerprint != null ? List.from(fingerprint) : null,
-        breadcrumbs = breadcrumbs != null ? List.from(breadcrumbs) : null;
+        tags = Map.from(tags ?? {}),
+        extra = Map.from(extra ?? {}),
+        fingerprint = List.from(fingerprint ?? []),
+        breadcrumbs = List.from(breadcrumbs ?? []);
 
   /// Refers to the default fingerprinting algorithm.
   ///
@@ -106,19 +106,19 @@ class SentryEvent {
   final String? culprit;
 
   /// Name/value pairs that events can be searched by.
-  final Map<String, String>? tags;
+  final Map<String, String> tags;
 
   /// Arbitrary name/value pairs attached to the event.
   ///
   /// Sentry.io docs do not talk about restrictions on the values, other than
   /// they must be JSON-serializable.
-  final Map<String, dynamic>? extra;
+  final Map<String, dynamic> extra;
 
   /// List of breadcrumbs for this event.
   ///
   /// See also:
   /// * https://docs.sentry.io/enriching-error-data/breadcrumbs/?platform=javascript
-  final List<Breadcrumb>? breadcrumbs;
+  final List<Breadcrumb> breadcrumbs;
 
   /// Information about the current user.
   ///
@@ -145,7 +145,7 @@ class SentryEvent {
   ///     var custom = ['foo', 'bar', 'baz'];
   ///     // A fingerprint that supplements the default one with value 'foo':
   ///     var supplemented = [SentryEvent.defaultFingerprint, 'foo'];
-  final List<String>? fingerprint;
+  final List<String> fingerprint;
 
   /// The SDK Interface describes the Sentry SDK and its configuration used to capture and transmit an event.
   final SdkVersion? sdk;
@@ -287,11 +287,11 @@ class SentryEvent {
       json['culprit'] = culprit;
     }
 
-    if (tags?.isNotEmpty ?? false) {
+    if (tags.isNotEmpty) {
       json['tags'] = tags;
     }
 
-    if (extra?.isNotEmpty ?? false) {
+    if (extra.isNotEmpty) {
       json['extra'] = extra;
     }
 
@@ -305,13 +305,13 @@ class SentryEvent {
       json['user'] = userMap;
     }
 
-    if (fingerprint?.isNotEmpty ?? false) {
+    if (fingerprint.isNotEmpty) {
       json['fingerprint'] = fingerprint;
     }
 
-    if (breadcrumbs?.isNotEmpty ?? false) {
+    if (breadcrumbs.isNotEmpty) {
       json['breadcrumbs'] =
-          breadcrumbs!.map((b) => b.toJson()).toList(growable: false);
+          breadcrumbs.map((b) => b.toJson()).toList(growable: false);
     }
 
     final sdkMap = sdk?.toJson();

--- a/dart/lib/src/protocol/sentry_exception.dart
+++ b/dart/lib/src/protocol/sentry_exception.dart
@@ -6,26 +6,26 @@ import '../protocol.dart';
 @immutable
 class SentryException {
   /// Required. The type of exception
-  final String type;
+  final String? type;
 
   /// Required. The value of the exception
-  final String value;
+  final String? value;
 
   /// The optional module, or package which the exception type lives in.
-  final String module;
+  final String? module;
 
   /// An optional stack trace object
-  final SentryStackTrace stackTrace;
+  final SentryStackTrace? stackTrace;
 
   /// An optional object describing the [Mechanism] that created this exception
-  final Mechanism mechanism;
+  final Mechanism? mechanism;
 
   /// Represents a thread id. not available in Dart
-  final int threadId;
+  final int? threadId;
 
   const SentryException({
-    @required this.type,
-    @required this.value,
+    required this.type,
+    required this.value,
     this.module,
     this.stackTrace,
     this.mechanism,
@@ -48,11 +48,11 @@ class SentryException {
     }
 
     if (stackTrace != null) {
-      json['stacktrace'] = stackTrace.toJson();
+      json['stacktrace'] = stackTrace!.toJson();
     }
 
     if (mechanism != null) {
-      json['mechanism'] = mechanism.toJson();
+      json['mechanism'] = mechanism!.toJson();
     }
 
     if (threadId != null) {
@@ -63,12 +63,12 @@ class SentryException {
   }
 
   SentryException copyWith({
-    String type,
-    String value,
-    String module,
-    SentryStackTrace stackTrace,
-    Mechanism mechanism,
-    int threadId,
+    String? type,
+    String? value,
+    String? module,
+    SentryStackTrace? stackTrace,
+    Mechanism? mechanism,
+    int? threadId,
   }) =>
       SentryException(
         type: type ?? this.type,

--- a/dart/lib/src/protocol/sentry_id.dart
+++ b/dart/lib/src/protocol/sentry_id.dart
@@ -12,7 +12,7 @@ class SentryId {
 
   static final Uuid _uuidGenerator = Uuid();
 
-  SentryId._internal({String id}) : _id = id ?? _uuidGenerator.v4();
+  SentryId._internal({String? id}) : _id = id ?? _uuidGenerator.v4();
 
   /// Generates a new SentryId
   factory SentryId.newId() => SentryId._internal();

--- a/dart/lib/src/protocol/sentry_package.dart
+++ b/dart/lib/src/protocol/sentry_package.dart
@@ -4,8 +4,7 @@ import 'package:meta/meta.dart';
 @immutable
 class SentryPackage {
   /// Creates an [SentryPackage] object that is part of the [Sdk].
-  const SentryPackage(this.name, this.version)
-      : assert(name != null && version != null);
+  const SentryPackage(this.name, this.version);
 
   /// The name of the SDK.
   final String name;

--- a/dart/lib/src/protocol/sentry_package.dart
+++ b/dart/lib/src/protocol/sentry_package.dart
@@ -22,8 +22,8 @@ class SentryPackage {
   }
 
   SentryPackage copyWith({
-    String name,
-    String version,
+    String? name,
+    String? version,
   }) =>
       SentryPackage(
         name ?? this.name,

--- a/dart/lib/src/protocol/sentry_runtime.dart
+++ b/dart/lib/src/protocol/sentry_runtime.dart
@@ -23,19 +23,19 @@ class SentryRuntime {
   /// in the Sentry UI. Defaults to lower case version of [name].
   ///
   /// Unused if only one [SentryRuntime] is provided in [Contexts].
-  final String key;
+  final String? key;
 
   /// The name of the runtime.
-  final String name;
+  final String? name;
 
   /// The version identifier of the runtime.
-  final String version;
+  final String? version;
 
   /// An unprocessed description string obtained by the runtime.
   ///
   /// For some well-known runtimes, Sentry will attempt to parse name
   /// and version from this string, if they are not explicitly given.
-  final String rawDescription;
+  final String? rawDescription;
 
   /// Produces a [Map] that can be serialized to JSON.
   Map<String, dynamic> toJson() {
@@ -64,10 +64,10 @@ class SentryRuntime {
       );
 
   SentryRuntime copyWith({
-    String key,
-    String name,
-    String version,
-    String rawDescription,
+    String? key,
+    String? name,
+    String? version,
+    String? rawDescription,
   }) =>
       SentryRuntime(
         key: key ?? this.key,

--- a/dart/lib/src/protocol/sentry_stack_frame.dart
+++ b/dart/lib/src/protocol/sentry_stack_frame.dart
@@ -27,30 +27,31 @@ class SentryStackFrame {
     List<String>? preContext,
     List<String>? postContext,
     Map<String, String>? vars,
-  })  : _framesOmitted = List.from(framesOmitted ?? []),
-        _preContext = List.from(preContext ?? []),
-        _postContext = List.from(postContext ?? []),
-        _vars = Map.from(vars ?? {});
+  })  : _framesOmitted =
+            framesOmitted != null ? List.from(framesOmitted) : null,
+        _preContext = preContext != null ? List.from(preContext) : null,
+        _postContext = postContext != null ? List.from(postContext) : null,
+        _vars = vars != null ? Map.from(vars) : null;
 
   /// The absolute path to filename.
   final String? absPath;
 
-  final List<String> _preContext;
+  final List<String>? _preContext;
 
   /// An immutable list of source code lines before context_line (in order) – usually [lineno - 5:lineno].
-  List<String> get preContext => List.unmodifiable(_preContext);
+  List<String> get preContext => List.unmodifiable(_preContext ?? const []);
 
-  final List<String> _postContext;
+  final List<String>? _postContext;
 
   /// An immutable list of source code lines after context_line (in order) – usually [lineno + 1:lineno + 5].
-  List<String> get postContext => List.unmodifiable(_postContext);
+  List<String> get postContext => List.unmodifiable(_postContext ?? const []);
 
-  final Map<String, String> _vars;
+  final Map<String, String>? _vars;
 
   /// An immutable mapping of variables which were available within this frame (usually context-locals).
-  Map<String, String> get vars => Map.unmodifiable(_vars);
+  Map<String, String> get vars => Map.unmodifiable(_vars ?? const {});
 
-  final List<int> _framesOmitted;
+  final List<int>? _framesOmitted;
 
   /// Which frames were omitted, if any.
   ///
@@ -61,7 +62,7 @@ class SentryStackFrame {
   /// Example : If you only removed the 8th frame, the value would be (8, 9),
   /// meaning it started at the 8th frame, and went untilthe 9th (the number of frames omitted is end-start).
   /// The values should be based on a one-index.
-  List<int> get framesOmitted => List.unmodifiable(_framesOmitted);
+  List<int> get framesOmitted => List.unmodifiable(_framesOmitted ?? const []);
 
   /// The relative file path to the call.
   final String? fileName;
@@ -110,19 +111,19 @@ class SentryStackFrame {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
 
-    if (_preContext.isNotEmpty) {
+    if (_preContext?.isNotEmpty ?? false) {
       json['pre_context'] = _preContext;
     }
 
-    if (_postContext.isNotEmpty) {
+    if (_postContext?.isNotEmpty ?? false) {
       json['post_context'] = _postContext;
     }
 
-    if (_vars.isNotEmpty) {
+    if (_vars?.isNotEmpty ?? false) {
       json['vars'] = _vars;
     }
 
-    if (_framesOmitted.isNotEmpty) {
+    if (_framesOmitted?.isNotEmpty ?? false) {
       json['frames_omitted'] = _framesOmitted;
     }
 

--- a/dart/lib/src/protocol/sentry_stack_frame.dart
+++ b/dart/lib/src/protocol/sentry_stack_frame.dart
@@ -27,31 +27,30 @@ class SentryStackFrame {
     List<String>? preContext,
     List<String>? postContext,
     Map<String, String>? vars,
-  })  : _framesOmitted =
-            framesOmitted != null ? List.from(framesOmitted) : null,
-        _preContext = preContext != null ? List.from(preContext) : null,
-        _postContext = postContext != null ? List.from(postContext) : null,
-        _vars = vars != null ? Map.from(vars) : null;
+  })  : _framesOmitted = List.from(framesOmitted ?? []),
+        _preContext = List.from(preContext ?? []),
+        _postContext = List.from(postContext ?? []),
+        _vars = Map.from(vars ?? {});
 
   /// The absolute path to filename.
   final String? absPath;
 
-  final List<String>? _preContext;
+  final List<String> _preContext;
 
   /// An immutable list of source code lines before context_line (in order) – usually [lineno - 5:lineno].
-  List<String> get preContext => List.unmodifiable(_preContext!);
+  List<String> get preContext => List.unmodifiable(_preContext);
 
-  final List<String>? _postContext;
+  final List<String> _postContext;
 
   /// An immutable list of source code lines after context_line (in order) – usually [lineno + 1:lineno + 5].
-  List<String> get postContext => List.unmodifiable(_postContext!);
+  List<String> get postContext => List.unmodifiable(_postContext);
 
-  final Map<String, String>? _vars;
+  final Map<String, String> _vars;
 
   /// An immutable mapping of variables which were available within this frame (usually context-locals).
-  Map<String, String> get vars => Map.unmodifiable(_vars!);
+  Map<String, String> get vars => Map.unmodifiable(_vars);
 
-  final List<int>? _framesOmitted;
+  final List<int> _framesOmitted;
 
   /// Which frames were omitted, if any.
   ///
@@ -62,7 +61,7 @@ class SentryStackFrame {
   /// Example : If you only removed the 8th frame, the value would be (8, 9),
   /// meaning it started at the 8th frame, and went untilthe 9th (the number of frames omitted is end-start).
   /// The values should be based on a one-index.
-  List<int> get framesOmitted => List.unmodifiable(_framesOmitted!);
+  List<int> get framesOmitted => List.unmodifiable(_framesOmitted);
 
   /// The relative file path to the call.
   final String? fileName;
@@ -111,19 +110,19 @@ class SentryStackFrame {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
 
-    if (_preContext != null && _preContext!.isNotEmpty) {
+    if (_preContext.isNotEmpty) {
       json['pre_context'] = _preContext;
     }
 
-    if (_postContext != null && _postContext!.isNotEmpty) {
+    if (_postContext.isNotEmpty) {
       json['post_context'] = _postContext;
     }
 
-    if (_vars != null && _vars!.isNotEmpty) {
+    if (_vars.isNotEmpty) {
       json['vars'] = _vars;
     }
 
-    if (_framesOmitted != null && _framesOmitted!.isNotEmpty) {
+    if (_framesOmitted.isNotEmpty) {
       json['frames_omitted'] = _framesOmitted;
     }
 

--- a/dart/lib/src/protocol/sentry_stack_frame.dart
+++ b/dart/lib/src/protocol/sentry_stack_frame.dart
@@ -23,10 +23,10 @@ class SentryStackFrame {
     this.symbolAddr,
     this.instructionAddr,
     this.rawFunction,
-    List<int> framesOmitted,
-    List<String> preContext,
-    List<String> postContext,
-    Map<String, String> vars,
+    List<int>? framesOmitted,
+    List<String>? preContext,
+    List<String>? postContext,
+    Map<String, String>? vars,
   })  : _framesOmitted =
             framesOmitted != null ? List.from(framesOmitted) : null,
         _preContext = preContext != null ? List.from(preContext) : null,
@@ -34,24 +34,24 @@ class SentryStackFrame {
         _vars = vars != null ? Map.from(vars) : null;
 
   /// The absolute path to filename.
-  final String absPath;
+  final String? absPath;
 
-  final List<String> _preContext;
+  final List<String>? _preContext;
 
   /// An immutable list of source code lines before context_line (in order) – usually [lineno - 5:lineno].
-  List<String> get preContext => List.unmodifiable(_preContext);
+  List<String> get preContext => List.unmodifiable(_preContext!);
 
-  final List<String> _postContext;
+  final List<String>? _postContext;
 
   /// An immutable list of source code lines after context_line (in order) – usually [lineno + 1:lineno + 5].
-  List<String> get postContext => List.unmodifiable(_postContext);
+  List<String> get postContext => List.unmodifiable(_postContext!);
 
-  final Map<String, String> _vars;
+  final Map<String, String>? _vars;
 
   /// An immutable mapping of variables which were available within this frame (usually context-locals).
-  Map<String, String> get vars => Map.unmodifiable(_vars);
+  Map<String, String> get vars => Map.unmodifiable(_vars!);
 
-  final List<int> _framesOmitted;
+  final List<int>? _framesOmitted;
 
   /// Which frames were omitted, if any.
   ///
@@ -62,68 +62,68 @@ class SentryStackFrame {
   /// Example : If you only removed the 8th frame, the value would be (8, 9),
   /// meaning it started at the 8th frame, and went untilthe 9th (the number of frames omitted is end-start).
   /// The values should be based on a one-index.
-  List<int> get framesOmitted => List.unmodifiable(_framesOmitted);
+  List<int> get framesOmitted => List.unmodifiable(_framesOmitted!);
 
   /// The relative file path to the call.
-  final String fileName;
+  final String? fileName;
 
   /// The name of the function being called.
-  final String function;
+  final String? function;
 
   /// Platform-specific module path.
-  final String module;
+  final String? module;
 
   /// The column number of the call
-  final int lineNo;
+  final int? lineNo;
 
   /// The column number of the call
-  final int colNo;
+  final int? colNo;
 
   /// Source code in filename at line number.
-  final String contextLine;
+  final String? contextLine;
 
   /// Signifies whether this frame is related to the execution of the relevant code in this stacktrace.
   ///
   /// For example, the frames that might power the framework’s web server of your app are probably not relevant, however calls to the framework’s library once you start handling code likely are.
-  final bool inApp;
+  final bool? inApp;
 
   /// The "package" the frame was contained in.
-  final String package;
+  final String? package;
 
-  final bool native;
+  final bool? native;
 
   /// This can override the platform for a single frame. Otherwise, the platform of the event is assumed. This can be used for multi-platform stack traces
-  final String platform;
+  final String? platform;
 
   /// Optionally an address of the debug image to reference.
-  final String imageAddr;
+  final String? imageAddr;
 
   /// An optional address that points to a symbol. We use the instruction address for symbolication, but this can be used to calculate an instruction offset automatically.
-  final String symbolAddr;
+  final String? symbolAddr;
 
   /// The instruction address
   /// The official docs refer to it as 'The difference between instruction address and symbol address in bytes.'
-  final String instructionAddr;
+  final String? instructionAddr;
 
   /// The original function name, if the function name is shortened or demangled. Sentry shows the raw function when clicking on the shortened one in the UI.
-  final String rawFunction;
+  final String? rawFunction;
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
 
-    if (_preContext != null && _preContext.isNotEmpty) {
+    if (_preContext != null && _preContext!.isNotEmpty) {
       json['pre_context'] = _preContext;
     }
 
-    if (_postContext != null && _postContext.isNotEmpty) {
+    if (_postContext != null && _postContext!.isNotEmpty) {
       json['post_context'] = _postContext;
     }
 
-    if (_vars != null && _vars.isNotEmpty) {
+    if (_vars != null && _vars!.isNotEmpty) {
       json['vars'] = _vars;
     }
 
-    if (_framesOmitted != null && _framesOmitted.isNotEmpty) {
+    if (_framesOmitted != null && _framesOmitted!.isNotEmpty) {
       json['frames_omitted'] = _framesOmitted;
     }
 
@@ -195,25 +195,25 @@ class SentryStackFrame {
   }
 
   SentryStackFrame copyWith({
-    String absPath,
-    String fileName,
-    String function,
-    String module,
-    int lineNo,
-    int colNo,
-    String contextLine,
-    bool inApp,
-    String package,
-    bool native,
-    String platform,
-    String imageAddr,
-    String symbolAddr,
-    String instructionAddr,
-    String rawFunction,
-    List<int> framesOmitted,
-    List<String> preContext,
-    List<String> postContext,
-    Map<String, String> vars,
+    String? absPath,
+    String? fileName,
+    String? function,
+    String? module,
+    int? lineNo,
+    int? colNo,
+    String? contextLine,
+    bool? inApp,
+    String? package,
+    bool? native,
+    String? platform,
+    String? imageAddr,
+    String? symbolAddr,
+    String? instructionAddr,
+    String? rawFunction,
+    List<int>? framesOmitted,
+    List<String>? preContext,
+    List<String>? postContext,
+    Map<String, String>? vars,
   }) =>
       SentryStackFrame(
         absPath: absPath ?? this.absPath,

--- a/dart/lib/src/protocol/sentry_stack_trace.dart
+++ b/dart/lib/src/protocol/sentry_stack_trace.dart
@@ -11,29 +11,29 @@ class SentryStackTrace {
   })  : _frames = frames,
         _registers = Map.from(registers ?? {});
 
-  final List<SentryStackFrame> _frames;
+  final List<SentryStackFrame>? _frames;
 
   /// Required. A non-empty immutable list of stack frames (see below).
   /// The list is ordered from caller to callee, or oldest to youngest.
   /// The last frame is the one creating the exception.
-  List<SentryStackFrame> get frames => List.unmodifiable(_frames);
+  List<SentryStackFrame> get frames => List.unmodifiable(_frames ?? const []);
 
-  final Map<String, String> _registers;
+  final Map<String, String>? _registers;
 
   /// Optional. A map of register names and their values.
   /// The values should contain the actual register values of the thread,
   /// thus mapping to the last frame in the list.
-  Map<String, String> get registers => Map.unmodifiable(_registers);
+  Map<String, String> get registers => Map.unmodifiable(_registers ?? const {});
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
 
-    if (_frames.isNotEmpty) {
+    if (_frames?.isNotEmpty ?? false) {
       json['frames'] =
-          _frames.map((frame) => frame.toJson()).toList(growable: false);
+          _frames?.map((frame) => frame.toJson()).toList(growable: false);
     }
 
-    if (_registers.isNotEmpty) {
+    if (_registers?.isNotEmpty ?? false) {
       json['registers'] = _registers;
     }
 

--- a/dart/lib/src/protocol/sentry_stack_trace.dart
+++ b/dart/lib/src/protocol/sentry_stack_trace.dart
@@ -28,12 +28,12 @@ class SentryStackTrace {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
 
-    if (_frames != null && _frames.isNotEmpty) {
+    if (_frames.isNotEmpty) {
       json['frames'] =
           _frames.map((frame) => frame.toJson()).toList(growable: false);
     }
 
-    if (_registers != null && _registers!.isNotEmpty ?? false) {
+    if (_registers != null && _registers!.isNotEmpty) {
       json['registers'] = _registers;
     }
 

--- a/dart/lib/src/protocol/sentry_stack_trace.dart
+++ b/dart/lib/src/protocol/sentry_stack_trace.dart
@@ -6,8 +6,8 @@ import 'sentry_stack_frame.dart';
 @immutable
 class SentryStackTrace {
   const SentryStackTrace({
-    @required List<SentryStackFrame> frames,
-    Map<String, String> registers,
+    required List<SentryStackFrame> frames,
+    Map<String, String>? registers,
   })  : _frames = frames,
         _registers = registers;
 
@@ -18,12 +18,12 @@ class SentryStackTrace {
   /// The last frame is the one creating the exception.
   List<SentryStackFrame> get frames => List.unmodifiable(_frames);
 
-  final Map<String, String> _registers;
+  final Map<String, String>? _registers;
 
   /// Optional. A map of register names and their values.
   /// The values should contain the actual register values of the thread,
   /// thus mapping to the last frame in the list.
-  Map<String, String> get registers => Map.unmodifiable(_registers);
+  Map<String, String> get registers => Map.unmodifiable(_registers!);
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -33,7 +33,7 @@ class SentryStackTrace {
           _frames.map((frame) => frame.toJson()).toList(growable: false);
     }
 
-    if (_registers != null && _registers.isNotEmpty ?? false) {
+    if (_registers != null && _registers!.isNotEmpty ?? false) {
       json['registers'] = _registers;
     }
 
@@ -41,8 +41,8 @@ class SentryStackTrace {
   }
 
   SentryStackTrace copyWith({
-    List<SentryStackFrame> frames,
-    Map<String, String> registers,
+    List<SentryStackFrame>? frames,
+    Map<String, String>? registers,
   }) =>
       SentryStackTrace(
         frames: frames ?? this.frames,

--- a/dart/lib/src/protocol/sentry_stack_trace.dart
+++ b/dart/lib/src/protocol/sentry_stack_trace.dart
@@ -5,11 +5,11 @@ import 'sentry_stack_frame.dart';
 /// Stacktrace holds information about the frames of the stack.
 @immutable
 class SentryStackTrace {
-  const SentryStackTrace({
+  SentryStackTrace({
     required List<SentryStackFrame> frames,
     Map<String, String>? registers,
   })  : _frames = frames,
-        _registers = registers;
+        _registers = Map.from(registers ?? {});
 
   final List<SentryStackFrame> _frames;
 
@@ -18,12 +18,12 @@ class SentryStackTrace {
   /// The last frame is the one creating the exception.
   List<SentryStackFrame> get frames => List.unmodifiable(_frames);
 
-  final Map<String, String>? _registers;
+  final Map<String, String> _registers;
 
   /// Optional. A map of register names and their values.
   /// The values should contain the actual register values of the thread,
   /// thus mapping to the last frame in the list.
-  Map<String, String> get registers => Map.unmodifiable(_registers!);
+  Map<String, String> get registers => Map.unmodifiable(_registers);
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -33,7 +33,7 @@ class SentryStackTrace {
           _frames.map((frame) => frame.toJson()).toList(growable: false);
     }
 
-    if (_registers != null && _registers!.isNotEmpty) {
+    if (_registers.isNotEmpty) {
       json['registers'] = _registers;
     }
 

--- a/dart/lib/src/protocol/user.dart
+++ b/dart/lib/src/protocol/user.dart
@@ -33,7 +33,7 @@ class User {
     this.ipAddress,
     Map<String, dynamic>? extras,
   })  : assert(id != null || ipAddress != null),
-        extras = extras != null ? Map.from(extras) : null;
+        extras = Map.from(extras ?? {});
 
   /// A unique identifier of the user.
   final String? id;
@@ -51,7 +51,7 @@ class User {
   ///
   /// These keys are stored as extra information but not specifically processed
   /// by Sentry.
-  final Map<String, dynamic>? extras;
+  final Map<String, dynamic> extras;
 
   /// Produces a [Map] that can be serialized to JSON.
   Map<String, dynamic> toJson() {

--- a/dart/lib/src/protocol/user.dart
+++ b/dart/lib/src/protocol/user.dart
@@ -33,7 +33,7 @@ class User {
     this.ipAddress,
     Map<String, dynamic>? extras,
   })  : assert(id != null || ipAddress != null),
-        extras = Map.from(extras ?? {});
+        extras = extras == null ? null : Map.from(extras);
 
   /// A unique identifier of the user.
   final String? id;
@@ -51,7 +51,7 @@ class User {
   ///
   /// These keys are stored as extra information but not specifically processed
   /// by Sentry.
-  final Map<String, dynamic> extras;
+  final Map<String, dynamic>? extras;
 
   /// Produces a [Map] that can be serialized to JSON.
   Map<String, dynamic> toJson() {

--- a/dart/lib/src/protocol/user.dart
+++ b/dart/lib/src/protocol/user.dart
@@ -31,27 +31,27 @@ class User {
     this.username,
     this.email,
     this.ipAddress,
-    Map<String, dynamic> extras,
+    Map<String, dynamic>? extras,
   })  : assert(id != null || ipAddress != null),
         extras = extras != null ? Map.from(extras) : null;
 
   /// A unique identifier of the user.
-  final String id;
+  final String? id;
 
   /// The username of the user.
-  final String username;
+  final String? username;
 
   /// The email address of the user.
-  final String email;
+  final String? email;
 
   /// The IP of the user.
-  final String ipAddress;
+  final String? ipAddress;
 
   /// Any other user context information that may be helpful.
   ///
   /// These keys are stored as extra information but not specifically processed
   /// by Sentry.
-  final Map<String, dynamic> extras;
+  final Map<String, dynamic>? extras;
 
   /// Produces a [Map] that can be serialized to JSON.
   Map<String, dynamic> toJson() {
@@ -65,11 +65,11 @@ class User {
   }
 
   User copyWith({
-    String id,
-    String username,
-    String email,
-    String ipAddress,
-    Map<String, dynamic> extras,
+    String? id,
+    String? username,
+    String? email,
+    String? ipAddress,
+    Map<String, dynamic>? extras,
   }) =>
       User(
         id: id ?? this.id,

--- a/dart/lib/src/scope.dart
+++ b/dart/lib/src/scope.dart
@@ -26,8 +26,8 @@ class Scope {
   ///     var custom = ['foo', 'bar', 'baz'];
   List<String> get fingerprint => List.unmodifiable(_fingerprint);
 
-  set fingerprint(List<String>? fingerprint) {
-    _fingerprint = List.from(fingerprint ?? []);
+  set fingerprint(List<String> fingerprint) {
+    _fingerprint = List.from(fingerprint);
   }
 
   /// List of breadcrumbs for this scope.
@@ -89,33 +89,28 @@ class Scope {
       return;
     }
 
+    Breadcrumb? processedBreadcrumb = breadcrumb;
     // run before breadcrumb callback if set
-    if (_options.beforeBreadcrumb == null) {
-      // remove first item if list if full
-      if (_breadcrumbs.length >= _options.maxBreadcrumbs &&
-          _breadcrumbs.isNotEmpty) {
-        _breadcrumbs.removeFirst();
-      }
+    if (_options.beforeBreadcrumb != null) {
+      processedBreadcrumb = _options.beforeBreadcrumb!(
+        processedBreadcrumb,
+        hint: hint,
+      );
 
-      _breadcrumbs.add(breadcrumb);
-      return;
+      if (processedBreadcrumb == null) {
+        _options.logger(
+            SentryLevel.info, 'Breadcrumb was dropped by beforeBreadcrumb');
+        return;
+      }
     }
 
-    var processedBreadcrumb =
-        _options.beforeBreadcrumb!(breadcrumb, hint: hint);
-
-    if (processedBreadcrumb == null) {
-      _options.logger(
-          SentryLevel.info, 'Breadcrumb was dropped by beforeBreadcrumb');
-    } else {
-      // remove first item if list if full
-      if (_breadcrumbs.length >= _options.maxBreadcrumbs &&
-          _breadcrumbs.isNotEmpty) {
-        _breadcrumbs.removeFirst();
-      }
-
-      _breadcrumbs.add(breadcrumb);
+    // remove first item if list if full
+    if (_breadcrumbs.length >= _options.maxBreadcrumbs &&
+        _breadcrumbs.isNotEmpty) {
+      _breadcrumbs.removeFirst();
     }
+
+    _breadcrumbs.add(breadcrumb);
   }
 
   /// Clear all the breadcrumbs

--- a/dart/lib/src/scope.dart
+++ b/dart/lib/src/scope.dart
@@ -81,18 +81,12 @@ class Scope {
   List<EventProcessor> get eventProcessors =>
       List.unmodifiable(_eventProcessors);
 
-  final SentryOptions _options;
+  final SentryOptions /*!*/ _options;
 
-  Scope(this._options) {
-    if (_options == null) {
-      throw ArgumentError('SentryOptions is required');
-    }
-  }
+  Scope(this._options);
 
   /// Adds a breadcrumb to the breadcrumbs queue
-  void addBreadcrumb(Breadcrumb breadcrumb, {dynamic hint}) {
-    assert(breadcrumb != null, "Breadcrumb can't be null");
-
+  void addBreadcrumb(Breadcrumb /*?*/ breadcrumb, {dynamic hint}) {
     // bail out if maxBreadcrumbs is zero
     if (_options.maxBreadcrumbs == 0) {
       return;
@@ -124,7 +118,7 @@ class Scope {
   }
 
   /// Adds an event processor
-  void addEventProcessor(EventProcessor eventProcessor) {
+  void addEventProcessor(EventProcessor /*!*/ eventProcessor) {
     assert(eventProcessor != null, "EventProcessor can't be null");
 
     _eventProcessors.add(eventProcessor);
@@ -143,7 +137,7 @@ class Scope {
   }
 
   /// Sets a tag to the Scope
-  void setTag(String key, String value) {
+  void setTag(String /*!*/ key, String /*!*/ value) {
     assert(key != null, "Key can't be null");
     assert(value != null, "Key can't be null");
 
@@ -151,12 +145,12 @@ class Scope {
   }
 
   /// Removes a tag from the Scope
-  void removeTag(String key) {
+  void removeTag(String /*!*/ key) {
     _tags.remove(key);
   }
 
   /// Sets an extra to the Scope
-  void setExtra(String key, dynamic value) {
+  void setExtra(String /*!*/ key, dynamic value) {
     assert(key != null, "Key can't be null");
     assert(value != null, "Value can't be null");
 
@@ -164,9 +158,10 @@ class Scope {
   }
 
   /// Removes an extra from the Scope
-  void removeExtra(String key) => _extra.remove(key);
+  void removeExtra(String /*!*/ key) => _extra.remove(key);
 
-  Future<SentryEvent> applyToEvent(SentryEvent event, dynamic hint) async {
+  Future<SentryEvent> applyToEvent(
+      SentryEvent /*!*/ event, dynamic hint) async {
     event = event.copyWith(
       transaction: event.transaction ?? transaction,
       user: event.user ?? user,
@@ -209,7 +204,7 @@ class Scope {
   }
 
   /// merge the scope contexts runtimes and the event contexts runtimes
-  void _mergeEventContextsRuntimes(List value, SentryEvent event) =>
+  void _mergeEventContextsRuntimes(List /*!*/ value, SentryEvent /*!*/ event) =>
       value.forEach((runtime) => event.contexts.addRuntime(runtime));
 
   /// if the scope and the event have tag entries with the same key,

--- a/dart/lib/src/scope.dart
+++ b/dart/lib/src/scope.dart
@@ -162,9 +162,10 @@ class Scope {
     event = event.copyWith(
       transaction: event.transaction ?? transaction,
       user: event.user ?? user,
-      fingerprint:
-          event.fingerprint.isNotEmpty ? event.fingerprint : _fingerprint,
-      breadcrumbs: event.breadcrumbs.isNotEmpty
+      fingerprint: (event.fingerprint?.isNotEmpty ?? false)
+          ? event.fingerprint
+          : _fingerprint,
+      breadcrumbs: (event.breadcrumbs?.isNotEmpty ?? false)
           ? event.breadcrumbs
           : List.from(_breadcrumbs),
       tags: tags.isNotEmpty ? _mergeEventTags(event) : event.tags,
@@ -209,12 +210,13 @@ class Scope {
   /// if the scope and the event have tag entries with the same key,
   /// the event tags will be kept
   Map<String, String> _mergeEventTags(SentryEvent event) =>
-      tags.map((key, value) => MapEntry(key, value))..addAll(event.tags);
+      tags.map((key, value) => MapEntry(key, value))..addAll(event.tags ?? {});
 
   /// if the scope and the event have extra entries with the same key,
   /// the event extra will be kept
   Map<String, dynamic> _mergeEventExtra(SentryEvent event) =>
-      extra.map((key, value) => MapEntry(key, value))..addAll(event.extra);
+      extra.map((key, value) => MapEntry(key, value))
+        ..addAll(event.extra ?? {});
 
   /// Clones the current Scope
   Scope clone() {

--- a/dart/lib/src/scope.dart
+++ b/dart/lib/src/scope.dart
@@ -104,7 +104,7 @@ class Scope {
       }
     }
 
-    // remove first item if list if full
+    // remove first item if list is full
     if (_breadcrumbs.length >= _options.maxBreadcrumbs &&
         _breadcrumbs.isNotEmpty) {
       _breadcrumbs.removeFirst();

--- a/dart/lib/src/scope.dart
+++ b/dart/lib/src/scope.dart
@@ -15,7 +15,7 @@ class Scope {
   /// Information about the current user.
   User? user;
 
-  List<String>? _fingerprint;
+  List<String> _fingerprint = [];
 
   /// Used to deduplicate events by grouping ones with the same fingerprint
   /// together.
@@ -24,11 +24,10 @@ class Scope {
   ///
   ///     // A completely custom fingerprint:
   ///     var custom = ['foo', 'bar', 'baz'];
-  List<String>? get fingerprint =>
-      _fingerprint != null ? List.unmodifiable(_fingerprint!) : null;
+  List<String> get fingerprint => List.unmodifiable(_fingerprint);
 
   set fingerprint(List<String>? fingerprint) {
-    _fingerprint = (fingerprint != null ? List.from(fingerprint) : fingerprint);
+    _fingerprint = List.from(fingerprint ?? []);
   }
 
   /// List of breadcrumbs for this scope.
@@ -128,7 +127,7 @@ class Scope {
     level = null;
     transaction = null;
     user = null;
-    _fingerprint = null;
+    _fingerprint = [];
     _tags.clear();
     _extra.clear();
     _eventProcessors.clear();
@@ -156,9 +155,11 @@ class Scope {
     event = event.copyWith(
       transaction: event.transaction ?? transaction,
       user: event.user ?? user,
-      fingerprint: event.fingerprint ??
-          (_fingerprint != null ? List.from(_fingerprint!) : null),
-      breadcrumbs: event.breadcrumbs ?? List.from(_breadcrumbs),
+      fingerprint:
+          event.fingerprint.isNotEmpty ? event.fingerprint : _fingerprint,
+      breadcrumbs: event.breadcrumbs.isNotEmpty
+          ? event.breadcrumbs
+          : List.from(_breadcrumbs),
       tags: tags.isNotEmpty ? _mergeEventTags(event) : event.tags,
       extra: extra.isNotEmpty ? _mergeEventExtra(event) : event.extra,
       level: level ?? event.level,
@@ -201,19 +202,18 @@ class Scope {
   /// if the scope and the event have tag entries with the same key,
   /// the event tags will be kept
   Map<String, String> _mergeEventTags(SentryEvent event) =>
-      tags.map((key, value) => MapEntry(key, value))..addAll(event.tags ?? {});
+      tags.map((key, value) => MapEntry(key, value))..addAll(event.tags);
 
   /// if the scope and the event have extra entries with the same key,
   /// the event extra will be kept
   Map<String, dynamic> _mergeEventExtra(SentryEvent event) =>
-      extra.map((key, value) => MapEntry(key, value))
-        ..addAll(event.extra ?? {});
+      extra.map((key, value) => MapEntry(key, value))..addAll(event.extra);
 
   /// Clones the current Scope
   Scope clone() {
     final clone = Scope(_options)
       ..user = user
-      ..fingerprint = fingerprint != null ? List.from(fingerprint!) : null
+      ..fingerprint = List.from(fingerprint)
       ..transaction = transaction;
 
     for (final tag in _tags.keys) {

--- a/dart/lib/src/scope.dart
+++ b/dart/lib/src/scope.dart
@@ -91,7 +91,7 @@ class Scope {
 
     // run before breadcrumb callback if set
     if (_options.beforeBreadcrumb == null) {
-      // remove first item if list if full
+      // remove first item if list is full
       if (_breadcrumbs.length >= _options.maxBreadcrumbs &&
           _breadcrumbs.isNotEmpty) {
         _breadcrumbs.removeFirst();

--- a/dart/lib/src/sentry.dart
+++ b/dart/lib/src/sentry.dart
@@ -36,27 +36,19 @@ class Sentry {
   /// such as SentryFlutter.
   static Future<void> init(
     OptionsConfiguration optionsConfiguration, {
-    AppRunner appRunner,
-    SentryOptions options,
+    AppRunner? appRunner,
+    SentryOptions? options,
   }) async {
-    if (optionsConfiguration == null) {
-      throw ArgumentError('OptionsConfiguration is required.');
-    }
-
     final sentryOptions = options ?? SentryOptions(dsn: '');
     await _initDefaultValues(sentryOptions, appRunner);
 
     await optionsConfiguration(sentryOptions);
 
-    if (sentryOptions == null) {
-      throw ArgumentError('SentryOptions is required.');
-    }
-
     await _init(sentryOptions, appRunner);
   }
 
   static Future<void> _initDefaultValues(
-      SentryOptions options, AppRunner appRunner) async {
+      SentryOptions options, AppRunner? appRunner) async {
     // We infer the enviroment based on the release/non-release and profile
     // constants.
     var environment = options.platformChecker.isReleaseMode()
@@ -84,7 +76,7 @@ class Sentry {
   }
 
   /// Initializes the SDK
-  static Future<void> _init(SentryOptions options, AppRunner appRunner) async {
+  static Future<void> _init(SentryOptions options, AppRunner? appRunner) async {
     if (isEnabled) {
       options.logger(
         SentryLevel.warning,
@@ -132,7 +124,7 @@ class Sentry {
 
   /// Reports an [event] to Sentry.io.
   static Future<SentryId> captureEvent(
-    SentryEvent event, {
+    SentryEvent? event, {
     dynamic stackTrace,
     dynamic hint,
   }) async =>
@@ -151,10 +143,10 @@ class Sentry {
       );
 
   static Future<SentryId> captureMessage(
-    String message, {
-    SentryLevel level,
-    String template,
-    List<dynamic> params,
+    String? message, {
+    SentryLevel? level,
+    String? template,
+    List<dynamic>? params,
     dynamic hint,
   }) async =>
       currentHub.captureMessage(
@@ -179,7 +171,7 @@ class Sentry {
   static SentryId get lastEventId => currentHub.lastEventId;
 
   /// Adds a breacrumb to the current Scope
-  static void addBreadcrumb(Breadcrumb crumb, {dynamic hint}) =>
+  static void addBreadcrumb(Breadcrumb? crumb, {dynamic hint}) =>
       currentHub.addBreadcrumb(crumb, hint: hint);
 
   /// Configures the scope through the callback.
@@ -193,12 +185,6 @@ class Sentry {
   static void bindClient(SentryClient client) => currentHub.bindClient(client);
 
   static bool _setDefaultConfiguration(SentryOptions options) {
-    // if DSN is null, let's crash the App.
-    if (options.dsn == null) {
-      throw ArgumentError(
-        'DSN is required. Use empty string to disable SDK.',
-      );
-    }
     // if the DSN is empty, let's disable the SDK
     if (options.dsn.isEmpty) {
       close();

--- a/dart/lib/src/sentry.dart
+++ b/dart/lib/src/sentry.dart
@@ -39,10 +39,14 @@ class Sentry {
     AppRunner? appRunner,
     SentryOptions? options,
   }) async {
-    final sentryOptions = options ?? SentryOptions(dsn: '');
+    final sentryOptions = options ?? SentryOptions();
     await _initDefaultValues(sentryOptions, appRunner);
 
     await optionsConfiguration(sentryOptions);
+
+    if (sentryOptions.dsn == null) {
+      throw ArgumentError('DSN is required.');
+    }
 
     await _init(sentryOptions, appRunner);
   }
@@ -124,7 +128,7 @@ class Sentry {
 
   /// Reports an [event] to Sentry.io.
   static Future<SentryId> captureEvent(
-    SentryEvent? event, {
+    SentryEvent event, {
     dynamic stackTrace,
     dynamic hint,
   }) async =>
@@ -171,7 +175,7 @@ class Sentry {
   static SentryId get lastEventId => currentHub.lastEventId;
 
   /// Adds a breacrumb to the current Scope
-  static void addBreadcrumb(Breadcrumb? crumb, {dynamic hint}) =>
+  static void addBreadcrumb(Breadcrumb crumb, {dynamic hint}) =>
       currentHub.addBreadcrumb(crumb, hint: hint);
 
   /// Configures the scope through the callback.
@@ -182,17 +186,17 @@ class Sentry {
   static Hub clone() => currentHub.clone();
 
   /// Binds a different client to the current hub
-  static void bindClient(SentryClient? client) => currentHub.bindClient(client);
+  static void bindClient(SentryClient client) => currentHub.bindClient(client);
 
   static bool _setDefaultConfiguration(SentryOptions options) {
     // if the DSN is empty, let's disable the SDK
-    if (options.dsn.isEmpty) {
+    if (options.dsn?.isEmpty ?? false) {
       close();
       return false;
     }
 
     // try parsing the dsn
-    Dsn.parse(options.dsn);
+    Dsn.parse(options.dsn!);
 
     // if logger os NoOp, let's set a logger that prints on the console
     if (options.debug && options.logger == noOpLogger) {

--- a/dart/lib/src/sentry.dart
+++ b/dart/lib/src/sentry.dart
@@ -148,7 +148,7 @@ class Sentry {
 
   static Future<SentryId> captureMessage(
     String? message, {
-    SentryLevel level = SentryLevel.info,
+    SentryLevel? level = SentryLevel.info,
     String? template,
     List<dynamic>? params,
     dynamic hint,

--- a/dart/lib/src/sentry.dart
+++ b/dart/lib/src/sentry.dart
@@ -144,7 +144,7 @@ class Sentry {
 
   static Future<SentryId> captureMessage(
     String? message, {
-    SentryLevel? level,
+    SentryLevel level = SentryLevel.info,
     String? template,
     List<dynamic>? params,
     dynamic hint,

--- a/dart/lib/src/sentry.dart
+++ b/dart/lib/src/sentry.dart
@@ -43,7 +43,7 @@ class Sentry {
       throw ArgumentError('OptionsConfiguration is required.');
     }
 
-    final sentryOptions = options ?? SentryOptions();
+    final sentryOptions = options ?? SentryOptions(dsn: '');
     await _initDefaultValues(sentryOptions, appRunner);
 
     await optionsConfiguration(sentryOptions);

--- a/dart/lib/src/sentry.dart
+++ b/dart/lib/src/sentry.dart
@@ -182,7 +182,7 @@ class Sentry {
   static Hub clone() => currentHub.clone();
 
   /// Binds a different client to the current hub
-  static void bindClient(SentryClient client) => currentHub.bindClient(client);
+  static void bindClient(SentryClient? client) => currentHub.bindClient(client);
 
   static bool _setDefaultConfiguration(SentryOptions options) {
     // if the DSN is empty, let's disable the SDK

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -154,7 +154,7 @@ class SentryClient {
   /// Reports the [template]
   Future<SentryId> captureMessage(
     String? formatted, {
-    SentryLevel? level = SentryLevel.info,
+    SentryLevel? level,
     String? template,
     List<dynamic>? params,
     Scope? scope,
@@ -162,7 +162,7 @@ class SentryClient {
   }) {
     final event = SentryEvent(
       message: Message(formatted, template: template, params: params),
-      level: level,
+      level: level ?? SentryLevel.info,
       timestamp: _options.clock(),
     );
 

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -153,7 +153,7 @@ class SentryClient {
 
   /// Reports the [template]
   Future<SentryId> captureMessage(
-    String? formatted, {
+    String formatted, {
     SentryLevel? level,
     String? template,
     List<dynamic>? params,

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -20,14 +20,10 @@ class SentryClient {
 
   late SentryExceptionFactory _exceptionFactory;
 
-  SentryStackTraceFactory? _stackTraceFactory;
+  late SentryStackTraceFactory _stackTraceFactory;
 
   /// Instantiates a client using [SentryOptions]
   factory SentryClient(SentryOptions options) {
-    if (options == null) {
-      throw ArgumentError('SentryOptions is required.');
-    }
-
     if (options.transport is NoOpTransport) {
       options.transport = HttpTransport(options);
     }
@@ -63,7 +59,7 @@ class SentryClient {
     SentryEvent? preparedEvent = _prepareEvent(event, stackTrace: stackTrace);
 
     if (scope != null) {
-      preparedEvent = await scope.applyToEvent(preparedEvent!, hint);
+      preparedEvent = await scope.applyToEvent(preparedEvent, hint);
     } else {
       _options.logger(SentryLevel.debug, 'No scope is defined');
     }
@@ -125,9 +121,9 @@ class SentryClient {
 
     if (stackTrace != null || _options.attachStacktrace) {
       stackTrace ??= StackTrace.current;
-      final frames = _stackTraceFactory!.getStackFrames(stackTrace);
+      final frames = _stackTraceFactory.getStackFrames(stackTrace);
 
-      if (frames != null && frames.isNotEmpty) {
+      if (frames.isNotEmpty) {
         event = event.copyWith(stackTrace: SentryStackTrace(frames: frames));
       }
     }
@@ -175,26 +171,27 @@ class SentryClient {
 
   void close() => _options.httpClient.close();
 
-  Future<SentryEvent> _processEvent(
+  Future<SentryEvent?> _processEvent(
     SentryEvent event, {
     dynamic hint,
     required List<EventProcessor> eventProcessors,
   }) async {
+    SentryEvent? processedEvent = event;
     for (final processor in eventProcessors) {
       try {
-        event = await processor(event, hint: hint)!;
+        processedEvent = await processor(processedEvent!, hint: hint)!;
       } catch (err) {
         _options.logger(
           SentryLevel.error,
           'An exception occurred while processing event by a processor : $err',
         );
       }
-      if (event == null) {
+      if (processedEvent == null) {
         _options.logger(SentryLevel.debug, 'Event was dropped by a processor');
         break;
       }
     }
-    return event;
+    return processedEvent;
   }
 
   bool _sampleRate() {

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -154,7 +154,7 @@ class SentryClient {
   /// Reports the [template]
   Future<SentryId> captureMessage(
     String? formatted, {
-    SentryLevel level,
+    SentryLevel level = SentryLevel.info,
     String? template,
     List<dynamic>? params,
     Scope? scope,
@@ -162,7 +162,7 @@ class SentryClient {
   }) {
     final event = SentryEvent(
       message: Message(formatted, template: template, params: params),
-      level: level ?? SentryLevel.info,
+      level: level,
       timestamp: _options.clock(),
     );
 

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -36,8 +36,8 @@ class SentryClient {
       : _random = _options.sampleRate == null ? null : Random() {
     _stackTraceFactory = SentryStackTraceFactory(_options);
     _exceptionFactory = SentryExceptionFactory(
-      options: _options,
-      stacktraceFactory: _stackTraceFactory,
+      _options,
+      _stackTraceFactory,
     );
   }
 

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -154,7 +154,7 @@ class SentryClient {
   /// Reports the [template]
   Future<SentryId> captureMessage(
     String? formatted, {
-    SentryLevel? level = SentryLevel.info,
+    SentryLevel level = SentryLevel.info,
     String? template,
     List<dynamic>? params,
     Scope? scope,

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -154,7 +154,7 @@ class SentryClient {
   /// Reports the [template]
   Future<SentryId> captureMessage(
     String? formatted, {
-    SentryLevel level = SentryLevel.info,
+    SentryLevel? level = SentryLevel.info,
     String? template,
     List<dynamic>? params,
     Scope? scope,

--- a/dart/lib/src/sentry_exception_factory.dart
+++ b/dart/lib/src/sentry_exception_factory.dart
@@ -14,8 +14,8 @@ class SentryExceptionFactory {
   SentryExceptionFactory._(this._options, this._stacktraceFactory);
 
   factory SentryExceptionFactory({
-    @required SentryOptions options,
-    @required SentryStackTraceFactory stacktraceFactory,
+    required SentryOptions? options,
+    required SentryStackTraceFactory? stacktraceFactory,
   }) {
     if (options == null) {
       throw ArgumentError('SentryOptions is required.');
@@ -44,7 +44,7 @@ class SentryExceptionFactory {
       stackTrace ??= StackTrace.current;
     }
 
-    SentryStackTrace sentryStackTrace;
+    SentryStackTrace? sentryStackTrace;
     if (stackTrace != null) {
       sentryStackTrace = SentryStackTrace(
         frames: _stacktraceFactory.getStackFrames(stackTrace),

--- a/dart/lib/src/sentry_exception_factory.dart
+++ b/dart/lib/src/sentry_exception_factory.dart
@@ -9,21 +9,7 @@ class SentryExceptionFactory {
 
   final SentryStackTraceFactory _stacktraceFactory;
 
-  SentryExceptionFactory._(this._options, this._stacktraceFactory);
-
-  factory SentryExceptionFactory({
-    required SentryOptions? options,
-    required SentryStackTraceFactory? stacktraceFactory,
-  }) {
-    if (options == null) {
-      throw ArgumentError('SentryOptions is required.');
-    }
-
-    if (stacktraceFactory == null) {
-      throw ArgumentError('SentryStackTraceFactory is required.');
-    }
-    return SentryExceptionFactory._(options, stacktraceFactory);
-  }
+  SentryExceptionFactory(this._options, this._stacktraceFactory);
 
   SentryException getSentryException(
     dynamic exception, {

--- a/dart/lib/src/sentry_exception_factory.dart
+++ b/dart/lib/src/sentry_exception_factory.dart
@@ -1,5 +1,3 @@
-import 'package:meta/meta.dart';
-
 import 'protocol.dart';
 import 'sentry_options.dart';
 import 'sentry_stack_trace_factory.dart';

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:math';
 
 import 'package:http/http.dart';
 
@@ -21,9 +20,9 @@ class SentryOptions {
   /// Default Log level if not specified Default is DEBUG
   static final SentryLevel _defaultDiagnosticLevel = SentryLevel.debug;
 
-  /// The DSN tells the SDK where to send the events to. If this value is not provided, the SDK will
-  ///  just not send any events.
-  String dsn;
+  /// The DSN tells the SDK where to send the events to. If an empty string is
+  /// used, the SDK will not send any events.
+  String /*!*/ dsn = '';
 
   /// If [compressPayload] is `true` the outgoing HTTP payloads are compressed
   /// using gzip. Otherwise, the payloads are sent in plain UTF8-encoded JSON
@@ -32,6 +31,7 @@ class SentryOptions {
 
   /// If [httpClient] is provided, it is used instead of the default client to
   /// make HTTP calls to Sentry.io. This is useful in tests.
+  /// If you don't need to send event, use [NoOpClient].
   Client httpClient = NoOpClient();
 
   /// If [clock] is provided, it is used to get time instead of the system
@@ -88,11 +88,11 @@ class SentryOptions {
 
   /// This function is called with an SDK specific event object and can return a modified event
   /// object or nothing to skip reporting the event
-  BeforeSendCallback beforeSend;
+  BeforeSendCallback /*?*/ beforeSend;
 
   /// This function is called with an SDK specific breadcrumb object before the breadcrumb is added
   /// to the scope. When nothing is returned from the function, the breadcrumb is dropped
-  BeforeBreadcrumbCallback beforeBreadcrumb;
+  BeforeBreadcrumbCallback /*?*/ beforeBreadcrumb;
 
   /// Sets the release. SDK will try to automatically configure a release out of the box
   String release;
@@ -156,7 +156,7 @@ class SentryOptions {
 
   // TODO: sendDefaultPii
 
-  SentryOptions({this.dsn}) {
+  SentryOptions({this.dsn = ''}) {
     sdk.addPackage('pub:sentry', sdkVersion);
   }
 
@@ -212,7 +212,7 @@ typedef EventProcessor = FutureOr<SentryEvent> Function(SentryEvent event,
     {dynamic hint});
 
 /// Logger interface to log useful debugging information if debug is enabled
-typedef SentryLogger = Function(SentryLevel level, String message);
+typedef SentryLogger = void Function(SentryLevel level, String message);
 
 /// Used to provide timestamp for logging.
 typedef ClockProvider = DateTime Function();

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math';
 
 import 'package:http/http.dart';
 
@@ -24,31 +25,18 @@ class SentryOptions {
   ///  just not send any events.
   String dsn;
 
-  bool _compressPayload = true;
-
   /// If [compressPayload] is `true` the outgoing HTTP payloads are compressed
   /// using gzip. Otherwise, the payloads are sent in plain UTF8-encoded JSON
   /// text. If not specified, the compression is enabled by default.
-  bool get compressPayload => _compressPayload;
-
-  set compressPayload(bool compressPayload) =>
-      _compressPayload = compressPayload ?? _compressPayload;
-
-  Client _httpClient = NoOpClient();
+  bool compressPayload = true;
 
   /// If [httpClient] is provided, it is used instead of the default client to
   /// make HTTP calls to Sentry.io. This is useful in tests.
-  Client get httpClient => _httpClient;
-
-  set httpClient(Client httpClient) => _httpClient = httpClient ?? _httpClient;
-
-  ClockProvider _clock = getUtcDateTime;
+  Client httpClient = NoOpClient();
 
   /// If [clock] is provided, it is used to get time instead of the system
   /// clock. This is useful in tests. Should be an implementation of [ClockProvider].
-  ClockProvider get clock => _clock;
-
-  set clock(ClockProvider clock) => _clock = clock ?? _clock;
+  ClockProvider clock = getUtcDateTime;
 
   int _maxBreadcrumbs = 100;
 
@@ -56,9 +44,8 @@ class SentryOptions {
   int get maxBreadcrumbs => _maxBreadcrumbs;
 
   set maxBreadcrumbs(int maxBreadcrumbs) {
-    _maxBreadcrumbs = (maxBreadcrumbs != null && maxBreadcrumbs >= 0)
-        ? maxBreadcrumbs
-        : _maxBreadcrumbs;
+    assert(maxBreadcrumbs >= 0);
+    _maxBreadcrumbs = maxBreadcrumbs;
   }
 
   SentryLogger _logger = noOpLogger;
@@ -67,7 +54,7 @@ class SentryOptions {
   SentryLogger get logger => _logger;
 
   set logger(SentryLogger logger) {
-    _logger = logger != null ? DiagnosticLogger(logger, this).log : _logger;
+    _logger = DiagnosticLogger(logger, this).log;
   }
 
   final List<EventProcessor> _eventProcessors = [];
@@ -88,24 +75,12 @@ class SentryOptions {
   /// along with code that inserts those bindings and activates them.
   List<Integration> get integrations => List.unmodifiable(_integrations);
 
-  bool _debug = false;
-
   /// Turns debug mode on or off. If debug is enabled SDK will attempt to print out useful debugging
   /// information if something goes wrong. Default is disabled.
-  bool get debug => _debug;
-
-  set debug(bool debug) {
-    _debug = debug ?? _debug;
-  }
-
-  SentryLevel _diagnosticLevel = _defaultDiagnosticLevel;
-
-  set diagnosticLevel(SentryLevel level) {
-    _diagnosticLevel = level ?? _diagnosticLevel;
-  }
+  bool debug = false;
 
   /// minimum LogLevel to be used if debug is enabled
-  SentryLevel get diagnosticLevel => _diagnosticLevel;
+  SentryLevel diagnosticLevel = _defaultDiagnosticLevel;
 
   /// Sentry client name used for the HTTP authHeader and userAgent eg
   /// sentry.{language}.{platform}/{version} eg sentry.java.android/2.0.0 would be a valid case
@@ -147,12 +122,8 @@ class SentryOptions {
   /// example : ['sentry'] will include exception from 'package:sentry/sentry.dart'
   List<String> get inAppIncludes => List.unmodifiable(_inAppIncludes);
 
-  Transport _transport = NoOpTransport();
-
   /// The transport is an internal construct of the client that abstracts away the event sending.
-  Transport get transport => _transport;
-
-  set transport(Transport transport) => _transport = transport ?? _transport;
+  Transport transport = NoOpTransport();
 
   /// Sets the distribution. Think about it together with release and environment
   String dist;
@@ -160,16 +131,8 @@ class SentryOptions {
   /// The server name used in the Sentry messages.
   String serverName;
 
-  SdkVersion _sdk = SdkVersion(name: sdkName, version: sdkVersion);
-
   /// Sdk object that contains the Sentry Client Name and its version
-  SdkVersion get sdk => _sdk;
-
-  set sdk(SdkVersion sdk) {
-    _sdk = sdk ?? _sdk;
-  }
-
-  bool _attachStacktrace = true;
+  SdkVersion sdk = SdkVersion(name: sdkName, version: sdkVersion);
 
   /// When enabled, stack traces are automatically attached to all messages logged.
   /// Stack traces are always attached to exceptions;
@@ -180,29 +143,14 @@ class SentryOptions {
   ///
   /// Grouping in Sentry is different for events with stack traces and without.
   /// As a result, you will get new groups as you enable or disable this flag for certain events.
-  bool get attachStacktrace => _attachStacktrace;
-
-  set attachStacktrace(bool attachStacktrace) {
-    _attachStacktrace = attachStacktrace ?? _attachStacktrace;
-  }
-
-  PlatformChecker _platformChecker = PlatformChecker();
+  bool attachStacktrace = true;
 
   /// If [platformChecker] is provided, it is used get the envirnoment.
   /// This is useful in tests. Should be an implementation of [PlatformChecker].
-  PlatformChecker get platformChecker => _platformChecker;
-
-  set platformChecker(PlatformChecker platformChecker) =>
-      _platformChecker = platformChecker ?? _platformChecker;
-
-  bool _attachThreads = false;
+  PlatformChecker platformChecker = PlatformChecker();
 
   /// When enabled, all the threads are automatically attached to all logged events (Android).
-  bool get attachThreads => _attachThreads;
-
-  set attachThreads(bool attachThreads) {
-    _attachThreads = attachThreads ?? _attachThreads;
-  }
+  bool attachThreads = false;
 
   // TODO: Scope observers, enableScopeSync
 

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -208,7 +208,7 @@ typedef BeforeBreadcrumbCallback = Breadcrumb? Function(Breadcrumb? breadcrumb,
 
 /// Are callbacks that run for every event. They can either return a new event which in most cases
 /// means just adding data OR return null in case the event will be dropped and not sent.
-typedef EventProcessor = FutureOr<SentryEvent>? Function(SentryEvent event,
+typedef EventProcessor = FutureOr<SentryEvent?> Function(SentryEvent event,
     {dynamic hint});
 
 /// Logger interface to log useful debugging information if debug is enabled

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -23,7 +23,7 @@ class SentryOptions {
 
   /// The DSN tells the SDK where to send the events to. If an empty string is
   /// used, the SDK will not send any events.
-  String /*!*/ dsn = '';
+  String dsn = '';
 
   /// If [compressPayload] is `true` the outgoing HTTP payloads are compressed
   /// using gzip. Otherwise, the payloads are sent in plain UTF8-encoded JSON
@@ -85,28 +85,28 @@ class SentryOptions {
 
   /// Sentry client name used for the HTTP authHeader and userAgent eg
   /// sentry.{language}.{platform}/{version} eg sentry.java.android/2.0.0 would be a valid case
-  String sentryClientName;
+  String? sentryClientName;
 
   /// This function is called with an SDK specific event object and can return a modified event
   /// object or nothing to skip reporting the event
-  BeforeSendCallback /*?*/ beforeSend;
+  BeforeSendCallback? beforeSend;
 
   /// This function is called with an SDK specific breadcrumb object before the breadcrumb is added
   /// to the scope. When nothing is returned from the function, the breadcrumb is dropped
-  BeforeBreadcrumbCallback /*?*/ beforeBreadcrumb;
+  BeforeBreadcrumbCallback? beforeBreadcrumb;
 
   /// Sets the release. SDK will try to automatically configure a release out of the box
-  String release;
+  String? release;
 
   /// Sets the environment. This string is freeform and not set by default. A release can be
   /// associated with more than one environment to separate them in the UI Think staging vs prod or
   /// similar.
-  String environment;
+  String? environment;
 
   /// Configures the sample rate as a percentage of events to be sent in the range of 0.0 to 1.0. if
   /// 1.0 is set it means that 100% of events are sent. If set to 0.1 only 10% of events will be
   /// sent. Events are picked randomly. Default is null (disabled)
-  double sampleRate;
+  double? sampleRate;
 
   final List<String> _inAppExcludes = [];
 
@@ -127,10 +127,10 @@ class SentryOptions {
   Transport transport = NoOpTransport();
 
   /// Sets the distribution. Think about it together with release and environment
-  String dist;
+  String? dist;
 
   /// The server name used in the Sentry messages.
-  String serverName;
+  String? serverName;
 
   /// Sdk object that contains the Sentry Client Name and its version
   SdkVersion sdk = SdkVersion(name: sdkName, version: sdkVersion);
@@ -157,7 +157,7 @@ class SentryOptions {
 
   // TODO: sendDefaultPii
 
-  SentryOptions({@required this.dsn}) : assert(dsn != null) {
+  SentryOptions({required this.dsn}) : assert(dsn != null) {
     sdk.addPackage('pub:sentry', sdkVersion);
   }
 
@@ -199,17 +199,17 @@ class SentryOptions {
 
 /// This function is called with an SDK specific event object and can return a modified event
 /// object or nothing to skip reporting the event
-typedef BeforeSendCallback = SentryEvent Function(SentryEvent event,
+typedef BeforeSendCallback = SentryEvent? Function(SentryEvent event,
     {dynamic hint});
 
 /// This function is called with an SDK specific breadcrumb object before the breadcrumb is added
 /// to the scope. When nothing is returned from the function, the breadcrumb is dropped
-typedef BeforeBreadcrumbCallback = Breadcrumb Function(Breadcrumb breadcrumb,
+typedef BeforeBreadcrumbCallback = Breadcrumb? Function(Breadcrumb? breadcrumb,
     {dynamic hint});
 
 /// Are callbacks that run for every event. They can either return a new event which in most cases
 /// means just adding data OR return null in case the event will be dropped and not sent.
-typedef EventProcessor = FutureOr<SentryEvent> Function(SentryEvent event,
+typedef EventProcessor = FutureOr<SentryEvent>? Function(SentryEvent event,
     {dynamic hint});
 
 /// Logger interface to log useful debugging information if debug is enabled

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:http/http.dart';
-import 'package:meta/meta.dart';
 
 import 'diagnostic_logger.dart';
 import 'integration.dart';
@@ -157,7 +156,7 @@ class SentryOptions {
 
   // TODO: sendDefaultPii
 
-  SentryOptions({required this.dsn}) : assert(dsn != null) {
+  SentryOptions({required this.dsn}) {
     sdk.addPackage('pub:sentry', sdkVersion);
   }
 

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -31,7 +31,7 @@ class SentryOptions {
 
   /// If [httpClient] is provided, it is used instead of the default client to
   /// make HTTP calls to Sentry.io. This is useful in tests.
-  /// If you don't need to send event, use [NoOpClient].
+  /// If you don't need to send events, use [NoOpClient].
   Client httpClient = NoOpClient();
 
   /// If [clock] is provided, it is used to get time instead of the system

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:http/http.dart';
+import 'package:meta/meta.dart';
 
 import 'diagnostic_logger.dart';
 import 'integration.dart';
@@ -156,7 +157,7 @@ class SentryOptions {
 
   // TODO: sendDefaultPii
 
-  SentryOptions({this.dsn = ''}) {
+  SentryOptions({@required this.dsn}) : assert(dsn != null) {
     sdk.addPackage('pub:sentry', sdkVersion);
   }
 

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -22,11 +22,11 @@ class SentryOptions {
 
   /// The DSN tells the SDK where to send the events to. If an empty string is
   /// used, the SDK will not send any events.
-  String dsn = '';
+  String? dsn;
 
   /// If [compressPayload] is `true` the outgoing HTTP payloads are compressed
   /// using gzip. Otherwise, the payloads are sent in plain UTF8-encoded JSON
-  /// text. If not specified, the compression is enabled by default.
+  /// text. The compression is enabled by default.
   bool compressPayload = true;
 
   /// If [httpClient] is provided, it is used instead of the default client to
@@ -156,7 +156,7 @@ class SentryOptions {
 
   // TODO: sendDefaultPii
 
-  SentryOptions({required this.dsn}) {
+  SentryOptions({this.dsn}) {
     sdk.addPackage('pub:sentry', sdkVersion);
   }
 

--- a/dart/lib/src/sentry_stack_trace_factory.dart
+++ b/dart/lib/src/sentry_stack_trace_factory.dart
@@ -17,8 +17,6 @@ class SentryStackTraceFactory {
 
   /// returns the [SentryStackFrame] list from a stackTrace ([StackTrace] or [String])
   List<SentryStackFrame> getStackFrames(dynamic stackTrace) {
-    if (stackTrace == null) return null;
-
     // TODO : fix : in release mode on Safari passing a stacktrace object fails, but works if it's passed as String
     final chain = (stackTrace is StackTrace)
         ? Chain.forTrace(stackTrace)
@@ -66,11 +64,11 @@ class SentryStackTraceFactory {
 
   /// converts [Frame] to [SentryStackFrame]
   @visibleForTesting
-  SentryStackFrame encodeStackTraceFrame(Frame frame,
+  SentryStackFrame? encodeStackTraceFrame(Frame frame,
       {bool symbolicated = true}) {
     final member = frame.member;
 
-    SentryStackFrame sentryStackFrame;
+    SentryStackFrame? sentryStackFrame;
 
     if (symbolicated) {
       final fileName = frame.uri.pathSegments.isNotEmpty
@@ -88,11 +86,11 @@ class SentryStackTraceFactory {
         package: frame.package,
       );
 
-      if (frame.line != null && frame.line >= 0) {
+      if (frame.line != null && frame.line! >= 0) {
         sentryStackFrame = sentryStackFrame.copyWith(lineNo: frame.line);
       }
 
-      if (frame.column != null && frame.column >= 0) {
+      if (frame.column != null && frame.column! >= 0) {
         sentryStackFrame = sentryStackFrame.copyWith(colNo: frame.column);
       }
     } else {
@@ -110,7 +108,7 @@ class SentryStackTraceFactory {
       // unparsed      #04 abs 000000723d4b8c3b virt 0000000000071c3b _kDartIsolateSnapshotInstructions+0x66c3b
 
       // we are only interested on the #01, 02... items which contains the 'abs' addresses.
-      final matches = _absRegex.allMatches(member);
+      final matches = _absRegex.allMatches(member!);
 
       if (matches.isNotEmpty) {
         final abs = matches.elementAt(0).group(1);
@@ -148,7 +146,7 @@ class SentryStackTraceFactory {
   bool isInApp(Frame frame) {
     final scheme = frame.uri.scheme;
 
-    if (scheme == null || scheme.isEmpty) {
+    if (scheme.isEmpty) {
       return true;
     }
 

--- a/dart/lib/src/sentry_stack_trace_factory.dart
+++ b/dart/lib/src/sentry_stack_trace_factory.dart
@@ -150,18 +150,15 @@ class SentryStackTraceFactory {
       return true;
     }
 
-    if (options.inAppIncludes != null) {
-      for (final include in options.inAppIncludes) {
-        if (frame.package != null && frame.package == include) {
-          return true;
-        }
+    for (final include in options.inAppIncludes) {
+      if (frame.package != null && frame.package == include) {
+        return true;
       }
     }
-    if (options.inAppExcludes != null) {
-      for (final exclude in options.inAppExcludes) {
-        if (frame.package != null && frame.package == exclude) {
-          return false;
-        }
+
+    for (final exclude in options.inAppExcludes) {
+      if (frame.package != null && frame.package == exclude) {
+        return false;
       }
     }
 

--- a/dart/lib/src/sentry_stack_trace_factory.dart
+++ b/dart/lib/src/sentry_stack_trace_factory.dart
@@ -7,18 +7,13 @@ import 'sentry_options.dart';
 
 /// converts [StackTrace] to [SentryStackFrames]
 class SentryStackTraceFactory {
-  SentryOptions _options;
+  SentryOptions options;
 
   final _absRegex = RegExp('abs +([A-Fa-f0-9]+)');
   static const _stackTraceViolateDartStandard =
       'This VM has been configured to produce stack traces that violate the Dart standard.';
 
-  SentryStackTraceFactory(SentryOptions options) {
-    if (options == null) {
-      throw ArgumentError('SentryOptions is required.');
-    }
-    _options = options;
-  }
+  SentryStackTraceFactory(this.options);
 
   /// returns the [SentryStackFrame] list from a stackTrace ([StackTrace] or [String])
   List<SentryStackFrame> getStackFrames(dynamic stackTrace) {
@@ -157,15 +152,15 @@ class SentryStackTraceFactory {
       return true;
     }
 
-    if (_options.inAppIncludes != null) {
-      for (final include in _options.inAppIncludes) {
+    if (options.inAppIncludes != null) {
+      for (final include in options.inAppIncludes) {
         if (frame.package != null && frame.package == include) {
           return true;
         }
       }
     }
-    if (_options.inAppExcludes != null) {
-      for (final exclude in _options.inAppExcludes) {
+    if (options.inAppExcludes != null) {
+      for (final exclude in options.inAppExcludes) {
         if (frame.package != null && frame.package == exclude) {
           return false;
         }

--- a/dart/lib/src/sentry_stack_trace_factory.dart
+++ b/dart/lib/src/sentry_stack_trace_factory.dart
@@ -93,7 +93,7 @@ class SentryStackTraceFactory {
       if (frame.column != null && frame.column! >= 0) {
         sentryStackFrame = sentryStackFrame.copyWith(colNo: frame.column);
       }
-    } else {
+    } else if (member != null) {
       // if --split-debug-info is enabled, thats what we see:
       // warning:  This VM has been configured to produce stack traces that violate the Dart standard.
       // ***       *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
@@ -108,7 +108,7 @@ class SentryStackTraceFactory {
       // unparsed      #04 abs 000000723d4b8c3b virt 0000000000071c3b _kDartIsolateSnapshotInstructions+0x66c3b
 
       // we are only interested on the #01, 02... items which contains the 'abs' addresses.
-      final matches = _absRegex.allMatches(member!);
+      final matches = _absRegex.allMatches(member);
 
       if (matches.isNotEmpty) {
         final abs = matches.elementAt(0).group(1);

--- a/dart/lib/src/sentry_stack_trace_factory.dart
+++ b/dart/lib/src/sentry_stack_trace_factory.dart
@@ -7,13 +7,13 @@ import 'sentry_options.dart';
 
 /// converts [StackTrace] to [SentryStackFrames]
 class SentryStackTraceFactory {
-  SentryOptions options;
+  final SentryOptions _options;
 
   final _absRegex = RegExp('abs +([A-Fa-f0-9]+)');
   static const _stackTraceViolateDartStandard =
       'This VM has been configured to produce stack traces that violate the Dart standard.';
 
-  SentryStackTraceFactory(this.options);
+  SentryStackTraceFactory(this._options);
 
   /// returns the [SentryStackFrame] list from a stackTrace ([StackTrace] or [String])
   List<SentryStackFrame> getStackFrames(dynamic stackTrace) {
@@ -150,13 +150,13 @@ class SentryStackTraceFactory {
       return true;
     }
 
-    for (final include in options.inAppIncludes) {
+    for (final include in _options.inAppIncludes) {
       if (frame.package != null && frame.package == include) {
         return true;
       }
     }
 
-    for (final exclude in options.inAppExcludes) {
+    for (final exclude in _options.inAppExcludes) {
       if (frame.package != null && frame.package == exclude) {
         return false;
       }

--- a/dart/lib/src/transport/http_transport.dart
+++ b/dart/lib/src/transport/http_transport.dart
@@ -20,7 +20,7 @@ class HttpTransport implements Transport {
 
   final Map<String, String> _headers;
 
-  factory HttpTransport(SentryOptions options) {
+  factory HttpTransport(SentryOptions/*!*/ options) {
     if (options == null) {
       throw ArgumentError('SentryOptions is required.');
     }

--- a/dart/lib/src/transport/http_transport.dart
+++ b/dart/lib/src/transport/http_transport.dart
@@ -16,15 +16,11 @@ class HttpTransport implements Transport {
 
   final Dsn _dsn;
 
-  _CredentialBuilder _credentialBuilder;
+  late _CredentialBuilder _credentialBuilder;
 
   final Map<String, String> _headers;
 
-  factory HttpTransport(SentryOptions/*!*/ options) {
-    if (options == null) {
-      throw ArgumentError('SentryOptions is required.');
-    }
-
+  factory HttpTransport(SentryOptions options) {
     if (options.httpClient is NoOpClient) {
       options.httpClient = Client();
     }
@@ -54,7 +50,7 @@ class HttpTransport implements Transport {
 
     final response = await _options.httpClient.post(
       _dsn.postUri,
-      headers: _credentialBuilder.configure(_headers),
+      headers: _credentialBuilder.configure(_headers) as Map<String, String>?,
       body: body,
     );
 
@@ -83,7 +79,7 @@ class HttpTransport implements Transport {
   List<int> _bodyEncoder(
     Map<String, dynamic> data,
     Map<String, String> headers, {
-    bool compressPayload,
+    required bool compressPayload,
   }) {
     // [SentryIOClient] implement gzip compression
     // gzip compression is not available on browser
@@ -118,9 +114,9 @@ class _CredentialBuilder {
   }
 
   static String _buildAuthHeader({
-    String publicKey,
-    String secretKey,
-    String sdkIdentifier,
+    String? publicKey,
+    String? secretKey,
+    String? sdkIdentifier,
   }) {
     var header = 'Sentry sentry_version=7, sentry_client=$sdkIdentifier, '
         'sentry_key=$publicKey';

--- a/dart/lib/src/transport/http_transport.dart
+++ b/dart/lib/src/transport/http_transport.dart
@@ -29,7 +29,7 @@ class HttpTransport implements Transport {
   }
 
   HttpTransport._(this._options)
-      : _dsn = Dsn.parse(_options.dsn),
+      : _dsn = Dsn.parse(_options.dsn!),
         _headers = _buildHeaders(_options.sdk.identifier) {
     _credentialBuilder = _CredentialBuilder(
       _dsn,
@@ -50,7 +50,7 @@ class HttpTransport implements Transport {
 
     final response = await _options.httpClient.post(
       _dsn.postUri,
-      headers: _credentialBuilder.configure(_headers) as Map<String, String>?,
+      headers: _credentialBuilder.configure(_headers),
       body: body,
     );
 
@@ -114,9 +114,9 @@ class _CredentialBuilder {
   }
 
   static String _buildAuthHeader({
-    String? publicKey,
+    required String publicKey,
     String? secretKey,
-    String? sdkIdentifier,
+    required String sdkIdentifier,
   }) {
     var header = 'Sentry sentry_version=7, sentry_client=$sdkIdentifier, '
         'sentry_key=$publicKey';
@@ -128,7 +128,7 @@ class _CredentialBuilder {
     return header;
   }
 
-  Map<String, dynamic> configure(Map<String, dynamic> headers) {
+  Map<String, String> configure(Map<String, String> headers) {
     return headers
       ..addAll(
         <String, String>{

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://docs.sentry.io/platforms/dart/
 repository: https://github.com/getsentry/sentry-dart
 
 environment:
-  sdk: ">=2.8.0 <3.0.0"
+  sdk: '>=2.12.0-259.8.beta <3.0.0'
 
 dependencies:
   http: ^0.13.0

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://docs.sentry.io/platforms/dart/
 repository: https://github.com/getsentry/sentry-dart
 
 environment:
-  sdk: '>=2.12.0-259.8.beta <3.0.0'
+  sdk: '>=2.12.0-259.9.beta <3.0.0'
 
 dependencies:
   http: ^0.13.0

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -10,15 +10,15 @@ environment:
   sdk: ">=2.8.0 <3.0.0"
 
 dependencies:
-  http: ^0.12.0
-  meta: ^1.0.0
-  stack_trace: ^1.0.0
-  uuid: ^2.0.0
+  http: ^0.13.0
+  meta: ^1.3.0-nullsafety.6
+  stack_trace: ^1.10.0
+  uuid: ^3.0.0-nullsafety.0
 
 dev_dependencies:
-  mockito: ^4.1.3
-  pedantic: ^1.9.2
-  test: ^1.15.7
-  yaml: ^2.2.1 # needed for version match (code and pubspec)
-  collection: ^1.14.13
-  coverage: ^0.14.2
+  mockito: ^5.0.0-nullsafety.7
+  pedantic: ^1.10.0
+  test: ^1.16.0
+  yaml: ^3.0.0 # needed for version match (code and pubspec)
+  collection: ^1.15.0
+  coverage: ^0.15.2

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -11,9 +11,9 @@ environment:
 
 dependencies:
   http: ^0.13.0
-  meta: ^1.3.0-nullsafety.6
+  meta: ^1.3.0
   stack_trace: ^1.10.0
-  uuid: ^3.0.0-nullsafety.0
+  uuid: ^3.0.0-nullsafety.1
 
 dev_dependencies:
   mockito: ^5.0.0-nullsafety.7

--- a/dart/test/contexts_test.dart
+++ b/dart/test/contexts_test.dart
@@ -111,11 +111,11 @@ void main() {
     test('clone context', () {
       final clone = contexts.clone();
 
-      expect(clone.app.toJson(), contexts.app.toJson());
-      expect(clone.browser.toJson(), contexts.browser.toJson());
-      expect(clone.device.toJson(), contexts.device.toJson());
-      expect(clone.operatingSystem.toJson(), contexts.operatingSystem.toJson());
-      expect(clone.gpu.toJson(), contexts.gpu.toJson());
+      expect(clone.app!.toJson(), contexts.app!.toJson());
+      expect(clone.browser!.toJson(), contexts.browser!.toJson());
+      expect(clone.device!.toJson(), contexts.device!.toJson());
+      expect(clone.operatingSystem!.toJson(), contexts.operatingSystem!.toJson());
+      expect(clone.gpu!.toJson(), contexts.gpu!.toJson());
 
       contexts.runtimes.forEach((element) {
         expect(
@@ -136,7 +136,7 @@ void main() {
       final contexts = Contexts.fromJson(jsonDecode(jsonContexts));
       expect(
         MapEquality().equals(
-          contexts.operatingSystem.toJson(),
+          contexts.operatingSystem!.toJson(),
           {
             'build': '19H2',
             'rooted': false,
@@ -149,7 +149,7 @@ void main() {
         true,
       );
       expect(
-        MapEquality().equals(contexts.device.toJson(), {
+        MapEquality().equals(contexts.device!.toJson(), {
           'simulator': true,
           'model_id': 'simulator',
           'arch': 'x86',
@@ -167,7 +167,7 @@ void main() {
 
       expect(
         MapEquality().equals(
-          contexts.app.toJson(),
+          contexts.app!.toJson(),
           {
             'app_name': 'sentry_flutter_example',
             'app_version': '0.1.2',
@@ -189,12 +189,12 @@ void main() {
         true,
       );
       expect(
-        MapEquality().equals(contexts.browser.toJson(), {'version': '12.3.4'}),
+        MapEquality().equals(contexts.browser!.toJson(), {'version': '12.3.4'}),
         true,
       );
       expect(
         MapEquality()
-            .equals(contexts.gpu.toJson(), {'name': 'Radeon', 'version': '1'}),
+            .equals(contexts.gpu!.toJson(), {'name': 'Radeon', 'version': '1'}),
         true,
       );
     });

--- a/dart/test/default_integrations_test.dart
+++ b/dart/test/default_integrations_test.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 import 'mocks.dart';
 
 void main() {
-  Fixture fixture;
+  late Fixture fixture;
 
   setUp(() {
     fixture = Fixture();

--- a/dart/test/default_integrations_test.dart
+++ b/dart/test/default_integrations_test.dart
@@ -1,8 +1,8 @@
-import 'package:mockito/mockito.dart';
 import 'package:sentry/sentry.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';
+import 'mocks/mock_hub.dart';
 
 void main() {
   late Fixture fixture;
@@ -42,16 +42,12 @@ void main() {
       // that handles and captures it.
       await handleIsolateError(fixture.hub, fixture.options, error);
 
-      final event = verify(
-        await fixture.hub.captureEvent(
-          captureAny,
-          stackTrace: captureAnyNamed('stackTrace'),
-        ),
-      ).captured.first as SentryEvent;
+      expect(fixture.hub.captureEventCalls.length, 1);
+      final event = fixture.hub.captureEventCalls.first.event;
 
-      expect(SentryLevel.fatal, event.level);
+      expect(SentryLevel.fatal, event?.level);
 
-      final throwableMechanism = event.throwable as ThrowableMechanism;
+      final throwableMechanism = event?.throwable as ThrowableMechanism;
       expect('isolateError', throwableMechanism.mechanism.type);
       expect(true, throwableMechanism.mechanism.handled);
       expect(throwable, throwableMechanism.throwable);
@@ -102,14 +98,12 @@ void main() {
 
     await integration(fixture.hub, fixture.options);
 
-    final event = verify(
-      await fixture.hub
-          .captureEvent(captureAny, stackTrace: captureAnyNamed('stackTrace')),
-    ).captured.first as SentryEvent;
+    expect(fixture.hub.captureEventCalls.length, 1);
+    final event = fixture.hub.captureEventCalls.first.event;
 
-    expect(SentryLevel.fatal, event.level);
+    expect(SentryLevel.fatal, event?.level);
 
-    final throwableMechanism = event.throwable as ThrowableMechanism;
+    final throwableMechanism = event?.throwable as ThrowableMechanism;
     expect('runZonedGuarded', throwableMechanism.mechanism.type);
     expect(true, throwableMechanism.mechanism.handled);
     expect(throwable, throwableMechanism.throwable);

--- a/dart/test/default_integrations_test.dart
+++ b/dart/test/default_integrations_test.dart
@@ -45,9 +45,9 @@ void main() {
       expect(fixture.hub.captureEventCalls.length, 1);
       final event = fixture.hub.captureEventCalls.first.event;
 
-      expect(SentryLevel.fatal, event?.level);
+      expect(SentryLevel.fatal, event.level);
 
-      final throwableMechanism = event?.throwable as ThrowableMechanism;
+      final throwableMechanism = event.throwable as ThrowableMechanism;
       expect('isolateError', throwableMechanism.mechanism.type);
       expect(true, throwableMechanism.mechanism.handled);
       expect(throwable, throwableMechanism.throwable);
@@ -101,9 +101,9 @@ void main() {
     expect(fixture.hub.captureEventCalls.length, 1);
     final event = fixture.hub.captureEventCalls.first.event;
 
-    expect(SentryLevel.fatal, event?.level);
+    expect(SentryLevel.fatal, event.level);
 
-    final throwableMechanism = event?.throwable as ThrowableMechanism;
+    final throwableMechanism = event.throwable as ThrowableMechanism;
     expect('runZonedGuarded', throwableMechanism.mechanism.type);
     expect(true, throwableMechanism.mechanism.handled);
     expect(throwable, throwableMechanism.throwable);

--- a/dart/test/default_integrations_test.dart
+++ b/dart/test/default_integrations_test.dart
@@ -118,5 +118,5 @@ void main() {
 
 class Fixture {
   final hub = MockHub();
-  final options = SentryOptions();
+  final options = SentryOptions(dsn: fakeDsn);
 }

--- a/dart/test/exception_factory_test.dart
+++ b/dart/test/exception_factory_test.dart
@@ -23,7 +23,7 @@ void main() {
       }
 
       expect(sentryException.type, 'StateError');
-      expect(sentryException.stackTrace.frames, isNotEmpty);
+      expect(sentryException.stackTrace!.frames, isNotEmpty);
     });
 
     test('should not override event.stacktrace', () {
@@ -42,9 +42,9 @@ void main() {
       }
 
       expect(sentryException.type, 'StateError');
-      expect(sentryException.stackTrace.frames.first.lineNo, 46);
-      expect(sentryException.stackTrace.frames.first.colNo, 9);
-      expect(sentryException.stackTrace.frames.first.fileName, 'test.dart');
+      expect(sentryException.stackTrace!.frames.first.lineNo, 46);
+      expect(sentryException.stackTrace!.frames.first.colNo, 9);
+      expect(sentryException.stackTrace!.frames.first.fileName, 'test.dart');
     });
   });
 

--- a/dart/test/exception_factory_test.dart
+++ b/dart/test/exception_factory_test.dart
@@ -3,9 +3,11 @@ import 'package:sentry/src/sentry_exception_factory.dart';
 import 'package:sentry/src/sentry_stack_trace_factory.dart';
 import 'package:test/test.dart';
 
+import 'mocks.dart';
+
 void main() {
   group('Exception factory', () {
-    final options = SentryOptions();
+    final options = SentryOptions(dsn: fakeDsn);
     final exceptionFactory = SentryExceptionFactory(
         options: options, stacktraceFactory: SentryStackTraceFactory(options));
 
@@ -50,7 +52,8 @@ void main() {
     expect(
         () => SentryExceptionFactory(
               options: null,
-              stacktraceFactory: SentryStackTraceFactory(SentryOptions()),
+              stacktraceFactory:
+                  SentryStackTraceFactory(SentryOptions(dsn: fakeDsn)),
             ),
         throwsArgumentError);
   });
@@ -58,7 +61,7 @@ void main() {
   test("stacktraceFactory can't be null", () {
     expect(
       () => SentryExceptionFactory(
-          options: SentryOptions(), stacktraceFactory: null),
+          options: SentryOptions(dsn: fakeDsn), stacktraceFactory: null),
       throwsArgumentError,
     );
   });

--- a/dart/test/exception_factory_test.dart
+++ b/dart/test/exception_factory_test.dart
@@ -9,7 +9,9 @@ void main() {
   group('Exception factory', () {
     final options = SentryOptions(dsn: fakeDsn);
     final exceptionFactory = SentryExceptionFactory(
-        options: options, stacktraceFactory: SentryStackTraceFactory(options));
+      options,
+      SentryStackTraceFactory(options),
+    );
 
     test('exceptionFactory.getSentryException', () {
       SentryException sentryException;
@@ -46,23 +48,5 @@ void main() {
       expect(sentryException.stackTrace!.frames.first.colNo, 9);
       expect(sentryException.stackTrace!.frames.first.fileName, 'test.dart');
     });
-  });
-
-  test("options can't be null", () {
-    expect(
-        () => SentryExceptionFactory(
-              options: null,
-              stacktraceFactory:
-                  SentryStackTraceFactory(SentryOptions(dsn: fakeDsn)),
-            ),
-        throwsArgumentError);
-  });
-
-  test("stacktraceFactory can't be null", () {
-    expect(
-      () => SentryExceptionFactory(
-          options: SentryOptions(dsn: fakeDsn), stacktraceFactory: null),
-      throwsArgumentError,
-    );
   });
 }

--- a/dart/test/fake_platform_checker.dart
+++ b/dart/test/fake_platform_checker.dart
@@ -20,9 +20,9 @@ class FakePlatformChecker implements PlatformChecker {
     _profileMode = true;
   }
 
-  bool _releaseMode;
-  bool _debugMode;
-  bool _profileMode;
+  late bool _releaseMode;
+  late bool _debugMode;
+  late bool _profileMode;
 
   @override
   bool isReleaseMode() {

--- a/dart/test/http_client/sentry_http_client_test.dart
+++ b/dart/test/http_client/sentry_http_client_test.dart
@@ -21,7 +21,7 @@ void main() {
 
       final client = SentryHttpClient(client: mockClient, hub: mockHub);
 
-      final response = await client.get('https://example.com');
+      final response = await client.get(Uri.parse('https://example.com'));
       expect(response.statusCode, 200);
 
       final breadcrumb = verify(mockHub.addBreadcrumb(captureAny))
@@ -47,7 +47,7 @@ void main() {
 
       final client = SentryHttpClient(client: mockClient, hub: mockHub);
 
-      final response = await client.get('https://example.com');
+      final response = await client.get(Uri.parse('https://example.com'));
       expect(response.statusCode, 404);
 
       final breadcrumb = verify(mockHub.addBreadcrumb(captureAny))
@@ -73,7 +73,7 @@ void main() {
 
       final client = SentryHttpClient(client: mockClient, hub: mockHub);
 
-      final response = await client.post('https://example.com');
+      final response = await client.post(Uri.parse('https://example.com'));
       expect(response.statusCode, 200);
 
       final breadcrumb = verify(mockHub.addBreadcrumb(captureAny))
@@ -98,7 +98,7 @@ void main() {
 
       final client = SentryHttpClient(client: mockClient, hub: mockHub);
 
-      final response = await client.put('https://example.com');
+      final response = await client.put(Uri.parse('https://example.com'));
       expect(response.statusCode, 200);
 
       final breadcrumb = verify(mockHub.addBreadcrumb(captureAny))
@@ -123,7 +123,7 @@ void main() {
 
       final client = SentryHttpClient(client: mockClient, hub: mockHub);
 
-      final response = await client.delete('https://example.com');
+      final response = await client.delete(Uri.parse('https://example.com'));
       expect(response.statusCode, 200);
 
       final breadcrumb = verify(mockHub.addBreadcrumb(captureAny))
@@ -156,7 +156,7 @@ void main() {
       final client = SentryHttpClient(client: mockClient, hub: mockHub);
 
       try {
-        await client.get('https://example.com');
+        await client.get(Uri.parse('https://example.com'));
         fail('Method did not throw');
       } on ClientException catch (e) {
         expect(e.message, 'test');
@@ -182,7 +182,7 @@ void main() {
       final client = SentryHttpClient(client: mockClient, hub: mockHub);
 
       try {
-        await client.get('https://example.com');
+        await client.get(Uri.parse('https://example.com'));
         fail('Method did not throw');
       } on SocketException catch (e) {
         expect(e.message, 'test');

--- a/dart/test/http_client/sentry_http_client_test.dart
+++ b/dart/test/http_client/sentry_http_client_test.dart
@@ -7,7 +7,7 @@ import 'package:sentry/sentry.dart';
 import 'package:sentry/src/http_client/sentry_http_client.dart';
 import 'package:test/test.dart';
 
-import '../mocks.dart';
+import '../mocks/mock_hub.dart';
 
 void main() {
   group(SentryHttpClient, () {
@@ -24,12 +24,11 @@ void main() {
       final response = await client.get(Uri.parse('https://example.com'));
       expect(response.statusCode, 200);
 
-      final breadcrumb = verify(mockHub.addBreadcrumb(captureAny))
-          .captured
-          .single as Breadcrumb;
+      expect(mockHub.addBreadcrumbCalls.length, 1);
+      final breadcrumb = mockHub.addBreadcrumbCalls.first.crumb;
 
-      expect(breadcrumb.type, 'http');
-      expect(breadcrumb.data, <String, dynamic>{
+      expect(breadcrumb?.type, 'http');
+      expect(breadcrumb?.data, <String, dynamic>{
         'url': 'https://example.com',
         'method': 'GET',
         'status_code': 200,
@@ -50,12 +49,11 @@ void main() {
       final response = await client.get(Uri.parse('https://example.com'));
       expect(response.statusCode, 404);
 
-      final breadcrumb = verify(mockHub.addBreadcrumb(captureAny))
-          .captured
-          .single as Breadcrumb;
+      expect(mockHub.addBreadcrumbCalls.length, 1);
+      final breadcrumb = mockHub.addBreadcrumbCalls.first.crumb;
 
-      expect(breadcrumb.type, 'http');
-      expect(breadcrumb.data, <String, dynamic>{
+      expect(breadcrumb?.type, 'http');
+      expect(breadcrumb?.data, <String, dynamic>{
         'url': 'https://example.com',
         'method': 'GET',
         'status_code': 404,
@@ -76,12 +74,11 @@ void main() {
       final response = await client.post(Uri.parse('https://example.com'));
       expect(response.statusCode, 200);
 
-      final breadcrumb = verify(mockHub.addBreadcrumb(captureAny))
-          .captured
-          .single as Breadcrumb;
+      expect(mockHub.addBreadcrumbCalls.length, 1);
+      final breadcrumb = mockHub.addBreadcrumbCalls.first.crumb;
 
-      expect(breadcrumb.type, 'http');
-      expect(breadcrumb.data, <String, dynamic>{
+      expect(breadcrumb?.type, 'http');
+      expect(breadcrumb?.data, <String, dynamic>{
         'url': 'https://example.com',
         'method': 'POST',
         'status_code': 200,
@@ -101,12 +98,11 @@ void main() {
       final response = await client.put(Uri.parse('https://example.com'));
       expect(response.statusCode, 200);
 
-      final breadcrumb = verify(mockHub.addBreadcrumb(captureAny))
-          .captured
-          .single as Breadcrumb;
+      expect(mockHub.addBreadcrumbCalls.length, 1);
+      final breadcrumb = mockHub.addBreadcrumbCalls.first.crumb;
 
-      expect(breadcrumb.type, 'http');
-      expect(breadcrumb.data, <String, dynamic>{
+      expect(breadcrumb?.type, 'http');
+      expect(breadcrumb?.data, <String, dynamic>{
         'url': 'https://example.com',
         'method': 'PUT',
         'status_code': 200,
@@ -126,12 +122,11 @@ void main() {
       final response = await client.delete(Uri.parse('https://example.com'));
       expect(response.statusCode, 200);
 
-      final breadcrumb = verify(mockHub.addBreadcrumb(captureAny))
-          .captured
-          .single as Breadcrumb;
+      expect(mockHub.addBreadcrumbCalls.length, 1);
+      final breadcrumb = mockHub.addBreadcrumbCalls.first.crumb;
 
-      expect(breadcrumb.type, 'http');
-      expect(breadcrumb.data, <String, dynamic>{
+      expect(breadcrumb?.type, 'http');
+      expect(breadcrumb?.data, <String, dynamic>{
         'url': 'https://example.com',
         'method': 'DELETE',
         'status_code': 200,
@@ -163,8 +158,8 @@ void main() {
         expect(e.uri, url);
       }
 
-      verifyNever(mockHub.addBreadcrumb(captureAny));
-      verifyNever(mockHub.captureException(captureAny));
+      expect(mockHub.addBreadcrumbCalls.length, 0);
+      expect(mockHub.captureExceptionCalls.length, 0);
     });
 
     /// SocketException are only a thing on dart:io platforms.
@@ -188,8 +183,8 @@ void main() {
         expect(e.message, 'test');
       }
 
-      verifyNever(mockHub.addBreadcrumb(captureAny));
-      verifyNever(mockHub.captureException(captureAny));
+      expect(mockHub.addBreadcrumbCalls.length, 0);
+      expect(mockHub.captureExceptionCalls.length, 0);
     });
 
     test('close does get called for user defined client', () async {
@@ -200,8 +195,8 @@ void main() {
       final client = SentryHttpClient(client: mockClient, hub: mockHub);
       client.close();
 
-      verifyNever(mockHub.addBreadcrumb(captureAny));
-      verifyNever(mockHub.captureException(captureAny));
+      expect(mockHub.addBreadcrumbCalls.length, 0);
+      expect(mockHub.captureExceptionCalls.length, 0);
       verify(mockClient.close());
     });
   });

--- a/dart/test/http_client/sentry_http_client_test.dart
+++ b/dart/test/http_client/sentry_http_client_test.dart
@@ -27,8 +27,8 @@ void main() {
       expect(mockHub.addBreadcrumbCalls.length, 1);
       final breadcrumb = mockHub.addBreadcrumbCalls.first.crumb;
 
-      expect(breadcrumb?.type, 'http');
-      expect(breadcrumb?.data, <String, dynamic>{
+      expect(breadcrumb.type, 'http');
+      expect(breadcrumb.data, <String, dynamic>{
         'url': 'https://example.com',
         'method': 'GET',
         'status_code': 200,
@@ -52,8 +52,8 @@ void main() {
       expect(mockHub.addBreadcrumbCalls.length, 1);
       final breadcrumb = mockHub.addBreadcrumbCalls.first.crumb;
 
-      expect(breadcrumb?.type, 'http');
-      expect(breadcrumb?.data, <String, dynamic>{
+      expect(breadcrumb.type, 'http');
+      expect(breadcrumb.data, <String, dynamic>{
         'url': 'https://example.com',
         'method': 'GET',
         'status_code': 404,
@@ -77,8 +77,8 @@ void main() {
       expect(mockHub.addBreadcrumbCalls.length, 1);
       final breadcrumb = mockHub.addBreadcrumbCalls.first.crumb;
 
-      expect(breadcrumb?.type, 'http');
-      expect(breadcrumb?.data, <String, dynamic>{
+      expect(breadcrumb.type, 'http');
+      expect(breadcrumb.data, <String, dynamic>{
         'url': 'https://example.com',
         'method': 'POST',
         'status_code': 200,
@@ -101,8 +101,8 @@ void main() {
       expect(mockHub.addBreadcrumbCalls.length, 1);
       final breadcrumb = mockHub.addBreadcrumbCalls.first.crumb;
 
-      expect(breadcrumb?.type, 'http');
-      expect(breadcrumb?.data, <String, dynamic>{
+      expect(breadcrumb.type, 'http');
+      expect(breadcrumb.data, <String, dynamic>{
         'url': 'https://example.com',
         'method': 'PUT',
         'status_code': 200,
@@ -125,8 +125,8 @@ void main() {
       expect(mockHub.addBreadcrumbCalls.length, 1);
       final breadcrumb = mockHub.addBreadcrumbCalls.first.crumb;
 
-      expect(breadcrumb?.type, 'http');
-      expect(breadcrumb?.data, <String, dynamic>{
+      expect(breadcrumb.type, 'http');
+      expect(breadcrumb.data, <String, dynamic>{
         'url': 'https://example.com',
         'method': 'DELETE',
         'status_code': 200,

--- a/dart/test/http_transport_test.dart
+++ b/dart/test/http_transport_test.dart
@@ -1,8 +1,4 @@
 import 'package:sentry/src/transport/http_transport.dart';
 import 'package:test/test.dart';
 
-void main() {
-  test("options can't be null", () {
-    expect(() => HttpTransport(null), throwsArgumentError);
-  });
-}
+void main() {}

--- a/dart/test/http_transport_test.dart
+++ b/dart/test/http_transport_test.dart
@@ -1,4 +1,0 @@
-import 'package:sentry/src/transport/http_transport.dart';
-import 'package:test/test.dart';
-
-void main() {}

--- a/dart/test/hub_test.dart
+++ b/dart/test/hub_test.dart
@@ -21,12 +21,6 @@ void main() {
   }
 
   group('Hub instantiation', () {
-    test('should not instantiate without a sentryOptions', () {
-      Hub hub;
-      expect(() => hub = Hub(null), throwsArgumentError);
-      expect(hub, null);
-    });
-
     test('should not instantiate without a dsn', () {
       expect(() => Hub(SentryOptions()), throwsArgumentError);
     });

--- a/dart/test/hub_test.dart
+++ b/dart/test/hub_test.dart
@@ -1,5 +1,4 @@
 import 'package:collection/collection.dart';
-import 'package:mockito/mockito.dart';
 import 'package:sentry/sentry.dart';
 import 'package:sentry/src/hub.dart';
 import 'package:test/test.dart';

--- a/dart/test/hub_test.dart
+++ b/dart/test/hub_test.dart
@@ -21,10 +21,6 @@ void main() {
   }
 
   group('Hub instantiation', () {
-    test('should not instantiate without a dsn', () {
-      expect(() => Hub(SentryOptions()), throwsArgumentError);
-    });
-
     test('should instantiate with a dsn', () {
       final hub = Hub(SentryOptions(dsn: fakeDsn));
       expect(hub.isEnabled, true);

--- a/dart/test/hub_test.dart
+++ b/dart/test/hub_test.dart
@@ -9,9 +9,9 @@ import 'package:test/test.dart';
 import 'mocks.dart';
 
 void main() {
-  bool scopeEquals(Scope a, Scope b) {
+  bool scopeEquals(Scope? a, Scope b) {
     return identical(a, b) ||
-        a.level == b.level &&
+        a!.level == b.level &&
             a.transaction == b.transaction &&
             a.user == b.user &&
             IterableEquality().equals(a.fingerprint, b.fingerprint) &&
@@ -28,9 +28,9 @@ void main() {
   });
 
   group('Hub captures', () {
-    Hub hub;
-    SentryOptions options;
-    MockSentryClient client;
+    late Hub hub;
+    late SentryOptions options;
+    late MockSentryClient client;
 
     setUp(() {
       options = SentryOptions(dsn: fakeDsn);
@@ -90,8 +90,8 @@ void main() {
   });
 
   group('Hub scope', () {
-    Hub hub;
-    SentryClient client;
+    late Hub hub;
+    late SentryClient client;
 
     setUp(() {
       hub = Hub(SentryOptions(dsn: fakeDsn));
@@ -113,7 +113,7 @@ void main() {
           fakeEvent,
           scope: captureAnyNamed('scope'),
         ),
-      ).captured.first as Scope;
+      ).captured.first as Scope?;
 
       expect(
         scopeEquals(
@@ -140,8 +140,8 @@ void main() {
   });
 
   group('Hub Client', () {
-    Hub hub;
-    SentryClient client;
+    late Hub hub;
+    late SentryClient client;
     SentryOptions options;
 
     setUp(() {

--- a/dart/test/mocks.dart
+++ b/dart/test/mocks.dart
@@ -4,11 +4,7 @@ import 'package:sentry/src/protocol.dart';
 
 class MockSentryClient extends Mock implements SentryClient {}
 
-class MockTransport extends Mock implements Transport {}
-
 class MockHub extends Mock implements Hub {}
-
-class MockIntegration extends Mock implements Integration {}
 
 final fakeDsn = 'https://abc@def.ingest.sentry.io/1234567';
 

--- a/dart/test/mocks.dart
+++ b/dart/test/mocks.dart
@@ -2,8 +2,6 @@ import 'package:mockito/mockito.dart';
 import 'package:sentry/sentry.dart';
 import 'package:sentry/src/protocol.dart';
 
-class MockHub extends Mock implements Hub {}
-
 final fakeDsn = 'https://abc@def.ingest.sentry.io/1234567';
 
 final fakeException = Exception('Error');

--- a/dart/test/mocks.dart
+++ b/dart/test/mocks.dart
@@ -1,4 +1,3 @@
-import 'package:mockito/mockito.dart';
 import 'package:sentry/sentry.dart';
 import 'package:sentry/src/protocol.dart';
 

--- a/dart/test/mocks.dart
+++ b/dart/test/mocks.dart
@@ -2,15 +2,17 @@ import 'package:mockito/mockito.dart';
 import 'package:sentry/sentry.dart';
 import 'package:sentry/src/protocol.dart';
 
-class MockSentryClient extends Mock implements SentryClient {}
-
 class MockHub extends Mock implements Hub {}
 
 final fakeDsn = 'https://abc@def.ingest.sentry.io/1234567';
 
 final fakeException = Exception('Error');
 
-final fakeMessage = Message('message 1', template: 'message %d', params: ['1']);
+final fakeMessage = Message(
+  'message 1',
+  template: 'message %d',
+  params: ['1'],
+);
 
 final fakeUser = User(id: '1', email: 'test@test');
 
@@ -28,28 +30,31 @@ final fakeEvent = SentryEvent(
   modules: const {'module1': 'factory'},
   sdk: SdkVersion(name: 'sdk1', version: '1.0.0'),
   user: User(
-      id: '800',
-      username: 'first-user',
-      email: 'first@user.lan',
-      ipAddress: '127.0.0.1',
-      extras: <String, String>{'first-sign-in': '2020-01-01'}),
+    id: '800',
+    username: 'first-user',
+    email: 'first@user.lan',
+    ipAddress: '127.0.0.1',
+    extras: <String, String>{'first-sign-in': '2020-01-01'},
+  ),
   breadcrumbs: [
     Breadcrumb(
-        message: 'UI Lifecycle',
-        timestamp: DateTime.now().toUtc(),
-        category: 'ui.lifecycle',
-        type: 'navigation',
-        data: {'screen': 'MainActivity', 'state': 'created'},
-        level: SentryLevel.info)
+      message: 'UI Lifecycle',
+      timestamp: DateTime.now().toUtc(),
+      category: 'ui.lifecycle',
+      type: 'navigation',
+      data: {'screen': 'MainActivity', 'state': 'created'},
+      level: SentryLevel.info,
+    )
   ],
   contexts: Contexts(
     operatingSystem: const OperatingSystem(
-        name: 'Android',
-        version: '5.0.2',
-        build: 'LRX22G.P900XXS0BPL2',
-        kernelVersion:
-            'Linux version 3.4.39-5726670 (dpi@SWHC3807) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Thu Dec 1 19:42:39 KST 2016',
-        rooted: false),
+      name: 'Android',
+      version: '5.0.2',
+      build: 'LRX22G.P900XXS0BPL2',
+      kernelVersion:
+          'Linux version 3.4.39-5726670 (dpi@SWHC3807) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Thu Dec 1 19:42:39 KST 2016',
+      rooted: false,
+    ),
     runtimes: [const SentryRuntime(name: 'ART', version: '5')],
     app: App(
         name: 'Example Dart App',

--- a/dart/test/mocks/mock_hub.dart
+++ b/dart/test/mocks/mock_hub.dart
@@ -9,30 +9,30 @@ class MockHub implements Hub {
   int closeCalls = 0;
 
   @override
-  void addBreadcrumb(Breadcrumb? crumb, {dynamic hint}) {
+  void addBreadcrumb(Breadcrumb crumb, {dynamic hint}) {
     addBreadcrumbCalls.add(AddBreadcrumbCall(crumb, hint));
   }
 
   @override
-  void bindClient(SentryClient? client) {
+  void bindClient(SentryClient client) {
     bindClientCalls.add(client);
   }
 
   @override
   Future<SentryId> captureEvent(
-    SentryEvent? event, {
+    SentryEvent event, {
     dynamic stackTrace,
     dynamic hint,
   }) async {
     captureEventCalls.add(CaptureEventCall(event, stackTrace, hint));
-    return event?.eventId ?? SentryId.empty();
+    return event.eventId;
   }
 
   @override
   Future<SentryId> captureException(
-    throwable, {
-    stackTrace,
-    hint,
+    dynamic throwable, {
+    dynamic stackTrace,
+    dynamic hint,
   }) async {
     captureExceptionCalls
         .add(CaptureExceptionCall(throwable, stackTrace, hint));
@@ -78,7 +78,7 @@ class MockHub implements Hub {
 }
 
 class CaptureEventCall {
-  final SentryEvent? event;
+  final SentryEvent event;
   final dynamic stackTrace;
   final dynamic hint;
 
@@ -114,7 +114,7 @@ class CaptureMessageCall {
 }
 
 class AddBreadcrumbCall {
-  final Breadcrumb? crumb;
+  final Breadcrumb crumb;
   final dynamic hint;
 
   AddBreadcrumbCall(this.crumb, this.hint);

--- a/dart/test/mocks/mock_hub.dart
+++ b/dart/test/mocks/mock_hub.dart
@@ -1,0 +1,63 @@
+import 'package:sentry/sentry.dart';
+
+class MockHub implements Hub {
+  @override
+  void addBreadcrumb(Breadcrumb? crumb, {dynamic hint}) {
+    // TODO: implement addBreadcrumb
+  }
+
+  @override
+  void bindClient(SentryClient? client) {
+    // TODO: implement bindClient
+  }
+
+  @override
+  Future<SentryId> captureEvent(
+    SentryEvent? event, {
+    dynamic stackTrace,
+    dynamic hint,
+  }) {
+    // TODO: implement captureEvent
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<SentryId> captureException(throwable, {stackTrace, hint}) {
+    // TODO: implement captureException
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<SentryId> captureMessage(String? message,
+      {SentryLevel level = SentryLevel.info,
+      String? template,
+      List? params,
+      hint}) {
+    // TODO: implement captureMessage
+    throw UnimplementedError();
+  }
+
+  @override
+  Hub clone() {
+    // TODO: implement clone
+    throw UnimplementedError();
+  }
+
+  @override
+  void close() {
+    // TODO: implement close
+  }
+
+  @override
+  void configureScope(callback) {
+    // TODO: implement configureScope
+  }
+
+  @override
+  // TODO: implement isEnabled
+  bool get isEnabled => throw UnimplementedError();
+
+  @override
+  // TODO: implement lastEventId
+  SentryId get lastEventId => throw UnimplementedError();
+}

--- a/dart/test/mocks/mock_hub.dart
+++ b/dart/test/mocks/mock_hub.dart
@@ -1,14 +1,21 @@
 import 'package:sentry/sentry.dart';
 
 class MockHub implements Hub {
+  List<CaptureEventCall> captureEventCalls = [];
+  List<CaptureExceptionCall> captureExceptionCalls = [];
+  List<CaptureMessageCall> captureMessageCalls = [];
+  List<AddBreadcrumbCall> addBreadcrumbCalls = [];
+  List<SentryClient?> bindClientCalls = [];
+  int closeCalls = 0;
+
   @override
   void addBreadcrumb(Breadcrumb? crumb, {dynamic hint}) {
-    // TODO: implement addBreadcrumb
+    addBreadcrumbCalls.add(AddBreadcrumbCall(crumb, hint));
   }
 
   @override
   void bindClient(SentryClient? client) {
-    // TODO: implement bindClient
+    bindClientCalls.add(client);
   }
 
   @override
@@ -16,25 +23,33 @@ class MockHub implements Hub {
     SentryEvent? event, {
     dynamic stackTrace,
     dynamic hint,
-  }) {
-    // TODO: implement captureEvent
-    throw UnimplementedError();
+  }) async {
+    captureEventCalls.add(CaptureEventCall(event, stackTrace, hint));
+    return event?.eventId ?? SentryId.empty();
   }
 
   @override
-  Future<SentryId> captureException(throwable, {stackTrace, hint}) {
-    // TODO: implement captureException
-    throw UnimplementedError();
+  Future<SentryId> captureException(
+    throwable, {
+    stackTrace,
+    hint,
+  }) async {
+    captureExceptionCalls
+        .add(CaptureExceptionCall(throwable, stackTrace, hint));
+    return SentryId.newId();
   }
 
   @override
-  Future<SentryId> captureMessage(String? message,
-      {SentryLevel level = SentryLevel.info,
-      String? template,
-      List? params,
-      hint}) {
-    // TODO: implement captureMessage
-    throw UnimplementedError();
+  Future<SentryId> captureMessage(
+    String? message, {
+    SentryLevel level = SentryLevel.info,
+    String? template,
+    List? params,
+    dynamic hint,
+  }) async {
+    captureMessageCalls
+        .add(CaptureMessageCall(message, level, template, params, hint));
+    return SentryId.newId();
   }
 
   @override
@@ -45,7 +60,7 @@ class MockHub implements Hub {
 
   @override
   void close() {
-    // TODO: implement close
+    closeCalls = closeCalls + 1;
   }
 
   @override
@@ -60,4 +75,47 @@ class MockHub implements Hub {
   @override
   // TODO: implement lastEventId
   SentryId get lastEventId => throw UnimplementedError();
+}
+
+class CaptureEventCall {
+  final SentryEvent? event;
+  final dynamic stackTrace;
+  final dynamic hint;
+
+  CaptureEventCall(this.event, this.stackTrace, this.hint);
+}
+
+class CaptureExceptionCall {
+  final dynamic throwable;
+  final dynamic stackTrace;
+  final dynamic hint;
+
+  CaptureExceptionCall(
+    this.throwable,
+    this.stackTrace,
+    this.hint,
+  );
+}
+
+class CaptureMessageCall {
+  final String? message;
+  final SentryLevel level;
+  final String? template;
+  final List? params;
+  final dynamic hint;
+
+  CaptureMessageCall(
+    this.message,
+    this.level,
+    this.template,
+    this.params,
+    this.hint,
+  );
+}
+
+class AddBreadcrumbCall {
+  final Breadcrumb? crumb;
+  final dynamic hint;
+
+  AddBreadcrumbCall(this.crumb, this.hint);
 }

--- a/dart/test/mocks/mock_hub.dart
+++ b/dart/test/mocks/mock_hub.dart
@@ -42,7 +42,7 @@ class MockHub implements Hub {
   @override
   Future<SentryId> captureMessage(
     String? message, {
-    SentryLevel level = SentryLevel.info,
+    SentryLevel? level = SentryLevel.info,
     String? template,
     List? params,
     dynamic hint,
@@ -99,7 +99,7 @@ class CaptureExceptionCall {
 
 class CaptureMessageCall {
   final String? message;
-  final SentryLevel level;
+  final SentryLevel? level;
   final String? template;
   final List? params;
   final dynamic hint;

--- a/dart/test/mocks/mock_integration.dart
+++ b/dart/test/mocks/mock_integration.dart
@@ -1,0 +1,18 @@
+import 'dart:async';
+
+import 'package:sentry/sentry.dart';
+
+class MockIntegration implements Integration {
+  int closeCalls = 0;
+  int callCalls = 0;
+
+  @override
+  FutureOr<void> call(Hub hub, SentryOptions options) async {
+    callCalls = callCalls + 1;
+  }
+
+  @override
+  void close() {
+    closeCalls = closeCalls + 1;
+  }
+}

--- a/dart/test/mocks/mock_sentry_client.dart
+++ b/dart/test/mocks/mock_sentry_client.dart
@@ -1,0 +1,111 @@
+import 'package:sentry/sentry.dart';
+
+class MockSentryClient implements SentryClient {
+  List<CaptureEventCall> captureEventCalls = [];
+  List<CaptureExceptionCall> captureExceptionCalls = [];
+  List<CaptureMessageCall> captureMessageCalls = [];
+  int closeCalls = 0;
+
+  @override
+  Future<SentryId> captureEvent(
+    SentryEvent event, {
+    Scope? scope,
+    dynamic stackTrace,
+    dynamic hint,
+  }) async {
+    captureEventCalls.add(CaptureEventCall(
+      event,
+      scope,
+      stackTrace,
+      hint,
+    ));
+    return event.eventId;
+  }
+
+  @override
+  Future<SentryId> captureException(
+    dynamic throwable, {
+    dynamic stackTrace,
+    Scope? scope,
+    dynamic hint,
+  }) async {
+    captureExceptionCalls.add(CaptureExceptionCall(
+      throwable,
+      stackTrace,
+      scope,
+      hint,
+    ));
+    return SentryId.newId();
+  }
+
+  @override
+  Future<SentryId> captureMessage(
+    String? formatted, {
+    SentryLevel level = SentryLevel.info,
+    String? template,
+    List? params,
+    Scope? scope,
+    dynamic hint,
+  }) async {
+    captureMessageCalls.add(CaptureMessageCall(
+      formatted,
+      level,
+      template,
+      params,
+      scope,
+      hint,
+    ));
+    return SentryId.newId();
+  }
+
+  @override
+  void close() {
+    closeCalls = closeCalls + 1;
+  }
+}
+
+class CaptureEventCall {
+  final SentryEvent event;
+  final Scope? scope;
+  final dynamic stackTrace;
+  final dynamic hint;
+
+  CaptureEventCall(
+    this.event,
+    this.scope,
+    this.stackTrace,
+    this.hint,
+  );
+}
+
+class CaptureExceptionCall {
+  final dynamic throwable;
+  final dynamic stackTrace;
+  final Scope? scope;
+  final dynamic hint;
+
+  CaptureExceptionCall(
+    this.throwable,
+    this.stackTrace,
+    this.scope,
+    this.hint,
+  );
+}
+
+class CaptureMessageCall {
+  final String? formatted;
+  final SentryLevel level;
+  final String? template;
+  final List? params;
+  final Scope? scope;
+  final dynamic hint;
+
+  CaptureMessageCall(
+    this.formatted,
+    this.level,
+    this.template,
+    this.params,
+    this.scope,
+    this.hint,
+  );
+}

--- a/dart/test/mocks/mock_sentry_client.dart
+++ b/dart/test/mocks/mock_sentry_client.dart
@@ -41,7 +41,7 @@ class MockSentryClient implements SentryClient {
   @override
   Future<SentryId> captureMessage(
     String? formatted, {
-    SentryLevel level = SentryLevel.info,
+    SentryLevel? level = SentryLevel.info,
     String? template,
     List? params,
     Scope? scope,
@@ -94,7 +94,7 @@ class CaptureExceptionCall {
 
 class CaptureMessageCall {
   final String? formatted;
-  final SentryLevel level;
+  final SentryLevel? level;
   final String? template;
   final List? params;
   final Scope? scope;

--- a/dart/test/mocks/mock_transport.dart
+++ b/dart/test/mocks/mock_transport.dart
@@ -10,6 +10,6 @@ class MockTransport implements Transport {
   @override
   Future<SentryId> send(SentryEvent event) async {
     events.add(event);
-    return SentryId.empty();
+    return event.eventId;
   }
 }

--- a/dart/test/mocks/mock_transport.dart
+++ b/dart/test/mocks/mock_transport.dart
@@ -1,0 +1,15 @@
+import 'package:sentry/sentry.dart';
+
+class MockTransport implements Transport {
+  List<SentryEvent> events = [];
+
+  bool called(int calls) {
+    return events.length == calls;
+  }
+
+  @override
+  Future<SentryId> send(SentryEvent event) async {
+    events.add(event);
+    return SentryId.empty();
+  }
+}

--- a/dart/test/protocol/app_test.dart
+++ b/dart/test/protocol/app_test.dart
@@ -39,7 +39,7 @@ void main() {
   });
 }
 
-App _generate({DateTime startTime}) => App(
+App _generate({DateTime/*?*/ startTime}) => App(
       name: 'name',
       version: 'version',
       identifier: 'identifier',

--- a/dart/test/protocol/app_test.dart
+++ b/dart/test/protocol/app_test.dart
@@ -39,7 +39,7 @@ void main() {
   });
 }
 
-App _generate({DateTime/*?*/ startTime}) => App(
+App _generate({DateTime? startTime}) => App(
       name: 'name',
       version: 'version',
       identifier: 'identifier',

--- a/dart/test/protocol/breadcrumb_test.dart
+++ b/dart/test/protocol/breadcrumb_test.dart
@@ -37,7 +37,7 @@ void main() {
   });
 }
 
-Breadcrumb _generate({DateTime timestamp}) => Breadcrumb(
+Breadcrumb _generate({DateTime/*?*/ timestamp}) => Breadcrumb(
       message: 'message',
       timestamp: timestamp ?? DateTime.now(),
       data: {'key': 'value'},

--- a/dart/test/protocol/breadcrumb_test.dart
+++ b/dart/test/protocol/breadcrumb_test.dart
@@ -37,7 +37,7 @@ void main() {
   });
 }
 
-Breadcrumb _generate({DateTime/*?*/ timestamp}) => Breadcrumb(
+Breadcrumb _generate({DateTime? timestamp}) => Breadcrumb(
       message: 'message',
       timestamp: timestamp ?? DateTime.now(),
       data: {'key': 'value'},

--- a/dart/test/protocol/contexts_test.dart
+++ b/dart/test/protocol/contexts_test.dart
@@ -32,15 +32,15 @@ void main() {
       gpu: gpu,
     );
 
-    expect(device.toJson(), copy.device.toJson());
-    expect(os.toJson(), copy.operatingSystem.toJson());
+    expect(device.toJson(), copy.device!.toJson());
+    expect(os.toJson(), copy.operatingSystem!.toJson());
     expect(
       ListEquality().equals(runtimes, copy.runtimes),
       true,
     );
-    expect(app.toJson(), copy.app.toJson());
-    expect(browser.toJson(), copy.browser.toJson());
-    expect(gpu.toJson(), copy.gpu.toJson());
+    expect(app.toJson(), copy.app!.toJson());
+    expect(browser.toJson(), copy.browser!.toJson());
+    expect(gpu.toJson(), copy.gpu!.toJson());
     expect('value', copy['extra']);
   });
 }

--- a/dart/test/protocol/debug_meta_test.dart
+++ b/dart/test/protocol/debug_meta_test.dart
@@ -18,7 +18,7 @@ void main() {
     final newSdkInfo = SdkInfo(
       sdkName: 'sdkName1',
     );
-    final newImageList = [DebugImage(uuid: 'uuid1')];
+    final newImageList = [DebugImage(type: 'macho', uuid: 'uuid1')];
 
     final copy = data.copyWith(
       sdk: newSdkInfo,
@@ -40,5 +40,5 @@ DebugMeta _generate() => DebugMeta(
       sdk: SdkInfo(
         sdkName: 'sdkName',
       ),
-      images: [DebugImage(uuid: 'uuid')],
+      images: [DebugImage(type: 'macho', uuid: 'uuid')],
     );

--- a/dart/test/protocol/debug_meta_test.dart
+++ b/dart/test/protocol/debug_meta_test.dart
@@ -30,7 +30,7 @@ void main() {
       true,
     );
     expect(
-      MapEquality().equals(newSdkInfo.toJson(), copy.sdk.toJson()),
+      MapEquality().equals(newSdkInfo.toJson(), copy.sdk!.toJson()),
       true,
     );
   });

--- a/dart/test/protocol/device_test.dart
+++ b/dart/test/protocol/device_test.dart
@@ -75,7 +75,7 @@ void main() {
   });
 }
 
-Device _generate({DateTime testBootTime}) => Device(
+Device _generate({DateTime/*?*/ testBootTime}) => Device(
       name: 'name',
       family: 'family',
       model: 'model',

--- a/dart/test/protocol/device_test.dart
+++ b/dart/test/protocol/device_test.dart
@@ -75,7 +75,7 @@ void main() {
   });
 }
 
-Device _generate({DateTime/*?*/ testBootTime}) => Device(
+Device _generate({DateTime? testBootTime}) => Device(
       name: 'name',
       family: 'family',
       model: 'model',

--- a/dart/test/protocol/sentry_exception_test.dart
+++ b/dart/test/protocol/sentry_exception_test.dart
@@ -111,8 +111,8 @@ void main() {
     expect('value1', copy.value);
     expect('module1', copy.module);
     expect(2, copy.threadId);
-    expect(mechanism.toJson(), copy.mechanism.toJson());
-    expect(stackTrace.toJson(), copy.stackTrace.toJson());
+    expect(mechanism.toJson(), copy.mechanism!.toJson());
+    expect(stackTrace.toJson(), copy.stackTrace!.toJson());
   });
 }
 

--- a/dart/test/scope_test.dart
+++ b/dart/test/scope_test.dart
@@ -272,7 +272,7 @@ void main() {
         ..setExtra('company-name', 'Dart Inc')
         ..setContexts('theme', 'material')
         ..addEventProcessor(
-          (event, {hint}) => event..tags.addAll({'page-locale': 'en-us'}),
+          (event, {hint}) => event..tags?.addAll({'page-locale': 'en-us'}),
         );
 
       final updatedEvent = await scope.applyToEvent(event, null);

--- a/dart/test/scope_test.dart
+++ b/dart/test/scope_test.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 import 'mocks.dart';
 
 void main() {
-  Fixture fixture;
+  late Fixture fixture;
 
   setUp(() {
     fixture = Fixture();
@@ -270,7 +270,7 @@ void main() {
         ..setExtra('company-name', 'Dart Inc')
         ..setContexts('theme', 'material')
         ..addEventProcessor(
-          (event, {hint}) => event..tags.addAll({'page-locale': 'en-us'}),
+          (event, {hint}) => event..tags!.addAll({'page-locale': 'en-us'}),
         );
 
       final updatedEvent = await scope.applyToEvent(event, null);
@@ -407,7 +407,7 @@ void main() {
 class Fixture {
   Scope getSut({
     int maxBreadcrumbs = 100,
-    BeforeBreadcrumbCallback beforeBreadcrumbCallback,
+    BeforeBreadcrumbCallback? beforeBreadcrumbCallback,
   }) {
     final options = SentryOptions(dsn: fakeDsn);
     options.maxBreadcrumbs = maxBreadcrumbs;
@@ -415,8 +415,8 @@ class Fixture {
     return Scope(options);
   }
 
-  SentryEvent processor(SentryEvent event, {dynamic hint}) => null;
+  SentryEvent? processor(SentryEvent event, {dynamic hint}) => null;
 
-  Breadcrumb beforeBreadcrumbCallback(Breadcrumb breadcrumb, {dynamic hint}) =>
+  Breadcrumb? beforeBreadcrumbCallback(Breadcrumb? breadcrumb, {dynamic hint}) =>
       null;
 }

--- a/dart/test/scope_test.dart
+++ b/dart/test/scope_test.dart
@@ -2,6 +2,8 @@ import 'package:collection/collection.dart';
 import 'package:sentry/sentry.dart';
 import 'package:test/test.dart';
 
+import 'mocks.dart';
+
 void main() {
   Fixture fixture;
 
@@ -258,7 +260,7 @@ void main() {
         tags: const {'etag': '987'},
         extra: const {'e-infos': 'abc'},
       );
-      final scope = Scope(SentryOptions())
+      final scope = Scope(SentryOptions(dsn: fakeDsn))
         ..user = scopeUser
         ..fingerprint = ['example-dart']
         ..addBreadcrumb(breadcrumb)
@@ -296,7 +298,7 @@ void main() {
         fingerprint: ['event-fingerprint'],
         breadcrumbs: [eventBreadcrumb],
       );
-      final scope = Scope(SentryOptions())
+      final scope = Scope(SentryOptions(dsn: fakeDsn))
         ..user = scopeUser
         ..fingerprint = ['example-dart']
         ..addBreadcrumb(breadcrumb)
@@ -323,7 +325,7 @@ void main() {
           operatingSystem: OperatingSystem(name: 'event-os'),
         ),
       );
-      final scope = Scope(SentryOptions())
+      final scope = Scope(SentryOptions(dsn: fakeDsn))
         ..setContexts(
           Device.type,
           Device(name: 'context-device'),
@@ -362,7 +364,7 @@ void main() {
 
     test('should apply the scope.contexts values ', () async {
       final event = SentryEvent();
-      final scope = Scope(SentryOptions())
+      final scope = Scope(SentryOptions(dsn: fakeDsn))
         ..setContexts(Device.type, Device(name: 'context-device'))
         ..setContexts(App.type, App(name: 'context-app'))
         ..setContexts(Gpu.type, Gpu(name: 'context-gpu'))
@@ -392,16 +394,13 @@ void main() {
 
     test('should apply the scope level', () async {
       final event = SentryEvent(level: SentryLevel.warning);
-      final scope = Scope(SentryOptions())..level = SentryLevel.error;
+      final scope = Scope(SentryOptions(dsn: fakeDsn))
+        ..level = SentryLevel.error;
 
       final updatedEvent = await scope.applyToEvent(event, null);
 
       expect(updatedEvent.level, SentryLevel.error);
     });
-  });
-
-  test("options can't be null", () {
-    expect(() => Scope(null), throwsArgumentError);
   });
 }
 
@@ -410,7 +409,7 @@ class Fixture {
     int maxBreadcrumbs = 100,
     BeforeBreadcrumbCallback beforeBreadcrumbCallback,
   }) {
-    final options = SentryOptions();
+    final options = SentryOptions(dsn: fakeDsn);
     options.maxBreadcrumbs = maxBreadcrumbs;
     options.beforeBreadcrumb = beforeBreadcrumbCallback;
     return Scope(options);

--- a/dart/test/scope_test.dart
+++ b/dart/test/scope_test.dart
@@ -275,16 +275,16 @@ void main() {
 
       final updatedEvent = await scope.applyToEvent(event, null);
 
-      expect(updatedEvent.user, scopeUser);
-      expect(updatedEvent.transaction, '/example/app');
-      expect(updatedEvent.fingerprint, ['example-dart']);
-      expect(updatedEvent.breadcrumbs, [breadcrumb]);
-      expect(updatedEvent.level, SentryLevel.warning);
-      expect(updatedEvent.tags,
+      expect(updatedEvent?.user, scopeUser);
+      expect(updatedEvent?.transaction, '/example/app');
+      expect(updatedEvent?.fingerprint, ['example-dart']);
+      expect(updatedEvent?.breadcrumbs, [breadcrumb]);
+      expect(updatedEvent?.level, SentryLevel.warning);
+      expect(updatedEvent?.tags,
           {'etag': '987', 'build': '579', 'page-locale': 'en-us'});
       expect(
-          updatedEvent.extra, {'e-infos': 'abc', 'company-name': 'Dart Inc'});
-      expect(updatedEvent.contexts['theme'], {'value': 'material'});
+          updatedEvent?.extra, {'e-infos': 'abc', 'company-name': 'Dart Inc'});
+      expect(updatedEvent?.contexts['theme'], {'value': 'material'});
     });
 
     test('should not apply the scope properties when event already has it ',
@@ -306,10 +306,10 @@ void main() {
 
       final updatedEvent = await scope.applyToEvent(event, null);
 
-      expect(updatedEvent.user, eventUser);
-      expect(updatedEvent.transaction, '/event/transaction');
-      expect(updatedEvent.fingerprint, ['event-fingerprint']);
-      expect(updatedEvent.breadcrumbs, [eventBreadcrumb]);
+      expect(updatedEvent?.user, eventUser);
+      expect(updatedEvent?.transaction, '/event/transaction');
+      expect(updatedEvent?.fingerprint, ['event-fingerprint']);
+      expect(updatedEvent?.breadcrumbs, [eventBreadcrumb]);
     });
 
     test(
@@ -353,13 +353,13 @@ void main() {
 
       final updatedEvent = await scope.applyToEvent(event, null);
 
-      expect(updatedEvent.contexts[Device.type].name, 'event-device');
-      expect(updatedEvent.contexts[App.type].name, 'event-app');
-      expect(updatedEvent.contexts[Gpu.type].name, 'event-gpu');
-      expect(updatedEvent.contexts[SentryRuntime.listType].first.name,
+      expect(updatedEvent?.contexts[Device.type].name, 'event-device');
+      expect(updatedEvent?.contexts[App.type].name, 'event-app');
+      expect(updatedEvent?.contexts[Gpu.type].name, 'event-gpu');
+      expect(updatedEvent?.contexts[SentryRuntime.listType].first.name,
           'event-runtime');
-      expect(updatedEvent.contexts[Browser.type].name, 'event-browser');
-      expect(updatedEvent.contexts[OperatingSystem.type].name, 'event-os');
+      expect(updatedEvent?.contexts[Browser.type].name, 'event-browser');
+      expect(updatedEvent?.contexts[OperatingSystem.type].name, 'event-os');
     });
 
     test('should apply the scope.contexts values ', () async {
@@ -378,18 +378,18 @@ void main() {
 
       final updatedEvent = await scope.applyToEvent(event, null);
 
-      expect(updatedEvent.contexts[Device.type].name, 'context-device');
-      expect(updatedEvent.contexts[App.type].name, 'context-app');
-      expect(updatedEvent.contexts[Gpu.type].name, 'context-gpu');
+      expect(updatedEvent?.contexts[Device.type].name, 'context-device');
+      expect(updatedEvent?.contexts[App.type].name, 'context-app');
+      expect(updatedEvent?.contexts[Gpu.type].name, 'context-gpu');
       expect(
-        updatedEvent.contexts[SentryRuntime.listType].first.name,
+        updatedEvent?.contexts[SentryRuntime.listType].first.name,
         'context-runtime',
       );
-      expect(updatedEvent.contexts[Browser.type].name, 'context-browser');
-      expect(updatedEvent.contexts[OperatingSystem.type].name, 'context-os');
-      expect(updatedEvent.contexts['theme']['value'], 'material');
-      expect(updatedEvent.contexts['version']['value'], 9);
-      expect(updatedEvent.contexts['location'], {'city': 'London'});
+      expect(updatedEvent?.contexts[Browser.type].name, 'context-browser');
+      expect(updatedEvent?.contexts[OperatingSystem.type].name, 'context-os');
+      expect(updatedEvent?.contexts['theme']['value'], 'material');
+      expect(updatedEvent?.contexts['version']['value'], 9);
+      expect(updatedEvent?.contexts['location'], {'city': 'London'});
     });
 
     test('should apply the scope level', () async {
@@ -399,7 +399,7 @@ void main() {
 
       final updatedEvent = await scope.applyToEvent(event, null);
 
-      expect(updatedEvent.level, SentryLevel.error);
+      expect(updatedEvent?.level, SentryLevel.error);
     });
   });
 }
@@ -417,6 +417,7 @@ class Fixture {
 
   SentryEvent? processor(SentryEvent event, {dynamic hint}) => null;
 
-  Breadcrumb? beforeBreadcrumbCallback(Breadcrumb? breadcrumb, {dynamic hint}) =>
+  Breadcrumb? beforeBreadcrumbCallback(Breadcrumb? breadcrumb,
+          {dynamic hint}) =>
       null;
 }

--- a/dart/test/scope_test.dart
+++ b/dart/test/scope_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:collection/collection.dart';
 import 'package:sentry/sentry.dart';
 import 'package:test/test.dart';
@@ -415,7 +417,9 @@ class Fixture {
     return Scope(options);
   }
 
-  SentryEvent? processor(SentryEvent event, {dynamic hint}) => null;
+  FutureOr<SentryEvent?> processor(SentryEvent event, {dynamic hint}) {
+    return null;
+  }
 
   Breadcrumb? beforeBreadcrumbCallback(Breadcrumb? breadcrumb,
           {dynamic hint}) =>

--- a/dart/test/scope_test.dart
+++ b/dart/test/scope_test.dart
@@ -221,7 +221,7 @@ void main() {
 
     expect(sut.user, null);
 
-    expect(sut.fingerprint, null);
+    expect(sut.fingerprint.length, 0);
 
     expect(sut.tags.length, 0);
 
@@ -272,7 +272,7 @@ void main() {
         ..setExtra('company-name', 'Dart Inc')
         ..setContexts('theme', 'material')
         ..addEventProcessor(
-          (event, {hint}) => event..tags!.addAll({'page-locale': 'en-us'}),
+          (event, {hint}) => event..tags.addAll({'page-locale': 'en-us'}),
         );
 
       final updatedEvent = await scope.applyToEvent(event, null);

--- a/dart/test/sentry_client_test.dart
+++ b/dart/test/sentry_client_test.dart
@@ -115,10 +115,7 @@ void main() {
         'simple message 1',
       );
 
-      final capturedEvent = (verify(
-        options.transport.send(captureAny),
-      ).captured.first) as SentryEvent;
-
+      final capturedEvent = (options.transport as MockTransport).events.first;
       expect(capturedEvent.level, SentryLevel.info);
     });
 

--- a/dart/test/sentry_client_test.dart
+++ b/dart/test/sentry_client_test.dart
@@ -1,13 +1,13 @@
-import 'package:mockito/mockito.dart';
 import 'package:sentry/sentry.dart';
 import 'package:sentry/src/sentry_stack_trace_factory.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';
+import 'mocks/mock_transport.dart';
 
 void main() {
   group('SentryClient captures message', () {
-    late SentryOptions options;
+    var options = SentryOptions(dsn: fakeDsn);
 
     setUp(() {
       options = SentryOptions(dsn: fakeDsn);
@@ -22,9 +22,7 @@ void main() {
         stackTrace: '#0      baz (file:///pathto/test.dart:50:3)',
       );
 
-      final capturedEvent = (verify(
-        options.transport.send(captureAny),
-      ).captured.first) as SentryEvent;
+      final capturedEvent = (options.transport as MockTransport).events.first;
 
       expect(capturedEvent.stackTrace is SentryStackTrace, true);
     });
@@ -34,9 +32,7 @@ void main() {
       final event = SentryEvent();
       await client.captureEvent(event);
 
-      final capturedEvent = (verify(
-        options.transport.send(captureAny),
-      ).captured.first) as SentryEvent;
+      final capturedEvent = (options.transport as MockTransport).events.first;
 
       expect(capturedEvent.stackTrace is SentryStackTrace, true);
     });
@@ -46,9 +42,7 @@ void main() {
       final event = SentryEvent();
       await client.captureEvent(event);
 
-      final capturedEvent = (verify(
-        options.transport.send(captureAny),
-      ).captured.first) as SentryEvent;
+      final capturedEvent = (options.transport as MockTransport).events.first;
 
       expect(capturedEvent.stackTrace, isNull);
     });
@@ -68,9 +62,7 @@ void main() {
         stackTrace: '#0      baz (file:///pathto/test.dart:50:3)',
       );
 
-      final capturedEvent = (verify(
-        options.transport.send(captureAny),
-      ).captured.first) as SentryEvent;
+      final capturedEvent = (options.transport as MockTransport).events.first;
 
       expect(capturedEvent.stackTrace, isNull);
       expect(capturedEvent.exception!.stackTrace, isNotNull);
@@ -94,9 +86,7 @@ void main() {
         stackTrace: '#0      baz (file:///pathto/test.dart:50:3)',
       );
 
-      final capturedEvent = (verify(
-        options.transport.send(captureAny),
-      ).captured.first) as SentryEvent;
+      final capturedEvent = (options.transport as MockTransport).events.first;
 
       expect(capturedEvent.stackTrace, isNull);
       expect(capturedEvent.exception!.stackTrace, isNotNull);
@@ -111,9 +101,7 @@ void main() {
         level: SentryLevel.error,
       );
 
-      final capturedEvent = (verify(
-        options.transport.send(captureAny),
-      ).captured.first) as SentryEvent;
+      final capturedEvent = (options.transport as MockTransport).events.first;
 
       expect(capturedEvent.message!.formatted, 'simple message 1');
       expect(capturedEvent.message!.template, 'simple message %d');
@@ -126,16 +114,14 @@ void main() {
       final client = SentryClient(options..attachStacktrace = false);
       await client.captureMessage('message', level: SentryLevel.error);
 
-      final capturedEvent = (verify(
-        options.transport.send(captureAny),
-      ).captured.first) as SentryEvent;
+      final capturedEvent = (options.transport as MockTransport).events.first;
 
       expect(capturedEvent.stackTrace, isNull);
     });
   });
 
   group('SentryClient captures exception', () {
-    late SentryOptions options;
+    var options = SentryOptions(dsn: fakeDsn);
 
     Error error;
     StackTrace stackTrace;
@@ -156,9 +142,7 @@ void main() {
       final client = SentryClient(options);
       await client.captureException(error, stackTrace: stackTrace);
 
-      final capturedEvent = (verify(
-        options.transport.send(captureAny),
-      ).captured.first) as SentryEvent;
+      final capturedEvent = (options.transport as MockTransport).events.first;
 
       expect(capturedEvent.throwable, error);
       expect(capturedEvent.exception is SentryException, true);
@@ -167,7 +151,7 @@ void main() {
   });
 
   group('SentryClient captures exception and stacktrace', () {
-    late SentryOptions options;
+    var options = SentryOptions(dsn: fakeDsn);
 
     Error error;
 
@@ -192,9 +176,7 @@ void main() {
       final client = SentryClient(options);
       await client.captureException(error, stackTrace: stacktrace);
 
-      final capturedEvent = (verify(
-        options.transport.send(captureAny),
-      ).captured.first) as SentryEvent;
+      final capturedEvent = (options.transport as MockTransport).events.first;
 
       expect(capturedEvent.throwable, error);
       expect(capturedEvent.exception is SentryException, true);
@@ -207,7 +189,7 @@ void main() {
   });
 
   group('SentryClient captures exception and stacktrace', () {
-    late SentryOptions options;
+    var options = SentryOptions(dsn: fakeDsn);
 
     dynamic exception;
 
@@ -232,9 +214,7 @@ void main() {
       final client = SentryClient(options);
       await client.captureException(exception, stackTrace: stacktrace);
 
-      final capturedEvent = (verify(
-        options.transport.send(captureAny),
-      ).captured.first) as SentryEvent;
+      final capturedEvent = (options.transport as MockTransport).events.first;
 
       expect(capturedEvent.throwable, exception);
       expect(capturedEvent.exception is SentryException, true);
@@ -254,9 +234,7 @@ void main() {
       final client = SentryClient(options);
       await client.captureException(exception);
 
-      final capturedEvent = (verify(
-        options.transport.send(captureAny),
-      ).captured.first) as SentryEvent;
+      final capturedEvent = (options.transport as MockTransport).events.first;
 
       expect(capturedEvent.exception!.stackTrace, isNotNull);
     });
@@ -271,9 +249,7 @@ void main() {
       final client = SentryClient(options..attachStacktrace = false);
       await client.captureException(exception);
 
-      final capturedEvent = (verify(
-        options.transport.send(captureAny),
-      ).captured.first) as SentryEvent;
+      final capturedEvent = (options.transport as MockTransport).events.first;
 
       expect(capturedEvent.exception!.stackTrace, isNull);
     });
@@ -295,9 +271,7 @@ void main() {
       final client = SentryClient(options);
       await client.captureException(exception, stackTrace: stacktrace);
 
-      final capturedEvent = (verify(
-        options.transport.send(captureAny),
-      ).captured.first) as SentryEvent;
+      final capturedEvent = (options.transport as MockTransport).events.first;
 
       expect(
         capturedEvent.exception!.stackTrace!.frames
@@ -308,8 +282,8 @@ void main() {
   });
 
   group('SentryClient : apply scope to the captured event', () {
-    late SentryOptions options;
-    late Scope scope;
+    var options = SentryOptions(dsn: fakeDsn);
+    var scope = Scope(options);
 
     final level = SentryLevel.error;
     const transaction = '/test/scope';
@@ -350,9 +324,7 @@ void main() {
       final client = SentryClient(options);
       await client.captureEvent(event, scope: scope);
 
-      final capturedEvent = (verify(
-        options.transport.send(captureAny),
-      ).captured.first) as SentryEvent;
+      final capturedEvent = (options.transport as MockTransport).events.first;
 
       expect(capturedEvent.user?.id, user.id);
       expect(capturedEvent.level!.name, SentryLevel.error.name);
@@ -371,8 +343,8 @@ void main() {
   });
 
   group('SentryClient : apply partial scope to the captured event', () {
-    late SentryOptions options;
-    late Scope scope;
+    var options = SentryOptions(dsn: fakeDsn);
+    var scope = Scope(options);
 
     final transaction = '/test/scope';
     final eventTransaction = '/event/transaction';
@@ -405,9 +377,7 @@ void main() {
       final client = SentryClient(options);
       await client.captureEvent(event, scope: scope);
 
-      final capturedEvent = (verify(
-        options.transport.send(captureAny),
-      ).captured.first) as SentryEvent;
+      final capturedEvent = (options.transport as MockTransport).events.first;
 
       expect(capturedEvent.user!.id, eventUser.id);
       expect(capturedEvent.level!.name, SentryLevel.warning.name);
@@ -418,7 +388,7 @@ void main() {
   });
 
   group('SentryClient sampling', () {
-    late SentryOptions options;
+    var options = SentryOptions(dsn: fakeDsn);
 
     setUp(() {
       options = SentryOptions(dsn: fakeDsn);
@@ -430,7 +400,7 @@ void main() {
       final client = SentryClient(options);
       await client.captureEvent(fakeEvent);
 
-      verify(options.transport.send(any)).called(1);
+      expect((options.transport as MockTransport).called(1), true);
     });
 
     test('do not capture event, sample rate is 0% disabled', () async {
@@ -438,7 +408,7 @@ void main() {
       final client = SentryClient(options);
       await client.captureEvent(fakeEvent);
 
-      verifyNever(options.transport.send(any));
+      expect((options.transport as MockTransport).called(0), true);
     });
 
     test('captures event, sample rate is null, disabled', () async {
@@ -446,12 +416,12 @@ void main() {
       final client = SentryClient(options);
       await client.captureEvent(fakeEvent);
 
-      verify(options.transport.send(any)).called(1);
+      expect((options.transport as MockTransport).called(1), true);
     });
   });
 
   group('SentryClient before send', () {
-    late SentryOptions options;
+    var options = SentryOptions(dsn: fakeDsn);
 
     setUp(() {
       options = SentryOptions(dsn: fakeDsn);
@@ -463,7 +433,7 @@ void main() {
       final client = SentryClient(options);
       await client.captureEvent(fakeEvent);
 
-      verifyNever(options.transport.send(any));
+      expect((options.transport as MockTransport).called(0), true);
     });
 
     test('before send returns an event and event is captured', () async {
@@ -471,8 +441,7 @@ void main() {
       final client = SentryClient(options);
       await client.captureEvent(fakeEvent);
 
-      final event = verify(options.transport.send(captureAny)).captured.first
-          as SentryEvent;
+      final event = (options.transport as MockTransport).events.first;
 
       expect(event.tags!.containsKey('theme'), true);
       expect(event.extra!.containsKey('host'), true);
@@ -492,7 +461,7 @@ void main() {
   });
 
   group('EventProcessors', () {
-    late SentryOptions options;
+    var options = SentryOptions(dsn: fakeDsn);
 
     setUp(() {
       options = SentryOptions(dsn: fakeDsn);
@@ -513,8 +482,7 @@ void main() {
       final client = SentryClient(options);
       await client.captureEvent(fakeEvent);
 
-      final event = verify(options.transport.send(captureAny)).captured.first
-          as SentryEvent;
+      final event = (options.transport as MockTransport).events.first;
       expect(event.tags!.containsKey('theme'), true);
       expect(event.extra!.containsKey('host'), true);
       expect(event.modules!.containsKey('core'), true);

--- a/dart/test/sentry_client_test.dart
+++ b/dart/test/sentry_client_test.dart
@@ -7,7 +7,7 @@ import 'mocks.dart';
 
 void main() {
   group('SentryClient captures message', () {
-    SentryOptions options;
+    late SentryOptions options;
 
     setUp(() {
       options = SentryOptions(dsn: fakeDsn);
@@ -73,7 +73,7 @@ void main() {
       ).captured.first) as SentryEvent;
 
       expect(capturedEvent.stackTrace, isNull);
-      expect(capturedEvent.exception.stackTrace, isNotNull);
+      expect(capturedEvent.exception!.stackTrace, isNotNull);
     });
 
     test('should not attach event stacktrace if event has exception', () async {
@@ -99,7 +99,7 @@ void main() {
       ).captured.first) as SentryEvent;
 
       expect(capturedEvent.stackTrace, isNull);
-      expect(capturedEvent.exception.stackTrace, isNotNull);
+      expect(capturedEvent.exception!.stackTrace, isNotNull);
     });
 
     test('should capture message', () async {
@@ -115,9 +115,9 @@ void main() {
         options.transport.send(captureAny),
       ).captured.first) as SentryEvent;
 
-      expect(capturedEvent.message.formatted, 'simple message 1');
-      expect(capturedEvent.message.template, 'simple message %d');
-      expect(capturedEvent.message.params, [1]);
+      expect(capturedEvent.message!.formatted, 'simple message 1');
+      expect(capturedEvent.message!.template, 'simple message %d');
+      expect(capturedEvent.message!.params, [1]);
 
       expect(capturedEvent.stackTrace is SentryStackTrace, true);
     });
@@ -135,7 +135,7 @@ void main() {
   });
 
   group('SentryClient captures exception', () {
-    SentryOptions options;
+    late SentryOptions options;
 
     Error error;
     StackTrace stackTrace;
@@ -162,12 +162,12 @@ void main() {
 
       expect(capturedEvent.throwable, error);
       expect(capturedEvent.exception is SentryException, true);
-      expect(capturedEvent.exception.stackTrace, isNotNull);
+      expect(capturedEvent.exception!.stackTrace, isNotNull);
     });
   });
 
   group('SentryClient captures exception and stacktrace', () {
-    SentryOptions options;
+    late SentryOptions options;
 
     Error error;
 
@@ -198,18 +198,18 @@ void main() {
 
       expect(capturedEvent.throwable, error);
       expect(capturedEvent.exception is SentryException, true);
-      expect(capturedEvent.exception.stackTrace, isNotNull);
-      expect(capturedEvent.exception.stackTrace.frames.first.fileName,
+      expect(capturedEvent.exception!.stackTrace, isNotNull);
+      expect(capturedEvent.exception!.stackTrace!.frames.first.fileName,
           'test.dart');
-      expect(capturedEvent.exception.stackTrace.frames.first.lineNo, 46);
-      expect(capturedEvent.exception.stackTrace.frames.first.colNo, 9);
+      expect(capturedEvent.exception!.stackTrace!.frames.first.lineNo, 46);
+      expect(capturedEvent.exception!.stackTrace!.frames.first.colNo, 9);
     });
   });
 
   group('SentryClient captures exception and stacktrace', () {
-    SentryOptions options;
+    late SentryOptions options;
 
-    Exception exception;
+    dynamic exception;
 
     setUp(() {
       options = SentryOptions(dsn: fakeDsn);
@@ -238,10 +238,10 @@ void main() {
 
       expect(capturedEvent.throwable, exception);
       expect(capturedEvent.exception is SentryException, true);
-      expect(capturedEvent.exception.stackTrace.frames.first.fileName,
+      expect(capturedEvent.exception!.stackTrace!.frames.first.fileName,
           'test.dart');
-      expect(capturedEvent.exception.stackTrace.frames.first.lineNo, 46);
-      expect(capturedEvent.exception.stackTrace.frames.first.colNo, 9);
+      expect(capturedEvent.exception!.stackTrace!.frames.first.lineNo, 46);
+      expect(capturedEvent.exception!.stackTrace!.frames.first.colNo, 9);
     });
 
     test('should capture exception with Stackframe.current', () async {
@@ -258,7 +258,7 @@ void main() {
         options.transport.send(captureAny),
       ).captured.first) as SentryEvent;
 
-      expect(capturedEvent.exception.stackTrace, isNotNull);
+      expect(capturedEvent.exception!.stackTrace, isNotNull);
     });
 
     test('should capture exception without Stackframe.current', () async {
@@ -275,7 +275,7 @@ void main() {
         options.transport.send(captureAny),
       ).captured.first) as SentryEvent;
 
-      expect(capturedEvent.exception.stackTrace, isNull);
+      expect(capturedEvent.exception!.stackTrace, isNull);
     });
 
     test('should not capture sentry frames exception', () async {
@@ -300,7 +300,7 @@ void main() {
       ).captured.first) as SentryEvent;
 
       expect(
-        capturedEvent.exception.stackTrace.frames
+        capturedEvent.exception!.stackTrace!.frames
             .every((frame) => frame.package != 'sentry'),
         true,
       );
@@ -308,8 +308,8 @@ void main() {
   });
 
   group('SentryClient : apply scope to the captured event', () {
-    SentryOptions options;
-    Scope scope;
+    late SentryOptions options;
+    late Scope scope;
 
     final level = SentryLevel.error;
     const transaction = '/test/scope';
@@ -355,10 +355,10 @@ void main() {
       ).captured.first) as SentryEvent;
 
       expect(capturedEvent.user?.id, user.id);
-      expect(capturedEvent.level.name, SentryLevel.error.name);
+      expect(capturedEvent.level!.name, SentryLevel.error.name);
       expect(capturedEvent.transaction, transaction);
       expect(capturedEvent.fingerprint, fingerprint);
-      expect(capturedEvent.breadcrumbs.first, crumb);
+      expect(capturedEvent.breadcrumbs!.first, crumb);
       expect(capturedEvent.tags, {
         scopeTagKey: scopeTagValue,
         eventTagKey: eventTagValue,
@@ -371,8 +371,8 @@ void main() {
   });
 
   group('SentryClient : apply partial scope to the captured event', () {
-    SentryOptions options;
-    Scope scope;
+    late SentryOptions options;
+    late Scope scope;
 
     final transaction = '/test/scope';
     final eventTransaction = '/event/transaction';
@@ -409,8 +409,8 @@ void main() {
         options.transport.send(captureAny),
       ).captured.first) as SentryEvent;
 
-      expect(capturedEvent.user.id, eventUser.id);
-      expect(capturedEvent.level.name, SentryLevel.warning.name);
+      expect(capturedEvent.user!.id, eventUser.id);
+      expect(capturedEvent.level!.name, SentryLevel.warning.name);
       expect(capturedEvent.transaction, eventTransaction);
       expect(capturedEvent.fingerprint, eventFingerprint);
       expect(capturedEvent.breadcrumbs, eventCrumbs);
@@ -418,7 +418,7 @@ void main() {
   });
 
   group('SentryClient sampling', () {
-    SentryOptions options;
+    late SentryOptions options;
 
     setUp(() {
       options = SentryOptions(dsn: fakeDsn);
@@ -451,7 +451,7 @@ void main() {
   });
 
   group('SentryClient before send', () {
-    SentryOptions options;
+    late SentryOptions options;
 
     setUp(() {
       options = SentryOptions(dsn: fakeDsn);
@@ -474,41 +474,37 @@ void main() {
       final event = verify(options.transport.send(captureAny)).captured.first
           as SentryEvent;
 
-      expect(event.tags.containsKey('theme'), true);
-      expect(event.extra.containsKey('host'), true);
-      expect(event.modules.containsKey('core'), true);
-      expect(event.sdk.integrations.contains('testIntegration'), true);
+      expect(event.tags!.containsKey('theme'), true);
+      expect(event.extra!.containsKey('host'), true);
+      expect(event.modules!.containsKey('core'), true);
+      expect(event.sdk!.integrations.contains('testIntegration'), true);
       expect(
-        event.sdk.packages.any((element) => element.name == 'test-pkg'),
+        event.sdk!.packages.any((element) => element.name == 'test-pkg'),
         true,
       );
       expect(
-        event.breadcrumbs
+        event.breadcrumbs!
             .any((element) => element.message == 'processor crumb'),
         true,
       );
-      expect(event.fingerprint.contains('process'), true);
+      expect(event.fingerprint!.contains('process'), true);
     });
   });
 
-  test("options can't be null", () {
-    expect(() => SentryClient(null), throwsArgumentError);
-  });
-
   group('EventProcessors', () {
-    SentryOptions options;
+    late SentryOptions options;
 
     setUp(() {
       options = SentryOptions(dsn: fakeDsn);
       options.addEventProcessor(
         (event, {hint}) => event
-          ..tags.addAll({'theme': 'material'})
-          ..extra['host'] = '0.0.0.1'
-          ..modules.addAll({'core': '1.0'})
-          ..breadcrumbs.add(Breadcrumb(message: 'processor crumb'))
-          ..fingerprint.add('process')
-          ..sdk.addIntegration('testIntegration')
-          ..sdk.addPackage('test-pkg', '1.0'),
+          ..tags!.addAll({'theme': 'material'})
+          ..extra!['host'] = '0.0.0.1'
+          ..modules!.addAll({'core': '1.0'})
+          ..breadcrumbs!.add(Breadcrumb(message: 'processor crumb'))
+          ..fingerprint!.add('process')
+          ..sdk!.addIntegration('testIntegration')
+          ..sdk!.addPackage('test-pkg', '1.0'),
       );
       options.transport = MockTransport();
     });
@@ -519,34 +515,34 @@ void main() {
 
       final event = verify(options.transport.send(captureAny)).captured.first
           as SentryEvent;
-      expect(event.tags.containsKey('theme'), true);
-      expect(event.extra.containsKey('host'), true);
-      expect(event.modules.containsKey('core'), true);
-      expect(event.sdk.integrations.contains('testIntegration'), true);
+      expect(event.tags!.containsKey('theme'), true);
+      expect(event.extra!.containsKey('host'), true);
+      expect(event.modules!.containsKey('core'), true);
+      expect(event.sdk!.integrations.contains('testIntegration'), true);
       expect(
-        event.sdk.packages.any((element) => element.name == 'test-pkg'),
+        event.sdk!.packages.any((element) => element.name == 'test-pkg'),
         true,
       );
       expect(
-        event.breadcrumbs
+        event.breadcrumbs!
             .any((element) => element.message == 'processor crumb'),
         true,
       );
-      expect(event.fingerprint.contains('process'), true);
+      expect(event.fingerprint!.contains('process'), true);
     });
   });
 }
 
-SentryEvent beforeSendCallbackDropEvent(SentryEvent event, {dynamic hint}) =>
+SentryEvent? beforeSendCallbackDropEvent(SentryEvent event, {dynamic hint}) =>
     null;
 
 SentryEvent beforeSendCallback(SentryEvent event, {dynamic hint}) {
   return event
-    ..tags.addAll({'theme': 'material'})
-    ..extra['host'] = '0.0.0.1'
-    ..modules.addAll({'core': '1.0'})
-    ..breadcrumbs.add(Breadcrumb(message: 'processor crumb'))
-    ..fingerprint.add('process')
-    ..sdk.addIntegration('testIntegration')
-    ..sdk.addPackage('test-pkg', '1.0');
+    ..tags!.addAll({'theme': 'material'})
+    ..extra!['host'] = '0.0.0.1'
+    ..modules!.addAll({'core': '1.0'})
+    ..breadcrumbs!.add(Breadcrumb(message: 'processor crumb'))
+    ..fingerprint!.add('process')
+    ..sdk!.addIntegration('testIntegration')
+    ..sdk!.addPackage('test-pkg', '1.0');
 }

--- a/dart/test/sentry_client_test.dart
+++ b/dart/test/sentry_client_test.dart
@@ -330,7 +330,7 @@ void main() {
       expect(capturedEvent.level!.name, SentryLevel.error.name);
       expect(capturedEvent.transaction, transaction);
       expect(capturedEvent.fingerprint, fingerprint);
-      expect(capturedEvent.breadcrumbs!.first, crumb);
+      expect(capturedEvent.breadcrumbs.first, crumb);
       expect(capturedEvent.tags, {
         scopeTagKey: scopeTagValue,
         eventTagKey: eventTagValue,
@@ -443,8 +443,8 @@ void main() {
 
       final event = (options.transport as MockTransport).events.first;
 
-      expect(event.tags!.containsKey('theme'), true);
-      expect(event.extra!.containsKey('host'), true);
+      expect(event.tags.containsKey('theme'), true);
+      expect(event.extra.containsKey('host'), true);
       expect(event.modules!.containsKey('core'), true);
       expect(event.sdk!.integrations.contains('testIntegration'), true);
       expect(
@@ -452,11 +452,11 @@ void main() {
         true,
       );
       expect(
-        event.breadcrumbs!
+        event.breadcrumbs
             .any((element) => element.message == 'processor crumb'),
         true,
       );
-      expect(event.fingerprint!.contains('process'), true);
+      expect(event.fingerprint.contains('process'), true);
     });
   });
 
@@ -467,11 +467,11 @@ void main() {
       options = SentryOptions(dsn: fakeDsn);
       options.addEventProcessor(
         (event, {hint}) => event
-          ..tags!.addAll({'theme': 'material'})
-          ..extra!['host'] = '0.0.0.1'
+          ..tags.addAll({'theme': 'material'})
+          ..extra['host'] = '0.0.0.1'
           ..modules!.addAll({'core': '1.0'})
-          ..breadcrumbs!.add(Breadcrumb(message: 'processor crumb'))
-          ..fingerprint!.add('process')
+          ..breadcrumbs.add(Breadcrumb(message: 'processor crumb'))
+          ..fingerprint.add('process')
           ..sdk!.addIntegration('testIntegration')
           ..sdk!.addPackage('test-pkg', '1.0'),
       );
@@ -483,8 +483,8 @@ void main() {
       await client.captureEvent(fakeEvent);
 
       final event = (options.transport as MockTransport).events.first;
-      expect(event.tags!.containsKey('theme'), true);
-      expect(event.extra!.containsKey('host'), true);
+      expect(event.tags.containsKey('theme'), true);
+      expect(event.extra.containsKey('host'), true);
       expect(event.modules!.containsKey('core'), true);
       expect(event.sdk!.integrations.contains('testIntegration'), true);
       expect(
@@ -492,11 +492,11 @@ void main() {
         true,
       );
       expect(
-        event.breadcrumbs!
+        event.breadcrumbs
             .any((element) => element.message == 'processor crumb'),
         true,
       );
-      expect(event.fingerprint!.contains('process'), true);
+      expect(event.fingerprint.contains('process'), true);
     });
   });
 }
@@ -506,11 +506,11 @@ SentryEvent? beforeSendCallbackDropEvent(SentryEvent event, {dynamic hint}) =>
 
 SentryEvent beforeSendCallback(SentryEvent event, {dynamic hint}) {
   return event
-    ..tags!.addAll({'theme': 'material'})
-    ..extra!['host'] = '0.0.0.1'
+    ..tags.addAll({'theme': 'material'})
+    ..extra['host'] = '0.0.0.1'
     ..modules!.addAll({'core': '1.0'})
-    ..breadcrumbs!.add(Breadcrumb(message: 'processor crumb'))
-    ..fingerprint!.add('process')
+    ..breadcrumbs.add(Breadcrumb(message: 'processor crumb'))
+    ..fingerprint.add('process')
     ..sdk!.addIntegration('testIntegration')
     ..sdk!.addPackage('test-pkg', '1.0');
 }

--- a/dart/test/sentry_client_test.dart
+++ b/dart/test/sentry_client_test.dart
@@ -330,7 +330,7 @@ void main() {
       expect(capturedEvent.level!.name, SentryLevel.error.name);
       expect(capturedEvent.transaction, transaction);
       expect(capturedEvent.fingerprint, fingerprint);
-      expect(capturedEvent.breadcrumbs.first, crumb);
+      expect(capturedEvent.breadcrumbs?.first, crumb);
       expect(capturedEvent.tags, {
         scopeTagKey: scopeTagValue,
         eventTagKey: eventTagValue,
@@ -443,8 +443,8 @@ void main() {
 
       final event = (options.transport as MockTransport).events.first;
 
-      expect(event.tags.containsKey('theme'), true);
-      expect(event.extra.containsKey('host'), true);
+      expect(event.tags!.containsKey('theme'), true);
+      expect(event.extra!.containsKey('host'), true);
       expect(event.modules!.containsKey('core'), true);
       expect(event.sdk!.integrations.contains('testIntegration'), true);
       expect(
@@ -452,11 +452,11 @@ void main() {
         true,
       );
       expect(
-        event.breadcrumbs
+        event.breadcrumbs!
             .any((element) => element.message == 'processor crumb'),
         true,
       );
-      expect(event.fingerprint.contains('process'), true);
+      expect(event.fingerprint!.contains('process'), true);
     });
   });
 
@@ -467,11 +467,11 @@ void main() {
       options = SentryOptions(dsn: fakeDsn);
       options.addEventProcessor(
         (event, {hint}) => event
-          ..tags.addAll({'theme': 'material'})
-          ..extra['host'] = '0.0.0.1'
+          ..tags!.addAll({'theme': 'material'})
+          ..extra!['host'] = '0.0.0.1'
           ..modules!.addAll({'core': '1.0'})
-          ..breadcrumbs.add(Breadcrumb(message: 'processor crumb'))
-          ..fingerprint.add('process')
+          ..breadcrumbs!.add(Breadcrumb(message: 'processor crumb'))
+          ..fingerprint!.add('process')
           ..sdk!.addIntegration('testIntegration')
           ..sdk!.addPackage('test-pkg', '1.0'),
       );
@@ -483,8 +483,8 @@ void main() {
       await client.captureEvent(fakeEvent);
 
       final event = (options.transport as MockTransport).events.first;
-      expect(event.tags.containsKey('theme'), true);
-      expect(event.extra.containsKey('host'), true);
+      expect(event.tags!.containsKey('theme'), true);
+      expect(event.extra!.containsKey('host'), true);
       expect(event.modules!.containsKey('core'), true);
       expect(event.sdk!.integrations.contains('testIntegration'), true);
       expect(
@@ -492,11 +492,11 @@ void main() {
         true,
       );
       expect(
-        event.breadcrumbs
+        event.breadcrumbs!
             .any((element) => element.message == 'processor crumb'),
         true,
       );
-      expect(event.fingerprint.contains('process'), true);
+      expect(event.fingerprint!.contains('process'), true);
     });
   });
 }
@@ -506,11 +506,11 @@ SentryEvent? beforeSendCallbackDropEvent(SentryEvent event, {dynamic hint}) =>
 
 SentryEvent beforeSendCallback(SentryEvent event, {dynamic hint}) {
   return event
-    ..tags.addAll({'theme': 'material'})
-    ..extra['host'] = '0.0.0.1'
+    ..tags!.addAll({'theme': 'material'})
+    ..extra!['host'] = '0.0.0.1'
     ..modules!.addAll({'core': '1.0'})
-    ..breadcrumbs.add(Breadcrumb(message: 'processor crumb'))
-    ..fingerprint.add('process')
+    ..breadcrumbs!.add(Breadcrumb(message: 'processor crumb'))
+    ..fingerprint!.add('process')
     ..sdk!.addIntegration('testIntegration')
     ..sdk!.addPackage('test-pkg', '1.0');
 }

--- a/dart/test/sentry_event_test.dart
+++ b/dart/test/sentry_event_test.dart
@@ -9,6 +9,8 @@ import 'package:sentry/src/utils.dart';
 import 'package:sentry/src/version.dart';
 import 'package:test/test.dart';
 
+import 'mocks.dart';
+
 void main() {
   group(SentryEvent, () {
     test('$Breadcrumb serializes', () {
@@ -212,7 +214,7 @@ void main() {
 
     test('should not serialize stacktrace if not SentryStacktrace', () {
       final stacktrace = SentryStackTrace(
-        frames: SentryStackTraceFactory(SentryOptions())
+        frames: SentryStackTraceFactory(SentryOptions(dsn: fakeDsn))
             .getStackFrames('#0      baz (file:///pathto/test.dart:50:3)'),
       );
       final serialized = SentryEvent(stackTrace: stacktrace).toJson();

--- a/dart/test/sentry_event_test.dart
+++ b/dart/test/sentry_event_test.dart
@@ -262,7 +262,7 @@ void main() {
 
     test('should not serialize null or empty fields', () {
       final event = SentryEvent(
-        message: Message(null),
+        message: null,
         modules: {},
         exception: SentryException(type: null, value: null),
         stackTrace: SentryStackTrace(frames: []),

--- a/dart/test/sentry_options_test.dart
+++ b/dart/test/sentry_options_test.dart
@@ -9,12 +9,6 @@ void main() {
     expect(NoOpClient(), options.httpClient);
   });
 
-  test('$Client is NoOp if null is set', () {
-    final options = SentryOptions();
-    options.httpClient = null;
-    expect(NoOpClient(), options.httpClient);
-  });
-
   test('$Client sets a custom client', () {
     final options = SentryOptions();
 
@@ -29,20 +23,6 @@ void main() {
     expect(100, options.maxBreadcrumbs);
   });
 
-  test('maxBreadcrumbs is default if null is set', () {
-    final options = SentryOptions();
-    options.maxBreadcrumbs = null;
-
-    expect(100, options.maxBreadcrumbs);
-  });
-
-  test('maxBreadcrumbs is default if negative number is set', () {
-    final options = SentryOptions();
-    options.maxBreadcrumbs = -1;
-
-    expect(100, options.maxBreadcrumbs);
-  });
-
   test('maxBreadcrumbs sets custom maxBreadcrumbs', () {
     final options = SentryOptions();
     options.maxBreadcrumbs = 200;
@@ -52,13 +32,6 @@ void main() {
 
   test('$SentryLogger is NoOp by default', () {
     final options = SentryOptions();
-
-    expect(noOpLogger, options.logger);
-  });
-
-  test('$SentryLogger is NoOp if null is set', () {
-    final options = SentryOptions();
-    options.logger = null;
 
     expect(noOpLogger, options.logger);
   });

--- a/dart/test/sentry_options_test.dart
+++ b/dart/test/sentry_options_test.dart
@@ -3,14 +3,16 @@ import 'package:sentry/sentry.dart';
 import 'package:sentry/src/noop_client.dart';
 import 'package:test/test.dart';
 
+import 'mocks.dart';
+
 void main() {
   test('$Client is NoOp', () {
-    final options = SentryOptions();
+    final options = SentryOptions(dsn: fakeDsn);
     expect(NoOpClient(), options.httpClient);
   });
 
   test('$Client sets a custom client', () {
-    final options = SentryOptions();
+    final options = SentryOptions(dsn: fakeDsn);
 
     final client = Client();
     options.httpClient = client;
@@ -18,26 +20,26 @@ void main() {
   });
 
   test('maxBreadcrumbs is 100 by default', () {
-    final options = SentryOptions();
+    final options = SentryOptions(dsn: fakeDsn);
 
     expect(100, options.maxBreadcrumbs);
   });
 
   test('maxBreadcrumbs sets custom maxBreadcrumbs', () {
-    final options = SentryOptions();
+    final options = SentryOptions(dsn: fakeDsn);
     options.maxBreadcrumbs = 200;
 
     expect(200, options.maxBreadcrumbs);
   });
 
   test('$SentryLogger is NoOp by default', () {
-    final options = SentryOptions();
+    final options = SentryOptions(dsn: fakeDsn);
 
     expect(noOpLogger, options.logger);
   });
 
   test('$SentryLogger sets a diagnostic logger', () {
-    final options = SentryOptions();
+    final options = SentryOptions(dsn: fakeDsn);
     options.logger = dartLogger;
 
     expect(false, options.logger == noOpLogger);

--- a/dart/test/sentry_test.dart
+++ b/dart/test/sentry_test.dart
@@ -33,11 +33,6 @@ void main() {
       expect(client.captureEventCalls.first.scope, isNotNull);
     });
 
-    test('should not capture a null event', () async {
-      await Sentry.captureEvent(null);
-      expect(client.captureEventCalls.length, 0);
-    });
-
     test('should not capture a null exception', () async {
       await Sentry.captureException(null);
       expect(client.captureExceptionCalls.length, 0);
@@ -55,6 +50,14 @@ void main() {
   group('Sentry is enabled or disabled', () {
     tearDown(() {
       Sentry.close();
+    });
+
+    test('null DSN', () {
+      expect(
+        () async => await Sentry.init((options) => options.dsn = null),
+        throwsArgumentError,
+      );
+      expect(Sentry.isEnabled, false);
     });
 
     test('appRunner should be optional', () async {

--- a/dart/test/sentry_test.dart
+++ b/dart/test/sentry_test.dart
@@ -5,13 +5,13 @@ import 'package:test/test.dart';
 import 'mocks.dart';
 import 'fake_platform_checker.dart';
 
-Function appRunner = () {};
+AppRunner appRunner = () {};
 
 void main() {
   group('Sentry capture methods', () {
-    SentryClient client;
+    late SentryClient client;
 
-    Exception anException;
+    late Exception anException;
 
     setUp(() async {
       await Sentry.init((options) => options.dsn = fakeDsn);
@@ -65,13 +65,6 @@ void main() {
     tearDown(() {
       Sentry.close();
     });
-    test('null DSN', () {
-      expect(
-        () async => await Sentry.init((options) => options.dsn = null),
-        throwsArgumentError,
-      );
-      expect(Sentry.isEnabled, false);
-    });
 
     test('appRunner should be optional', () async {
       expect(Sentry.isEnabled, false);
@@ -116,7 +109,7 @@ void main() {
     });
 
     test('should add default integrations', () async {
-      SentryOptions optionsReference;
+      late SentryOptions optionsReference;
       await Sentry.init(
         (options) {
           options.dsn = fakeDsn;
@@ -160,9 +153,9 @@ void main() {
         },
       );
 
-      await Sentry.close();
+      Sentry.close();
 
-      verify(integration(any, any)).called(1);
+      verify(integration.call(any, any)).called(1);
       verify(integration.close()).called(1);
     });
   });

--- a/dart/test/sentry_test.dart
+++ b/dart/test/sentry_test.dart
@@ -47,15 +47,14 @@ void main() {
     });
 
     test('should capture message', () async {
-      await Sentry.captureMessage(fakeMessage.formatted,
-          level: SentryLevel.warning);
-      verify(
-        client.captureMessage(
-          fakeMessage.formatted,
-          level: SentryLevel.warning,
-          scope: anyNamed('scope'),
-        ),
-      ).called(1);
+      await Sentry.captureMessage(
+        fakeMessage.formatted,
+        level: SentryLevel.warning,
+      );
+
+      expect(client.captureMessageCalls.length, 1);
+      expect(client.captureMessageCalls.first.formatted, fakeMessage.formatted);
+      expect(client.captureMessageCalls.first.level, SentryLevel.warning);
     });
   });
 

--- a/dart/test/sentry_test.dart
+++ b/dart/test/sentry_test.dart
@@ -167,17 +167,6 @@ void main() {
     });
   });
 
-  test(
-    "options can't be null",
-    () {
-      expect(
-          () async => await Sentry.init(
-                (options) => options = null,
-              ),
-          throwsArgumentError);
-    },
-  );
-
   test('options.environment debug', () async {
     final sentryOptions = SentryOptions()
       ..platformChecker = FakePlatformChecker.debugMode();

--- a/dart/test/sentry_test.dart
+++ b/dart/test/sentry_test.dart
@@ -168,7 +168,7 @@ void main() {
   });
 
   test('options.environment debug', () async {
-    final sentryOptions = SentryOptions()
+    final sentryOptions = SentryOptions(dsn: fakeDsn)
       ..platformChecker = FakePlatformChecker.debugMode();
 
     await Sentry.init((options) {
@@ -178,7 +178,7 @@ void main() {
   });
 
   test('options.environment profile', () async {
-    final sentryOptions = SentryOptions()
+    final sentryOptions = SentryOptions(dsn: fakeDsn)
       ..platformChecker = FakePlatformChecker.profileMode();
     await Sentry.init((options) {
       options.dsn = fakeDsn;
@@ -187,7 +187,7 @@ void main() {
   });
 
   test('options.environment production (defaultEnvironment)', () async {
-    final sentryOptions = SentryOptions()
+    final sentryOptions = SentryOptions(dsn: fakeDsn)
       ..platformChecker = FakePlatformChecker.releaseMode();
     await Sentry.init((options) {
       options.dsn = fakeDsn;

--- a/dart/test/sentry_test.dart
+++ b/dart/test/sentry_test.dart
@@ -4,6 +4,7 @@ import 'package:test/test.dart';
 
 import 'mocks.dart';
 import 'fake_platform_checker.dart';
+import 'mocks/mock_integration.dart';
 
 AppRunner appRunner = () {};
 
@@ -105,7 +106,7 @@ void main() {
         },
       );
 
-      verify(integration(any, any)).called(1);
+      expect(integration.callCalls, 1);
     });
 
     test('should add default integrations', () async {
@@ -155,8 +156,8 @@ void main() {
 
       Sentry.close();
 
-      verify(integration.call(any, any)).called(1);
-      verify(integration.close()).called(1);
+      expect(integration.callCalls, 1);
+      expect(integration.closeCalls, 1);
     });
   });
 

--- a/dart/test/stack_trace_test.dart
+++ b/dart/test/stack_trace_test.dart
@@ -18,7 +18,7 @@ void main() {
 
       expect(
         SentryStackTraceFactory(SentryOptions(dsn: fakeDsn))
-            .encodeStackTraceFrame(frame)
+            .encodeStackTraceFrame(frame)!
             .toJson(),
         {
           'abs_path': '${eventOrigin}dart:core',
@@ -35,7 +35,7 @@ void main() {
       final frame = Frame(Uri.parse('file://foo/bar/baz.dart'), 1, 2, 'buzz');
       expect(
         SentryStackTraceFactory(SentryOptions(dsn: fakeDsn))
-            .encodeStackTraceFrame(frame)
+            .encodeStackTraceFrame(frame)!
             .toJson()['abs_path'],
         '${eventOrigin}baz.dart',
       );
@@ -45,7 +45,7 @@ void main() {
       final frame = Frame(Uri.parse('package:toolkit/baz.dart'), 1, 2, 'buzz');
       final serializedFrame = SentryStackTraceFactory(
               SentryOptions(dsn: fakeDsn)..addInAppExclude('toolkit'))
-          .encodeStackTraceFrame(frame)
+          .encodeStackTraceFrame(frame)!
           .toJson();
       expect(serializedFrame['package'], 'toolkit');
     });
@@ -54,7 +54,7 @@ void main() {
       final frame = Frame(Uri.parse('package:toolkit/baz.dart'), 1, 2, 'buzz');
       final serializedFrame = SentryStackTraceFactory(
               SentryOptions(dsn: fakeDsn)..addInAppExclude('toolkit'))
-          .encodeStackTraceFrame(frame)
+          .encodeStackTraceFrame(frame)!
           .toJson();
       expect(serializedFrame['in_app'], false);
     });
@@ -63,7 +63,7 @@ void main() {
       final frame = Frame(Uri.parse('package:toolkit/baz.dart'), 1, 2, 'buzz');
       final serializedFrame = SentryStackTraceFactory(
               SentryOptions(dsn: fakeDsn)..addInAppInclude('toolkit'))
-          .encodeStackTraceFrame(frame)
+          .encodeStackTraceFrame(frame)!
           .toJson();
       expect(serializedFrame['in_app'], true);
     });
@@ -73,7 +73,7 @@ void main() {
           Frame(Uri.parse('package:flutter/material.dart'), 1, 2, 'buzz');
       final serializedFrame =
           SentryStackTraceFactory(SentryOptions(dsn: fakeDsn))
-              .encodeStackTraceFrame(frame)
+              .encodeStackTraceFrame(frame)!
               .toJson();
       expect(serializedFrame['in_app'], false);
     });
@@ -84,7 +84,7 @@ void main() {
           SentryStackTraceFactory(SentryOptions(dsn: fakeDsn)
                 ..addInAppInclude('toolkit')
                 ..addInAppExclude('toolkit'))
-              .encodeStackTraceFrame(frame)
+              .encodeStackTraceFrame(frame)!
               .toJson();
       expect(serializedFrame['in_app'], true);
     });

--- a/dart/test/stack_trace_test.dart
+++ b/dart/test/stack_trace_test.dart
@@ -9,13 +9,15 @@ import 'package:sentry/src/sentry_stack_trace_factory.dart';
 import 'package:stack_trace/stack_trace.dart';
 import 'package:test/test.dart';
 
+import 'mocks.dart';
+
 void main() {
   group('encodeStackTraceFrame', () {
     test('marks dart: frames as not app frames', () {
       final frame = Frame(Uri.parse('dart:core'), 1, 2, 'buzz');
 
       expect(
-        SentryStackTraceFactory(SentryOptions())
+        SentryStackTraceFactory(SentryOptions(dsn: fakeDsn))
             .encodeStackTraceFrame(frame)
             .toJson(),
         {
@@ -32,7 +34,7 @@ void main() {
     test('cleanses absolute paths', () {
       final frame = Frame(Uri.parse('file://foo/bar/baz.dart'), 1, 2, 'buzz');
       expect(
-        SentryStackTraceFactory(SentryOptions())
+        SentryStackTraceFactory(SentryOptions(dsn: fakeDsn))
             .encodeStackTraceFrame(frame)
             .toJson()['abs_path'],
         '${eventOrigin}baz.dart',
@@ -41,123 +43,136 @@ void main() {
 
     test('send exception package', () {
       final frame = Frame(Uri.parse('package:toolkit/baz.dart'), 1, 2, 'buzz');
-      final serializedFrame =
-          SentryStackTraceFactory(SentryOptions()..addInAppExclude('toolkit'))
-              .encodeStackTraceFrame(frame)
-              .toJson();
+      final serializedFrame = SentryStackTraceFactory(
+              SentryOptions(dsn: fakeDsn)..addInAppExclude('toolkit'))
+          .encodeStackTraceFrame(frame)
+          .toJson();
       expect(serializedFrame['package'], 'toolkit');
     });
 
     test('apply inAppExcludes', () {
       final frame = Frame(Uri.parse('package:toolkit/baz.dart'), 1, 2, 'buzz');
-      final serializedFrame =
-          SentryStackTraceFactory(SentryOptions()..addInAppExclude('toolkit'))
-              .encodeStackTraceFrame(frame)
-              .toJson();
+      final serializedFrame = SentryStackTraceFactory(
+              SentryOptions(dsn: fakeDsn)..addInAppExclude('toolkit'))
+          .encodeStackTraceFrame(frame)
+          .toJson();
       expect(serializedFrame['in_app'], false);
     });
 
     test('apply inAppIncludes', () {
       final frame = Frame(Uri.parse('package:toolkit/baz.dart'), 1, 2, 'buzz');
-      final serializedFrame =
-          SentryStackTraceFactory(SentryOptions()..addInAppInclude('toolkit'))
-              .encodeStackTraceFrame(frame)
-              .toJson();
+      final serializedFrame = SentryStackTraceFactory(
+              SentryOptions(dsn: fakeDsn)..addInAppInclude('toolkit'))
+          .encodeStackTraceFrame(frame)
+          .toJson();
       expect(serializedFrame['in_app'], true);
     });
 
     test('flutter package is not inApp', () {
       final frame =
           Frame(Uri.parse('package:flutter/material.dart'), 1, 2, 'buzz');
-      final serializedFrame = SentryStackTraceFactory(SentryOptions())
-          .encodeStackTraceFrame(frame)
-          .toJson();
+      final serializedFrame =
+          SentryStackTraceFactory(SentryOptions(dsn: fakeDsn))
+              .encodeStackTraceFrame(frame)
+              .toJson();
       expect(serializedFrame['in_app'], false);
     });
 
     test('apply inAppIncludes with precedence', () {
       final frame = Frame(Uri.parse('package:toolkit/baz.dart'), 1, 2, 'buzz');
-      final serializedFrame = SentryStackTraceFactory(SentryOptions()
-            ..addInAppInclude('toolkit')
-            ..addInAppExclude('toolkit'))
-          .encodeStackTraceFrame(frame)
-          .toJson();
+      final serializedFrame =
+          SentryStackTraceFactory(SentryOptions(dsn: fakeDsn)
+                ..addInAppInclude('toolkit')
+                ..addInAppExclude('toolkit'))
+              .encodeStackTraceFrame(frame)
+              .toJson();
       expect(serializedFrame['in_app'], true);
     });
   });
 
   group('encodeStackTrace', () {
     test('encodes a simple stack trace', () {
-      expect(SentryStackTraceFactory(SentryOptions()).getStackFrames('''
+      expect(
+          SentryStackTraceFactory(SentryOptions(dsn: fakeDsn))
+              .getStackFrames('''
 #0      baz (file:///pathto/test.dart:50:3)
 #1      bar (file:///pathto/test.dart:46:9)
-      ''').map((frame) => frame.toJson()), [
-        {
-          'abs_path': '${eventOrigin}test.dart',
-          'function': 'bar',
-          'lineno': 46,
-          'colno': 9,
-          'in_app': true,
-          'filename': 'test.dart'
-        },
-        {
-          'abs_path': '${eventOrigin}test.dart',
-          'function': 'baz',
-          'lineno': 50,
-          'colno': 3,
-          'in_app': true,
-          'filename': 'test.dart'
-        },
-      ]);
+      ''').map((frame) => frame.toJson()),
+          [
+            {
+              'abs_path': '${eventOrigin}test.dart',
+              'function': 'bar',
+              'lineno': 46,
+              'colno': 9,
+              'in_app': true,
+              'filename': 'test.dart'
+            },
+            {
+              'abs_path': '${eventOrigin}test.dart',
+              'function': 'baz',
+              'lineno': 50,
+              'colno': 3,
+              'in_app': true,
+              'filename': 'test.dart'
+            },
+          ]);
     });
 
     test('encodes an asynchronous stack trace', () {
-      expect(SentryStackTraceFactory(SentryOptions()).getStackFrames('''
+      expect(
+          SentryStackTraceFactory(SentryOptions(dsn: fakeDsn))
+              .getStackFrames('''
 #0      baz (file:///pathto/test.dart:50:3)
 <asynchronous suspension>
 #1      bar (file:///pathto/test.dart:46:9)
-      ''').map((frame) => frame.toJson()), [
-        {
-          'abs_path': '${eventOrigin}test.dart',
-          'function': 'bar',
-          'lineno': 46,
-          'colno': 9,
-          'in_app': true,
-          'filename': 'test.dart'
-        },
-        {
-          'abs_path': '<asynchronous suspension>',
-        },
-        {
-          'abs_path': '${eventOrigin}test.dart',
-          'function': 'baz',
-          'lineno': 50,
-          'colno': 3,
-          'in_app': true,
-          'filename': 'test.dart'
-        },
-      ]);
+      ''').map((frame) => frame.toJson()),
+          [
+            {
+              'abs_path': '${eventOrigin}test.dart',
+              'function': 'bar',
+              'lineno': 46,
+              'colno': 9,
+              'in_app': true,
+              'filename': 'test.dart'
+            },
+            {
+              'abs_path': '<asynchronous suspension>',
+            },
+            {
+              'abs_path': '${eventOrigin}test.dart',
+              'function': 'baz',
+              'lineno': 50,
+              'colno': 3,
+              'in_app': true,
+              'filename': 'test.dart'
+            },
+          ]);
     });
 
     test('sets instruction_addr if stack trace violates dart standard', () {
-      expect(SentryStackTraceFactory(SentryOptions()).getStackFrames('''
+      expect(
+          SentryStackTraceFactory(SentryOptions(dsn: fakeDsn))
+              .getStackFrames('''
       warning:  This VM has been configured to produce stack traces that violate the Dart standard.
       unparsed      #00 abs 000000723d6346d7 virt 00000000001ed6d7 _kDartIsolateSnapshotInstructions+0x1e26d7
       unparsed      #01 abs 000000723d637527 virt 00000000001f0527 _kDartIsolateSnapshotInstructions+0x1e5527
-      ''').map((frame) => frame.toJson()), [
-        {
-          'platform': 'native',
-          'instruction_addr': '0x000000723d637527',
-        },
-        {
-          'platform': 'native',
-          'instruction_addr': '0x000000723d6346d7',
-        },
-      ]);
+      ''').map((frame) => frame.toJson()),
+          [
+            {
+              'platform': 'native',
+              'instruction_addr': '0x000000723d637527',
+            },
+            {
+              'platform': 'native',
+              'instruction_addr': '0x000000723d6346d7',
+            },
+          ]);
     });
 
     test('sets instruction_addr and ignores noise', () {
-      expect(SentryStackTraceFactory(SentryOptions()).getStackFrames('''
+      expect(
+          SentryStackTraceFactory(SentryOptions(dsn: fakeDsn))
+              .getStackFrames('''
       warning:  This VM has been configured to produce stack traces that violate the Dart standard.
       ***       *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
       unparsed  pid: 30930, tid: 30990, name 1.ui
@@ -166,16 +181,17 @@ void main() {
       unparsed  isolate_instructions: 723d452000, vm_instructions: 723d449000
       unparsed      #00 abs 000000723d6346d7 virt 00000000001ed6d7 _kDartIsolateSnapshotInstructions+0x1e26d7
       unparsed      #01 abs 000000723d637527 virt 00000000001f0527 _kDartIsolateSnapshotInstructions+0x1e5527
-      ''').map((frame) => frame.toJson()), [
-        {
-          'platform': 'native',
-          'instruction_addr': '0x000000723d637527',
-        },
-        {
-          'platform': 'native',
-          'instruction_addr': '0x000000723d6346d7',
-        },
-      ]);
+      ''').map((frame) => frame.toJson()),
+          [
+            {
+              'platform': 'native',
+              'instruction_addr': '0x000000723d637527',
+            },
+            {
+              'platform': 'native',
+              'instruction_addr': '0x000000723d6346d7',
+            },
+          ]);
     });
   });
 }

--- a/dart/test/test_utils.dart
+++ b/dart/test/test_utils.dart
@@ -58,12 +58,12 @@ Future testCaptureException(
 ) async {
   final fakeClockProvider = () => DateTime.utc(2017, 1, 2);
 
-  String postUri;
+  Uri postUri;
   Map<String, String> headers;
   List<int> body;
   final httpMock = MockClient((http.Request request) async {
     if (request.method == 'POST') {
-      postUri = request.url.toString();
+      postUri = request.url;
       headers = request.headers;
       body = request.bodyBytes;
       return http.Response('{"id": "test-event-id"}', 200);
@@ -191,7 +191,7 @@ void runTest({Codec<List<int>, List<int>> gzip, bool isWeb = false}) {
     expect(dsn.uri, Uri.parse(testDsn));
     expect(
       dsn.postUri,
-      'https://sentry.example.com/api/1/store/',
+      Uri.parse('https://sentry.example.com/api/1/store/'),
     );
     expect(dsn.publicKey, 'public');
     expect(dsn.secretKey, 'secret');
@@ -208,7 +208,7 @@ void runTest({Codec<List<int>, List<int>> gzip, bool isWeb = false}) {
     expect(dsn.uri, Uri.parse(_testDsnWithoutSecret));
     expect(
       dsn.postUri,
-      'https://sentry.example.com/api/1/store/',
+      Uri.parse('https://sentry.example.com/api/1/store/'),
     );
     expect(dsn.publicKey, 'public');
     expect(dsn.secretKey, null);
@@ -225,7 +225,7 @@ void runTest({Codec<List<int>, List<int>> gzip, bool isWeb = false}) {
     expect(dsn.uri, Uri.parse(_testDsnWithPath));
     expect(
       dsn.postUri,
-      'https://sentry.example.com/path/api/1/store/',
+      Uri.parse('https://sentry.example.com/path/api/1/store/'),
     );
     expect(dsn.publicKey, 'public');
     expect(dsn.secretKey, 'secret');
@@ -241,7 +241,7 @@ void runTest({Codec<List<int>, List<int>> gzip, bool isWeb = false}) {
     expect(dsn.uri, Uri.parse(_testDsnWithPort));
     expect(
       dsn.postUri,
-      'https://sentry.example.com:8888/api/1/store/',
+      Uri.parse('https://sentry.example.com:8888/api/1/store/'),
     );
     expect(dsn.publicKey, 'public');
     expect(dsn.secretKey, 'secret');
@@ -259,7 +259,8 @@ void runTest({Codec<List<int>, List<int>> gzip, bool isWeb = false}) {
         return http.Response('{"id": "testeventid"}', 200);
       }
       fail(
-          'Unexpected request on ${request.method} ${request.url} in HttpMock');
+        'Unexpected request on ${request.method} ${request.url} in HttpMock',
+      );
     });
 
     final client = SentryClient(
@@ -312,7 +313,8 @@ void runTest({Codec<List<int>, List<int>> gzip, bool isWeb = false}) {
         });
       }
       fail(
-          'Unexpected request on ${request.method} ${request.url} in HttpMock');
+        'Unexpected request on ${request.method} ${request.url} in HttpMock',
+      );
     });
 
     final client = SentryClient(
@@ -348,12 +350,17 @@ void runTest({Codec<List<int>, List<int>> gzip, bool isWeb = false}) {
         final decoded = const Utf8Codec().decode(bodyData);
         final dynamic decodedJson = jsonDecode(decoded);
         loggedUserId = decodedJson['user']['id'] as String;
-        return http.Response('', 401, headers: <String, String>{
-          'x-sentry-error': 'Invalid api key',
-        });
+        return http.Response(
+          '',
+          401,
+          headers: <String, String>{
+            'x-sentry-error': 'Invalid api key',
+          },
+        );
       }
       fail(
-          'Unexpected request on ${request.method} ${request.url} in HttpMock');
+        'Unexpected request on ${request.method} ${request.url} in HttpMock',
+      );
     });
 
     final clientUser = User(

--- a/dart/test/test_utils.dart
+++ b/dart/test/test_utils.dart
@@ -90,7 +90,7 @@ Future testCaptureException(
     expect('$sentryId', 'testeventid');
   }
 
-  final dsn = Dsn.parse(options.dsn);
+  final dsn = Dsn.parse(options.dsn!);
   expect(postUri, dsn.postUri);
 
   testHeaders(
@@ -188,7 +188,7 @@ void runTest({Codec<List<int>, List<int>?>? gzip, bool isWeb = false}) {
     final options = SentryOptions(dsn: testDsn);
     final client = SentryClient(options);
 
-    final dsn = Dsn.parse(options.dsn);
+    final dsn = Dsn.parse(options.dsn!);
 
     expect(dsn.uri, Uri.parse(testDsn));
     expect(
@@ -205,7 +205,7 @@ void runTest({Codec<List<int>, List<int>?>? gzip, bool isWeb = false}) {
     final options = SentryOptions(dsn: _testDsnWithoutSecret);
     final client = SentryClient(options);
 
-    final dsn = Dsn.parse(options.dsn);
+    final dsn = Dsn.parse(options.dsn!);
 
     expect(dsn.uri, Uri.parse(_testDsnWithoutSecret));
     expect(
@@ -222,7 +222,7 @@ void runTest({Codec<List<int>, List<int>?>? gzip, bool isWeb = false}) {
     final options = SentryOptions(dsn: _testDsnWithPath);
     final client = SentryClient(options);
 
-    final dsn = Dsn.parse(options.dsn);
+    final dsn = Dsn.parse(options.dsn!);
 
     expect(dsn.uri, Uri.parse(_testDsnWithPath));
     expect(
@@ -238,7 +238,7 @@ void runTest({Codec<List<int>, List<int>?>? gzip, bool isWeb = false}) {
     final options = SentryOptions(dsn: _testDsnWithPort);
     final client = SentryClient(options);
 
-    final dsn = Dsn.parse(options.dsn);
+    final dsn = Dsn.parse(options.dsn!);
 
     expect(dsn.uri, Uri.parse(_testDsnWithPort));
     expect(

--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -306,7 +306,7 @@ Future<void> makeWebRequest(BuildContext context) async {
   final client = SentryHttpClient();
   // We don't do any exception handling here.
   // In case of an exception, let it get caught and reported to Sentry
-  final response = await client.get('https://flutter.dev/');
+  final response = await client.get(Uri.parse('https://flutter.dev/'));
 
   await showDialog<void>(
     context: context,

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -5,7 +5,7 @@ import 'package:sentry/sentry.dart';
 /// Note that some of these options require native Sentry integration, which is
 /// not available on all platforms.
 class SentryFlutterOptions extends SentryOptions {
-  SentryFlutterOptions({String dsn = ''}) : super(dsn: dsn);
+  SentryFlutterOptions({String dsn}) : super(dsn: dsn);
 
   bool _enableAutoSessionTracking = true;
 

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -5,7 +5,7 @@ import 'package:sentry/sentry.dart';
 /// Note that some of these options require native Sentry integration, which is
 /// not available on all platforms.
 class SentryFlutterOptions extends SentryOptions {
-  SentryFlutterOptions() : super();
+  SentryFlutterOptions({String dsn = ''}) : super(dsn: dsn);
 
   bool _enableAutoSessionTracking = true;
 

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -14,8 +14,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   # this should point to pub
-  sentry:
-    path: ../dart
+  sentry: ^4.0.5
   package_info: ^2.0.0
 
 dev_dependencies:
@@ -25,9 +24,9 @@ dev_dependencies:
   yaml: ^3.0.0 # needed for version match (code and pubspec)
   pedantic: ^1.10.0
 
-# dependency_overrides:
-#  sentry:
-#    path: ../dart
+dependency_overrides:
+  sentry:
+    path: ../dart
 
 flutter:
   plugin:

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -13,20 +13,21 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  sentry: ">=4.0.0 <5.0.0"
-  package_info: ^0.4.0
+  # this should point to pub
+  sentry:
+    path: ../dart
+  package_info: ^0.5.0-nullsafety
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: ^4.1.3
-  test: ^1.15.7
-  yaml: ^2.2.1 # needed for version match (code and pubspec)
-  pedantic: ^1.9.2
+  mockito: ^5.0.0-nullsafety.7
+  yaml: ^3.0.0 # needed for version match (code and pubspec)
+  pedantic: ^1.10.0
 
-dependency_overrides:
-  sentry:
-    path: ../dart
+# dependency_overrides:
+#  sentry:
+#    path: ../dart
 
 flutter:
   plugin:

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   # this should point to pub
   sentry:
     path: ../dart
-  package_info: ^0.5.0-nullsafety
+  package_info: ^2.0.0
 
 dev_dependencies:
   flutter_test:

--- a/flutter/test/file_system_transport_test.dart
+++ b/flutter/test/file_system_transport_test.dart
@@ -84,7 +84,7 @@ void main() {
 
 class Fixture {
   FileSystemTransport getSut(MethodChannel channel) {
-    final options = SentryOptions();
+    final options = SentryOptions(dsn: '');
     return FileSystemTransport(channel, options);
   }
 }

--- a/flutter/test/sentry_flutter_web_test.dart
+++ b/flutter/test/sentry_flutter_web_test.dart
@@ -2,7 +2,7 @@
 // import 'package:sentry_flutter/sentry_flutter.dart';
 
 @TestOn('browser')
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 // import 'sentry_flutter_util_test.dart';
 

--- a/flutter/test/version_test.dart
+++ b/flutter/test/version_test.dart
@@ -6,8 +6,8 @@
 
 import 'dart:io';
 
+import 'package:flutter_test/flutter_test.dart';
 import 'package:sentry_flutter/src/version.dart';
-import 'package:test/test.dart';
 import 'package:yaml/yaml.dart' as yaml;
 
 void main() {


### PR DESCRIPTION
## :scroll: Description

This PR migrates the Dart part of this Sentry SDK to null safety.

Some notes:
- Darts migrate tool is really helpful
- mockito makes a lot of problems with non-nullable fields. It's basically useless for them.
- Some tests failed because mockito can't handle non-nullable fields. They were rewritten
- Some mocks were written manually. They're kinda inspired by the [bloc library tests for nullsafety](https://github.com/felangel/bloc/blob/null_safety/packages/bloc/test/mocks/mock_bloc_observer.dart)
- CI builds with Dart & Flutter beta
- `dynamic` can hold null values by default, even without a `?`
- https://dart.dev/null-safety/migration-guide

A lot of test were touched so they should be reviewed carefully.
Most of the user facing APIs accept null values. However events, messages or exceptions are getting dropped if they are null.
So the question is should the API allow null values? I would guess so because it makes the API a little bit more user friendly but I'm kinda torn on that. For now null values are allowed.


## :bulb: Motivation and Context

https://github.com/getsentry/sentry-dart/issues/247

## :green_heart: How did you test it?
- Tests are passing
- Manual tests with Dart example
- Manual tests with Flutter example

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
- Migrate the Sentry Flutter SDK to nullsafety
- Version number should be changed because this is a breaking change
    - should be something like `5.0.0-nullsafety.0` according to https://dart.dev/null-safety/migration-guide
- Decide how mocks should be written in the future
- Re-enable CI on stable once Dart and Flutter releases their null safe versions.