### PR TITLE
Fix: sentry_flutter static analysis (pana) using stable version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Bump: sentry-android to v4.0.0
 * Fix: Pana Flutter upper bound deprecation
+* Fix: sentry_flutter static analysis (pana) using stable version
 
 # 4.0.4
 

--- a/flutter/analysis_options.yaml
+++ b/flutter/analysis_options.yaml
@@ -12,6 +12,7 @@ analyzer:
     # to annotate every member in every test, assert, etc, when we deprecate something)
     deprecated_member_use_from_same_package: warning
     # ignore sentry/path on pubspec as we change it on deployment
+    # only available thru beta channel
     # invalid_dependency: ignore
 
     # ignore because of SentryFlutterWeb.registrar

--- a/flutter/analysis_options.yaml
+++ b/flutter/analysis_options.yaml
@@ -13,6 +13,9 @@ analyzer:
     deprecated_member_use_from_same_package: warning
     # ignore sentry/path on pubspec as we change it on deployment
     # invalid_dependency: ignore
+
+    # ignore because of SentryFlutterWeb.registrar
+    deprecated_member_use: ignore
   exclude:
     - example/**
 

--- a/flutter/analysis_options.yaml
+++ b/flutter/analysis_options.yaml
@@ -12,7 +12,7 @@ analyzer:
     # to annotate every member in every test, assert, etc, when we deprecate something)
     deprecated_member_use_from_same_package: warning
     # ignore sentry/path on pubspec as we change it on deployment
-    invalid_dependency: ignore
+    # invalid_dependency: ignore
   exclude:
     - example/**
 

--- a/flutter/lib/src/sentry_flutter_web.dart
+++ b/flutter/lib/src/sentry_flutter_web.dart
@@ -9,7 +9,7 @@ class SentryFlutterWeb {
     final channel = MethodChannel(
       'sentry_flutter',
       const StandardMethodCodec(),
-      registrar,
+      registrar.messenger,
     );
 
     final pluginInstance = SentryFlutterWeb();


### PR DESCRIPTION
## :scroll: Description
Fix: sentry_flutter static analysis (pana) using stable version


## :bulb: Motivation and Context
https://pub.dev/packages/sentry_flutter/score score now is collected using stable pana version
Revert #253
Fix #300

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
