### PR TITLE
Add missing await for Sentry.close

### DIFF
--- a/dart/test/environment_test.dart
+++ b/dart/test/environment_test.dart
@@ -8,8 +8,8 @@ void main() {
   // See https://docs.sentry.io/platforms/dart/configuration/options/
   // and https://github.com/getsentry/sentry-dart/issues/306
   group('Environment Variables', () {
-    tearDown(() {
-      Sentry.close();
+    tearDown(() async {
+      await Sentry.close();
     });
 
     test('SentryOptions are not overriden by environment', () async {

--- a/flutter/test/sentry_flutter_test.dart
+++ b/flutter/test/sentry_flutter_test.dart
@@ -19,8 +19,8 @@ void main() {
       _channel.setMockMethodCallHandler((MethodCall methodCall) async {});
     });
 
-    tearDown(() {
-      Sentry.close();
+    tearDown(() async {
+      await Sentry.close();
     });
 
     test('Will run default configurations on Android', () async {
@@ -56,9 +56,9 @@ void main() {
           .thenAnswer((realInvocation) => Future.value(SentryId.newId()));
     });
 
-    tearDown(() {
+    tearDown(() async {
       _channel.setMockMethodCallHandler(null);
-      Sentry.close();
+      await Sentry.close();
     });
 
     test('should add loadContextsIntegration on ios', () async {


### PR DESCRIPTION
## :scroll: Description
Add missing await for Sentry.close

_#skip-changelog_


## :bulb: Motivation and Context
https://github.com/getsentry/sentry-dart/pull/395


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
