### PR TITLE
Feat: Add tracing for routes

### DIFF
--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -33,11 +33,6 @@ class MyApp extends StatefulWidget {
 
 class _MyAppState extends State<MyApp> {
   @override
-  void initState() {
-    super.initState();
-  }
-
-  @override
   Widget build(BuildContext context) {
     return feedback.BetterFeedback(
       child: ChangeNotifierProvider<ThemeProvider>(
@@ -45,7 +40,7 @@ class _MyAppState extends State<MyApp> {
         child: Builder(
           builder: (context) => MaterialApp(
             navigatorObservers: [
-              SentryNavigatorObserver(),
+              SentryNavigatorObserver(enableTracing: true),
             ],
             theme: Provider.of<ThemeProvider>(context).theme,
             home: const MainScaffold(),
@@ -473,11 +468,15 @@ class SecondaryScaffold extends StatelessWidget {
 }
 
 Future<void> makeWebRequest(BuildContext context) async {
+  /*
+  SentryNavigatorObserver already startet a transaction, 
+  so we don't have to start another one
   final transaction = Sentry.startTransaction(
     'flutterwebrequest',
     'request',
     bindToScope: true,
   );
+  */
 
   final client = SentryHttpClient(
     captureFailedRequests: true,
@@ -488,7 +487,9 @@ Future<void> makeWebRequest(BuildContext context) async {
   // In case of an exception, let it get caught and reported to Sentry
   final response = await client.get(Uri.parse('https://flutter.dev/'));
 
-  await transaction.finish(status: SpanStatus.ok());
+  // SentryNavigatorObserver already startet a transaction,
+  // so we don't have to finish the one
+  //await transaction.finish(status: SpanStatus.ok());
 
   await showDialog<void>(
     context: context,

--- a/flutter/lib/src/navigation/sentry_navigator_observer.dart
+++ b/flutter/lib/src/navigation/sentry_navigator_observer.dart
@@ -7,7 +7,7 @@ import '../../sentry_flutter.dart';
 const _navigationKey = 'navigation';
 
 /// Used as value for [SentrySpanContext.operation]
-const _transactionOp = 'page_view';
+const _transactionOp = 'ui.load';
 
 /// This is a navigation observer to record navigational breadcrumbs.
 /// For now it only records navigation events and no gestures.


### PR DESCRIPTION
## :scroll: Description
This creates a transaction for each route and a span for each dialog.
I'm not quite sure if the keys and names for transactions and spans are chosen correctly, so some guidance there would be nice.

The transactions don't actually cover the life span of a scaffold. The are startet as soon as the become pushed on the navigation stack. They are finished when a new route is pushed on the navigation stack even though the previous route may still be alive. The transaction for the first route is started again when the second route is popped.

I hope that makes sense.

Some issues I can see coming up are corner cases:
- What if the app is closed? An active transaction may never be closed.
- What if the user never navigates away from the first route? The transaction may never be finished.

## :bulb: Motivation and Context
See description

## :green_heart: How did you test it?
Not tested yet, still a draft.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
