### PR TITLE
Feat: Make reporting of packages configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Feat: Enable or disable reporting of packages
+
 # 6.0.0-beta.4
 
 ## Breaking Changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-* Feat: Enable or disable reporting of packages
+* Feat: Enable or disable reporting of packages (#563)
 
 # 6.0.0-beta.4
 

--- a/flutter/lib/src/flutter_enricher_event_processor.dart
+++ b/flutter/lib/src/flutter_enricher_event_processor.dart
@@ -73,7 +73,10 @@ class FlutterEnricherEventProcessor extends EventProcessor {
   /// - Only packages with licenses are known
   /// - No version information is available
   /// - Flutter's native dependencies are also included.
-  FutureOr<Map<String, String>> _getPackages() async {
+  FutureOr<Map<String, String>?> _getPackages() async {
+    if (!_options.reportPackages) {
+      return null;
+    }
     if (_packages.isEmpty) {
       // This can take some time.
       // Therefore we cache this after running

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -11,6 +11,9 @@ class SentryFlutterOptions extends SentryOptions {
     enableBreadcrumbTrackingForCurrentPlatform();
   }
 
+  /// Enable or disable reporting of used packages.
+  bool reportPackages = true;
+
   /// Enable or disable the Auto session tracking on the Native SDKs (Android/iOS)
   bool enableAutoSessionTracking = true;
 

--- a/flutter/test/flutter_enricher_test.dart
+++ b/flutter/test/flutter_enricher_test.dart
@@ -156,6 +156,31 @@ void main() {
       });
     });
 
+    testWidgets('do no add packages if disabled', (WidgetTester tester) async {
+      final enricher = fixture.getSut(
+        binding: () => tester.binding,
+        reportPackages: false,
+      );
+
+      LicenseRegistry.addLicense(
+        () => Stream.fromIterable(
+          [
+            LicenseEntryWithLineBreaks(
+              [
+                'foo_package',
+                'bar_package',
+              ],
+              'Test License Text',
+            ),
+          ],
+        ),
+      );
+
+      final event = await enricher.apply(SentryEvent());
+
+      expect(event.modules, null);
+    });
+
     testWidgets('adds packages only once', (WidgetTester tester) async {
       final enricher = fixture.getSut(
         binding: () => tester.binding,
@@ -253,6 +278,7 @@ class Fixture {
     required WidgetBindingGetter binding,
     PlatformChecker? checker,
     bool hasNativeIntegration = false,
+    bool reportPackages = true,
   }) {
     final platformChecker = checker ??
         MockPlatformChecker(
@@ -261,7 +287,7 @@ class Fixture {
     final options = SentryFlutterOptions(
       dsn: fakeDsn,
       checker: platformChecker,
-    );
+    )..reportPackages = reportPackages;
     return FlutterEnricherEventProcessor(
       options,
       binding,


### PR DESCRIPTION
## :scroll: Description
Reporting of packages is now configurable.


## :bulb: Motivation and Context
We don't know the version of the packages, and there can be quite a lot of them.
So I can imagine user to not want to report them.

## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
