### PR TITLE
Enhancement: Make selection of Breacrumb tracking mockable

### DIFF
--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart' as foundation;
 import 'package:sentry/sentry.dart';
 
 // TODO: Scope observers, enableScopeSync

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -161,15 +161,7 @@ class SentryFlutterOptions extends SentryOptions {
   /// available in the Flutter environment. This way you get more detailed
   /// information where available.
   void enableBreadcrumbTrackingForCurrentPlatform() {
-    configureBreadcrumbTrackingForPlatform(platformChecker);
-  }
-
-  /// You should probably use [enableBreadcrumbTrackingForCurrentPlatform].
-  /// This should only be used if you really want to override the default
-  /// platform behavior.
-  @foundation.visibleForTesting
-  void configureBreadcrumbTrackingForPlatform(PlatformChecker checker) {
-    if (checker.hasNativeIntegration) {
+    if (platformChecker.hasNativeIntegration) {
       useNativeBreadcrumbTracking();
     } else {
       useFlutterBreadcrumbTracking();

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -1,11 +1,14 @@
 import 'package:flutter/foundation.dart' as foundation;
 import 'package:sentry/sentry.dart';
 
+// TODO: Scope observers, enableScopeSync
+
 /// This class adds options which are only availble in a Flutter environment.
 /// Note that some of these options require native Sentry integration, which is
 /// not available on all platforms.
 class SentryFlutterOptions extends SentryOptions {
-  SentryFlutterOptions({String? dsn}) : super(dsn: dsn) {
+  SentryFlutterOptions({String? dsn, PlatformChecker? checker})
+      : super(dsn: dsn, checker: checker) {
     enableBreadcrumbTrackingForCurrentPlatform();
   }
 
@@ -158,46 +161,18 @@ class SentryFlutterOptions extends SentryOptions {
   /// available in the Flutter environment. This way you get more detailed
   /// information where available.
   void enableBreadcrumbTrackingForCurrentPlatform() {
-    // defaultTargetPlatform returns the platform this code currently runs on.
-    // See https://api.flutter.dev/flutter/foundation/defaultTargetPlatform.html
-    //
-    // To test this method one can set
-    // foundation.debugDefaultTargetPlatformOverride as one likes.
-    configureBreadcrumbTrackingForPlatform(foundation.defaultTargetPlatform);
+    configureBreadcrumbTrackingForPlatform(platformChecker);
   }
 
   /// You should probably use [enableBreadcrumbTrackingForCurrentPlatform].
   /// This should only be used if you really want to override the default
   /// platform behavior.
   @foundation.visibleForTesting
-  void configureBreadcrumbTrackingForPlatform(
-      foundation.TargetPlatform platform) {
-    // Bacause platform reports the Operating System and not if it is running
-    // in a browser. So we have to check if this is Flutter for web.
-    // See https://github.com/flutter/flutter/blob/c5a69b9b8ad186e9fce017fd4bfb8ce63f9f4d13/packages/flutter/lib/src/foundation/_platform_web.dart
-    if (foundation.kIsWeb) {
-      // Flutter for web has no native integration, just use the Flutter
-      // integration.
+  void configureBreadcrumbTrackingForPlatform(PlatformChecker checker) {
+    if (checker.hasNativeIntegration) {
+      useNativeBreadcrumbTracking();
+    } else {
       useFlutterBreadcrumbTracking();
-      return;
-    }
-
-    // On all other platforms than web, we can just check the platform
-    switch (platform) {
-      case foundation.TargetPlatform.android:
-      case foundation.TargetPlatform.iOS:
-      case foundation.TargetPlatform.macOS:
-        useNativeBreadcrumbTracking();
-        break;
-      case foundation.TargetPlatform.fuchsia:
-      case foundation.TargetPlatform.linux:
-      case foundation.TargetPlatform.windows:
-        // These platforms have no native integration, so just use the Flutter
-        // integration.
-        useFlutterBreadcrumbTracking();
-        break;
     }
   }
-
-  // TODO: Scope observers, enableScopeSync
 }

--- a/flutter/test/sentry_flutter_options_test.dart
+++ b/flutter/test/sentry_flutter_options_test.dart
@@ -1,47 +1,32 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:sentry/src/platform/platform.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:sentry_flutter/src/sentry_flutter_options.dart';
 
 void main() {
   group('SentryFlutterOptions', () {
-    testWidgets('auto breadcrumb tracking', (WidgetTester tester) async {
-      final options = SentryFlutterOptions();
+    testWidgets('auto breadcrumb tracking: has native integration',
+        (WidgetTester tester) async {
+      final options = SentryFlutterOptions(checker: MockPlatformChecker(true));
 
-      final platformsWithNativeIntegration = [
-        TargetPlatform.android,
-        TargetPlatform.iOS,
-        TargetPlatform.macOS,
-      ];
+      expect(options.enableAppLifecycleBreadcrumbs, isFalse);
+      expect(options.enableWindowMetricBreadcrumbs, isFalse);
+      expect(options.enableBrightnessChangeBreadcrumbs, isFalse);
+      expect(options.enableTextScaleChangeBreadcrumbs, isFalse);
+      expect(options.enableMemoryPressureBreadcrumbs, isFalse);
+      expect(options.enableAutoNativeBreadcrumbs, isTrue);
+    });
 
-      for (final platform in platformsWithNativeIntegration) {
-        options.configureBreadcrumbTrackingForPlatform(platform);
+    testWidgets('auto breadcrumb tracking: without native integration',
+        (WidgetTester tester) async {
+      final options = SentryFlutterOptions(checker: MockPlatformChecker(false));
 
-        expect(options.enableAppLifecycleBreadcrumbs, isFalse);
-        expect(options.enableWindowMetricBreadcrumbs, isFalse);
-        expect(options.enableBrightnessChangeBreadcrumbs, isFalse);
-        expect(options.enableTextScaleChangeBreadcrumbs, isFalse);
-        expect(options.enableMemoryPressureBreadcrumbs, isFalse);
-        expect(options.enableAutoNativeBreadcrumbs, isTrue);
-      }
-
-      // for all other platform the inverse is true
-      final platformsWithoutNativeIntegration = [
-        TargetPlatform.fuchsia,
-        TargetPlatform.linux,
-        TargetPlatform.windows,
-      ];
-
-      for (final platform in platformsWithoutNativeIntegration) {
-        options.configureBreadcrumbTrackingForPlatform(platform);
-
-        expect(options.enableAppLifecycleBreadcrumbs, isTrue);
-        expect(options.enableWindowMetricBreadcrumbs, isTrue);
-        expect(options.enableBrightnessChangeBreadcrumbs, isTrue);
-        expect(options.enableTextScaleChangeBreadcrumbs, isTrue);
-        expect(options.enableMemoryPressureBreadcrumbs, isTrue);
-        expect(options.enableAutoNativeBreadcrumbs, isFalse);
-      }
+      expect(options.enableAppLifecycleBreadcrumbs, isTrue);
+      expect(options.enableWindowMetricBreadcrumbs, isTrue);
+      expect(options.enableBrightnessChangeBreadcrumbs, isTrue);
+      expect(options.enableTextScaleChangeBreadcrumbs, isTrue);
+      expect(options.enableMemoryPressureBreadcrumbs, isTrue);
+      expect(options.enableAutoNativeBreadcrumbs, isFalse);
     });
 
     testWidgets('useFlutterBreadcrumbTracking', (WidgetTester tester) async {
@@ -68,4 +53,28 @@ void main() {
       expect(options.enableAutoNativeBreadcrumbs, isFalse);
     });
   });
+}
+
+class MockPlatformChecker implements PlatformChecker {
+  MockPlatformChecker(this.hasNativeIntegrationValue);
+
+  final bool hasNativeIntegrationValue;
+
+  @override
+  bool get hasNativeIntegration => hasNativeIntegrationValue;
+
+  @override
+  bool isDebugMode() => true;
+
+  @override
+  bool isProfileMode() => false;
+
+  @override
+  bool isReleaseMode() => false;
+
+  @override
+  bool get isWeb => false;
+
+  @override
+  Platform get platform => throw UnimplementedError();
 }


### PR DESCRIPTION
## :scroll: Description
This change uses `PlatformChecker` to choose which Breadcrumb tracking gets enabled.
It greatly simplifies how it gets enabled.

__#skip-changelog__


## :bulb: Motivation and Context
https://github.com/getsentry/sentry-dart/issues/390#issuecomment-810164155


## :green_heart: How did you test it?
Tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
