### PR TITLE
Fix integration adding in browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Feature: Log calls to `print()` as Breadcrumbs (#439)
 * Fix: `dist` was read from `SENTRY_DSN`, now it's read from `SENTRY_DIST` (#442)
 * Bump: sentry-cocoa to v7.0.3 (#445)
+* Fix: Fix adding integrations on web (#450)
 
 # 5.0.0
 

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -89,12 +89,14 @@ mixin SentryFlutter {
     }
 
     // Will enrich events with device context, native packages and integrations
-    if (options.platformChecker.platform.isIOS ||
-        options.platformChecker.platform.isMacOS) {
+    if (!options.platformChecker.isWeb &&
+        (options.platformChecker.platform.isIOS ||
+            options.platformChecker.platform.isMacOS)) {
       integrations.add(LoadContextsIntegration(channel));
     }
 
-    if (options.platformChecker.platform.isAndroid) {
+    if (!options.platformChecker.isWeb &&
+        options.platformChecker.platform.isAndroid) {
       integrations.add(LoadAndroidImageListIntegration(channel));
     }
 

--- a/flutter/test/sentry_flutter_test.dart
+++ b/flutter/test/sentry_flutter_test.dart
@@ -142,6 +142,67 @@ void main() {
         ),
       );
     });
+
+    test('Web && (iOS || macOS) ', () async {
+      // Tests that iOS || macOS integrations aren't added on a browswer which
+      // runs on iOS or macOS
+      await SentryFlutter.init(
+        getConfigurationTester(
+          hasFileSystemTransport: false,
+          shouldHaveIntegrations: platformAgnosticIntegrations,
+          shouldNotHaveIntegrations: [
+            ...androidIntegrations,
+            ...iOsAndMacOsIntegrations,
+            ...nativeIntegrations,
+          ],
+        ),
+        appRunner: appRunner,
+        packageLoader: loadTestPackage,
+        platformChecker: getPlatformChecker(
+          isWeb: true,
+          platform: MockPlatform.iOs(),
+        ),
+      );
+
+      await SentryFlutter.init(
+        getConfigurationTester(
+          hasFileSystemTransport: false,
+          shouldHaveIntegrations: platformAgnosticIntegrations,
+          shouldNotHaveIntegrations: [
+            ...androidIntegrations,
+            ...iOsAndMacOsIntegrations,
+            ...nativeIntegrations,
+          ],
+        ),
+        appRunner: appRunner,
+        packageLoader: loadTestPackage,
+        platformChecker: getPlatformChecker(
+          isWeb: true,
+          platform: MockPlatform.macOs(),
+        ),
+      );
+    });
+
+    test('Web && Android', () async {
+      // Tests that Android integrations aren't added on an Android browswer
+      await SentryFlutter.init(
+        getConfigurationTester(
+          hasFileSystemTransport: false,
+          shouldHaveIntegrations: platformAgnosticIntegrations,
+          shouldNotHaveIntegrations: [
+            ...androidIntegrations,
+            ...iOsAndMacOsIntegrations,
+            ...nativeIntegrations,
+          ],
+        ),
+        appRunner: appRunner,
+        packageLoader: loadTestPackage,
+        platformChecker: getPlatformChecker(
+          isWeb: true,
+          platform: MockPlatform.android(),
+        ),
+      );
+    });
   });
 
   group('initial values', () {


### PR DESCRIPTION
## :scroll: Description
Fixes a bug where iOS/macOS integrations were added on an iOS/macOS browser. The same happened also on Android.

## :bulb: Motivation and Context

## :green_heart: How did you test it?
I've added regression tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
