### PR TITLE
Fix: event.origin and event.environment tags have wrong value for iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Fix: event.origin and event.environment tags have wrong value for iOS
+
 # 4.1.0-nullsafety.1
 
 * Bump: sentry-android to v4.3.0 (#343)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-* Fix: event.origin and event.environment tags have wrong value for iOS
+* Fix: event.origin and event.environment tags have wrong value for iOS (#365)
 
 # 4.1.0-nullsafety.1
 

--- a/flutter/ios/Classes/SwiftSentryFlutterPlugin.swift
+++ b/flutter/ios/Classes/SwiftSentryFlutterPlugin.swift
@@ -201,16 +201,14 @@ public class SwiftSentryFlutterPlugin: NSObject, FlutterPlugin {
             case "sentry.dart.flutter":
                 setEventEnvironmentTag(event: event, origin: "flutter", environment: "dart")
             case "sentry.cocoa":
-                setEventEnvironmentTag(event: event, origin: "flutter", environment: "dart")
-            case "sentry.native":
-                setEventEnvironmentTag(event: event, origin: "flutter", environment: "dart")
+                setEventEnvironmentTag(event: event, origin: "ios", environment: "native")
             default:
                 return
             }
         }
     }
 
-    private func setEventEnvironmentTag(event: Event, origin: String = "ios", environment: String) {
+    private func setEventEnvironmentTag(event: Event, origin: String, environment: String) {
         event.tags?["event.origin"] = origin
         event.tags?["event.environment"] = environment
     }


### PR DESCRIPTION
## :scroll: Description
Fix: event.origin and event.environment tags have wrong value for iOS


## :bulb: Motivation and Context
Bug found by @jennmueng while writing integrations for Cordova


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
