### PR TITLE
Fix: Always call Flutter.onError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 
 * Enhancement: Call `toString()` on all non-serializable fields (#528)
-* Fix: Always call `Flutter.onError` in order to not swallow messages
+* Fix: Always call `Flutter.onError` in order to not swallow messages (#533)
 
 # 6.0.0-beta.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Enhancement: Call `toString()` on all non-serializable fields (#528)
+* Fix: Always call `Flutter.onError` in order to not swallow messages
 
 # 6.0.0-beta.2
 

--- a/flutter/lib/src/default_integrations.dart
+++ b/flutter/lib/src/default_integrations.dart
@@ -73,7 +73,7 @@ class FlutterErrorIntegration extends Integration<SentryFlutterOptions> {
         );
       }
       // Call original handler, regardless of `errorDetails.silent` or
-      // `reportSilentFlutterErrors`. This ensures, that we doen't swallow
+      // `reportSilentFlutterErrors`. This ensures, that we don't swallow
       // messages.
       if (_defaultOnError != null) {
         _defaultOnError!(errorDetails);

--- a/flutter/lib/src/default_integrations.dart
+++ b/flutter/lib/src/default_integrations.dart
@@ -62,12 +62,6 @@ class FlutterErrorIntegration extends Integration<SentryFlutterOptions> {
         );
 
         await hub.captureEvent(event, stackTrace: errorDetails.stack);
-
-        // call original handler
-        if (_defaultOnError != null) {
-          _defaultOnError!(errorDetails);
-        }
-
         // we don't call Zone.current.handleUncaughtError because we'd like
         // to set a specific mechanism for FlutterError.onError.
       } else {
@@ -77,6 +71,12 @@ class FlutterErrorIntegration extends Integration<SentryFlutterOptions> {
           'Enable [SentryFlutterOptions.reportSilentFlutterErrors] '
           'if you wish to capture silent errors',
         );
+      }
+      // Call original handler, regardless of `errorDetails.silent` or
+      // `reportSilentFlutterErrors`. This ensures, that we doen't swallow
+      // messages.
+      if (_defaultOnError != null) {
+        _defaultOnError!(errorDetails);
       }
     };
     FlutterError.onError = _integrationOnError;


### PR DESCRIPTION
## :scroll: Description
See motivation


## :bulb: Motivation and Context
Closes #522


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
