### PR TITLE
craft config

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,0 +1,19 @@
+minVersion: '0.17.1'
+github:
+  owner: getsentry
+  repo: sentry-dart
+changelogPolicy: auto
+statusProvider:
+  name: github
+artifactProvider:
+  name: none
+targets:
+  - name: github
+  - name: registry
+    type: sdk
+    config:
+      canonical: "pub:sentry"
+  - name: registry
+    type: sdk
+    config:
+      canonical: "pub:sentry_flutter"


### PR DESCRIPTION
Using `artifact:none` so far so we can use craft for the release registry and github parts and at the end run `pub publish` manually until we write the craft target.

Resolves #318 
Depends on https://github.com/getsentry/sentry-release-registry/pull/46

#skip-changelog