### PR TITLE
Fix: Use correct environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Bump: sentry-cocoa to v7.0.0 (#424)
 * Feat: Support for Out-of-Memory-Tracking on macOS/iOS (#424)
 * Fix: Trim `\u0000` from Windows package info (#420)
+* Fix: `dist` was read from `SENTRY_DSN`, now it's read from `SENTRY_DIST` (#442)
 
 # 5.0.0
 

--- a/dart/lib/src/environment_variables.dart
+++ b/dart/lib/src/environment_variables.dart
@@ -7,7 +7,7 @@ class EnvironmentVariables {
   static const _sentryEnvironment = 'SENTRY_ENVIRONMENT';
   static const _sentryDsn = 'SENTRY_DSN';
   static const _sentryRelease = 'SENTRY_RELEASE';
-  static const _sentryDist = 'SENTRY_DSN';
+  static const _sentryDist = 'SENTRY_DIST';
 
   /// `SENTRY_ENVIRONMENT`
   /// See [SentryOptions.environment]


### PR DESCRIPTION
## :scroll: Description
The `dist` was also read from `SENTRY_DSN`. That is clearly wrong.


## :bulb: Motivation and Context
See description


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
