### PR TITLE
Feat: Make `beforeSend` async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 
 * Feat: Add Culture Context (#491)
-* Feat: `beforeSend` callback accepts async code
+* Feat: `beforeSend` callback accepts async code (#494)
 
 ## Breaking Changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Feat: Add Culture Context (#491)
+* Feat: `beforeSend` callback accepts async code
 
 ## Breaking Changes:
 

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -91,7 +91,7 @@ class SentryClient {
     final beforeSend = _options.beforeSend;
     if (beforeSend != null) {
       try {
-        preparedEvent = beforeSend(preparedEvent, hint: hint);
+        preparedEvent = await beforeSend(preparedEvent, hint: hint);
       } catch (err) {
         _options.logger(
           SentryLevel.error,

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:developer';
 
 import 'package:http/http.dart';
@@ -242,8 +243,10 @@ class SentryOptions {
 
 /// This function is called with an SDK specific event object and can return a modified event
 /// object or nothing to skip reporting the event
-typedef BeforeSendCallback = SentryEvent? Function(SentryEvent event,
-    {dynamic hint});
+typedef BeforeSendCallback = FutureOr<SentryEvent?> Function(
+  SentryEvent event, {
+  dynamic hint,
+});
 
 /// This function is called with an SDK specific breadcrumb object before the breadcrumb is added
 /// to the scope. When nothing is returned from the function, the breadcrumb is dropped


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
Closes https://github.com/getsentry/sentry-dart/issues/459


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
