### PR TITLE
Fix: Add missing `SentryDevice` properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Fix: Fix adding integrations on web (#450)
 * Fix: Use `log()` instead of `print()` for SDK logging (#453)
 * Feature: Add `withScope` callback to capture methods (#463)
+* Fix: Add missing `language`, `screenHeightPixels` and `screenWidthPixels` to `SentryDevice`
 
 # 5.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 * Fix: Fix adding integrations on web (#450)
 * Fix: Use `log()` instead of `print()` for SDK logging (#453)
 * Feature: Add `withScope` callback to capture methods (#463)
-* Fix: Add missing `language`, `screenHeightPixels` and `screenWidthPixels` to `SentryDevice`
+* Fix: Add missing properties `language`, `screenHeightPixels` and `screenWidthPixels` to `SentryDevice` (#465)
 
 # 5.0.0
 

--- a/dart/lib/src/protocol/sentry_device.dart
+++ b/dart/lib/src/protocol/sentry_device.dart
@@ -19,6 +19,8 @@ class SentryDevice {
     this.manufacturer,
     this.brand,
     this.screenResolution,
+    this.screenHeightPixels,
+    this.screenWidthPixels,
     this.screenDensity,
     this.screenDpi,
     this.online,
@@ -34,6 +36,7 @@ class SentryDevice {
     this.externalFreeStorage,
     this.bootTime,
     this.timezone,
+    this.language,
   }) : assert(
           batteryLevel == null || (batteryLevel >= 0 && batteryLevel <= 100),
         );
@@ -49,6 +52,8 @@ class SentryDevice {
         manufacturer: data['manufacturer'],
         brand: data['brand'],
         screenResolution: data['screen_resolution'],
+        screenHeightPixels: data['screen_height_pixels'],
+        screenWidthPixels: data['screen_width_pixels'],
         screenDensity: data['screen_density'],
         screenDpi: data['screen_dpi'],
         online: data['online'],
@@ -66,6 +71,7 @@ class SentryDevice {
             ? DateTime.tryParse(data['boot_time'])
             : null,
         timezone: data['timezone'],
+        language: data['language'],
       );
 
   /// The name of the device. This is typically a hostname.
@@ -102,6 +108,12 @@ class SentryDevice {
 
   /// The screen resolution. (e.g.: `800x600`, `3040x1444`).
   final String? screenResolution;
+
+  /// The screen height in pixels. (e.g.: `600`, `1080`).
+  final int? screenHeightPixels;
+
+  /// The screen width in pixels. (e.g.: `800`, `1920`).
+  final int? screenWidthPixels;
 
   /// A floating point denoting the screen density.
   final double? screenDensity;
@@ -149,6 +161,9 @@ class SentryDevice {
 
   /// The timezone of the device, e.g.: `Europe/Vienna`.
   final String? timezone;
+
+  /// The language of the device, e.g.: `en_US`.
+  final String? language;
 
   /// Produces a [Map] that can be serialized to JSON.
   Map<String, dynamic> toJson() {
@@ -206,6 +221,14 @@ class SentryDevice {
 
     if (screenResolution != null) {
       json['screen_resolution'] = screenResolution;
+    }
+
+    if (screenWidthPixels != null) {
+      json['screen_width_pixels'] = screenWidthPixels;
+    }
+
+    if (screenHeightPixels != null) {
+      json['screen_height_pixels'] = screenHeightPixels;
     }
 
     if (screenDensity != null) {
@@ -268,6 +291,10 @@ class SentryDevice {
       json['timezone'] = timezone;
     }
 
+    if (language != null) {
+      json['language'] = language;
+    }
+
     return json;
   }
 
@@ -310,6 +337,8 @@ class SentryDevice {
     String? manufacturer,
     String? brand,
     String? screenResolution,
+    int? screenHeightPixels,
+    int? screenWidthPixels,
     double? screenDensity,
     int? screenDpi,
     bool? online,
@@ -325,6 +354,7 @@ class SentryDevice {
     int? externalFreeStorage,
     DateTime? bootTime,
     String? timezone,
+    String? language,
   }) =>
       SentryDevice(
         name: name ?? this.name,
@@ -337,6 +367,8 @@ class SentryDevice {
         manufacturer: manufacturer ?? this.manufacturer,
         brand: brand ?? this.brand,
         screenResolution: screenResolution ?? this.screenResolution,
+        screenHeightPixels: screenHeightPixels ?? this.screenHeightPixels,
+        screenWidthPixels: screenWidthPixels ?? this.screenWidthPixels,
         screenDensity: screenDensity ?? this.screenDensity,
         screenDpi: screenDpi ?? this.screenDpi,
         online: online ?? this.online,
@@ -352,5 +384,6 @@ class SentryDevice {
         externalFreeStorage: externalFreeStorage ?? this.externalFreeStorage,
         bootTime: bootTime ?? this.bootTime,
         timezone: timezone ?? this.timezone,
+        language: language ?? this.language,
       );
 }

--- a/dart/test/protocol/device_test.dart
+++ b/dart/test/protocol/device_test.dart
@@ -30,6 +30,8 @@ void main() {
       manufacturer: 'manufacturer1',
       brand: 'brand1',
       screenResolution: '123x3451',
+      screenHeightPixels: 900,
+      screenWidthPixels: 700,
       screenDensity: 99.2,
       screenDpi: 99,
       online: true,
@@ -45,6 +47,7 @@ void main() {
       externalFreeStorage: 987654,
       bootTime: bootTime,
       timezone: 'Austria/Vienna',
+      language: 'en_US',
     );
 
     expect('name1', copy.name);
@@ -57,6 +60,8 @@ void main() {
     expect('manufacturer1', copy.manufacturer);
     expect('brand1', copy.brand);
     expect('123x3451', copy.screenResolution);
+    expect(900, copy.screenHeightPixels);
+    expect(700, copy.screenWidthPixels);
     expect(99.2, copy.screenDensity);
     expect(99, copy.screenDpi);
     expect(true, copy.online);
@@ -72,6 +77,7 @@ void main() {
     expect(987654, copy.externalFreeStorage);
     expect(bootTime, copy.bootTime);
     expect('Austria/Vienna', copy.timezone);
+    expect('en_US', copy.language);
   });
 }
 
@@ -86,6 +92,8 @@ SentryDevice _generate({DateTime? testBootTime}) => SentryDevice(
       manufacturer: 'manufacturer',
       brand: 'brand',
       screenResolution: '123x345',
+      screenHeightPixels: 600,
+      screenWidthPixels: 800,
       screenDensity: 99.1,
       screenDpi: 100,
       online: false,
@@ -101,4 +109,5 @@ SentryDevice _generate({DateTime? testBootTime}) => SentryDevice(
       externalFreeStorage: 98765,
       bootTime: testBootTime ?? DateTime.now(),
       timezone: 'Australia/Melbourne',
+      language: 'en_US',
     );


### PR DESCRIPTION
## :scroll: Description
This adds the properties `language`, `screenHeightPixels` and `screenWidthPixels` to `SentryDevice`.


## :bulb: Motivation and Context
This is part of https://github.com/getsentry/sentry-dart/issues/464


## :green_heart: How did you test it?
Added to existing tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
