### PR TITLE
Fix: Change return type of `Sentry.close` and `Integration.close`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ## Breaking Changes:
 
+* Return type of `Sentry.close()` changed from `void` to `Future<void>`
 * Remove deprecated member `enableLifecycleBreadcrumbs`. Use `enableAppLifecycleBreadcrumbs` instead. (#366)
 
 # 4.1.0-nullsafety.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ## Breaking Changes:
 
-* Return type of `Sentry.close()` changed from `void` to `Future<void>`
+* Return type of `Sentry.close()` changed from `void` to `Future<void>` and `Integration.close()` changed from `void` to `FutureOr<void>` (#395)
 * Remove deprecated member `enableLifecycleBreadcrumbs`. Use `enableAppLifecycleBreadcrumbs` instead. (#366)
 
 # 4.1.0-nullsafety.1

--- a/dart/lib/src/hub.dart
+++ b/dart/lib/src/hub.dart
@@ -208,7 +208,7 @@ class Hub {
   }
 
   /// Flushes out the queue for up to timeout seconds and disable the Hub.
-  void close() {
+  Future<void> close() async {
     if (!_isEnabled) {
       _options.logger(
         SentryLevel.warning,
@@ -217,7 +217,7 @@ class Hub {
     } else {
       // close integrations
       for (final integration in _options.integrations) {
-        integration.close();
+        await integration.close();
       }
 
       final item = _peek();

--- a/dart/lib/src/hub_adapter.dart
+++ b/dart/lib/src/hub_adapter.dart
@@ -66,7 +66,7 @@ class HubAdapter implements Hub {
   Hub clone() => Sentry.clone();
 
   @override
-  void close() => Sentry.close();
+  Future<void> close() => Sentry.close();
 
   @override
   void configureScope(ScopeCallback callback) =>

--- a/dart/lib/src/integration.dart
+++ b/dart/lib/src/integration.dart
@@ -10,5 +10,5 @@ abstract class Integration<T extends SentryOptions> {
   FutureOr<void> call(Hub hub, T options);
 
   /// NoOp by default : only closeable integrations need to override
-  void close() {}
+  FutureOr<void> close() {}
 }

--- a/dart/lib/src/noop_hub.dart
+++ b/dart/lib/src/noop_hub.dart
@@ -46,7 +46,7 @@ class NoOpHub implements Hub {
   Hub clone() => this;
 
   @override
-  void close() {}
+  Future<void> close() async {}
 
   @override
   void configureScope(callback) {}

--- a/dart/lib/src/sentry.dart
+++ b/dart/lib/src/sentry.dart
@@ -97,10 +97,10 @@ class Sentry {
     }
 
     // let's set the default values to options
-    if (_setDefaultConfiguration(options)) {
+    if (await _setDefaultConfiguration(options)) {
       final hub = currentHub;
       _hub = Hub(options);
-      hub.close();
+      await hub.close();
     }
 
     // execute integrations after hub being enabled
@@ -168,10 +168,10 @@ class Sentry {
       );
 
   /// Close the client SDK
-  static void close() {
+  static Future<void> close() async {
     final hub = currentHub;
     _hub = NoOpHub();
-    hub.close();
+    await hub.close();
   }
 
   /// Check if the current Hub is enabled/active.
@@ -194,10 +194,10 @@ class Sentry {
   /// Binds a different client to the current hub
   static void bindClient(SentryClient client) => currentHub.bindClient(client);
 
-  static bool _setDefaultConfiguration(SentryOptions options) {
+  static Future<bool> _setDefaultConfiguration(SentryOptions options) async {
     // if the DSN is empty, let's disable the SDK
     if (options.dsn?.isEmpty ?? false) {
-      close();
+      await close();
       return false;
     }
 

--- a/dart/test/hub_test.dart
+++ b/dart/test/hub_test.dart
@@ -153,8 +153,8 @@ void main() {
       expect(client2.captureEventCalls.first.scope, isNotNull);
     });
 
-    test('should close its client', () {
-      hub.close();
+    test('should close its client', () async {
+      await hub.close();
 
       expect(hub.isEnabled, false);
       expect((client as MockSentryClient).closeCalls, 1);

--- a/dart/test/mocks/mock_hub.dart
+++ b/dart/test/mocks/mock_hub.dart
@@ -59,7 +59,7 @@ class MockHub implements Hub {
   }
 
   @override
-  void close() {
+  Future<void> close() async {
     closeCalls = closeCalls + 1;
   }
 

--- a/dart/test/sentry_test.dart
+++ b/dart/test/sentry_test.dart
@@ -21,8 +21,8 @@ void main() {
       client = MockSentryClient();
       Sentry.bindClient(client);
     });
-    tearDown(() {
-      Sentry.close();
+    tearDown(() async {
+      await Sentry.close();
     });
 
     test('should capture the event', () async {
@@ -59,8 +59,8 @@ void main() {
   });
 
   group('Sentry is enabled or disabled', () {
-    tearDown(() {
-      Sentry.close();
+    tearDown(() async {
+      await Sentry.close();
     });
 
     test('null DSN', () {
@@ -102,15 +102,15 @@ void main() {
 
       expect(Sentry.isEnabled, true);
 
-      Sentry.close();
+      await Sentry.close();
 
       expect(Sentry.isEnabled, false);
     });
   });
 
   group('Sentry init', () {
-    tearDown(() {
-      Sentry.close();
+    tearDown(() async {
+      await Sentry.close();
     });
 
     test('should install integrations', () async {
@@ -171,7 +171,7 @@ void main() {
         },
       );
 
-      Sentry.close();
+      await Sentry.close();
 
       expect(integration.callCalls, 1);
       expect(integration.closeCalls, 1);

--- a/flutter/lib/src/default_integrations.dart
+++ b/flutter/lib/src/default_integrations.dart
@@ -84,7 +84,7 @@ class FlutterErrorIntegration extends Integration<SentryFlutterOptions> {
   }
 
   @override
-  void close() {
+  FutureOr<void> close() {
     /// Restore default if the integration error is still set.
     if (FlutterError.onError == _integrationOnError) {
       FlutterError.onError = _defaultOnError;
@@ -253,7 +253,7 @@ class WidgetsBindingIntegration extends Integration<SentryFlutterOptions> {
   }
 
   @override
-  void close() {
+  FutureOr<void> close() {
     final instance = WidgetsBinding.instance;
     if (instance != null && _observer != null) {
       instance.removeObserver(_observer!);

--- a/flutter/test/default_integrations_test.dart
+++ b/flutter/test/default_integrations_test.dart
@@ -92,7 +92,7 @@ void main() {
 
     final integrationA = FlutterErrorIntegration();
     integrationA.call(fixture.hub, fixture.options);
-    integrationA.close();
+    await integrationA.close();
 
     final integrationB = FlutterErrorIntegration();
     integrationB.call(fixture.hub, fixture.options);
@@ -104,7 +104,7 @@ void main() {
     expect(numberOfDefaultCalls, 1);
   });
 
-  test('FlutterErrorIntegration close restored default onError', () {
+  test('FlutterErrorIntegration close restored default onError', () async {
     final defaultOnError = (FlutterErrorDetails errorDetails) async {};
     FlutterError.onError = defaultOnError;
 
@@ -112,12 +112,12 @@ void main() {
     integration.call(fixture.hub, fixture.options);
     expect(false, defaultOnError == FlutterError.onError);
 
-    integration.close();
+    await integration.close();
     expect(FlutterError.onError, defaultOnError);
   });
 
   test('FlutterErrorIntegration default not restored if set after integration',
-      () {
+      () async {
     final defaultOnError = (FlutterErrorDetails errorDetails) async {};
     FlutterError.onError = defaultOnError;
 
@@ -128,7 +128,7 @@ void main() {
     final afterIntegrationOnError = (FlutterErrorDetails errorDetails) async {};
     FlutterError.onError = afterIntegrationOnError;
 
-    integration.close();
+    await integration.close();
     expect(FlutterError.onError, afterIntegrationOnError);
   });
 


### PR DESCRIPTION
## :scroll: Description
Change return type of `Sentry.close` and `Integration.close`.


## :bulb: Motivation and Context
https://github.com/getsentry/sentry-dart/issues/393


## :green_heart: How did you test it?
Current tests are passing.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
Add this to https://github.com/getsentry/sentry-docs/pull/3287