### PR TITLE
Fix: SentryEvent.throwable returns the unwrapped throwable instead of the throwableMechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # vNext
 
 * Fix: captureMessage defaults SentryLevel to info
+* Fix: Expose SentryEvent.originThrowable to get access to the origin Throwable
 
 # 4.0.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # vNext
 
 * Fix: captureMessage defaults SentryLevel to info
-* Fix: Expose SentryEvent.originThrowable to get access to the origin Throwable
+* Fix: SentryEvent.throwable returns the unwrapped throwable instead of the throwableMechanism
 
 # 4.0.5
 

--- a/dart/lib/src/protocol/sentry_event.dart
+++ b/dart/lib/src/protocol/sentry_event.dart
@@ -25,7 +25,7 @@ class SentryEvent {
     this.environment,
     this.message,
     this.transaction,
-    this.throwable,
+    dynamic throwable,
     this.stackTrace,
     this.exception,
     this.level,
@@ -41,7 +41,8 @@ class SentryEvent {
         tags = tags != null ? Map.from(tags) : null,
         extra = extra != null ? Map.from(extra) : null,
         fingerprint = fingerprint != null ? List.from(fingerprint) : null,
-        breadcrumbs = breadcrumbs != null ? List.from(breadcrumbs) : null;
+        breadcrumbs = breadcrumbs != null ? List.from(breadcrumbs) : null,
+        _throwable = throwable;
 
   /// Refers to the default fingerprinting algorithm.
   ///
@@ -81,20 +82,25 @@ class SentryEvent {
   /// Generally an event either contains a [message] or an [exception].
   final Message message;
 
+  dynamic _throwable;
+
   /// An object that was thrown.
   ///
   /// It's `runtimeType` and `toString()` are logged.
   /// If it's an Error, with a stackTrace, the stackTrace is logged.
   /// If this behavior is undesirable, consider using a custom formatted [message] instead.
-  final dynamic throwable;
+  dynamic get throwable => (_throwable is ThrowableMechanism)
+      ? (_throwable as ThrowableMechanism).throwable
+      : _throwable;
 
-  /// Returns the captured Throwable or null. If a throwable is wrapped in
-  /// ThrowableMechanism, returns unwrapped throwable.
+  set throwable(dynamic throwable) {
+    _throwable = throwable;
+  }
+
+  /// A Throwable decorator that holds a Mechanism related to the decorated Throwable
   ///
-  /// returns the Throwable or null
-  dynamic get originThrowable => (throwable is ThrowableMechanism)
-      ? (throwable as ThrowableMechanism).throwable
-      : throwable;
+  /// Use the 'throwable' directly if you don't want the decorated Throwable
+  dynamic get throwableMechanism => _throwable;
 
   /// an optional attached StackTrace
   /// used when event has no throwable or exception, see [SentryOptions.attachStacktrace]
@@ -206,7 +212,7 @@ class SentryEvent {
         modules: (modules != null ? Map.from(modules) : null) ?? this.modules,
         message: message ?? this.message,
         transaction: transaction ?? this.transaction,
-        throwable: throwable ?? this.throwable,
+        throwable: throwable ?? _throwable,
         exception: exception ?? this.exception,
         stackTrace: stackTrace ?? this.stackTrace,
         level: level ?? this.level,

--- a/dart/lib/src/protocol/sentry_event.dart
+++ b/dart/lib/src/protocol/sentry_event.dart
@@ -1,6 +1,7 @@
 import 'package:meta/meta.dart';
 
 import '../protocol.dart';
+import '../throwable_mechanism.dart';
 import '../utils.dart';
 
 /// An event to be reported to Sentry.io.
@@ -86,6 +87,14 @@ class SentryEvent {
   /// If it's an Error, with a stackTrace, the stackTrace is logged.
   /// If this behavior is undesirable, consider using a custom formatted [message] instead.
   final dynamic throwable;
+
+  /// Returns the captured Throwable or null. If a throwable is wrapped in
+  /// ThrowableMechanism, returns unwrapped throwable.
+  ///
+  /// returns the Throwable or null
+  dynamic get originThrowable => (throwable is ThrowableMechanism)
+      ? (throwable as ThrowableMechanism).throwable
+      : throwable;
 
   /// an optional attached StackTrace
   /// used when event has no throwable or exception, see [SentryOptions.attachStacktrace]

--- a/dart/lib/src/protocol/sentry_event.dart
+++ b/dart/lib/src/protocol/sentry_event.dart
@@ -82,7 +82,7 @@ class SentryEvent {
   /// Generally an event either contains a [message] or an [exception].
   final Message message;
 
-  dynamic _throwable;
+  final dynamic _throwable;
 
   /// An object that was thrown.
   ///
@@ -92,10 +92,6 @@ class SentryEvent {
   dynamic get throwable => (_throwable is ThrowableMechanism)
       ? (_throwable as ThrowableMechanism).throwable
       : _throwable;
-
-  set throwable(dynamic throwable) {
-    _throwable = throwable;
-  }
 
   /// A Throwable decorator that holds a Mechanism related to the decorated Throwable
   ///

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -114,9 +114,9 @@ class SentryClient {
 
     if (event.exception != null) return event;
 
-    if (event.throwable != null) {
+    if (event.throwableMechanism != null) {
       final sentryException = _exceptionFactory
-          .getSentryException(event.throwable, stackTrace: stackTrace);
+          .getSentryException(event.throwableMechanism, stackTrace: stackTrace);
 
       return event.copyWith(exception: sentryException);
     }

--- a/dart/test/default_integrations_test.dart
+++ b/dart/test/default_integrations_test.dart
@@ -51,7 +51,7 @@ void main() {
 
       expect(SentryLevel.fatal, event.level);
 
-      final throwableMechanism = event.throwable as ThrowableMechanism;
+      final throwableMechanism = event.throwableMechanism as ThrowableMechanism;
       expect('isolateError', throwableMechanism.mechanism.type);
       expect(true, throwableMechanism.mechanism.handled);
       expect(throwable, throwableMechanism.throwable);
@@ -109,7 +109,7 @@ void main() {
 
     expect(SentryLevel.fatal, event.level);
 
-    final throwableMechanism = event.throwable as ThrowableMechanism;
+    final throwableMechanism = event.throwableMechanism as ThrowableMechanism;
     expect('runZonedGuarded', throwableMechanism.mechanism.type);
     expect(true, throwableMechanism.mechanism.handled);
     expect(throwable, throwableMechanism.throwable);

--- a/dart/test/sentry_event_test.dart
+++ b/dart/test/sentry_event_test.dart
@@ -287,25 +287,25 @@ void main() {
     });
 
     test(
-        'throwable and originThrowable should return origin throwable if no mechanism',
+        'throwable and throwableMechanism should return the error if no mechanism',
         () {
       final error = StateError('test-error');
       final event = SentryEvent(throwable: error);
 
       expect(event.throwable, error);
-      expect(event.originThrowable, error);
+      expect(event.throwableMechanism, error);
     });
 
     test(
-        'originThrowable getter should return origin throwable if theres a mechanism',
+        'throwableMechanism getter should return the ThrowableMechanism if theres a mechanism',
         () {
       final error = StateError('test-error');
       final mechanism = Mechanism(type: 'FlutterError', handled: true);
       final throwableMechanism = ThrowableMechanism(mechanism, error);
       final event = SentryEvent(throwable: throwableMechanism);
 
-      expect(event.throwable, throwableMechanism);
-      expect(event.originThrowable, error);
+      expect(event.throwable, error);
+      expect(event.throwableMechanism, throwableMechanism);
     });
   });
 }

--- a/dart/test/sentry_event_test.dart
+++ b/dart/test/sentry_event_test.dart
@@ -285,5 +285,27 @@ void main() {
       expect(eventMap['request'], isNull);
       expect(eventMap['debug_meta'], isNull);
     });
+
+    test(
+        'throwable and originThrowable should return origin throwable if no mechanism',
+        () {
+      final error = StateError('test-error');
+      final event = SentryEvent(throwable: error);
+
+      expect(event.throwable, error);
+      expect(event.originThrowable, error);
+    });
+
+    test(
+        'originThrowable getter should return origin throwable if theres a mechanism',
+        () {
+      final error = StateError('test-error');
+      final mechanism = Mechanism(type: 'FlutterError', handled: true);
+      final throwableMechanism = ThrowableMechanism(mechanism, error);
+      final event = SentryEvent(throwable: throwableMechanism);
+
+      expect(event.throwable, throwableMechanism);
+      expect(event.originThrowable, error);
+    });
   });
 }

--- a/flutter/test/default_integrations_test.dart
+++ b/flutter/test/default_integrations_test.dart
@@ -53,7 +53,7 @@ void main() {
 
     expect(SentryLevel.fatal, event.level);
 
-    final throwableMechanism = event.throwable as ThrowableMechanism;
+    final throwableMechanism = event.throwableMechanism as ThrowableMechanism;
     expect('FlutterError', throwableMechanism.mechanism.type);
     expect(true, throwableMechanism.mechanism.handled);
     expect(exception, throwableMechanism.throwable);


### PR DESCRIPTION
## :scroll: Description
Fix: SentryEvent.throwable returns the unwrapped throwable instead of the throwableMechanism


## :bulb: Motivation and Context
#304


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
