### PR TITLE
Fix: Empty DSN disables the SDK and runs the App

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Fix: Do not append stack trace to the exception if there are no frames
+* Fix: Empty DSN disables the SDK and runs the App
 
 # 4.0.6
 

--- a/dart/lib/src/sentry.dart
+++ b/dart/lib/src/sentry.dart
@@ -93,13 +93,11 @@ class Sentry {
     }
 
     // let's set the default values to options
-    if (!_setDefaultConfiguration(options)) {
-      return;
+    if (_setDefaultConfiguration(options)) {
+      final hub = currentHub;
+      _hub = Hub(options);
+      hub.close();
     }
-
-    final hub = currentHub;
-    _hub = Hub(options);
-    hub.close();
 
     // execute integrations after hub being enabled
     if (appRunner != null) {

--- a/dart/test/sentry_test.dart
+++ b/dart/test/sentry_test.dart
@@ -96,6 +96,19 @@ void main() {
       expect(Sentry.isEnabled, false);
     });
 
+    test('empty DSN disables the SDK but runs the integrations', () async {
+      final integration = MockIntegration();
+
+      await Sentry.init(
+        (options) {
+          options.dsn = '';
+          options.addIntegration(integration);
+        },
+      );
+
+      verify(integration(any, any)).called(1);
+    });
+
     test('close disables the SDK', () async {
       await Sentry.init((options) => options.dsn = fakeDsn);
 


### PR DESCRIPTION
## :scroll: Description
Fix: Empty DSN disables the SDK and runs the App


## :bulb: Motivation and Context
#326 this was a bug introduced by #280 that now depends on the integrations to run the App.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
