### PR TITLE
Fix: Multiple FlutterError.onError calls in FlutterErrorIntegration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 
 * Bump: sentry-android to v4.3.0 (#343)
-* Fix: Multiple FlutterError.onError calls in FlutterErrorIntegration
+* Fix: Multiple FlutterError.onError calls in FlutterErrorIntegration (#345)
 
 # 4.1.0-nullsafety.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Bump: sentry-android to v4.3.0 (#343)
+* Fix: Multiple FlutterError.onError calls in FlutterErrorIntegration
 
 # 4.1.0-nullsafety.0
 

--- a/flutter/lib/src/default_integrations.dart
+++ b/flutter/lib/src/default_integrations.dart
@@ -86,7 +86,6 @@ class FlutterErrorIntegration extends Integration<SentryFlutterOptions> {
   void close() {
     /// Restore default
     FlutterError.onError = defaultOnError;
-    defaultOnError = null;
     super.close();
   }
 }

--- a/flutter/lib/src/default_integrations.dart
+++ b/flutter/lib/src/default_integrations.dart
@@ -86,6 +86,7 @@ class FlutterErrorIntegration extends Integration<SentryFlutterOptions> {
   void close() {
     /// Restore default
     FlutterError.onError = defaultOnError;
+    defaultOnError = null;
     super.close();
   }
 }

--- a/flutter/test/default_integrations_test.dart
+++ b/flutter/test/default_integrations_test.dart
@@ -111,7 +111,7 @@ void main() {
     expect(false, defaultOnError == FlutterError.onError);
 
     integration.close();
-    expect(defaultOnError == FlutterError.onError, true);
+    expect(FlutterError.onError, defaultOnError);
   });
 
   test('FlutterErrorIntegration default not restored if set after integration',
@@ -127,7 +127,7 @@ void main() {
     FlutterError.onError = afterIntegrationOnError;
 
     integration.close();
-    expect(afterIntegrationOnError == FlutterError.onError, true);
+    expect(FlutterError.onError, afterIntegrationOnError);
   });
 
   test('FlutterError do not capture if silent error', () async {

--- a/flutter/test/default_integrations_test.dart
+++ b/flutter/test/default_integrations_test.dart
@@ -148,7 +148,7 @@ void main() {
     FlutterErrorIntegration()(fixture.hub, fixture.options);
 
     expect(fixture.options.sdk.integrations.contains('flutterErrorIntegration'),
-      true);
+        true);
   });
 
   test('nativeSdkIntegration adds integration', () async {
@@ -159,7 +159,7 @@ void main() {
     await integration(fixture.hub, fixture.options);
 
     expect(fixture.options.sdk.integrations.contains('nativeSdkIntegration'),
-      true);
+        true);
   });
 
   test('nativeSdkIntegration do not throw', () async {
@@ -172,7 +172,7 @@ void main() {
     await integration(fixture.hub, fixture.options);
 
     expect(fixture.options.sdk.integrations.contains('nativeSdkIntegration'),
-      false);
+        false);
   });
 
   test('loadContextsIntegration adds integration', () async {
@@ -183,16 +183,17 @@ void main() {
     await integration(fixture.hub, fixture.options);
 
     expect(fixture.options.sdk.integrations.contains('loadContextsIntegration'),
-      true);
+        true);
   });
 
   test('WidgetsFlutterBindingIntegration adds integration', () async {
     final integration = WidgetsFlutterBindingIntegration();
     await integration(fixture.hub, fixture.options);
 
-    expect(fixture.options.sdk.integrations
-      .contains('widgetsFlutterBindingIntegration'), 
-      true);
+    expect(
+        fixture.options.sdk.integrations
+            .contains('widgetsFlutterBindingIntegration'),
+        true);
   });
 
   test('WidgetsFlutterBindingIntegration calls ensureInitialized', () async {

--- a/flutter/test/default_integrations_test.dart
+++ b/flutter/test/default_integrations_test.dart
@@ -22,6 +22,7 @@ void main() {
 
   tearDown(() {
     _channel.setMockMethodCallHandler(null);
+    FlutterErrorIntegration.defaultOnError = null;
   });
 
   void _reportError({

--- a/flutter/test/default_integrations_test.dart
+++ b/flutter/test/default_integrations_test.dart
@@ -102,7 +102,7 @@ void main() {
     expect(numberOfDefaultCalls, 1);
   });
 
-  test('FlutterErrorIntegration close restored default onError', () async {
+  test('FlutterErrorIntegration close restored default onError', () {
     final defaultOnError = (FlutterErrorDetails errorDetails) async {};
     FlutterError.onError = defaultOnError;
 
@@ -115,7 +115,7 @@ void main() {
   });
 
   test('FlutterErrorIntegration default not restored if set after integration',
-    () async {
+      () {
     final defaultOnError = (FlutterErrorDetails errorDetails) async {};
     FlutterError.onError = defaultOnError;
 
@@ -144,7 +144,7 @@ void main() {
     verify(await fixture.hub.captureEvent(captureAny));
   });
 
-  test('FlutterError adds integration', () async {
+  test('FlutterError adds integration', () {
     FlutterErrorIntegration()(fixture.hub, fixture.options);
 
     expect(fixture.options.sdk.integrations.contains('flutterErrorIntegration'),


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Hold the a static reference to the default `FlutterError.onError` in `FlutterErrorIntegration` and restore it in integrations `close()` method.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When doing multiple close/init on the SDK, multiple `FlutterErrorIntegration` instances are instantiated during application lifetime. Every one of them would replace `FlutterError.onError` function and reference the previous one. This resulted in a chain of calls, where errors were reported multiple times.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
