### PR TITLE
Fix: Deprecated registrar.messenger call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-* Fix: Fix deprecated `registrar.messenger` call in `SentryFlutterWeb`
+* Fix: Fix deprecated `registrar.messenger` call in `SentryFlutterWeb` (#364)
 
 # 4.1.0-nullsafety.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Fix: Fix deprecated `registrar.messenger` call in `SentryFlutterWeb`
+
 # 4.1.0-nullsafety.1
 
 * Bump: sentry-android to v4.3.0 (#343)

--- a/flutter/analysis_options.yaml
+++ b/flutter/analysis_options.yaml
@@ -13,8 +13,6 @@ analyzer:
     deprecated_member_use_from_same_package: warning
     # ignore sentry/path on pubspec as we change it on deployment
     invalid_dependency: ignore
-    # ignore because of SentryFlutterWeb.registrar
-    deprecated_member_use: ignore
   exclude:
     - example/**
 

--- a/flutter/lib/sentry_flutter_web.dart
+++ b/flutter/lib/sentry_flutter_web.dart
@@ -9,7 +9,7 @@ class SentryFlutterWeb {
     final channel = MethodChannel(
       'sentry_flutter',
       const StandardMethodCodec(),
-      registrar.messenger,
+      registrar,
     );
 
     final pluginInstance = SentryFlutterWeb();


### PR DESCRIPTION
## :scroll: Description
Remove the deprecated `registrar.messenger` call.


## :bulb: Motivation and Context
See #361


## :green_heart: How did you test it?
I've removed the lint and it didn't complain anymore. Building for web also still works as expected.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
