### PR TITLE
Fix: Disable Flutter beta builds on CI

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         target: ['ios', 'android', 'web']
-        channel: ['stable', 'beta']
+        channel: ['stable']
         exclude:
           - os: ubuntu-latest
             target: ios

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -17,6 +17,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         target: ['ios', 'android', 'web']
+        # 'beta' channel is not working https://github.com/flutter/flutter/issues/78785
         channel: ['stable']
         exclude:
           - os: ubuntu-latest

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -42,11 +42,6 @@ jobs:
 
         - run: flutter upgrade
 
-        # https://github.com/flutter/flutter/issues/59522#issuecomment-646208247
-        - name: Fix iOS build bug
-          if: matrix.target == 'ios'
-          run: rm flutter/example/ios/Podfile
-
         - name: Test
           run: |
             cd flutter

--- a/flutter/ios/sentry_flutter.podspec
+++ b/flutter/ios/sentry_flutter.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
 Sentry SDK for Flutter with support to native through sentry-cocoa.
                        DESC
   s.homepage         = 'https://sentry.io'
-  s.license          = { :type => 'MIT', :file => '../../LICENSE' }
+  s.license          = { :type => 'MIT', :file => '../LICENSE' }
   s.authors          = "Sentry"
   s.source           = { :git => "https://github.com/getsentry/sentry-dart.git",
                          :tag => s.version.to_s }


### PR DESCRIPTION
## :scroll: Description
This change disables Flutter beta builds.
It also removes a fix which is not longer needed and fixes the LICENSE path in the `sentry_flutter.podspec` file.

_#skip-changelog_


## :bulb: Motivation and Context
Currently Flutter beta fails for Android and iOS.

I tried to fix it in https://github.com/getsentry/sentry-dart/pull/378 but I didn't succeed.
Also see https://github.com/flutter/flutter/issues/78785


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
Fix Android beta builds