### PR TITLE
Fix: Mark `Sentry.currentHub` as deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 
 * Fix: `Sentry.close()` closes native SDK integrations (#388)
-* Fix: Mark `Sentry.currentHub` as deprecated
+* Fix: Mark `Sentry.currentHub` as deprecated (#406)
 
 # 5.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Fix: `Sentry.close()` closes native SDK integrations (#388)
+* Fix: Mark `Sentry.currentHub` as deprecated
 
 # 5.0.0
 

--- a/dart/lib/src/sentry.dart
+++ b/dart/lib/src/sentry.dart
@@ -26,6 +26,7 @@ class Sentry {
   Sentry._();
 
   /// Returns the current hub
+  @Deprecated('This is scheduled to be removed in Sentry v6.0.0')
   static Hub get currentHub => _hub;
 
   /// Initializes the SDK
@@ -98,7 +99,7 @@ class Sentry {
 
     // let's set the default values to options
     if (await _setDefaultConfiguration(options)) {
-      final hub = currentHub;
+      final hub = _hub;
       _hub = Hub(options);
       await hub.close();
     }
@@ -138,7 +139,7 @@ class Sentry {
     dynamic stackTrace,
     dynamic hint,
   }) async =>
-      currentHub.captureEvent(event, stackTrace: stackTrace, hint: hint);
+      _hub.captureEvent(event, stackTrace: stackTrace, hint: hint);
 
   /// Reports the [throwable] and optionally its [stackTrace] to Sentry.io.
   static Future<SentryId> captureException(
@@ -146,7 +147,7 @@ class Sentry {
     dynamic stackTrace,
     dynamic hint,
   }) async =>
-      currentHub.captureException(
+      _hub.captureException(
         throwable,
         stackTrace: stackTrace,
         hint: hint,
@@ -159,7 +160,7 @@ class Sentry {
     List<dynamic>? params,
     dynamic hint,
   }) async =>
-      currentHub.captureMessage(
+      _hub.captureMessage(
         message,
         level: level,
         template: template,
@@ -169,30 +170,30 @@ class Sentry {
 
   /// Close the client SDK
   static Future<void> close() async {
-    final hub = currentHub;
+    final hub = _hub;
     _hub = NoOpHub();
     await hub.close();
   }
 
   /// Check if the current Hub is enabled/active.
-  static bool get isEnabled => currentHub.isEnabled;
+  static bool get isEnabled => _hub.isEnabled;
 
   /// Last event id recorded by the current Hub
-  static SentryId get lastEventId => currentHub.lastEventId;
+  static SentryId get lastEventId => _hub.lastEventId;
 
   /// Adds a breacrumb to the current Scope
   static void addBreadcrumb(Breadcrumb crumb, {dynamic hint}) =>
-      currentHub.addBreadcrumb(crumb, hint: hint);
+      _hub.addBreadcrumb(crumb, hint: hint);
 
   /// Configures the scope through the callback.
   static void configureScope(ScopeCallback callback) =>
-      currentHub.configureScope(callback);
+      _hub.configureScope(callback);
 
   /// Clones the current Hub
-  static Hub clone() => currentHub.clone();
+  static Hub clone() => _hub.clone();
 
   /// Binds a different client to the current hub
-  static void bindClient(SentryClient client) => currentHub.bindClient(client);
+  static void bindClient(SentryClient client) => _hub.bindClient(client);
 
   static Future<bool> _setDefaultConfiguration(SentryOptions options) async {
     // if the DSN is empty, let's disable the SDK

--- a/dart/lib/src/sentry.dart
+++ b/dart/lib/src/sentry.dart
@@ -26,7 +26,10 @@ class Sentry {
   Sentry._();
 
   /// Returns the current hub
-  @Deprecated('This is scheduled to be removed in Sentry v6.0.0')
+  @Deprecated(
+    'This is scheduled to be removed in Sentry v6.0.0. '
+    'Instead of currentHub you should use Sentry\'s static methods.',
+  )
   static Hub get currentHub => _hub;
 
   /// Initializes the SDK


### PR DESCRIPTION
## :scroll: Description
`Sentry.currentHub` was marked deprecated. 


## :bulb: Motivation and Context
https://github.com/getsentry/sentry-dart/issues/405

## :green_heart: How did you test it?
All tests are still green.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
