### PR TITLE
Fix: Do not append empty stack trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Fix: Do not append stack trace to the exception if there are no frames
+
 # 4.0.6
 
 * Fix: captureMessage defaults SentryLevel to info

--- a/dart/lib/src/sentry_exception_factory.dart
+++ b/dart/lib/src/sentry_exception_factory.dart
@@ -46,9 +46,12 @@ class SentryExceptionFactory {
 
     SentryStackTrace sentryStackTrace;
     if (stackTrace != null) {
-      sentryStackTrace = SentryStackTrace(
-        frames: _stacktraceFactory.getStackFrames(stackTrace),
-      );
+      final frames = _stacktraceFactory.getStackFrames(stackTrace);
+      if (frames != null && frames.isNotEmpty) {
+        sentryStackTrace = SentryStackTrace(
+          frames: frames,
+        );
+      }
     }
 
     // if --obfuscate feature is enabled, 'type' won't be human readable.

--- a/dart/test/exception_factory_test.dart
+++ b/dart/test/exception_factory_test.dart
@@ -9,7 +9,7 @@ void main() {
     final exceptionFactory = SentryExceptionFactory(
         options: options, stacktraceFactory: SentryStackTraceFactory(options));
 
-    test('exceptionFactory.getSentryException', () {
+    test('getSentryException with frames', () {
       SentryException sentryException;
       try {
         throw StateError('a state error');
@@ -22,6 +22,21 @@ void main() {
 
       expect(sentryException.type, 'StateError');
       expect(sentryException.stackTrace.frames, isNotEmpty);
+    });
+
+    test('getSentryException without frames', () {
+      SentryException sentryException;
+      try {
+        throw StateError('a state error');
+      } catch (err, _) {
+        sentryException = exceptionFactory.getSentryException(
+          err,
+          stackTrace: '',
+        );
+      }
+
+      expect(sentryException.type, 'StateError');
+      expect(sentryException.stackTrace, isNull);
     });
 
     test('should not override event.stacktrace', () {


### PR DESCRIPTION
## :scroll: Description
Fix: Do not append stack trace to the exception if there are no frames


## :bulb: Motivation and Context
<img width="656" alt="Screenshot 2021-03-01 at 18 50 35" src="https://user-images.githubusercontent.com/5731772/109537349-108dc200-7abf-11eb-8ef6-71f78ac0ba63.png">



## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
