### PR TITLE
Ref: Use Duration class for time intervals in SentryOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Feat: Add Culture Context (#491)
 * Feat: Capture failed requests as event (#473)
 * Feat: `beforeSend` callback accepts async code (#494)
+* Feat: Change timespans to Durations in SentryOptions (#504)
 
 ## Breaking Changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 * Feat: Add Culture Context (#491)
 * Feat: Capture failed requests as event (#473)
 * Feat: `beforeSend` callback accepts async code (#494)
-* Feat: Change timespans to Durations in SentryOptions (#504)
 
 ## Breaking Changes:
 
@@ -14,6 +13,7 @@
   * The method signature of `Transport` changed from `Future<SentryId> send(SentryEvent event)` to `Future<SentryId> send(SentryEnvelope envelope)`
 * Remove `Sentry.currentHub` (#490)
 * Ref: Rename `cacheDirSize` to `maxCacheItems` and add `maxCacheItems` for iOS (#495)
+* Feat: Change timespans to Durations in SentryOptions (#504)
 
 # 5.1.0
 

--- a/flutter/lib/src/default_integrations.dart
+++ b/flutter/lib/src/default_integrations.dart
@@ -209,7 +209,7 @@ class NativeSdkIntegration extends Integration<SentryFlutterOptions> {
         'attachStacktrace': options.attachStacktrace,
         'attachThreads': options.attachThreads,
         'autoSessionTrackingIntervalMillis':
-            options.autoSessionTrackingIntervalMillis,
+            options.autoSessionTrackingInterval.abs().inMilliseconds,
         'dist': options.dist,
         'integrations': options.sdk.integrations,
         'packages':
@@ -217,7 +217,8 @@ class NativeSdkIntegration extends Integration<SentryFlutterOptions> {
         'diagnosticLevel': options.diagnosticLevel.name,
         'maxBreadcrumbs': options.maxBreadcrumbs,
         'anrEnabled': options.anrEnabled,
-        'anrTimeoutIntervalMillis': options.anrTimeoutIntervalMillis,
+        'anrTimeoutIntervalMillis':
+            options.anrTimeoutInterval.abs().inMilliseconds,
         'enableAutoNativeBreadcrumbs': options.enableAutoNativeBreadcrumbs,
         'maxCacheItems': options.maxCacheItems,
         'sendDefaultPii': options.sendDefaultPii,

--- a/flutter/lib/src/default_integrations.dart
+++ b/flutter/lib/src/default_integrations.dart
@@ -209,7 +209,7 @@ class NativeSdkIntegration extends Integration<SentryFlutterOptions> {
         'attachStacktrace': options.attachStacktrace,
         'attachThreads': options.attachThreads,
         'autoSessionTrackingIntervalMillis':
-            options.autoSessionTrackingInterval.abs().inMilliseconds,
+            options.autoSessionTrackingInterval.inMilliseconds,
         'dist': options.dist,
         'integrations': options.sdk.integrations,
         'packages':
@@ -217,8 +217,7 @@ class NativeSdkIntegration extends Integration<SentryFlutterOptions> {
         'diagnosticLevel': options.diagnosticLevel.name,
         'maxBreadcrumbs': options.maxBreadcrumbs,
         'anrEnabled': options.anrEnabled,
-        'anrTimeoutIntervalMillis':
-            options.anrTimeoutInterval.abs().inMilliseconds,
+        'anrTimeoutIntervalMillis': options.anrTimeoutInterval.inMilliseconds,
         'enableAutoNativeBreadcrumbs': options.enableAutoNativeBreadcrumbs,
         'maxCacheItems': options.maxCacheItems,
         'sendDefaultPii': options.sendDefaultPii,

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -25,18 +25,26 @@ class SentryFlutterOptions extends SentryOptions {
   /// feature, as this is required to mark Sessions as Crashed.
   bool enableNativeCrashHandling = true;
 
-  int _autoSessionTrackingIntervalMillis = 30000;
-
   /// The session tracking interval in millis. This is the interval to end a
   /// session if the App goes to the background.
   /// See: [enableAutoSessionTracking]
+  @Deprecated('Use autoSessionTrackingInterval instead')
   int get autoSessionTrackingIntervalMillis =>
-      _autoSessionTrackingIntervalMillis;
+      autoSessionTrackingInterval.inMilliseconds;
 
+  @Deprecated('Use autoSessionTrackingInterval instead')
   set autoSessionTrackingIntervalMillis(int value) {
-    _autoSessionTrackingIntervalMillis =
-        value >= 0 ? value : _autoSessionTrackingIntervalMillis;
+    autoSessionTrackingInterval = value >= 0
+        ? Duration(milliseconds: value)
+        : autoSessionTrackingInterval;
   }
+
+  /// The session tracking interval. This is the interval to end a
+  /// session if the App goes to the background.
+  /// Default is 30 seconds/30000 milliseconds.
+  /// See: [enableAutoSessionTracking]
+  /// Always uses the given duration as a positiv timespan.
+  Duration autoSessionTrackingInterval = Duration(milliseconds: 30000);
 
   /// Enable or disable ANR (Application Not Responding).
   /// Available only for Android.
@@ -45,16 +53,23 @@ class SentryFlutterOptions extends SentryOptions {
   /// Java/Kotlin code as well.
   bool anrEnabled = false;
 
-  int _anrTimeoutIntervalMillis = 5000;
-
   /// ANR Timeout internal in Millis Default is 5000 = 5s Used by AnrIntegration.
   /// Available only for Android.
   /// See: [anrEnabled]
-  int get anrTimeoutIntervalMillis => _anrTimeoutIntervalMillis;
+  @Deprecated('Use anrTimeoutInterval instead')
+  int get anrTimeoutIntervalMillis => anrTimeoutInterval.inMilliseconds;
 
+  @Deprecated('Use anrTimeoutInterval instead')
   set anrTimeoutIntervalMillis(int value) {
-    _anrTimeoutIntervalMillis = value >= 0 ? value : _anrTimeoutIntervalMillis;
+    anrTimeoutInterval =
+        value >= 0 ? Duration(milliseconds: value) : anrTimeoutInterval;
   }
+
+  /// ANR Timeout internal. Default is 5000 milliseconds or 5 seconds.
+  /// Used by Androids AnrIntegration. Available only on Android.
+  /// See: [anrEnabled]
+  /// Always uses the given duration as a positiv timespan.
+  Duration anrTimeoutInterval = Duration(milliseconds: 5000);
 
   /// Enable or disable the Automatic breadcrumbs on the Native platforms (Android/iOS)
   /// Screen's lifecycle, App's lifecycle, System events, etc...

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -39,12 +39,20 @@ class SentryFlutterOptions extends SentryOptions {
         : autoSessionTrackingInterval;
   }
 
+  Duration _autoSessionTrackingInterval = Duration(milliseconds: 30000);
+
   /// The session tracking interval. This is the interval to end a
   /// session if the App goes to the background.
   /// Default is 30 seconds/30000 milliseconds.
   /// See: [enableAutoSessionTracking]
   /// Always uses the given duration as a positiv timespan.
-  Duration autoSessionTrackingInterval = Duration(milliseconds: 30000);
+  Duration get autoSessionTrackingInterval => _autoSessionTrackingInterval;
+
+  set autoSessionTrackingInterval(Duration value) {
+    assert(!value.isNegative);
+    assert(value > Duration.zero);
+    _autoSessionTrackingInterval = value;
+  }
 
   /// Enable or disable ANR (Application Not Responding).
   /// Available only for Android.
@@ -61,15 +69,24 @@ class SentryFlutterOptions extends SentryOptions {
 
   @Deprecated('Use anrTimeoutInterval instead')
   set anrTimeoutIntervalMillis(int value) {
+    assert(value > 0);
     anrTimeoutInterval =
-        value >= 0 ? Duration(milliseconds: value) : anrTimeoutInterval;
+        value > 0 ? Duration(milliseconds: value) : anrTimeoutInterval;
   }
+
+  Duration _anrTimeoutInterval = Duration(milliseconds: 5000);
 
   /// ANR Timeout internal. Default is 5000 milliseconds or 5 seconds.
   /// Used by Androids AnrIntegration. Available only on Android.
   /// See: [anrEnabled]
   /// Always uses the given duration as a positiv timespan.
-  Duration anrTimeoutInterval = Duration(milliseconds: 5000);
+  Duration get anrTimeoutInterval => _anrTimeoutInterval;
+
+  set anrTimeoutInterval(Duration value) {
+    assert(!value.isNegative);
+    assert(value > Duration.zero);
+    _anrTimeoutInterval = value;
+  }
 
   /// Enable or disable the Automatic breadcrumbs on the Native platforms (Android/iOS)
   /// Screen's lifecycle, App's lifecycle, System events, etc...

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -49,7 +49,6 @@ class SentryFlutterOptions extends SentryOptions {
   Duration get autoSessionTrackingInterval => _autoSessionTrackingInterval;
 
   set autoSessionTrackingInterval(Duration value) {
-    assert(!value.isNegative);
     assert(value > Duration.zero);
     _autoSessionTrackingInterval = value;
   }
@@ -83,7 +82,6 @@ class SentryFlutterOptions extends SentryOptions {
   Duration get anrTimeoutInterval => _anrTimeoutInterval;
 
   set anrTimeoutInterval(Duration value) {
-    assert(!value.isNegative);
     assert(value > Duration.zero);
     _anrTimeoutInterval = value;
   }

--- a/flutter/test/native_sdk_integration_test.dart
+++ b/flutter/test/native_sdk_integration_test.dart
@@ -70,12 +70,12 @@ void main() {
         ..enableNativeCrashHandling = false
         ..attachStacktrace = false
         ..attachThreads = true
-        ..autoSessionTrackingIntervalMillis = 240000
+        ..autoSessionTrackingInterval = Duration(milliseconds: 240000)
         ..dist = 'distfoo'
         ..diagnosticLevel = SentryLevel.error
         ..maxBreadcrumbs = 0
         ..anrEnabled = false
-        ..anrTimeoutIntervalMillis = 0
+        ..anrTimeoutInterval = Duration.zero
         ..enableAutoNativeBreadcrumbs = false
         ..maxCacheItems = 0
         ..sendDefaultPii = true

--- a/flutter/test/native_sdk_integration_test.dart
+++ b/flutter/test/native_sdk_integration_test.dart
@@ -75,7 +75,7 @@ void main() {
         ..diagnosticLevel = SentryLevel.error
         ..maxBreadcrumbs = 0
         ..anrEnabled = false
-        ..anrTimeoutInterval = Duration.zero
+        ..anrTimeoutInterval = Duration(seconds: 1)
         ..enableAutoNativeBreadcrumbs = false
         ..maxCacheItems = 0
         ..sendDefaultPii = true
@@ -108,7 +108,7 @@ void main() {
         'diagnosticLevel': 'error',
         'maxBreadcrumbs': 0,
         'anrEnabled': false,
-        'anrTimeoutIntervalMillis': 0,
+        'anrTimeoutIntervalMillis': 1000,
         'enableAutoNativeBreadcrumbs': false,
         'maxCacheItems': 0,
         'sendDefaultPii': true,


### PR DESCRIPTION
## :scroll: Description
Use Duration instead of ints for time spans in SentryOptions.
Old options are still existing but marked as deprecated, so not breaking.


## :bulb: Motivation and Context
Closes #497


## :green_heart: How did you test it?
Existing tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
