### PR TITLE
Feat: HTTP Breadcrumbs with request/response size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Feat: Collect more information for exceptions collected via `FlutterError.onError` (#538)
+* Feat: HTTP breadcrumbs have the request & response size if available (#552)
 
 # 6.0.0-beta.3
 

--- a/dart/lib/src/http_client/breadcrumb_client.dart
+++ b/dart/lib/src/http_client/breadcrumb_client.dart
@@ -56,6 +56,7 @@ class BreadcrumbClient extends BaseClient {
     var requestHadException = false;
     int? statusCode;
     String? reason;
+    int? responseBodySize;
 
     final stopwatch = Stopwatch();
     stopwatch.start();
@@ -65,6 +66,7 @@ class BreadcrumbClient extends BaseClient {
 
       statusCode = response.statusCode;
       reason = response.reasonPhrase;
+      responseBodySize = response.contentLength;
 
       return response;
     } catch (_) {
@@ -80,6 +82,8 @@ class BreadcrumbClient extends BaseClient {
         statusCode: statusCode,
         reason: reason,
         requestDuration: stopwatch.elapsed,
+        requestBodySize: request.contentLength,
+        responseBodySize: responseBodySize,
       );
 
       _hub.addBreadcrumb(breadcrumb);

--- a/dart/lib/src/protocol/breadcrumb.dart
+++ b/dart/lib/src/protocol/breadcrumb.dart
@@ -2,8 +2,10 @@ import 'package:meta/meta.dart';
 
 import '../utils.dart';
 import 'sentry_level.dart';
+import '../protocol.dart';
 
-/// Structed data to describe more information pior to the event [captured][Sentry.captureEvent].
+/// Structed data to describe more information pior to the event captured.
+/// See `Sentry.captureEvent()`.
 ///
 /// The outgoing JSON representation is:
 ///
@@ -21,7 +23,7 @@ import 'sentry_level.dart';
 /// * https://develop.sentry.dev/sdk/event-payloads/breadcrumbs/
 @immutable
 class Breadcrumb {
-  /// Creates a breadcrumb that can be attached to an [Event].
+  /// Creates a breadcrumb that can be attached to an [SentryEvent].
   Breadcrumb({
     this.message,
     DateTime? timestamp,
@@ -40,6 +42,12 @@ class Breadcrumb {
     Duration? requestDuration,
     SentryLevel? level,
     DateTime? timestamp,
+
+    // Size of the request body in bytes
+    int? requestBodySize,
+
+    // Size of the response body in bytes
+    int? responseBodySize,
   }) {
     return Breadcrumb(
       type: 'http',
@@ -52,6 +60,8 @@ class Breadcrumb {
         if (statusCode != null) 'status_code': statusCode,
         if (reason != null) 'reason': reason,
         if (requestDuration != null) 'duration': requestDuration.toString(),
+        if (requestBodySize != null) 'request_body_size': requestBodySize,
+        if (responseBodySize != null) 'response_body_size': responseBodySize,
       },
     );
   }

--- a/dart/test/http_client/breadcrumb_client_test.dart
+++ b/dart/test/http_client/breadcrumb_client_test.dart
@@ -35,6 +35,8 @@ void main() {
       expect(breadcrumb.data?['status_code'], 200);
       expect(breadcrumb.data?['reason'], 'OK');
       expect(breadcrumb.data?['duration'], isNotNull);
+      expect(breadcrumb.data?['request_body_size'], isNotNull);
+      expect(breadcrumb.data?['response_body_size'], isNotNull);
     });
 
     test('GET: happy path for 404', () async {

--- a/dart/test/protocol/breadcrumb_test.dart
+++ b/dart/test/protocol/breadcrumb_test.dart
@@ -88,6 +88,8 @@ void main() {
       statusCode: 200,
       requestDuration: Duration.zero,
       timestamp: DateTime.now(),
+      requestBodySize: 2,
+      responseBodySize: 3,
     );
     final json = breadcrumb.toJson();
 
@@ -99,9 +101,30 @@ void main() {
         'method': 'GET',
         'status_code': 200,
         'reason': 'OK',
-        'duration': '0:00:00.000000'
+        'duration': '0:00:00.000000',
+        'request_body_size': 2,
+        'response_body_size': 3,
       },
       'level': 'fatal',
+      'type': 'http',
+    });
+  });
+
+  test('Minimal Breadcrumb http ctor', () {
+    final breadcrumb = Breadcrumb.http(
+      url: Uri.parse('https://example.org'),
+      method: 'GET',
+    );
+    final json = breadcrumb.toJson();
+
+    expect(json, {
+      'timestamp': formatDateAsIso8601WithMillisPrecision(breadcrumb.timestamp),
+      'category': 'http',
+      'data': {
+        'url': 'https://example.org',
+        'method': 'GET',
+      },
+      'level': 'info',
       'type': 'http',
     });
   });


### PR DESCRIPTION
## :scroll: Description
Added request and response size to HTTP breadcrumbs according to https://develop.sentry.dev/sdk/features/#http-client-integrations


## :bulb: Motivation and Context
See https://develop.sentry.dev/sdk/features/#http-client-integrations


## :green_heart: How did you test it?
I've added tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
