### PR TITLE
Fix: missing event.origin and event.environment tags for non-native events on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Fix: Enable breadcrumb recording mechanism based on platform (#366)
 * Feat: Send default PII options (#360)
 * Bump: sentry-cocoa to v6.2.1 (#360)
-* Fix: missing event.origin and event.environment tags for non-native events on iOS
+* Fix: missing event.origin and event.environment tags for non-native events on iOS (#369)
 
 ## Breaking Changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix: Enable breadcrumb recording mechanism based on platform (#366)
 * Feat: Send default PII options (#360)
 * Bump: sentry-cocoa to v6.2.1 (#360)
+* Fix: missing event.origin and event.environment tags for non-native events on iOS
 
 ## Breaking Changes:
 

--- a/flutter/ios/Classes/SwiftSentryFlutterPlugin.swift
+++ b/flutter/ios/Classes/SwiftSentryFlutterPlugin.swift
@@ -202,8 +202,6 @@ public class SwiftSentryFlutterPlugin: NSObject, FlutterPlugin {
         if isValidSdk(sdk: sdk) {
 
             switch sdk["name"] as? String {
-            case "sentry.dart.flutter":
-                setEventEnvironmentTag(event: event, origin: "flutter", environment: "dart")
             case "sentry.cocoa":
                 setEventEnvironmentTag(event: event, origin: "ios", environment: "native")
             default:

--- a/flutter/lib/src/default_integrations.dart
+++ b/flutter/lib/src/default_integrations.dart
@@ -157,6 +157,15 @@ class LoadContextsIntegration extends Integration<SentryFlutterOptions> {
             sdk.addPackage(package['sdk_name']!, package['version']!);
             event = event.copyWith(sdk: sdk);
           }
+
+          // on iOS, captureEnvelope does not call the beforeSend callback,
+          // hence we need to add these tags here.
+          if (event.sdk?.name == 'sentry.dart.flutter') {
+            final tags = event.tags ?? {};
+            tags['event.origin'] = 'flutter';
+            tags['event.environment'] = 'dart';
+            event = event.copyWith(tags: tags);
+          }
         } catch (error) {
           options.logger(
             SentryLevel.error,


### PR DESCRIPTION
## :scroll: Description
Fix: missing event.origin and event.environment tags for non-native events on iOS #369


## :bulb: Motivation and Context
similar to https://github.com/getsentry/sentry-cordova/pull/204


## :green_heart: How did you test it?
triggering an event on flutter and ios

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
