### PR TITLE
Ref: Disable print breadcrumbs on Flutter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Ref: Disable `print()` breadcrumbs by default on Flutter
+
 # 6.0.0-beta.1
 
 * Feat: Browser detection (#502)

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -174,6 +174,9 @@ class SentryOptions {
 
   /// Enable this option if you want to record calls to `print()` as
   /// breadcrumbs.
+  /// Enabling this on Flutter can result in excessive breadcrumbs as
+  /// [FlutterError.reportError](https://api.flutter.dev/flutter/foundation/FlutterError/reportError.html)
+  /// prints to console via `print()`.
   bool enablePrintBreadcrumbs = true;
 
   /// If [platformChecker] is provided, it is used get the envirnoment.

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -9,6 +9,7 @@ class SentryFlutterOptions extends SentryOptions {
   SentryFlutterOptions({String? dsn, PlatformChecker? checker})
       : super(dsn: dsn, checker: checker) {
     enableBreadcrumbTrackingForCurrentPlatform();
+    enablePrintBreadcrumbs = false;
   }
 
   /// Enable or disable the Auto session tracking on the Native SDKs (Android/iOS)

--- a/flutter/test/sentry_flutter_options_test.dart
+++ b/flutter/test/sentry_flutter_options_test.dart
@@ -55,5 +55,12 @@ void main() {
       expect(options.enableMemoryPressureBreadcrumbs, isTrue);
       expect(options.enableAutoNativeBreadcrumbs, isFalse);
     });
+
+    testWidgets('enablePrintBreadcrumbs is disabled on Flutter by default',
+        (WidgetTester tester) async {
+      final options = SentryFlutterOptions();
+
+      expect(options.enablePrintBreadcrumbs, isFalse);
+    });
   });
 }


### PR DESCRIPTION
## :scroll: Description
This disables print() breadcrumbs on Flutter

## :bulb: Motivation and Context
#492


## :green_heart: How did you test it?
New test 

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
