### PR TITLE
Feat: Add some more information for exceptions collected via `FlutterError.onError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Enhancement: Call `toString()` on all non-serializable fields (#528)
 * Fix: Always call `Flutter.onError` in order to not swallow messages (#533)
 * Bump: Android SDK to 5.1.0-beta.6 (#535)
+* Feat: Collect more information for exceptions collected via `FlutterError.onError`
 
 # 6.0.0-beta.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Unreleased
 
+* Feat: Collect more information for exceptions collected via `FlutterError.onError` (#538)
+
 # 6.0.0-beta.3
 
 * Fix: Re-initialization of Flutter SDK (#526)
 * Enhancement: Call `toString()` on all non-serializable fields (#528)
 * Fix: Always call `Flutter.onError` in order to not swallow messages (#533)
 * Bump: Android SDK to 5.1.0-beta.6 (#535)
-* Feat: Collect more information for exceptions collected via `FlutterError.onError` (#538)
 
 # 6.0.0-beta.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Enhancement: Call `toString()` on all non-serializable fields (#528)
 * Fix: Always call `Flutter.onError` in order to not swallow messages (#533)
 * Bump: Android SDK to 5.1.0-beta.6 (#535)
-* Feat: Collect more information for exceptions collected via `FlutterError.onError`
+* Feat: Collect more information for exceptions collected via `FlutterError.onError` (#538)
 
 # 6.0.0-beta.2
 

--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -147,6 +147,26 @@ class MainScaffold extends StatelessWidget {
                   () => throw Exception('Throws in Future.delayed')),
             ),
             RaisedButton(
+              child: const Text('Capture from FlutterError.onError'),
+              onPressed: () {
+                // modeled after a real exception
+                FlutterError.onError?.call(FlutterErrorDetails(
+                  exception: Exception('A really bad exception'),
+                  silent: false,
+                  context: DiagnosticsNode.message('while handling a gesture'),
+                  library: 'gesture',
+                  informationCollector: () => [
+                    DiagnosticsNode.message(
+                        'Handler: "onTap" Recognizer: TapGestureRecognizer'),
+                    DiagnosticsNode.message(
+                        'Handler: "onTap" Recognizer: TapGestureRecognizer'),
+                    DiagnosticsNode.message(
+                        'Handler: "onTap" Recognizer: TapGestureRecognizer'),
+                  ],
+                ));
+              },
+            ),
+            RaisedButton(
               child: const Text('Dart: Web request'),
               onPressed: () => makeWebRequest(context),
             ),

--- a/flutter/lib/src/default_integrations.dart
+++ b/flutter/lib/src/default_integrations.dart
@@ -64,7 +64,8 @@ class FlutterErrorIntegration extends Integration<SentryFlutterOptions> {
           type: 'FlutterError',
           handled: true,
           data: {
-            if (context != null) 'context': context,
+            // This is a message which should make sense if written after the word `thrown`: https://api.flutter.dev/flutter/foundation/FlutterErrorDetails/context.html
+            if (context != null) 'context': 'thrown $context',
             if (collector.isNotEmpty) 'information': information,
             if (library != null) 'library': library,
           },

--- a/flutter/lib/src/default_integrations.dart
+++ b/flutter/lib/src/default_integrations.dart
@@ -64,7 +64,9 @@ class FlutterErrorIntegration extends Integration<SentryFlutterOptions> {
           type: 'FlutterError',
           handled: true,
           data: {
-            // This is a message which should make sense if written after the word `thrown`: https://api.flutter.dev/flutter/foundation/FlutterErrorDetails/context.html
+            // This is a message which should make sense if written after the
+            // word `thrown`:
+            // https://api.flutter.dev/flutter/foundation/FlutterErrorDetails/context.html
             if (context != null) 'context': 'thrown $context',
             if (collector.isNotEmpty) 'information': information,
             if (library != null) 'library': library,

--- a/flutter/test/default_integrations_test.dart
+++ b/flutter/test/default_integrations_test.dart
@@ -46,6 +46,9 @@ void main() {
     final details = FlutterErrorDetails(
       exception: throwable,
       silent: silent,
+      context: DiagnosticsNode.message('while handling a gesture'),
+      library: 'sentry',
+      informationCollector: () => [DiagnosticsNode.message('foo bar')],
     );
     FlutterError.reportError(details);
   }
@@ -64,6 +67,10 @@ void main() {
     final throwableMechanism = event.throwableMechanism as ThrowableMechanism;
     expect(throwableMechanism.mechanism.type, 'FlutterError');
     expect(throwableMechanism.mechanism.handled, true);
+    expect(throwableMechanism.mechanism.data['library'], 'sentry');
+    expect(throwableMechanism.mechanism.data['context'],
+        'while handling a gesture');
+    expect(throwableMechanism.mechanism.data['information'], 'foo bar');
     expect(throwableMechanism.throwable, exception);
   });
 


### PR DESCRIPTION
## :scroll: Description
![Bildschirmfoto 2021-07-24 um 17 26 41](https://user-images.githubusercontent.com/1270149/126873278-7a17bcb7-dc5c-4432-b5e4-e5421887edd9.png)

The information in the red square is added by this PR.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?
Changed test accordingly

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
