### PR TITLE
Feature: Log `print()` calls as Breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix: Use name from pubspec.yaml for release if package id is not available (#411)
 * Feat: `SentryHttpClient` tracks the duration which a request takes and logs failed requests (#414)
 * Fix: Trim `\u0000` from Windows package info (#420)
+* Feature: Log calls to `print()` as Breadcrumbs (#439)
 
 # 5.0.0
 

--- a/dart/lib/src/default_integrations.dart
+++ b/dart/lib/src/default_integrations.dart
@@ -36,9 +36,9 @@ class RunZonedGuardedIntegration extends Integration {
       },
       zoneSpecification: ZoneSpecification(
         print: (self, parent, zone, line) {
-          if (!hub.isEnabled) {
+          if (!hub.isEnabled || !options.enablePrintBreadcrumbs) {
             // early bail out, in order to better guard against the recursion
-            // as decribed below.
+            // as described below.
             parent.print(zone, line);
             return;
           }

--- a/dart/lib/src/protocol/breadcrumb.dart
+++ b/dart/lib/src/protocol/breadcrumb.dart
@@ -18,7 +18,7 @@ import 'sentry_level.dart';
 /// }
 /// ```
 /// See also:
-/// * https://docs.sentry.io/development/sdk-dev/event-payloads/breadcrumbs/
+/// * https://develop.sentry.dev/sdk/event-payloads/breadcrumbs/
 @immutable
 class Breadcrumb {
   /// Creates a breadcrumb that can be attached to an [Event].
@@ -50,7 +50,7 @@ class Breadcrumb {
   ///
   /// See also:
   ///
-  /// * https://docs.sentry.io/development/sdk-dev/event-payloads/breadcrumbs/#breadcrumb-types
+  /// * https://develop.sentry.dev/sdk/event-payloads/breadcrumbs/#breadcrumb-types
   final Map<String, dynamic>? data;
 
   /// Severity of the breadcrumb.
@@ -66,7 +66,7 @@ class Breadcrumb {
   ///
   /// See also:
   ///
-  /// * https://docs.sentry.io/development/sdk-dev/event-payloads/breadcrumbs/#breadcrumb-types
+  /// * https://develop.sentry.dev/sdk/event-payloads/breadcrumbs/#breadcrumb-types
   final String? type;
 
   /// The time the breadcrumb was recorded.

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -158,6 +158,10 @@ class SentryOptions {
   /// As a result, you will get new groups as you enable or disable this flag for certain events.
   bool attachStacktrace = true;
 
+  /// Enable this option if you want to record calls to `print()` as
+  /// breadcrumbs.
+  bool enablePrintBreadcrumbs = true;
+
   /// If [platformChecker] is provided, it is used get the envirnoment.
   /// This is useful in tests. Should be an implementation of [PlatformChecker].
   PlatformChecker platformChecker = PlatformChecker();

--- a/dart/test/default_integrations_test.dart
+++ b/dart/test/default_integrations_test.dart
@@ -110,28 +110,23 @@ void main() {
   });
 
   test('Run zoned guarded logs calls to print as breadcrumb', () async {
-    Future<void> callback() async {
-      print('foo bar');
-    }
-
-    final integration = RunZonedGuardedIntegration(callback);
+    final integration = fixture.getSut();
 
     await integration(fixture.hub, fixture.options);
 
     expect(fixture.hub.addBreadcrumbCalls.length, 1);
     final breadcrumb = fixture.hub.addBreadcrumbCalls.first.crumb;
-    expect(breadcrumb.message, 'foo bar');
+    expect(breadcrumb.level, SentryLevel.debug);
+    expect(breadcrumb.category, 'console');
+    expect(breadcrumb.type, 'debug');
   });
 
   test(
       'Run zoned guarded does not log calls to print as breadcrumb if disabled',
       () async {
     fixture.options.enablePrintBreadcrumbs = false;
-    Future<void> callback() async {
-      print('foo bar');
-    }
 
-    final integration = RunZonedGuardedIntegration(callback);
+    final integration = fixture.getSut();
 
     await integration(fixture.hub, fixture.options);
 
@@ -141,11 +136,7 @@ void main() {
   test('Run zoned guarded: No addBreadcrumb calls for disabled Hub', () async {
     await fixture.hub.close();
 
-    Future<void> callback() async {
-      print('foo bar');
-    }
-
-    final integration = RunZonedGuardedIntegration(callback);
+    final integration = fixture.getSut();
 
     await integration(fixture.hub, fixture.options);
 
@@ -156,23 +147,30 @@ void main() {
     final options = SentryOptions(dsn: fakeDsn);
     final hub = PrintRecursionMockHub();
 
-    Future<void> callback() async {
-      print('foo bar');
-    }
-
-    final integration = RunZonedGuardedIntegration(callback);
+    final integration = fixture.getSut();
 
     await integration(hub, options);
 
     expect(hub.addBreadcrumbCalls.length, 1);
     final breadcrumb = hub.addBreadcrumbCalls.first.crumb;
     expect(breadcrumb.message, 'foo bar');
+    expect(breadcrumb.level, SentryLevel.debug);
+    expect(breadcrumb.category, 'console');
+    expect(breadcrumb.type, 'debug');
   });
 }
 
 class Fixture {
   final hub = MockHub();
   final options = SentryOptions(dsn: fakeDsn);
+
+  RunZonedGuardedIntegration getSut() {
+    Future<void> callback() async {
+      print('foo bar');
+    }
+
+    return RunZonedGuardedIntegration(callback);
+  }
 }
 
 class PrintRecursionMockHub extends MockHub {

--- a/dart/test/default_integrations_test.dart
+++ b/dart/test/default_integrations_test.dart
@@ -123,6 +123,21 @@ void main() {
     expect(breadcrumb.message, 'foo bar');
   });
 
+  test(
+      'Run zoned guarded does not log calls to print as breadcrumb if disabled',
+      () async {
+    fixture.options.enablePrintBreadcrumbs = false;
+    Future<void> callback() async {
+      print('foo bar');
+    }
+
+    final integration = RunZonedGuardedIntegration(callback);
+
+    await integration(fixture.hub, fixture.options);
+
+    expect(fixture.hub.addBreadcrumbCalls.length, 0);
+  });
+
   test('Run zoned guarded: No addBreadcrumb calls for disabled Hub', () async {
     await fixture.hub.close();
 

--- a/dart/test/mocks/mock_hub.dart
+++ b/dart/test/mocks/mock_hub.dart
@@ -7,6 +7,7 @@ class MockHub implements Hub {
   List<AddBreadcrumbCall> addBreadcrumbCalls = [];
   List<SentryClient?> bindClientCalls = [];
   int closeCalls = 0;
+  bool _isEnabled = true;
 
   @override
   void addBreadcrumb(Breadcrumb crumb, {dynamic hint}) {
@@ -61,6 +62,7 @@ class MockHub implements Hub {
   @override
   Future<void> close() async {
     closeCalls = closeCalls + 1;
+    _isEnabled = false;
   }
 
   @override
@@ -69,8 +71,7 @@ class MockHub implements Hub {
   }
 
   @override
-  // TODO: implement isEnabled
-  bool get isEnabled => throw UnimplementedError();
+  bool get isEnabled => _isEnabled;
 
   @override
   // TODO: implement lastEventId

--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -113,6 +113,12 @@ class MainScaffold extends StatelessWidget {
               child: const Text('Dart: Web request'),
               onPressed: () => makeWebRequest(context),
             ),
+            RaisedButton(
+              child: const Text('Record print() as breadcrumb'),
+              onPressed: () {
+                print('Foo bar');
+              },
+            ),
             if (UniversalPlatform.isIOS || UniversalPlatform.isMacOS)
               const CocoaExample(),
             if (UniversalPlatform.isAndroid) const AndroidExample(),

--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -116,7 +116,8 @@ class MainScaffold extends StatelessWidget {
             RaisedButton(
               child: const Text('Record print() as breadcrumb'),
               onPressed: () {
-                print('Foo bar');
+                print('A print breadcrumb');
+                Sentry.captureMessage('A message with a print() Breadcrumb');
               },
             ),
             if (UniversalPlatform.isIOS || UniversalPlatform.isMacOS)


### PR DESCRIPTION
## :scroll: Description
We can now record calls to `print()` as Breadcrumbs.

- One can easily run into recursion. I added a tests so that it should not happen. See comments.
- Should this be an option in `SentryOptions`? -> Yes

Example event: https://sentry.io/share/issue/9aba382a0ae649baafaea54522729709/

## :bulb: Motivation and Context
Closes https://github.com/getsentry/sentry-dart/issues/423


## :green_heart: How did you test it?
I've written new tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
