### PR TITLE
Fix: event.origin tag for macOS and other Apple platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Bump: Sentry-Android to 5.2.4 and Sentry-Cocoa to 7.4.6 (#621)
+* Fix: event.origin tag for macOS and other Apple platforms (#)
 
 # 6.1.0-beta.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 
 * Bump: Sentry-Android to 5.2.4 and Sentry-Cocoa to 7.4.6 (#621)
-* Fix: event.origin tag for macOS and other Apple platforms (#)
+* Fix: event.origin tag for macOS and other Apple platforms (#622)
 
 # 6.1.0-beta.1
 

--- a/flutter/ios/Classes/SentryFlutterPluginApple.swift
+++ b/flutter/ios/Classes/SentryFlutterPluginApple.swift
@@ -240,7 +240,21 @@ public class SentryFlutterPluginApple: NSObject, FlutterPlugin {
 
             switch sdk["name"] as? String {
             case "sentry.cocoa":
-                setEventEnvironmentTag(event: event, origin: "ios", environment: "native")
+                #if os(OSX)
+                    let origin = "mac"
+                #elseif os(watchOS)
+                    let origin = "watch"
+                #elseif os(tvOS)
+                    let origin = "tv"
+                #elseif os(iOS)
+                    #if targetEnvironment(macCatalyst)
+                        let origin = "macCatalyst"
+                    #else
+                        let origin = "ios"
+                    #endif
+                #endif
+                setEventEnvironmentTag(event: event, origin: origin, environment: "native")
+                break
             default:
                 return
             }

--- a/flutter/ios/Classes/SentryFlutterPluginApple.swift
+++ b/flutter/ios/Classes/SentryFlutterPluginApple.swift
@@ -254,7 +254,6 @@ public class SentryFlutterPluginApple: NSObject, FlutterPlugin {
                     #endif
                 #endif
                 setEventEnvironmentTag(event: event, origin: origin, environment: "native")
-                break
             default:
                 return
             }


### PR DESCRIPTION
## :scroll: Description
Fix: event.origin tag for macOS and other Apple platforms


## :bulb: Motivation and Context
Fix https://github.com/getsentry/sentry-dart/issues/614


## :green_heart: How did you test it?
running on iOS and macOS

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] I updated the docs if needed
- [X] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
