### PR TITLE
Update PackageInfoPlus usages to make CI green

### DIFF
--- a/flutter/test/default_integrations_test.dart
+++ b/flutter/test/default_integrations_test.dart
@@ -257,6 +257,7 @@ void main() {
           packageName: '',
           version: '1.2.3',
           buildNumber: '789',
+          buildSignature: '',
         ));
       };
       await fixture
@@ -275,6 +276,7 @@ void main() {
           packageName: '',
           version: '1.2.3',
           buildNumber: '789',
+          buildSignature: '',
         ));
       };
       await fixture
@@ -299,6 +301,7 @@ void main() {
           packageName: '',
           version: '1.0.0\u{0000}',
           buildNumber: '',
+          buildSignature: '',
         ));
       };
       await fixture
@@ -323,6 +326,7 @@ void main() {
           packageName: 'sentry_flutter_example\u{0000}',
           version: '',
           buildNumber: '123\u{0000}',
+          buildSignature: '',
         ));
       };
       await fixture
@@ -339,6 +343,7 @@ void main() {
           packageName: 'a.b.c',
           version: '1.0.0',
           buildNumber: '',
+          buildSignature: '',
         ));
       };
       await fixture
@@ -364,6 +369,7 @@ class Fixture {
       packageName: 'foo.bar',
       version: '1.2.3',
       buildNumber: '789',
+      buildSignature: '',
     ));
   }
 }

--- a/flutter/test/sentry_flutter_test.dart
+++ b/flutter/test/sentry_flutter_test.dart
@@ -241,6 +241,7 @@ Future<PackageInfo> loadTestPackage() async {
     packageName: 'packageName',
     version: 'version',
     buildNumber: 'buildNumber',
+    buildSignature: '',
   );
 }
 


### PR DESCRIPTION
## :scroll: Description
There's an update which requires us to update our test usages to make it compatible with the latest version.

_#skip-changelog_


## :bulb: Motivation and Context
All other PRs are currently failing due to this.

## :green_heart: How did you test it?
This is a test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
