### PR TITLE
Fixed LateInitializationError

### DIFF
--- a/dart/lib/src/isolate_error_integration.dart
+++ b/dart/lib/src/isolate_error_integration.dart
@@ -10,21 +10,23 @@ import 'sentry_options.dart';
 import 'throwable_mechanism.dart';
 
 class IsolateErrorIntegration extends Integration {
-  late RawReceivePort _receivePort;
+  RawReceivePort? _receivePort;
 
   @override
   FutureOr<void> call(Hub hub, SentryOptions options) async {
     _receivePort = _createPort(hub, options);
 
-    Isolate.current.addErrorListener(_receivePort.sendPort);
+    Isolate.current.addErrorListener(_receivePort!.sendPort);
 
     options.sdk.addIntegration('isolateErrorIntegration');
   }
 
   @override
   void close() {
-    _receivePort.close();
-    Isolate.current.removeErrorListener(_receivePort.sendPort);
+    if (_receivePort != null) {
+      _receivePort!.close();
+      Isolate.current.removeErrorListener(_receivePort!.sendPort);
+    }
   }
 }
 


### PR DESCRIPTION
Fix for #508

## :scroll: Description
Updated the class `IsolatedErrorIntegration` to handle the case where the `close` method is called before the `_receivePort` being initialized.


## :bulb: Motivation and Context
I was seeing an error when reinitializing the Sentry SDK with different options.

Closes #508


## :green_heart: How did you test it?
I edited the source files locally and the error disappeared.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes

