### PR TITLE
Fix: EventProcessors were not dropping events when returning null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Bump: sentry-android to v4.3.0 (#343)
 * Fix: Multiple FlutterError.onError calls in FlutterErrorIntegration (#345)
-* Fix: EventProcessors were not dropping events when returning null
+* Fix: EventProcessors were not dropping events when returning null (#353)
 
 # 4.1.0-nullsafety.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Bump: sentry-android to v4.3.0 (#343)
 * Fix: Multiple FlutterError.onError calls in FlutterErrorIntegration (#345)
+* Fix: EventProcessors were not dropping events when returning null
 
 # 4.1.0-nullsafety.0
 

--- a/dart/lib/src/scope.dart
+++ b/dart/lib/src/scope.dart
@@ -182,7 +182,7 @@ class Scope {
     SentryEvent? processedEvent = event;
     for (final processor in _eventProcessors) {
       try {
-        processedEvent = await processor(processedEvent!, hint: hint)!;
+        processedEvent = await processor(processedEvent!, hint: hint);
       } catch (err) {
         _options.logger(
           SentryLevel.error,

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -179,7 +179,7 @@ class SentryClient {
     SentryEvent? processedEvent = event;
     for (final processor in eventProcessors) {
       try {
-        processedEvent = await processor(processedEvent!, hint: hint)!;
+        processedEvent = await processor(processedEvent!, hint: hint);
       } catch (err) {
         _options.logger(
           SentryLevel.error,

--- a/dart/test/scope_test.dart
+++ b/dart/test/scope_test.dart
@@ -404,6 +404,17 @@ void main() {
       expect(updatedEvent?.level, SentryLevel.error);
     });
   });
+
+  test('event processor drops the event', () async {
+    final sut = fixture.getSut();
+
+    sut.addEventProcessor(fixture.processor);
+
+    final event = SentryEvent();
+    var newEvent = await sut.applyToEvent(event, null);
+
+    expect(newEvent, isNull);
+  });
 }
 
 class Fixture {

--- a/dart/test/sentry_client_test.dart
+++ b/dart/test/sentry_client_test.dart
@@ -507,6 +507,14 @@ void main() {
       );
       expect(event.fingerprint!.contains('process'), true);
     });
+
+    test('event processor drops the event', () async {
+      options.addEventProcessor(eventProcessorDropEvent);
+      final client = SentryClient(options);
+      await client.captureEvent(fakeEvent);
+
+      expect((options.transport as MockTransport).called(0), true);
+    });
   });
 }
 
@@ -522,4 +530,8 @@ SentryEvent beforeSendCallback(SentryEvent event, {dynamic hint}) {
     ..fingerprint!.add('process')
     ..sdk!.addIntegration('testIntegration')
     ..sdk!.addPackage('test-pkg', '1.0');
+}
+
+SentryEvent? eventProcessorDropEvent(SentryEvent event, {dynamic hint}) {
+  return null;
 }


### PR DESCRIPTION
## :scroll: Description
EventProcessors were not dropping events when returning null


## :bulb: Motivation and Context
Fix #351


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
