### PR TITLE
Fix: Set `SentryOptions.debug` in sentry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Bump: sentry-cocoa to v6.2.1 (#360)
 * Fix: missing event.origin and event.environment tags for non-native events on iOS (#369)
 * Fix: Read all environment variables in sentry_dart (#375)
+* Fix: Set `SentryOptions.debug` in sentry_dart (#376)
 
 ## Breaking Changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Bump: sentry-cocoa to v6.2.1 (#360)
 * Fix: missing event.origin and event.environment tags for non-native events on iOS (#369)
 * Fix: Read all environment variables in sentry_dart (#375)
-* Fix: Set `SentryOptions.debug` in sentry_dart (#376)
+* Fix: Set `SentryOptions.debug` in `sentry` (#376)
 
 ## Breaking Changes:
 

--- a/dart/lib/src/sentry.dart
+++ b/dart/lib/src/sentry.dart
@@ -53,7 +53,11 @@ class Sentry {
   }
 
   static Future<void> _initDefaultValues(
-      SentryOptions options, AppRunner? appRunner) async {
+    SentryOptions options,
+    AppRunner? appRunner,
+  ) async {
+    options.debug = options.platformChecker.isDebugMode();
+
     var environment = options.platformChecker.environment;
     options.environment = options.environment ?? environment;
 

--- a/dart/test/sentry_test.dart
+++ b/dart/test/sentry_test.dart
@@ -185,6 +185,7 @@ void main() {
     await Sentry.init((options) {
       options.dsn = fakeDsn;
       expect(options.environment, 'debug');
+      expect(options.debug, true);
     }, options: sentryOptions);
   });
 
@@ -194,6 +195,7 @@ void main() {
     await Sentry.init((options) {
       options.dsn = fakeDsn;
       expect(options.environment, 'profile');
+      expect(options.debug, false);
     }, options: sentryOptions);
   });
 
@@ -203,6 +205,7 @@ void main() {
     await Sentry.init((options) {
       options.dsn = fakeDsn;
       expect(options.environment, defaultEnvironment);
+      expect(options.debug, false);
     }, options: sentryOptions);
   });
 }

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -60,8 +60,6 @@ mixin SentryFlutter {
     SentryFlutterOptions options,
     MethodChannel channel,
   ) async {
-    options.debug = kDebugMode;
-
     // web still uses a http transport for Web which is set by default
     if (!kIsWeb) {
       options.transport = FileSystemTransport(channel, options);


### PR DESCRIPTION
## :scroll: Description

This change sets `SentryOptions.debug` in sentry_dart so it is available on all platforms/frameworks and not just Flutter.

## :bulb: Motivation and Context
https://github.com/getsentry/sentry-dart/issues/307


## :green_heart: How did you test it?
I added more `expects` to existing tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
