### PR TITLE
Upgrade dependencies (`http 0.13.0` etc) for Flutter 2 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-* Upgrade dependencies (`http 0.13.0` etc) as it is widely used after Flutter 2 release!
+* Upgrade dependencies (`http 0.13.0` etc) for Flutter 2 upgrade (#339)
 * Fix: Do not append stack trace to the exception if there are no frames
 * Fix: Empty DSN disables the SDK and runs the App
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Upgrade dependencies (`http 0.13.0` etc) as it is widely used after Flutter 2 release!
 * Fix: Do not append stack trace to the exception if there are no frames
 * Fix: Empty DSN disables the SDK and runs the App
 

--- a/dart/lib/src/noop_client.dart
+++ b/dart/lib/src/noop_client.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
-import 'dart:typed_data';
 import 'dart:convert';
+import 'dart:typed_data';
+
 import 'package:http/http.dart';
 
 class NoOpClient implements Client {
@@ -22,7 +23,9 @@ class NoOpClient implements Client {
   void close() {}
 
   @override
-  Future<Response> delete(url, {Map<String, String> headers}) => _response;
+  Future<Response> delete(url,
+          {Object body, Encoding encoding, Map<String, String> headers}) =>
+      _response;
 
   @override
   Future<Response> get(url, {Map<String, String> headers}) => _response;

--- a/dart/lib/src/transport/http_transport.dart
+++ b/dart/lib/src/transport/http_transport.dart
@@ -53,7 +53,7 @@ class HttpTransport implements Transport {
     );
 
     final response = await _options.httpClient.post(
-      _dsn.postUri,
+      Uri.parse(_dsn.postUri),
       headers: _credentialBuilder.configure(_headers),
       body: body,
     );

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sentry
-version: 4.0.8
+version: 4.0.7
 description: >
   A crash reporting library for Dart that sends crash reports to Sentry.io.
   This library supports Dart VM and Web. For Flutter consider sentry_flutter instead.

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sentry
-version: 4.0.7
+version: 4.0.8
 description: >
   A crash reporting library for Dart that sends crash reports to Sentry.io.
   This library supports Dart VM and Web. For Flutter consider sentry_flutter instead.
@@ -10,10 +10,10 @@ environment:
   sdk: ">=2.8.0 <3.0.0"
 
 dependencies:
-  http: ^0.12.0
-  meta: ^1.0.0
-  stack_trace: ^1.0.0
-  uuid: ^2.0.0
+  http: ^0.13.0
+  meta: ^1.3.0
+  stack_trace: ^1.10.0
+  uuid: ^3.0.1
 
 dev_dependencies:
   mockito: ^4.1.3

--- a/dart/test/http_client/sentry_http_client_test.dart
+++ b/dart/test/http_client/sentry_http_client_test.dart
@@ -21,7 +21,7 @@ void main() {
 
       final client = SentryHttpClient(client: mockClient, hub: mockHub);
 
-      final response = await client.get('https://example.com');
+      final response = await client.get(Uri.parse('https://example.com'));
       expect(response.statusCode, 200);
 
       final breadcrumb = verify(mockHub.addBreadcrumb(captureAny))
@@ -47,7 +47,7 @@ void main() {
 
       final client = SentryHttpClient(client: mockClient, hub: mockHub);
 
-      final response = await client.get('https://example.com');
+      final response = await client.get(Uri.parse('https://example.com'));
       expect(response.statusCode, 404);
 
       final breadcrumb = verify(mockHub.addBreadcrumb(captureAny))
@@ -73,7 +73,7 @@ void main() {
 
       final client = SentryHttpClient(client: mockClient, hub: mockHub);
 
-      final response = await client.post('https://example.com');
+      final response = await client.post(Uri.parse('https://example.com'));
       expect(response.statusCode, 200);
 
       final breadcrumb = verify(mockHub.addBreadcrumb(captureAny))
@@ -98,7 +98,7 @@ void main() {
 
       final client = SentryHttpClient(client: mockClient, hub: mockHub);
 
-      final response = await client.put('https://example.com');
+      final response = await client.put(Uri.parse('https://example.com'));
       expect(response.statusCode, 200);
 
       final breadcrumb = verify(mockHub.addBreadcrumb(captureAny))
@@ -123,7 +123,7 @@ void main() {
 
       final client = SentryHttpClient(client: mockClient, hub: mockHub);
 
-      final response = await client.delete('https://example.com');
+      final response = await client.delete(Uri.parse('https://example.com'));
       expect(response.statusCode, 200);
 
       final breadcrumb = verify(mockHub.addBreadcrumb(captureAny))
@@ -156,7 +156,7 @@ void main() {
       final client = SentryHttpClient(client: mockClient, hub: mockHub);
 
       try {
-        await client.get('https://example.com');
+        await client.get(Uri.parse('https://example.com'));
         fail('Method did not throw');
       } on ClientException catch (e) {
         expect(e.message, 'test');
@@ -182,7 +182,7 @@ void main() {
       final client = SentryHttpClient(client: mockClient, hub: mockHub);
 
       try {
-        await client.get('https://example.com');
+        await client.get(Uri.parse('https://example.com'));
         fail('Method did not throw');
       } on SocketException catch (e) {
         expect(e.message, 'test');

--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -306,7 +306,7 @@ Future<void> makeWebRequest(BuildContext context) async {
   final client = SentryHttpClient();
   // We don't do any exception handling here.
   // In case of an exception, let it get caught and reported to Sentry
-  final response = await client.get('https://flutter.dev/');
+  final response = await client.get(Uri.parse('https://flutter.dev/'));
 
   await showDialog<void>(
     context: context,

--- a/flutter/lib/src/version.dart
+++ b/flutter/lib/src/version.dart
@@ -1,5 +1,5 @@
 /// The SDK version reported to Sentry.io in the submitted events.
-const String sdkVersion = '4.0.8';
+const String sdkVersion = '4.0.7';
 
 /// The default SDK name reported to Sentry.io in the submitted events.
 const String sdkName = 'sentry.dart.flutter';

--- a/flutter/lib/src/version.dart
+++ b/flutter/lib/src/version.dart
@@ -1,5 +1,5 @@
 /// The SDK version reported to Sentry.io in the submitted events.
-const String sdkVersion = '4.0.7';
+const String sdkVersion = '4.0.8';
 
 /// The default SDK name reported to Sentry.io in the submitted events.
 const String sdkName = 'sentry.dart.flutter';


### PR DESCRIPTION
## :scroll: Description
Upgrade dependencies (`http 0.13.0` etc) as it is widely used after Flutter 2 release!  

## :bulb: Motivation and Context
After Flutter2 release, `http 0.13.0` is the preferred version used by many developers. `Sentry` package dependencies required to be up2date to meet this demand. 

## :green_heart: How did you test it?
My apps which have the latest and greatest package versions began failing caused by the issue as described in #338 . The updates in this PR resolves it. 

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ x ] I reviewed submitted code
- [ x ] I added tests to verify changes
- [ x ] I updated the docs if needed
- [ x ] All tests passing
- [ x ] No breaking changes


## :crystal_ball: Next steps
Review and publish a new release after merge  