### PR TITLE
Fix: Run `pod lib lint`

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -139,13 +139,13 @@ jobs:
             exit 1
           fi
 
-# uncomment after fixing #348
-#   pod-lint:
-#     runs-on: macos-latest
-#     steps:
-#       - uses: actions/checkout@v2
-#       # https://github.com/CocoaPods/CocoaPods/issues/5275#issuecomment-315461879
-#       - run: pod lib lint flutter/ios/sentry_flutter.podspec --skip-import-validation --allow-warnings
+  pod-lint:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      # https://github.com/CocoaPods/CocoaPods/issues/5275#issuecomment-315461879
+      - run: pod lib lint flutter/ios/sentry_flutter.podspec --configuration=Debug --skip-import-validation --allow-warnings
+      - run: pod lib lint flutter/macos/sentry_flutter.podspec --configuration=Debug --skip-import-validation --allow-warnings
 
   swift-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## :scroll: Description
Run `pod lib lint` again for iOS and also enable it for macOS.

The trick was to run it with `--configuration=Debug` as seen [here](https://github.com/flutter/plugins/blob/master/script/tool/lib/src/lint_podspecs_command.dart#L126) in the Flutter Plugin Repo.

_#skip-changelog_

## :bulb: Motivation and Context
Closes https://github.com/getsentry/sentry-dart/issues/348


## :green_heart: How did you test it?
CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
