### PR TITLE
Fix: Use App Name if Package Name is not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fix: `Sentry.close()` closes native SDK integrations (#388)
 * Fix: Mark `Sentry.currentHub` as deprecated (#406)
+* Fix: Use name from pubspec.yaml for release if package id is not available
 
 # 5.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Fix: `Sentry.close()` closes native SDK integrations (#388)
 * Fix: Mark `Sentry.currentHub` as deprecated (#406)
-* Fix: Use name from pubspec.yaml for release if package id is not available
+* Fix: Use name from pubspec.yaml for release if package id is not available (#411)
 
 # 5.0.0
 

--- a/flutter/lib/src/default_integrations.dart
+++ b/flutter/lib/src/default_integrations.dart
@@ -367,8 +367,13 @@ class LoadReleaseIntegration extends Integration<SentryFlutterOptions> {
       if (!kIsWeb) {
         if (options.release == null || options.dist == null) {
           final packageInfo = await _packageLoader();
+          var name = packageInfo.packageName;
+          if (name.isEmpty) {
+            name = packageInfo.appName;
+          }
+
           final release =
-              '${packageInfo.packageName}@${packageInfo.version}+${packageInfo.buildNumber}';
+              '${name}@${packageInfo.version}+${packageInfo.buildNumber}';
           options.logger(SentryLevel.debug, 'release: $release');
 
           options.release = options.release ?? release;

--- a/flutter/lib/src/default_integrations.dart
+++ b/flutter/lib/src/default_integrations.dart
@@ -393,11 +393,12 @@ class LoadReleaseIntegration extends Integration<SentryFlutterOptions> {
   String _cleanAppName(String appName) {
     // Replace disallowed chars with an underscore '_'
     // https://docs.sentry.io/platforms/flutter/configuration/releases/#bind-the-version
-    return appName.replaceAll('/','_')
-        .replaceAll('\\','_')
-        .replaceAll('\t','_')
-        .replaceAll('\r\n','_')
-        .replaceAll('\r','_')
-        .replaceAll('\n','_');
+    return appName
+        .replaceAll('/', '_')
+        .replaceAll('\\', '_')
+        .replaceAll('\t', '_')
+        .replaceAll('\r\n', '_')
+        .replaceAll('\r', '_')
+        .replaceAll('\n', '_');
   }
 }

--- a/flutter/lib/src/default_integrations.dart
+++ b/flutter/lib/src/default_integrations.dart
@@ -371,11 +371,11 @@ class LoadReleaseIntegration extends Integration<SentryFlutterOptions> {
           if (name.isEmpty) {
             // Not all platforms have a packageName
             // https://github.com/getsentry/sentry-dart/issues/410
-            name = packageInfo.appName;
+            name = _cleanAppName(packageInfo.appName);
           }
 
           final release =
-              '${name}@${packageInfo.version}+${packageInfo.buildNumber}';
+              '$name@${packageInfo.version}+${packageInfo.buildNumber}';
           options.logger(SentryLevel.debug, 'release: $release');
 
           options.release = options.release ?? release;
@@ -388,5 +388,16 @@ class LoadReleaseIntegration extends Integration<SentryFlutterOptions> {
     }
 
     options.sdk.addIntegration('loadReleaseIntegration');
+  }
+
+  String _cleanAppName(String appName) {
+    // Replace disallowed chars with an underscore '_'
+    // https://docs.sentry.io/platforms/flutter/configuration/releases/#bind-the-version
+    return appName.replaceAll('/','_')
+        .replaceAll('\\','_')
+        .replaceAll('\t','_')
+        .replaceAll('\r\n','_')
+        .replaceAll('\r','_')
+        .replaceAll('\n','_');
   }
 }

--- a/flutter/lib/src/default_integrations.dart
+++ b/flutter/lib/src/default_integrations.dart
@@ -369,6 +369,8 @@ class LoadReleaseIntegration extends Integration<SentryFlutterOptions> {
           final packageInfo = await _packageLoader();
           var name = packageInfo.packageName;
           if (name.isEmpty) {
+            // Not all platforms have a packageName
+            // https://github.com/getsentry/sentry-dart/issues/410
             name = packageInfo.appName;
           }
 

--- a/flutter/lib/src/default_integrations.dart
+++ b/flutter/lib/src/default_integrations.dart
@@ -369,8 +369,8 @@ class LoadReleaseIntegration extends Integration<SentryFlutterOptions> {
           final packageInfo = await _packageLoader();
           var name = packageInfo.packageName;
           if (name.isEmpty) {
-            // Not all platforms have a packageName
-            // https://github.com/getsentry/sentry-dart/issues/410
+            // Not all platforms have a packageName.
+            // If no packageName is available, use the appName instead.
             name = _cleanAppName(packageInfo.appName);
           }
 

--- a/flutter/test/default_integrations_test.dart
+++ b/flutter/test/default_integrations_test.dart
@@ -274,6 +274,23 @@ void main() {
       expect(options.release, 'sentry_flutter@1.2.3+789');
       expect(options.dist, '789');
     });
+
+    test('release name does not contain ivalid chars', () async {
+      final options = SentryFlutterOptions(dsn: fakeDsn);
+
+      final integration = LoadReleaseIntegration(() {
+        return Future.value(PackageInfo(
+          appName: '\\/sentry\tflutter \r\nfoo\nbar\r',
+          packageName: '',
+          version: '1.2.3',
+          buildNumber: '789',
+        ));
+      });
+      await integration.call(MockHub(), options);
+
+      expect(options.release, '__sentry_flutter _foo_bar_@1.2.3+789');
+      expect(options.dist, '789');
+    });
   });
 }
 

--- a/flutter/test/default_integrations_test.dart
+++ b/flutter/test/default_integrations_test.dart
@@ -257,6 +257,23 @@ void main() {
       expect(options.release, 'foo.bar@1.2.3+789');
       expect(options.dist, '789');
     });
+
+    test('sets app name as in release if packagename is empty', () async {
+      final options = SentryFlutterOptions(dsn: fakeDsn);
+
+      final integration = LoadReleaseIntegration(() {
+        return Future.value(PackageInfo(
+          appName: 'sentry_flutter',
+          packageName: '',
+          version: '1.2.3',
+          buildNumber: '789',
+        ));
+      });
+      await integration.call(MockHub(), options);
+
+      expect(options.release, 'sentry_flutter@1.2.3+789');
+      expect(options.dist, '789');
+    });
   });
 }
 

--- a/flutter/test/default_integrations_test.dart
+++ b/flutter/test/default_integrations_test.dart
@@ -227,10 +227,10 @@ void main() {
   });
 
   group('$LoadReleaseIntegration', () {
-    late LoadReleaseIntegrationFixture fixture;
+    late Fixture fixture;
 
     setUp(() {
-      fixture = LoadReleaseIntegrationFixture();
+      fixture = Fixture();
     });
 
     test('does not overwrite options', () async {
@@ -287,11 +287,6 @@ void main() {
 }
 
 class Fixture {
-  final hub = MockHub();
-  final options = SentryFlutterOptions();
-}
-
-class LoadReleaseIntegrationFixture {
   final hub = MockHub();
   final options = SentryFlutterOptions(dsn: fakeDsn);
 


### PR DESCRIPTION
## :scroll: Description
Not all platforms have a concept of an package id like on Android or iOS. Thus we need some other identifier. This identifier is the app name.


## :bulb: Motivation and Context
https://github.com/getsentry/sentry-dart/issues/410


## :green_heart: How did you test it?
New test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
