### PR TITLE
Fix: New formatting with Flutter 2.2.0

### DIFF
--- a/flutter/lib/src/widgets_binding_observer.dart
+++ b/flutter/lib/src/widgets_binding_observer.dart
@@ -21,7 +21,7 @@ class SentryWidgetsBindingObserver with WidgetsBindingObserver {
   SentryWidgetsBindingObserver({
     Hub? hub,
     required SentryFlutterOptions options,
-  })   : _hub = hub ?? HubAdapter(),
+  })  : _hub = hub ?? HubAdapter(),
         _options = options;
 
   final Hub _hub;


### PR DESCRIPTION
## :scroll: Description
Flutter format found a new violation now that we're at Dart 2.13 and Flutter 2.2.0. This fixes the formatting.

_#skip-changelog_


## :bulb: Motivation and Context
See above


## :green_heart: How did you test it?
No code changes, just formatting

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
