### PR TITLE
fix: use fqdn in readme pub.dev link

### DIFF
--- a/flutter/README.md
+++ b/flutter/README.md
@@ -79,7 +79,7 @@ MaterialApp(
 )
 // ...
 ```
-For a more throughout example see the [example](example/lib/main.dart).
+For a more throughout example see the [example](https://github.com/getsentry/sentry-dart/blob/main/flutter/example/lib/main.dart).
 
 ##### Tracking HTTP events
 


### PR DESCRIPTION
The link did not work when clicking from pub.dev.


## :pencil: Checklist

- [x ] I reviewed submitted code
- [x ] I added tests to verify changes
- [x ] I updated the docs if needed
- [x ] All tests passing
- [x ] No breaking changes



