### PR TITLE
Set name of current route as transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Feat: Add current route as transaction (#560)
+
 # 6.0.0-beta.4
 
 ## Breaking Changes:

--- a/dart/lib/src/enricher/web_enricher_event_processor.dart
+++ b/dart/lib/src/enricher/web_enricher_event_processor.dart
@@ -29,6 +29,7 @@ class WebEnricherEventProcessor extends EventProcessor {
     return event.copyWith(
       contexts: contexts,
       request: _getRequest(event.request),
+      transaction: event.transaction ?? _window.location.pathname,
     );
   }
 

--- a/dart/test/enricher/web_enricher_test.dart
+++ b/dart/test/enricher/web_enricher_test.dart
@@ -16,6 +16,20 @@ void main() {
       fixture = Fixture();
     });
 
+    test('add path as transaction if transaction is null', () async {
+      var enricher = fixture.getSut();
+      final event = await enricher.apply(SentryEvent());
+
+      expect(event.transaction, isNotNull);
+    });
+
+    test("don't overwrite transaction", () async {
+      var enricher = fixture.getSut();
+      final event = await enricher.apply(SentryEvent(transaction: 'foobar'));
+
+      expect(event.transaction, 'foobar');
+    });
+
     test('add request with user-agent header', () async {
       var enricher = fixture.getSut();
       final event = await enricher.apply(SentryEvent());

--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -418,6 +418,12 @@ class SecondaryScaffold extends StatelessWidget {
                 Navigator.pop(context);
               },
             ),
+            MaterialButton(
+              child: const Text('throw uncaught exception'),
+              onPressed: () {
+                throw Exception('Exception from SecondaryScaffold');
+              },
+            ),
           ],
         ),
       ),

--- a/flutter/lib/src/navigation/sentry_navigator_observer.dart
+++ b/flutter/lib/src/navigation/sentry_navigator_observer.dart
@@ -35,13 +35,16 @@ const _navigationKey = 'navigation';
 ///   - [RouteObserver](https://api.flutter.dev/flutter/widgets/RouteObserver-class.html)
 ///   - [Navigating with arguments](https://flutter.dev/docs/cookbook/navigation/navigate-with-arguments)
 class SentryNavigatorObserver extends RouteObserver<PageRoute<dynamic>> {
-  SentryNavigatorObserver({Hub? hub}) : hub = hub ?? HubAdapter();
+  SentryNavigatorObserver({Hub? hub, this.setTransaction = true})
+      : _hub = hub ?? HubAdapter();
 
-  final Hub hub;
+  final Hub _hub;
+  final bool setTransaction;
 
   @override
   void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
     super.didPush(route, previousRoute);
+    setCurrentRoute(route.settings.name);
     _addBreadcrumb(
       type: 'didPush',
       from: previousRoute?.settings,
@@ -52,7 +55,7 @@ class SentryNavigatorObserver extends RouteObserver<PageRoute<dynamic>> {
   @override
   void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
     super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
-
+    setCurrentRoute(newRoute?.settings.name);
     _addBreadcrumb(
       type: 'didReplace',
       from: oldRoute?.settings,
@@ -63,7 +66,7 @@ class SentryNavigatorObserver extends RouteObserver<PageRoute<dynamic>> {
   @override
   void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
     super.didPop(route, previousRoute);
-
+    setCurrentRoute(previousRoute?.settings.name);
     _addBreadcrumb(
       type: 'didPop',
       from: route.settings,
@@ -76,11 +79,19 @@ class SentryNavigatorObserver extends RouteObserver<PageRoute<dynamic>> {
     RouteSettings? from,
     RouteSettings? to,
   }) {
-    hub.addBreadcrumb(RouteObserverBreadcrumb(
+    _hub.addBreadcrumb(RouteObserverBreadcrumb(
       navigationType: type,
       from: from,
       to: to,
     ));
+  }
+
+  void setCurrentRoute(String? name) {
+    if (setTransaction) {
+      _hub.configureScope((scope) {
+        scope.transaction = name;
+      });
+    }
   }
 }
 


### PR DESCRIPTION
## :scroll: Description
This change adds the current route as `SentryEvent.transaction`.

## :bulb: Motivation and Context
https://develop.sentry.dev/sdk/event-payloads/ suggests to use the current route as transaction name.


## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
