### PR TITLE
Set timeout on CI to 15 minutes

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -11,6 +11,7 @@ jobs:
   build:
     name: Build ${{matrix.sdk}} on ${{matrix.os}}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: ./dart
@@ -53,6 +54,7 @@ jobs:
 
   analyze:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: ./dart
@@ -68,6 +70,7 @@ jobs:
 
   package-analysis:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v2
       - uses: axel-op/dart-package-analyzer@v3

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -11,6 +11,7 @@ jobs:
   build:
     name: ${{ matrix.target }} | ${{ matrix.os }} | ${{ matrix.channel }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       # max-parallel: 4
@@ -109,6 +110,7 @@ jobs:
 
   analyze:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1
@@ -120,6 +122,7 @@ jobs:
 
   package-analysis:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v2
       - uses: axel-op/dart-package-analyzer@d56ba070e9dcacc6d8ba48a41938b1e2b973de41


### PR DESCRIPTION
## :scroll: Description
Sometimes the tests do not work correctly and they take ages to complete. This PR introduces a significantly reduced timeout to abort CI runs.

_#skip-changelog_

## :bulb: Motivation and Context
Part of #500


## :green_heart: How did you test it?
This is just CI stuff.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
