### PR TITLE
Feat: SentryHttpClient tracks request durations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 * Fix: `Sentry.close()` closes native SDK integrations (#388)
 * Fix: Mark `Sentry.currentHub` as deprecated (#406)
-* Feat: `SentryHttpClient` tracks the duration which a request takes and logs failed requests
 * Fix: Use name from pubspec.yaml for release if package id is not available (#411)
+* Feat: `SentryHttpClient` tracks the duration which a request takes and logs failed requests (#414)
 
 # 5.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fix: `Sentry.close()` closes native SDK integrations (#388)
 * Fix: Mark `Sentry.currentHub` as deprecated (#406)
+* Feat: `SentryHttpClient` tracks the duration which a request takes and logs failed requests
 
 # 5.0.0
 

--- a/dart/lib/src/http_client/sentry_http_client.dart
+++ b/dart/lib/src/http_client/sentry_http_client.dart
@@ -42,11 +42,6 @@ import '../hub_adapter.dart';
 ///  client.close();
 /// }
 /// ```
-//
-// Possible enhancement:
-// Track the time the HTTP request took.
-// For example with Darts Stopwatch:
-// https://api.dart.dev/stable/2.10.4/dart-core/Stopwatch-class.html
 class SentryHttpClient extends BaseClient {
   SentryHttpClient({Client? client, Hub? hub})
       : _hub = hub ?? HubAdapter(),

--- a/dart/test/http_client/sentry_http_client_test.dart
+++ b/dart/test/http_client/sentry_http_client_test.dart
@@ -200,17 +200,13 @@ void main() {
 class CloseableMockClient extends Mock implements BaseClient {}
 
 class Fixture {
-  // every test does final sut = fixture.getSut() either passing MockClient or not
   SentryHttpClient getSut([MockClient? client]) {
     final mc = client ?? getClient();
     return SentryHttpClient(client: mc, hub: hub);
   }
 
-  // tests could assert or expect fixture.hub
   late MockHub hub = MockHub();
 
-  // could optionally have reasonPhrase, status etc with defaults values
-  // so tests could also do sut = fixture.getSut(fixture.getClient(500, 'my reason'))
   MockClient getClient({int statusCode = 200, String? reason}) {
     return MockClient((request) async {
       expect(request.url, requestUri);

--- a/dart/test/http_client/sentry_http_client_test.dart
+++ b/dart/test/http_client/sentry_http_client_test.dart
@@ -28,12 +28,11 @@ void main() {
       final breadcrumb = mockHub.addBreadcrumbCalls.first.crumb;
 
       expect(breadcrumb.type, 'http');
-      expect(breadcrumb.data, <String, dynamic>{
-        'url': 'https://example.com',
-        'method': 'GET',
-        'status_code': 200,
-        'reason': 'OK',
-      });
+      expect(breadcrumb.data?['url'], 'https://example.com');
+      expect(breadcrumb.data?['method'], 'GET');
+      expect(breadcrumb.data?['status_code'], 200);
+      expect(breadcrumb.data?['reason'], 'OK');
+      expect(breadcrumb.data?['duration'], isNotNull);
     });
 
     test('GET: happy path for 404', () async {
@@ -53,12 +52,11 @@ void main() {
       final breadcrumb = mockHub.addBreadcrumbCalls.first.crumb;
 
       expect(breadcrumb.type, 'http');
-      expect(breadcrumb.data, <String, dynamic>{
-        'url': 'https://example.com',
-        'method': 'GET',
-        'status_code': 404,
-        'reason': 'NOT FOUND',
-      });
+      expect(breadcrumb.data?['url'], 'https://example.com');
+      expect(breadcrumb.data?['method'], 'GET');
+      expect(breadcrumb.data?['status_code'], 404);
+      expect(breadcrumb.data?['reason'], 'NOT FOUND');
+      expect(breadcrumb.data?['duration'], isNotNull);
     });
 
     test('POST: happy path', () async {
@@ -78,11 +76,10 @@ void main() {
       final breadcrumb = mockHub.addBreadcrumbCalls.first.crumb;
 
       expect(breadcrumb.type, 'http');
-      expect(breadcrumb.data, <String, dynamic>{
-        'url': 'https://example.com',
-        'method': 'POST',
-        'status_code': 200,
-      });
+      expect(breadcrumb.data?['url'], 'https://example.com');
+      expect(breadcrumb.data?['method'], 'POST');
+      expect(breadcrumb.data?['status_code'], 200);
+      expect(breadcrumb.data?['duration'], isNotNull);
     });
 
     test('PUT: happy path', () async {
@@ -102,11 +99,11 @@ void main() {
       final breadcrumb = mockHub.addBreadcrumbCalls.first.crumb;
 
       expect(breadcrumb.type, 'http');
-      expect(breadcrumb.data, <String, dynamic>{
-        'url': 'https://example.com',
-        'method': 'PUT',
-        'status_code': 200,
-      });
+      expect(breadcrumb.data?['url'], 'https://example.com');
+      expect(breadcrumb.data?['method'], 'PUT');
+      expect(breadcrumb.data?['status_code'], 200);
+      expect(breadcrumb.data?['reason'], 'NOT FOUND');
+      expect(breadcrumb.data?['duration'], isNotNull);
     });
 
     test('DELETE: happy path', () async {
@@ -126,19 +123,16 @@ void main() {
       final breadcrumb = mockHub.addBreadcrumbCalls.first.crumb;
 
       expect(breadcrumb.type, 'http');
-      expect(breadcrumb.data, <String, dynamic>{
-        'url': 'https://example.com',
-        'method': 'DELETE',
-        'status_code': 200,
-        'reason': 'OK',
-      });
+      expect(breadcrumb.data?['url'], 'https://example.com');
+      expect(breadcrumb.data?['method'], 'DELETE');
+      expect(breadcrumb.data?['status_code'], 200);
+      expect(breadcrumb.data?['duration'], isNotNull);
     });
 
     /// Tests, that in case an exception gets thrown, that
-    ///   - no breadcrumb gets added
-    ///   - no exception gets reported by Sentry, in case the user wants to
-    ///     handle the exception
-    test('no breadcrumb for ClientException', () async {
+    /// no exception gets reported by Sentry, in case the user wants to
+    /// handle the exception
+    test('no captureException for ClientException', () async {
       final url = Uri.parse('https://example.com');
 
       final mockHub = MockHub();
@@ -158,13 +152,12 @@ void main() {
         expect(e.uri, url);
       }
 
-      expect(mockHub.addBreadcrumbCalls.length, 0);
       expect(mockHub.captureExceptionCalls.length, 0);
     });
 
     /// SocketException are only a thing on dart:io platforms.
     /// otherwise this is equal to the test above
-    test('no breadcrumb for SocketException', () async {
+    test('no captureException for SocketException', () async {
       final url = Uri.parse('https://example.com');
 
       final mockHub = MockHub();
@@ -183,8 +176,35 @@ void main() {
         expect(e.message, 'test');
       }
 
-      expect(mockHub.addBreadcrumbCalls.length, 0);
       expect(mockHub.captureExceptionCalls.length, 0);
+    });
+
+    test('breadcrumb gets added when an exception gets thrown', () async {
+      final url = Uri.parse('https://example.com');
+
+      final mockHub = MockHub();
+
+      final mockClient = MockClient((request) async {
+        expect(request.url, url);
+        throw Exception('foo bar');
+      });
+
+      final client = SentryHttpClient(client: mockClient, hub: mockHub);
+
+      try {
+        await client.get(Uri.parse('https://example.com'));
+        fail('Method did not throw');
+      } on Exception catch (_) {}
+
+      expect(mockHub.addBreadcrumbCalls.length, 1);
+
+      final breadcrumb = mockHub.addBreadcrumbCalls.first.crumb;
+
+      expect(breadcrumb.type, 'http');
+      expect(breadcrumb.data?['url'], 'https://example.com');
+      expect(breadcrumb.data?['method'], 'GET');
+      expect(breadcrumb.level, SentryLevel.error);
+      expect(breadcrumb.data?['duration'], isNotNull);
     });
 
     test('close does get called for user defined client', () async {
@@ -198,6 +218,28 @@ void main() {
       expect(mockHub.addBreadcrumbCalls.length, 0);
       expect(mockHub.captureExceptionCalls.length, 0);
       verify(mockClient.close());
+    });
+
+    test('Breadcrumb has correct duration', () async {
+      final mockHub = MockHub();
+
+      final mockClient = MockClient((request) async {
+        expect(request.url, Uri.parse('https://example.com'));
+        await Future.delayed(Duration(seconds: 1));
+        return Response('', 200, reasonPhrase: 'OK');
+      });
+
+      final client = SentryHttpClient(client: mockClient, hub: mockHub);
+
+      final response = await client.get(Uri.parse('https://example.com'));
+      expect(response.statusCode, 200);
+
+      expect(mockHub.addBreadcrumbCalls.length, 1);
+      final breadcrumb = mockHub.addBreadcrumbCalls.first.crumb;
+
+      var durationString = breadcrumb.data!['duration']! as String;
+      // we don't check for anything below a second
+      expect(durationString.startsWith('0:00:01'), true);
     });
   });
 }


### PR DESCRIPTION
## :scroll: Description
`SentryHttpClient` now tracks the duration of a request. It also logs failed requests and their durations.


## :bulb: Motivation and Context
https://github.com/getsentry/sentry-dart/issues/412


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
