### PR TITLE
Replace package_info_plus instead by package_info

### DIFF
--- a/flutter/example/windows/flutter/generated_plugin_registrant.cc
+++ b/flutter/example/windows/flutter/generated_plugin_registrant.cc
@@ -1,0 +1,14 @@
+//
+//  Generated file. Do not edit.
+//
+
+// clang-format off
+
+#include "generated_plugin_registrant.h"
+
+#include <sentry_flutter/sentry_flutter_plugin.h>
+
+void RegisterPlugins(flutter::PluginRegistry* registry) {
+  SentryFlutterPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("SentryFlutterPlugin"));
+}

--- a/flutter/example/windows/flutter/generated_plugin_registrant.h
+++ b/flutter/example/windows/flutter/generated_plugin_registrant.h
@@ -1,0 +1,15 @@
+//
+//  Generated file. Do not edit.
+//
+
+// clang-format off
+
+#ifndef GENERATED_PLUGIN_REGISTRANT_
+#define GENERATED_PLUGIN_REGISTRANT_
+
+#include <flutter/plugin_registry.h>
+
+// Registers Flutter plugins.
+void RegisterPlugins(flutter::PluginRegistry* registry);
+
+#endif  // GENERATED_PLUGIN_REGISTRANT_

--- a/flutter/example/windows/flutter/generated_plugins.cmake
+++ b/flutter/example/windows/flutter/generated_plugins.cmake
@@ -1,0 +1,16 @@
+#
+# Generated file, do not edit.
+#
+
+list(APPEND FLUTTER_PLUGIN_LIST
+  sentry_flutter
+)
+
+set(PLUGIN_BUNDLED_LIBRARIES)
+
+foreach(plugin ${FLUTTER_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${plugin}/windows plugins/${plugin})
+  target_link_libraries(${BINARY_NAME} PRIVATE ${plugin}_plugin)
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES $<TARGET_FILE:${plugin}_plugin>)
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${plugin}_bundled_libraries})
+endforeach(plugin)

--- a/flutter/lib/src/default_integrations.dart
+++ b/flutter/lib/src/default_integrations.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/services.dart';
-import 'package:package_info_plus/package_info_plus.dart';
+import 'package:package_info/package_info.dart';
 import 'package:sentry/sentry.dart';
 import 'sentry_flutter_options.dart';
 import 'widgets_binding_observer.dart';

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/services.dart';
-import 'package:package_info_plus/package_info_plus.dart';
+import 'package:package_info/package_info.dart';
 import 'package:sentry/sentry.dart';
 
 import 'flutter_enricher_event_processor.dart';

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   sentry: ^6.0.0-beta.1
-  package_info_plus: ^1.0.0
+  package_info: ^2.0.2
 
 dev_dependencies:
   flutter_test:

--- a/flutter/test/default_integrations_test.dart
+++ b/flutter/test/default_integrations_test.dart
@@ -5,7 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
-import 'package:package_info_plus/package_info_plus.dart';
+import 'package:package_info/package_info.dart';
 import 'package:sentry/sentry.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:sentry_flutter/src/sentry_flutter_options.dart';
@@ -257,7 +257,6 @@ void main() {
           packageName: '',
           version: '1.2.3',
           buildNumber: '789',
-          buildSignature: '',
         ));
       };
       await fixture
@@ -276,7 +275,6 @@ void main() {
           packageName: '',
           version: '1.2.3',
           buildNumber: '789',
-          buildSignature: '',
         ));
       };
       await fixture
@@ -301,7 +299,6 @@ void main() {
           packageName: '',
           version: '1.0.0\u{0000}',
           buildNumber: '',
-          buildSignature: '',
         ));
       };
       await fixture
@@ -326,7 +323,6 @@ void main() {
           packageName: 'sentry_flutter_example\u{0000}',
           version: '',
           buildNumber: '123\u{0000}',
-          buildSignature: '',
         ));
       };
       await fixture
@@ -343,7 +339,6 @@ void main() {
           packageName: 'a.b.c',
           version: '1.0.0',
           buildNumber: '',
-          buildSignature: '',
         ));
       };
       await fixture
@@ -369,7 +364,6 @@ class Fixture {
       packageName: 'foo.bar',
       version: '1.2.3',
       buildNumber: '789',
-      buildSignature: '',
     ));
   }
 }

--- a/flutter/test/sentry_flutter_test.dart
+++ b/flutter/test/sentry_flutter_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:package_info_plus/package_info_plus.dart';
+import 'package:package_info/package_info.dart';
 import 'package:sentry/sentry.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:sentry/src/platform_checker.dart';
@@ -241,7 +241,6 @@ Future<PackageInfo> loadTestPackage() async {
     packageName: 'packageName',
     version: 'version',
     buildNumber: 'buildNumber',
-    buildSignature: '',
   );
 }
 


### PR DESCRIPTION

## :scroll: Description
package_info_plus-1.0.4/android/src/main/java/dev/fluttercommunity/plus/packageinfo/PackageInfoPlugin.java uses or overrides a deprecated API.



## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
