### PR TITLE
changed flutter init to provide a way to hook into the widget tree. closes issue #577

### DIFF
--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -9,10 +9,15 @@ import 'package:universal_platform/universal_platform.dart';
 import 'package:feedback/feedback.dart' as feedback;
 import 'package:provider/provider.dart';
 import 'user_feedback_dialog.dart';
+import 'package:flutter/widgets.dart';
 
 // ATTENTION: Change the DSN below with your own to see the events in Sentry. Get one at sentry.io
 const String _exampleDsn =
     'https://9934c532bf8446ef961450973c898537@o447951.ingest.sentry.io/5428562';
+
+
+
+typedef AppRunner = FutureOr<Widget?> Function();
 
 Future<void> main() async {
   await SentryFlutter.init(
@@ -22,8 +27,14 @@ Future<void> main() async {
       options.reportPackages = false;
     },
     // Init your App.
-    appRunner: () => runApp(MyApp()),
+    appRunner: () => MyApp(),
   );
+}
+
+// inside SentryFlutter.init
+final widget = await appRunner();
+if(widget != null) {
+  runApp(SentryWidget(child: widget));
 }
 
 class MyApp extends StatefulWidget {


### PR DESCRIPTION

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

![Screenshot 2021-10-19 at 11 39 15 AM](https://user-images.githubusercontent.com/64458868/137853343-97afb220-8018-4bd4-82c1-f66948e840d7.png)

we can wrap the users widget and call runApp ourself.
If the user doesn't want to do that, he can still call runApp himself and return null.
runApp returns just void and is a fire and forget method, so it should work.

This would enable us to hook into the widget tree for the Screenshot feature (#556) and also for the dialog for crashes on the last run (#441)
<!--- If it fixes an open issue, please link to the issue here. -->
closes issue : #577 




## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code


