### PR TITLE
Fix: Enabled breadcrumb recording mechanism based on platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * Fix: Fix deprecated `registrar.messenger` call in `SentryFlutterWeb` (#364)
 * Fix: Enable breadcrumb recording mechanism based on platform
 * Remove deprecated member `enableLifecycleBreadcrumbs`. Use `enableAppLifecycleBreadcrumbs` instead.
+* Fix: Enable breadcrumb recording mechanism based on platform ((#366))
+* Remove deprecated member `enableLifecycleBreadcrumbs`. Use `enableAppLifecycleBreadcrumbs` instead. ((#366))
 
 # 4.1.0-nullsafety.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 * Remove deprecated member `enableLifecycleBreadcrumbs`. Use `enableAppLifecycleBreadcrumbs` instead.
 * Fix: Enable breadcrumb recording mechanism based on platform ((#366))
 * Remove deprecated member `enableLifecycleBreadcrumbs`. Use `enableAppLifecycleBreadcrumbs` instead. ((#366))
+* Fix: Enable breadcrumb recording mechanism based on platform (#366)
+
+## Breaking Changes:
+
+* Remove deprecated member `enableLifecycleBreadcrumbs`. Use `enableAppLifecycleBreadcrumbs` instead. (#366)
 
 # 4.1.0-nullsafety.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Fix: event.origin and event.environment tags have wrong value for iOS (#365)
 * Fix: Fix deprecated `registrar.messenger` call in `SentryFlutterWeb` (#364)
+* Fix: Enable breadcrumb recording mechanism based on platform
+* Remove deprecated member `enableLifecycleBreadcrumbs`. Use `enableAppLifecycleBreadcrumbs` instead.
 
 # 4.1.0-nullsafety.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 * Fix: event.origin and event.environment tags have wrong value for iOS (#365)
 * Fix: Fix deprecated `registrar.messenger` call in `SentryFlutterWeb` (#364)
-* Fix: Enable breadcrumb recording mechanism based on platform
-* Remove deprecated member `enableLifecycleBreadcrumbs`. Use `enableAppLifecycleBreadcrumbs` instead.
-* Fix: Enable breadcrumb recording mechanism based on platform ((#366))
-* Remove deprecated member `enableLifecycleBreadcrumbs`. Use `enableAppLifecycleBreadcrumbs` instead. ((#366))
 * Fix: Enable breadcrumb recording mechanism based on platform (#366)
 
 ## Breaking Changes:

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -5,7 +5,9 @@ import 'package:sentry/sentry.dart';
 /// Note that some of these options require native Sentry integration, which is
 /// not available on all platforms.
 class SentryFlutterOptions extends SentryOptions {
-  SentryFlutterOptions({String? dsn}) : super(dsn: dsn);
+  SentryFlutterOptions({String? dsn}) : super(dsn: dsn) {
+    enableBreadcrumbTrackingForCurrentPlatform();
+  }
 
   /// Enable or disable the Auto session tracking on the Native SDKs (Android/iOS)
   bool enableAutoSessionTracking = true;
@@ -68,19 +70,6 @@ class SentryFlutterOptions extends SentryOptions {
   set cacheDirSize(int value) {
     _cacheDirSize = value >= 0 ? value : _cacheDirSize;
   }
-
-  @Deprecated(
-    'Use enableAppLifecycleBreadcrumbs instead. '
-    'This option gets removed in Sentry 5.0.0',
-  )
-  bool get enableLifecycleBreadcrumbs => enableAppLifecycleBreadcrumbs;
-
-  @Deprecated(
-    'Use enableAppLifecycleBreadcrumbs instead. '
-    'This option gets removed in Sentry 5.0.0',
-  )
-  set enableLifecycleBreadcrumbs(bool value) =>
-      enableAppLifecycleBreadcrumbs = value;
 
   /// Consider disabling [enableAutoNativeBreadcrumbs] if you
   /// enable this. Otherwise you might record app lifecycle events twice.


### PR DESCRIPTION
## :scroll: Description
This change enables the breadcrumb recording mechanism based on the platform.
It also removes the deprecated member `SentryFlutterOptions.enableLifecycleBreadcrumbs`.

I'm not sure if this is considered a breaking change.


## :bulb: Motivation and Context
See #288


## :green_heart: How did you test it?
There are already tests which make sure that `SentryFlutterOptions.enableBreadcrumbTrackingForCurrentPlatform()` works.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
