### PR TITLE
Fix: captureMessage defaults SentryLevel to info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # vNext
 
+* Fix: captureMessage defaults SentryLevel to info
+
 # 4.0.5
 
 * Bump: sentry-android to v4.0.0

--- a/dart/lib/src/hub.dart
+++ b/dart/lib/src/hub.dart
@@ -150,7 +150,7 @@ class Hub {
   /// Captures the message.
   Future<SentryId> captureMessage(
     String message, {
-    SentryLevel level = SentryLevel.info,
+    SentryLevel level,
     String template,
     List<dynamic> params,
     dynamic hint,

--- a/dart/lib/src/hub_adapter.dart
+++ b/dart/lib/src/hub_adapter.dart
@@ -49,7 +49,7 @@ class HubAdapter implements Hub {
   @override
   Future<SentryId> captureMessage(
     String message, {
-    SentryLevel level = SentryLevel.info,
+    SentryLevel level,
     String template,
     List params,
     dynamic hint,

--- a/dart/lib/src/noop_hub.dart
+++ b/dart/lib/src/noop_hub.dart
@@ -35,7 +35,7 @@ class NoOpHub implements Hub {
   @override
   Future<SentryId> captureMessage(
     String message, {
-    SentryLevel level = SentryLevel.info,
+    SentryLevel level,
     String template,
     List params,
     dynamic hint,

--- a/dart/lib/src/noop_sentry_client.dart
+++ b/dart/lib/src/noop_sentry_client.dart
@@ -34,7 +34,7 @@ class NoOpSentryClient implements SentryClient {
   @override
   Future<SentryId> captureMessage(
     String message, {
-    SentryLevel level = SentryLevel.info,
+    SentryLevel level,
     String template,
     List<dynamic> params,
     Scope scope,

--- a/dart/lib/src/protocol/breadcrumb.dart
+++ b/dart/lib/src/protocol/breadcrumb.dart
@@ -27,9 +27,10 @@ class Breadcrumb {
     DateTime timestamp,
     this.category,
     this.data,
-    this.level = SentryLevel.info,
+    SentryLevel level,
     this.type,
-  }) : timestamp = timestamp ?? getUtcDateTime();
+  })  : timestamp = timestamp ?? getUtcDateTime(),
+        level = level ?? SentryLevel.info;
 
   /// Describes the breadcrumb.
   ///

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -156,7 +156,7 @@ class SentryClient {
   /// Reports the [template]
   Future<SentryId> captureMessage(
     String formatted, {
-    SentryLevel level = SentryLevel.info,
+    SentryLevel level,
     String template,
     List<dynamic> params,
     Scope scope,
@@ -164,7 +164,7 @@ class SentryClient {
   }) {
     final event = SentryEvent(
       message: Message(formatted, template: template, params: params),
-      level: level,
+      level: level ?? SentryLevel.info,
       timestamp: _options.clock(),
     );
 

--- a/dart/test/hub_test.dart
+++ b/dart/test/hub_test.dart
@@ -76,11 +76,12 @@ void main() {
     });
 
     test('should capture message', () async {
-      await hub.captureMessage(fakeMessage.formatted, level: SentryLevel.info);
+      await hub.captureMessage(fakeMessage.formatted,
+          level: SentryLevel.warning);
       verify(
         client.captureMessage(
           fakeMessage.formatted,
-          level: SentryLevel.info,
+          level: SentryLevel.warning,
           scope: anyNamed('scope'),
         ),
       ).called(1);

--- a/dart/test/sentry_client_test.dart
+++ b/dart/test/sentry_client_test.dart
@@ -118,8 +118,7 @@ void main() {
       expect(capturedEvent.message.formatted, 'simple message 1');
       expect(capturedEvent.message.template, 'simple message %d');
       expect(capturedEvent.message.params, [1]);
-
-      expect(capturedEvent.stackTrace is SentryStackTrace, true);
+      expect(capturedEvent.level, SentryLevel.error);
     });
 
     test('capture message defaults to info level', () async {

--- a/dart/test/sentry_client_test.dart
+++ b/dart/test/sentry_client_test.dart
@@ -122,6 +122,19 @@ void main() {
       expect(capturedEvent.stackTrace is SentryStackTrace, true);
     });
 
+    test('capture message defaults to info level', () async {
+      final client = SentryClient(options);
+      await client.captureMessage(
+        'simple message 1',
+      );
+
+      final capturedEvent = (verify(
+        options.transport.send(captureAny),
+      ).captured.first) as SentryEvent;
+
+      expect(capturedEvent.level, SentryLevel.info);
+    });
+
     test('should capture message without stacktrace', () async {
       final client = SentryClient(options..attachStacktrace = false);
       await client.captureMessage('message', level: SentryLevel.error);

--- a/dart/test/sentry_test.dart
+++ b/dart/test/sentry_test.dart
@@ -59,6 +59,18 @@ void main() {
         ),
       ).called(1);
     });
+
+    test('should capture message', () async {
+      await Sentry.captureMessage(fakeMessage.formatted,
+          level: SentryLevel.warning);
+      verify(
+        client.captureMessage(
+          fakeMessage.formatted,
+          level: SentryLevel.warning,
+          scope: anyNamed('scope'),
+        ),
+      ).called(1);
+    });
   });
 
   group('Sentry is enabled or disabled', () {

--- a/flutter/lib/src/navigation/sentry_navigator_observer.dart
+++ b/flutter/lib/src/navigation/sentry_navigator_observer.dart
@@ -101,7 +101,7 @@ class RouteObserverBreadcrumb extends Breadcrumb {
     @required String navigationType,
     RouteSettings from,
     RouteSettings to,
-    SentryLevel level = SentryLevel.info,
+    SentryLevel level,
   }) {
     final dynamic fromArgs = _formatArgs(from?.arguments);
     final dynamic toArgs = _formatArgs(to?.arguments);
@@ -121,7 +121,7 @@ class RouteObserverBreadcrumb extends Breadcrumb {
     dynamic fromArgs,
     String to,
     dynamic toArgs,
-    SentryLevel level = SentryLevel.info,
+    SentryLevel level,
   })  : assert(navigationType != null),
         super(
             category: _navigationKey,


### PR DESCRIPTION
## :scroll: Description
Fix: captureMessage defaults SentryLevel to info

## :bulb: Motivation and Context
Fix #305


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
