### PR TITLE
Fix: Use 'navigation' instead of 'ui.load' for auto transaction operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Fix: Use 'navigation' instead of 'ui.load' for auto transaction operation (#675)
+
 # 6.3.0-alpha.1
 
 * Feat: Automatically create transactions when navigating between screens (#643)

--- a/flutter/lib/src/navigation/sentry_navigator_observer.dart
+++ b/flutter/lib/src/navigation/sentry_navigator_observer.dart
@@ -133,7 +133,7 @@ class SentryNavigatorObserver extends RouteObserver<PageRoute<dynamic>> {
     }
     _transaction = _hub.startTransaction(
       name,
-      'ui.load',
+      'navigation',
       waitForChildren: true,
       autoFinishAfter: Duration(seconds: 3),
     );

--- a/flutter/test/sentry_navigator_observer_test.dart
+++ b/flutter/test/sentry_navigator_observer_test.dart
@@ -45,7 +45,7 @@ void main() {
 
       verify(hub.startTransaction(
         'Current Route',
-        'ui.load',
+        'navigation',
         waitForChildren: true,
         autoFinishAfter: Duration(seconds: 3),
       ));
@@ -67,7 +67,7 @@ void main() {
 
       verifyNever(hub.startTransaction(
         'Current Route',
-        'ui.load',
+        'navigation',
         waitForChildren: true,
         autoFinishAfter: Duration(seconds: 3),
       ));
@@ -89,7 +89,7 @@ void main() {
 
       verifyNever(hub.startTransaction(
         'Current Route',
-        'ui.load',
+        'navigation',
         waitForChildren: true,
         autoFinishAfter: Duration(seconds: 3),
       ));
@@ -112,7 +112,7 @@ void main() {
 
       verify(hub.startTransaction(
         'Current Route',
-        'ui.load',
+        'navigation',
         waitForChildren: true,
         autoFinishAfter: Duration(seconds: 3),
       ));
@@ -171,7 +171,7 @@ void main() {
 
       verify(hub.startTransaction(
         'Previous Route',
-        'ui.load',
+        'navigation',
         waitForChildren: true,
         autoFinishAfter: Duration(seconds: 3),
       ));


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

- Use 'navigation' instead of 'ui.load' for auto transaction operation

Closes #670

## :green_heart: How did you test it?

- Updated unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes
