### PR TITLE
Fix: Read all environment variables in sentry 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Feat: Send default PII options (#360)
 * Bump: sentry-cocoa to v6.2.1 (#360)
 * Fix: missing event.origin and event.environment tags for non-native events on iOS (#369)
+* Fix: Set `SentryOptions.debug` in `sentry` (#376)
 * Fix: Read all environment variables in `sentry` (#375)
 
 ## Breaking Changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Feat: Send default PII options (#360)
 * Bump: sentry-cocoa to v6.2.1 (#360)
 * Fix: missing event.origin and event.environment tags for non-native events on iOS (#369)
-* Fix: Read all environment variables in sentry_dart
+* Fix: Read all environment variables in sentry_dart (#375)
 
 ## Breaking Changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Feat: Send default PII options (#360)
 * Bump: sentry-cocoa to v6.2.1 (#360)
 * Fix: missing event.origin and event.environment tags for non-native events on iOS (#369)
-* Fix: Read all environment variables in sentry_dart (#375)
+* Fix: Read all environment variables in `sentry` (#375)
 
 ## Breaking Changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Feat: Send default PII options (#360)
 * Bump: sentry-cocoa to v6.2.1 (#360)
 * Fix: missing event.origin and event.environment tags for non-native events on iOS (#369)
+* Fix: Read all environment variables in sentry_dart
 
 ## Breaking Changes:
 

--- a/dart/lib/src/environment_variables.dart
+++ b/dart/lib/src/environment_variables.dart
@@ -1,3 +1,5 @@
+import 'platform_checker.dart';
+
 /// Reads environment variables from the system.
 /// In an Flutter environment these can be set via
 /// `flutter build --dart-define=VARIABLE_NAME=VARIABLE_VALUE`.
@@ -30,4 +32,19 @@ class EnvironmentVariables {
   String? get dist => const bool.hasEnvironment(_sentryDist)
       ? const String.fromEnvironment(_sentryDist)
       : null;
+
+  /// Returns an environment based on the compilation mode of Dart or Flutter.
+  /// This can be set as [SentryOptions.environment]
+  String environmentForMode(PlatformChecker checker) {
+    // We infer the enviroment based on the release/non-release and profile
+    // constants.
+
+    if (checker.isReleaseMode()) {
+      return 'production';
+    }
+    if (checker.isProfileMode()) {
+      return 'profile';
+    }
+    return 'debug';
+  }
 }

--- a/dart/lib/src/environment_variables.dart
+++ b/dart/lib/src/environment_variables.dart
@@ -4,10 +4,6 @@ import 'sentry_options.dart';
 
 /// This method reads available environment variables and uses them
 /// accordingly.
-///
-/// Please note, that environment variables are overriden by the values of
-/// [SentryOptions].
-///
 /// To see which environment variables are available, see [EnvironmentVariables]
 ///
 /// The precendence of these options are tricky,

--- a/dart/lib/src/environment_variables.dart
+++ b/dart/lib/src/environment_variables.dart
@@ -41,5 +41,7 @@ class EnvironmentVariables {
   String? get dist => _readString('SENTRY_DIST');
 
   String? _readString(String key) =>
-      bool.hasEnvironment(key) ? String.fromEnvironment(key) : null;
+      bool.fromEnvironment(key, defaultValue: false)
+          ? String.fromEnvironment(key)
+          : null;
 }

--- a/dart/lib/src/environment_variables.dart
+++ b/dart/lib/src/environment_variables.dart
@@ -1,0 +1,49 @@
+import 'package:meta/meta.dart';
+
+import 'sentry_options.dart';
+
+/// This method reads available environment variables and uses them
+/// accordingly.
+///
+/// Please note, that environment variables are overriden by the values of
+/// [SentryOptions].
+///
+/// To see which environment variables are available, see [EnvironmentVariables]
+///
+/// The precendence of these options are tricky,
+/// see https://docs.sentry.io/platforms/dart/configuration/options/
+/// and https://github.com/getsentry/sentry-dart/issues/306
+@internal
+void setEnvironmentVariables(SentryOptions options, EnvironmentVariables vars) {
+  // options has precendence over vars
+  options.dsn = options.dsn ?? vars.dsn;
+
+  // vars has precedence over options
+  options.environment = vars.environment ?? options.environment;
+  options.release = vars.release ?? options.release;
+  options.dist = vars.dist ?? options.dist;
+}
+
+/// Reads environment variables from the system.
+/// In an Flutter environment these can be set via
+/// `flutter build --dart-define=VARIABLE_NAME=VARIABLE_VALUE`.
+class EnvironmentVariables {
+  /// `SENTRY_ENVIRONMENT`
+  /// See [SentryOptions.environment]
+  String? get environment => _readString('SENTRY_ENVIRONMENT');
+
+  /// `SENTRY_DSN`
+  /// See [SentryOptions.dsn]
+  String? get dsn => _readString('SENTRY_DSN');
+
+  // `SENTRY_RELEASE`
+  /// See [SentryOptions.release]
+  String? get release => _readString('SENTRY_RELEASE');
+
+  /// `SENTRY_DIST`
+  /// See [SentryOptions.dist]
+  String? get dist => _readString('SENTRY_DIST');
+
+  String? _readString(String key) =>
+      bool.hasEnvironment(key) ? String.fromEnvironment(key) : null;
+}

--- a/dart/lib/src/environment_variables.dart
+++ b/dart/lib/src/environment_variables.dart
@@ -1,30 +1,3 @@
-import 'package:meta/meta.dart';
-
-import 'sentry_options.dart';
-
-/// This method reads available environment variables and uses them
-/// accordingly.
-/// To see which environment variables are available, see [EnvironmentVariables]
-///
-/// The precendence of these options are tricky,
-/// see https://docs.sentry.io/platforms/dart/configuration/options/
-/// and https://github.com/getsentry/sentry-dart/issues/306
-@internal
-void setEnvironmentVariables(SentryOptions options, EnvironmentVariables vars) {
-  // options has precendence over vars
-  options.dsn = options.dsn ?? vars.dsn;
-
-  var environment = options.platformChecker.environment;
-  options.environment = options.environment ?? environment;
-
-  // vars has precedence over options
-  options.environment = vars.environment ?? options.environment;
-
-  // vars has precedence over options
-  options.release = vars.release ?? options.release;
-  options.dist = vars.dist ?? options.dist;
-}
-
 /// Reads environment variables from the system.
 /// In an Flutter environment these can be set via
 /// `flutter build --dart-define=VARIABLE_NAME=VARIABLE_VALUE`.

--- a/dart/lib/src/environment_variables.dart
+++ b/dart/lib/src/environment_variables.dart
@@ -14,8 +14,13 @@ void setEnvironmentVariables(SentryOptions options, EnvironmentVariables vars) {
   // options has precendence over vars
   options.dsn = options.dsn ?? vars.dsn;
 
+  var environment = options.platformChecker.environment;
+  options.environment = options.environment ?? environment;
+
   // vars has precedence over options
   options.environment = vars.environment ?? options.environment;
+
+  // vars has precedence over options
   options.release = vars.release ?? options.release;
   options.dist = vars.dist ?? options.dist;
 }

--- a/dart/lib/src/environment_variables.dart
+++ b/dart/lib/src/environment_variables.dart
@@ -29,24 +29,32 @@ void setEnvironmentVariables(SentryOptions options, EnvironmentVariables vars) {
 /// In an Flutter environment these can be set via
 /// `flutter build --dart-define=VARIABLE_NAME=VARIABLE_VALUE`.
 class EnvironmentVariables {
+  static const _sentryEnvironment = 'SENTRY_ENVIRONMENT';
+  static const _sentryDsn = 'SENTRY_DSN';
+  static const _sentryRelease = 'SENTRY_RELEASE';
+  static const _sentryDist = 'SENTRY_DSN';
+
   /// `SENTRY_ENVIRONMENT`
   /// See [SentryOptions.environment]
-  String? get environment => _readString('SENTRY_ENVIRONMENT');
+  String? get environment => const bool.hasEnvironment(_sentryEnvironment)
+      ? const String.fromEnvironment(_sentryEnvironment)
+      : null;
 
   /// `SENTRY_DSN`
   /// See [SentryOptions.dsn]
-  String? get dsn => _readString('SENTRY_DSN');
+  String? get dsn => const bool.hasEnvironment(_sentryDsn)
+      ? const String.fromEnvironment(_sentryDsn)
+      : null;
 
   // `SENTRY_RELEASE`
   /// See [SentryOptions.release]
-  String? get release => _readString('SENTRY_RELEASE');
+  String? get release => const bool.hasEnvironment(_sentryRelease)
+      ? const String.fromEnvironment(_sentryRelease)
+      : null;
 
   /// `SENTRY_DIST`
   /// See [SentryOptions.dist]
-  String? get dist => _readString('SENTRY_DIST');
-
-  String? _readString(String key) =>
-      bool.fromEnvironment(key, defaultValue: false)
-          ? String.fromEnvironment(key)
-          : null;
+  String? get dist => const bool.hasEnvironment(_sentryDist)
+      ? const String.fromEnvironment(_sentryDist)
+      : null;
 }

--- a/dart/lib/src/platform_checker.dart
+++ b/dart/lib/src/platform_checker.dart
@@ -1,3 +1,5 @@
+import '../sentry.dart';
+
 /// Helper to check in which enviroment the library is running.
 /// The envirment checks (release/debug/profile) are mutually exclusive.
 class PlatformChecker {
@@ -16,5 +18,19 @@ class PlatformChecker {
   /// Check if running in profile environment
   bool isProfileMode() {
     return const bool.fromEnvironment('dart.vm.profile', defaultValue: false);
+  }
+
+  /// This can be set as [SentryOptions.environment]
+  String get environment {
+    // We infer the enviroment based on the release/non-release and profile
+    // constants.
+
+    if (isReleaseMode()) {
+      return defaultEnvironment;
+    }
+    if (isProfileMode()) {
+      return 'profile';
+    }
+    return 'debug';
   }
 }

--- a/dart/lib/src/platform_checker.dart
+++ b/dart/lib/src/platform_checker.dart
@@ -1,5 +1,3 @@
-import 'sentry_options.dart';
-
 /// Helper to check in which enviroment the library is running.
 /// The envirment checks (release/debug/profile) are mutually exclusive.
 class PlatformChecker {
@@ -18,19 +16,5 @@ class PlatformChecker {
   /// Check if running in profile environment
   bool isProfileMode() {
     return const bool.fromEnvironment('dart.vm.profile', defaultValue: false);
-  }
-
-  /// This can be set as [SentryOptions.environment]
-  String get environment {
-    // We infer the enviroment based on the release/non-release and profile
-    // constants.
-
-    if (isReleaseMode()) {
-      return defaultEnvironment;
-    }
-    if (isProfileMode()) {
-      return 'profile';
-    }
-    return 'debug';
   }
 }

--- a/dart/lib/src/platform_checker.dart
+++ b/dart/lib/src/platform_checker.dart
@@ -1,4 +1,4 @@
-import '../sentry.dart';
+import 'sentry_options.dart';
 
 /// Helper to check in which enviroment the library is running.
 /// The envirment checks (release/debug/profile) are mutually exclusive.

--- a/dart/lib/src/sentry.dart
+++ b/dart/lib/src/sentry.dart
@@ -54,9 +54,6 @@ class Sentry {
 
   static Future<void> _initDefaultValues(
       SentryOptions options, AppRunner? appRunner) async {
-    var environment = options.platformChecker.environment;
-    options.environment = options.environment ?? environment;
-
     setEnvironmentVariables(options, EnvironmentVariables());
 
     // Throws when running on the browser

--- a/dart/lib/src/sentry.dart
+++ b/dart/lib/src/sentry.dart
@@ -58,7 +58,7 @@ class Sentry {
   ) async {
     options.debug = options.platformChecker.isDebugMode();
 
-    setEnvironmentVariables(options, EnvironmentVariables());
+    _setEnvironmentVariables(options);
 
     // Throws when running on the browser
     if (!isWeb) {
@@ -66,6 +66,25 @@ class Sentry {
       // in the ‘root zone’ where all Dart programs start
       options.addIntegrationByIndex(0, IsolateErrorIntegration());
     }
+  }
+
+  /// This method reads available environment variables and uses them
+  /// accordingly.
+  /// To see which environment variables are available, see [EnvironmentVariables]
+  ///
+  /// The precendence of these options are also described on
+  /// https://docs.sentry.io/platforms/dart/configuration/options/
+  static void _setEnvironmentVariables(SentryOptions options) {
+    final vars = options.environmentVariables;
+    options.dsn = options.dsn ?? vars.dsn;
+
+    if (options.environment == null) {
+      var environment = options.platformChecker.environment;
+      options.environment = vars.environment ?? environment;
+    }
+
+    options.release = options.release ?? vars.release;
+    options.dist = options.dist ?? vars.dist;
   }
 
   /// Initializes the SDK

--- a/dart/lib/src/sentry.dart
+++ b/dart/lib/src/sentry.dart
@@ -53,7 +53,11 @@ class Sentry {
   }
 
   static Future<void> _initDefaultValues(
-      SentryOptions options, AppRunner? appRunner) async {
+    SentryOptions options,
+    AppRunner? appRunner,
+  ) async {
+    options.debug = options.platformChecker.isDebugMode();
+
     setEnvironmentVariables(options, EnvironmentVariables());
 
     // Throws when running on the browser

--- a/dart/lib/src/sentry.dart
+++ b/dart/lib/src/sentry.dart
@@ -1,8 +1,7 @@
 import 'dart:async';
 
-import 'package:sentry/src/environment_variables.dart';
-
 import 'default_integrations.dart';
+import 'environment_variables.dart';
 import 'hub.dart';
 import 'hub_adapter.dart';
 import 'noop_isolate_error_integration.dart'

--- a/dart/lib/src/sentry.dart
+++ b/dart/lib/src/sentry.dart
@@ -79,7 +79,7 @@ class Sentry {
     options.dsn = options.dsn ?? vars.dsn;
 
     if (options.environment == null) {
-      var environment = options.platformChecker.environment;
+      var environment = vars.environmentForMode(options.platformChecker);
       options.environment = vars.environment ?? environment;
     }
 

--- a/dart/lib/src/sentry.dart
+++ b/dart/lib/src/sentry.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:sentry/src/environment_variables.dart';
+
 import 'default_integrations.dart';
 import 'hub.dart';
 import 'hub_adapter.dart';
@@ -53,23 +55,10 @@ class Sentry {
 
   static Future<void> _initDefaultValues(
       SentryOptions options, AppRunner? appRunner) async {
-    // We infer the enviroment based on the release/non-release and profile
-    // constants.
-    var environment = options.platformChecker.isReleaseMode()
-        ? defaultEnvironment
-        : options.platformChecker.isProfileMode()
-            ? 'profile'
-            : 'debug';
+    var environment = options.platformChecker.environment;
+    options.environment = options.environment ?? environment;
 
-    // if the SENTRY_ENVIRONMENT is set, we read from it.
-    options.environment = const bool.hasEnvironment('SENTRY_ENVIRONMENT')
-        ? const String.fromEnvironment('SENTRY_ENVIRONMENT')
-        : environment;
-
-    // if the SENTRY_DSN is set, we read from it.
-    options.dsn = const bool.hasEnvironment('SENTRY_DSN')
-        ? const String.fromEnvironment('SENTRY_DSN')
-        : options.dsn;
+    setEnvironmentVariables(options, EnvironmentVariables());
 
     // Throws when running on the browser
     if (!isWeb) {

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -13,9 +13,6 @@ import 'utils.dart';
 import 'version.dart';
 import 'platform_checker.dart';
 
-/// Default Environment is none is set
-const defaultEnvironment = 'production';
-
 // TODO: Scope observers, enableScopeSync
 // TODO: shutdownTimeout, flushTimeoutMillis
 // https://api.dart.dev/stable/2.10.2/dart-io/HttpClient/close.html doesn't have a timeout param, we'd need to implement manually

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -16,6 +16,9 @@ import 'platform_checker.dart';
 const defaultEnvironment = 'production';
 
 /// Sentry SDK options
+// TODO: Scope observers, enableScopeSync
+// TODO: shutdownTimeout, flushTimeoutMillis
+// https://api.dart.dev/stable/2.10.2/dart-io/HttpClient/close.html doesn't have a timeout param, we'd need to implement manually
 class SentryOptions {
   /// Default Log level if not specified Default is DEBUG
   static final SentryLevel _defaultDiagnosticLevel = SentryLevel.debug;
@@ -68,9 +71,6 @@ class SentryOptions {
 
   final List<Integration> _integrations = [];
 
-  // TODO: shutdownTimeout, flushTimeoutMillis
-  // https://api.dart.dev/stable/2.10.2/dart-io/HttpClient/close.html doesn't have a timeout param, we'd need to implement manually
-
   /// Code that provides middlewares, bindings or hooks into certain frameworks or environments,
   /// along with code that inserts those bindings and activates them.
   List<Integration> get integrations => List.unmodifiable(_integrations);
@@ -95,11 +95,13 @@ class SentryOptions {
   BeforeBreadcrumbCallback? beforeBreadcrumb;
 
   /// Sets the release. SDK will try to automatically configure a release out of the box
+  /// See [docs for further information](https://docs.sentry.io/platforms/flutter/configuration/releases/)
   String? release;
 
   /// Sets the environment. This string is freeform and not set by default. A release can be
   /// associated with more than one environment to separate them in the UI Think staging vs prod or
   /// similar.
+  /// See [docs for further information](https://docs.sentry.io/platforms/flutter/configuration/environments/)
   String? environment;
 
   /// Configures the sample rate as a percentage of events to be sent in the range of 0.0 to 1.0. if
@@ -139,7 +141,7 @@ class SentryOptions {
   /// however, when this option is set, stack traces are also sent with messages.
   /// This option, for instance, means that stack traces appear next to all log messages.
   ///
-  /// This option is true` by default.
+  /// This option is `true` by default.
   ///
   /// Grouping in Sentry is different for events with stack traces and without.
   /// As a result, you will get new groups as you enable or disable this flag for certain events.
@@ -154,8 +156,6 @@ class SentryOptions {
 
   /// Whether to send personal identifiable information along with events
   bool sendDefaultPii = false;
-
-  // TODO: Scope observers, enableScopeSync
 
   SentryOptions({this.dsn}) {
     sdk.addPackage('pub:sentry', sdkVersion);

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:http/http.dart';
 
 import 'diagnostic_logger.dart';
+import 'environment_variables.dart';
 import 'integration.dart';
 import 'noop_client.dart';
 import 'protocol.dart';
@@ -151,6 +152,10 @@ class SentryOptions {
   /// If [platformChecker] is provided, it is used get the envirnoment.
   /// This is useful in tests. Should be an implementation of [PlatformChecker].
   PlatformChecker platformChecker = PlatformChecker();
+
+  /// If [environmentVariables] is provided, it is used get the envirnoment
+  /// variables. This is useful in tests.
+  EnvironmentVariables environmentVariables = EnvironmentVariables();
 
   /// When enabled, all the threads are automatically attached to all logged events (Android).
   bool attachThreads = false;

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -15,10 +15,11 @@ import 'platform_checker.dart';
 /// Default Environment is none is set
 const defaultEnvironment = 'production';
 
-/// Sentry SDK options
 // TODO: Scope observers, enableScopeSync
 // TODO: shutdownTimeout, flushTimeoutMillis
 // https://api.dart.dev/stable/2.10.2/dart-io/HttpClient/close.html doesn't have a timeout param, we'd need to implement manually
+
+/// Sentry SDK options
 class SentryOptions {
   /// Default Log level if not specified Default is DEBUG
   static final SentryLevel _defaultDiagnosticLevel = SentryLevel.debug;

--- a/dart/test/environment_test.dart
+++ b/dart/test/environment_test.dart
@@ -1,0 +1,51 @@
+import 'package:sentry/sentry.dart';
+import 'package:sentry/src/environment_variables.dart';
+import 'package:test/test.dart';
+
+import 'mocks.dart';
+import 'mocks/mock_environment_variables.dart';
+
+void main() {
+  group('Environment Variables', () {
+    // See https://docs.sentry.io/platforms/dart/configuration/options/
+    // and https://github.com/getsentry/sentry-dart/issues/306
+    test('SentryOptions are correctly overriden by environment', () {
+      final options = SentryOptions(dsn: fakeDsn);
+      options.release = 'release-1.2.3';
+      options.dist = 'foo';
+      options.environment = 'prod';
+
+      setEnvironmentVariables(
+        options,
+        MockEnvironmentVariables(
+          dsn: 'foo-bar',
+          environment: 'staging',
+          release: 'release-9.8.7',
+          dist: 'bar',
+        ),
+      );
+
+      expect(options.dsn, fakeDsn);
+      expect(options.environment, 'staging');
+      expect(options.release, 'release-9.8.7');
+      expect(options.dist, 'bar');
+    });
+
+    test('No environment variables are set', () {
+      final options = SentryOptions(dsn: fakeDsn);
+      options.environment = 'prod';
+      options.release = 'release-1.2.3';
+      options.dist = 'foo';
+
+      setEnvironmentVariables(
+        options,
+        MockEnvironmentVariables(),
+      );
+
+      expect(options.dsn, fakeDsn);
+      expect(options.environment, 'prod');
+      expect(options.release, 'release-1.2.3');
+      expect(options.dist, 'foo');
+    });
+  });
+}

--- a/dart/test/environment_test.dart
+++ b/dart/test/environment_test.dart
@@ -8,6 +8,10 @@ void main() {
   // See https://docs.sentry.io/platforms/dart/configuration/options/
   // and https://github.com/getsentry/sentry-dart/issues/306
   group('Environment Variables', () {
+    tearDown(() {
+      Sentry.close();
+    });
+
     test('SentryOptions are not overriden by environment', () async {
       final options = SentryOptions(dsn: fakeDsn);
       options.release = 'release-1.2.3';

--- a/dart/test/environment_test.dart
+++ b/dart/test/environment_test.dart
@@ -35,7 +35,7 @@ void main() {
       expect(options.dist, 'foo');
     });
 
-    test('No options are set', () async {
+    test('SentryOptions are overriden by environment', () async {
       final options = SentryOptions();
       options.environmentVariables = MockEnvironmentVariables(
         dsn: 'foo-bar',

--- a/dart/test/fake_platform_checker.dart
+++ b/dart/test/fake_platform_checker.dart
@@ -1,7 +1,7 @@
 import 'package:sentry/src/platform_checker.dart';
 
 /// Fake class to be used in unit tests for mocking different environments
-class FakePlatformChecker implements PlatformChecker {
+class FakePlatformChecker extends PlatformChecker {
   FakePlatformChecker.releaseMode() {
     _releaseMode = true;
     _debugMode = false;

--- a/dart/test/mocks/mock_environment_variables.dart
+++ b/dart/test/mocks/mock_environment_variables.dart
@@ -1,6 +1,6 @@
 import 'package:sentry/src/environment_variables.dart';
 
-class MockEnvironmentVariables implements EnvironmentVariables {
+class MockEnvironmentVariables extends EnvironmentVariables {
   MockEnvironmentVariables({
     String? dist,
     String? dsn,

--- a/dart/test/mocks/mock_environment_variables.dart
+++ b/dart/test/mocks/mock_environment_variables.dart
@@ -1,0 +1,30 @@
+import 'package:sentry/src/environment_variables.dart';
+
+class MockEnvironmentVariables implements EnvironmentVariables {
+  MockEnvironmentVariables({
+    String? dist,
+    String? dsn,
+    String? environment,
+    String? release,
+  })  : _dist = dist,
+        _dsn = dsn,
+        _environment = environment,
+        _release = release;
+
+  final String? _dist;
+  final String? _dsn;
+  final String? _environment;
+  final String? _release;
+
+  @override
+  String? get dist => _dist;
+
+  @override
+  String? get dsn => _dsn;
+
+  @override
+  String? get environment => _environment;
+
+  @override
+  String? get release => _release;
+}

--- a/dart/test/sentry_test.dart
+++ b/dart/test/sentry_test.dart
@@ -185,6 +185,7 @@ void main() {
     await Sentry.init((options) {
       options.dsn = fakeDsn;
       expect(options.environment, 'debug');
+      expect(options.debug, true);
     }, options: sentryOptions);
   });
 
@@ -194,6 +195,7 @@ void main() {
     await Sentry.init((options) {
       options.dsn = fakeDsn;
       expect(options.environment, 'profile');
+      expect(options.debug, false);
     }, options: sentryOptions);
   });
 
@@ -203,6 +205,7 @@ void main() {
     await Sentry.init((options) {
       options.dsn = fakeDsn;
       expect(options.environment, defaultEnvironment);
+      expect(options.debug, false);
     }, options: sentryOptions);
   });
 }

--- a/dart/test/sentry_test.dart
+++ b/dart/test/sentry_test.dart
@@ -204,7 +204,7 @@ void main() {
       ..platformChecker = FakePlatformChecker.releaseMode();
     await Sentry.init((options) {
       options.dsn = fakeDsn;
-      expect(options.environment, defaultEnvironment);
+      expect(options.environment, 'production');
       expect(options.debug, false);
     }, options: sentryOptions);
   });

--- a/flutter/lib/src/default_integrations.dart
+++ b/flutter/lib/src/default_integrations.dart
@@ -349,15 +349,16 @@ class LoadReleaseIntegration extends Integration<SentryFlutterOptions> {
   @override
   FutureOr<void> call(Hub hub, SentryFlutterOptions options) async {
     try {
-      // For non Flutter apps, we read the environment variables in sentry_dart
       if (!kIsWeb) {
-        final packageInfo = await _packageLoader();
-        final release =
-            '${packageInfo.packageName}@${packageInfo.version}+${packageInfo.buildNumber}';
-        options.logger(SentryLevel.debug, 'release: $release');
+        if (options.release == null || options.dist == null) {
+          final packageInfo = await _packageLoader();
+          final release =
+              '${packageInfo.packageName}@${packageInfo.version}+${packageInfo.buildNumber}';
+          options.logger(SentryLevel.debug, 'release: $release');
 
-        options.release = release;
-        options.dist = packageInfo.buildNumber;
+          options.release = options.release ?? release;
+          options.dist = options.dist ?? packageInfo.buildNumber;
+        }
       }
     } catch (error) {
       options.logger(

--- a/flutter/lib/src/default_integrations.dart
+++ b/flutter/lib/src/default_integrations.dart
@@ -340,8 +340,7 @@ class LoadAndroidImageListIntegration
 /// a PackageInfo wrapper to make it testable
 typedef PackageLoader = Future<PackageInfo> Function();
 
-/// an Integration that loads the Release version from Native Apps
-/// or SENTRY_RELEASE and SENTRY_DIST variables
+/// An [Integration] that loads the release version from native apps
 class LoadReleaseIntegration extends Integration<SentryFlutterOptions> {
   final PackageLoader _packageLoader;
 
@@ -350,7 +349,7 @@ class LoadReleaseIntegration extends Integration<SentryFlutterOptions> {
   @override
   FutureOr<void> call(Hub hub, SentryFlutterOptions options) async {
     try {
-      // For web we read the environment variables in sentry_dart
+      // For non Flutter apps, we read the environment variables in sentry_dart
       if (!kIsWeb) {
         final packageInfo = await _packageLoader();
         final release =

--- a/flutter/lib/src/default_integrations.dart
+++ b/flutter/lib/src/default_integrations.dart
@@ -350,6 +350,7 @@ class LoadReleaseIntegration extends Integration<SentryFlutterOptions> {
   @override
   FutureOr<void> call(Hub hub, SentryFlutterOptions options) async {
     try {
+      // For web we read the environment variables in sentry_dart
       if (!kIsWeb) {
         final packageInfo = await _packageLoader();
         final release =
@@ -358,15 +359,6 @@ class LoadReleaseIntegration extends Integration<SentryFlutterOptions> {
 
         options.release = release;
         options.dist = packageInfo.buildNumber;
-      } else {
-        // for non-mobile builds, we read the release and dist from the
-        // system variables (SENTRY_RELEASE and SENTRY_DIST).
-        options.release = const bool.hasEnvironment('SENTRY_RELEASE')
-            ? const String.fromEnvironment('SENTRY_RELEASE')
-            : options.release;
-        options.dist = const bool.hasEnvironment('SENTRY_DIST')
-            ? const String.fromEnvironment('SENTRY_DIST')
-            : options.dist;
       }
     } catch (error) {
       options.logger(

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -60,8 +60,6 @@ mixin SentryFlutter {
     SentryFlutterOptions options,
     MethodChannel channel,
   ) async {
-    options.debug = kDebugMode;
-
     // web still uses a http transport for Web which is set by default
     if (!kIsWeb) {
       options.transport = FileSystemTransport(channel, options);

--- a/flutter/test/default_integrations_test.dart
+++ b/flutter/test/default_integrations_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
-import 'package:package_info/package_info.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:sentry/sentry.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:sentry_flutter/src/sentry_flutter_options.dart';

--- a/flutter/test/default_integrations_test.dart
+++ b/flutter/test/default_integrations_test.dart
@@ -3,10 +3,12 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
+import 'package:package_info/package_info.dart';
 import 'package:sentry/sentry.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:sentry_flutter/src/sentry_flutter_options.dart';
 
+import 'mocks.dart';
 import 'mocks.mocks.dart';
 
 void main() {
@@ -206,6 +208,39 @@ void main() {
     await integration(fixture.hub, fixture.options);
 
     expect(called, true);
+  });
+
+  group('$LoadReleaseIntegration', () {
+    Future<PackageInfo> loadRelease() {
+      return Future.value(PackageInfo(
+        appName: 'sentry_flutter',
+        packageName: 'foo.bar',
+        version: '1.2.3',
+        buildNumber: '789',
+      ));
+    }
+
+    test('does not overwrite options', () async {
+      final options = SentryFlutterOptions(dsn: fakeDsn);
+      options.release = '1.0.0';
+      options.dist = 'dist';
+
+      final integration = LoadReleaseIntegration(loadRelease);
+      await integration.call(MockHub(), options);
+
+      expect(options.release, '1.0.0');
+      expect(options.dist, 'dist');
+    });
+
+    test('sets release and dist if not set on options', () async {
+      final options = SentryFlutterOptions(dsn: fakeDsn);
+
+      final integration = LoadReleaseIntegration(loadRelease);
+      await integration.call(MockHub(), options);
+
+      expect(options.release, 'foo.bar@1.2.3+789');
+      expect(options.dist, '789');
+    });
   });
 }
 


### PR DESCRIPTION
## :scroll: Description

Environment variables are now read in sentry.
This also includes https://github.com/getsentry/sentry-dart/pull/376

## :bulb: Motivation and Context

https://github.com/getsentry/sentry-dart/issues/306

## :green_heart: How did you test it?
I've written new tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
