### PR TITLE
Rename onpremise to self-hosted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,7 @@
 
 ## Sentry Self Hosted Compatibility
 
-* Since version `6.0.0` of the `sentry`, [Sentry's version >= v20.6.0](https://github.com/getsentry/onpremise/releases) is required. This only applies to on-premise Sentry, if you are using sentry.io no action is needed.
+* Since version `6.0.0` of the `sentry`, [Sentry's version >= v20.6.0](https://github.com/getsentry/self-hosted/releases) is required. This only applies to on-premise Sentry, if you are using sentry.io no action is needed.
 
 # 5.1.0
 
@@ -136,7 +136,7 @@
 
 ## Sentry Self Hosted Compatibility
 
-* This version of the `sentry` Dart package requires [Sentry server >= v20.6.0](https://github.com/getsentry/onpremise/releases). This only applies to on-premise Sentry, if you are using sentry.io no action is needed.
+* This version of the `sentry` Dart package requires [Sentry server >= v20.6.0](https://github.com/getsentry/self-hosted/releases). This only applies to on-premise Sentry, if you are using sentry.io no action is needed.
 
 # 5.0.0
 
@@ -262,7 +262,7 @@ Packages were released on [sentry pubdev](https://pub.dev/packages/sentry) and [
 
 ## Sentry Self Hosted Compatibility
 
-* Since version `4.0.0` of the `sentry_flutter`, [Sentry's version >= v20.6.0](https://github.com/getsentry/onpremise/releases) is required. This only applies to on-premise Sentry, if you are using sentry.io no action is needed.
+* Since version `4.0.0` of the `sentry_flutter`, [Sentry's version >= v20.6.0](https://github.com/getsentry/self-hosted/releases) is required. This only applies to on-premise Sentry, if you are using sentry.io no action is needed.
 
 # 4.0.0-beta.2
 


### PR DESCRIPTION
https://github.com/getsentry/self-hosted/issues/796

How do you feel about rewriting the changelog like this, @marandaneto? GitHub does redirect so this is not strictly necessary.

#skip-changelog