### PR TITLE
Allow to set startTimestamp & endTimestamp manually to SentrySpan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Feat: Allow to set startTimestamp & endTimestamp manually to SentrySpan (#676)
 * Bump: Sentry-Cocoa to 7.10.0 (#777)
 * Feat: Additional Dart/Flutter context information (#778)
 * Bump: Kotlin plugin to 1.5.31 (#763)

--- a/dart/lib/src/hub.dart
+++ b/dart/lib/src/hub.dart
@@ -342,6 +342,7 @@ class Hub {
     String name,
     String operation, {
     String? description,
+    DateTime? startTimestamp,
     bool? bindToScope,
     bool? waitForChildren,
     Duration? autoFinishAfter,
@@ -354,6 +355,7 @@ class Hub {
           operation,
           description: description,
         ),
+        startTimestamp: startTimestamp,
         bindToScope: bindToScope,
         waitForChildren: waitForChildren,
         autoFinishAfter: autoFinishAfter,
@@ -365,6 +367,7 @@ class Hub {
   ISentrySpan startTransactionWithContext(
     SentryTransactionContext transactionContext, {
     Map<String, dynamic>? customSamplingContext,
+    DateTime? startTimestamp,
     bool? bindToScope,
     bool? waitForChildren,
     Duration? autoFinishAfter,
@@ -395,6 +398,7 @@ class Hub {
       final tracer = SentryTracer(
         transactionContext,
         this,
+        startTimestamp: startTimestamp,
         waitForChildren: waitForChildren ?? false,
         autoFinishAfter: autoFinishAfter,
         trimEnd: trimEnd ?? false,

--- a/dart/lib/src/hub_adapter.dart
+++ b/dart/lib/src/hub_adapter.dart
@@ -108,6 +108,7 @@ class HubAdapter implements Hub {
   ISentrySpan startTransactionWithContext(
     SentryTransactionContext transactionContext, {
     Map<String, dynamic>? customSamplingContext,
+    DateTime? startTimestamp,
     bool? bindToScope,
     bool? waitForChildren,
     Duration? autoFinishAfter,
@@ -116,6 +117,7 @@ class HubAdapter implements Hub {
       Sentry.startTransactionWithContext(
         transactionContext,
         customSamplingContext: customSamplingContext,
+        startTimestamp: startTimestamp,
         bindToScope: bindToScope,
         waitForChildren: waitForChildren,
         autoFinishAfter: autoFinishAfter,
@@ -127,6 +129,7 @@ class HubAdapter implements Hub {
     String name,
     String operation, {
     String? description,
+    DateTime? startTimestamp,
     bool? bindToScope,
     bool? waitForChildren,
     Duration? autoFinishAfter,
@@ -137,6 +140,7 @@ class HubAdapter implements Hub {
         name,
         operation,
         description: description,
+        startTimestamp: startTimestamp,
         bindToScope: bindToScope,
         waitForChildren: waitForChildren,
         autoFinishAfter: autoFinishAfter,

--- a/dart/lib/src/noop_hub.dart
+++ b/dart/lib/src/noop_hub.dart
@@ -87,6 +87,7 @@ class NoOpHub implements Hub {
     String name,
     String operation, {
     String? description,
+    DateTime? startTimestamp,
     bool? bindToScope,
     bool? waitForChildren,
     Duration? autoFinishAfter,
@@ -99,6 +100,7 @@ class NoOpHub implements Hub {
   ISentrySpan startTransactionWithContext(
     SentryTransactionContext transactionContext, {
     Map<String, dynamic>? customSamplingContext,
+    DateTime? startTimestamp,
     bool? bindToScope,
     bool? waitForChildren,
     Duration? autoFinishAfter,

--- a/dart/lib/src/noop_sentry_span.dart
+++ b/dart/lib/src/noop_sentry_span.dart
@@ -41,7 +41,11 @@ class NoOpSentrySpan extends ISentrySpan {
   void setTag(String key, String value) {}
 
   @override
-  ISentrySpan startChild(String operation, {String? description}) =>
+  ISentrySpan startChild(
+    String operation, {
+    String? description,
+    DateTime? startTimestamp,
+  }) =>
       NoOpSentrySpan();
 
   @override

--- a/dart/lib/src/noop_sentry_span.dart
+++ b/dart/lib/src/noop_sentry_span.dart
@@ -26,7 +26,7 @@ class NoOpSentrySpan extends ISentrySpan {
   }
 
   @override
-  Future<void> finish({SpanStatus? status}) async {}
+  Future<void> finish({SpanStatus? status, DateTime? endTimestamp}) async {}
 
   @override
   void removeData(String key) {}

--- a/dart/lib/src/protocol/sentry_span.dart
+++ b/dart/lib/src/protocol/sentry_span.dart
@@ -10,7 +10,7 @@ import '../utils.dart';
 class SentrySpan extends ISentrySpan {
   final SentrySpanContext _context;
   DateTime? _timestamp;
-  final DateTime _startTimestamp = getUtcDateTime();
+  late final DateTime _startTimestamp;
   final Hub _hub;
 
   final SentryTracer _tracer;
@@ -28,9 +28,11 @@ class SentrySpan extends ISentrySpan {
     this._tracer,
     this._context,
     this._hub, {
+    DateTime? startTimestamp,
     bool? sampled,
     Function()? finishedCallback,
   }) {
+    _startTimestamp = startTimestamp?.toUtc() ?? getUtcDateTime();
     this.sampled = sampled;
     _finishedCallback = finishedCallback;
   }
@@ -94,8 +96,17 @@ class SentrySpan extends ISentrySpan {
   ISentrySpan startChild(
     String operation, {
     String? description,
+    DateTime? startTimestamp,
   }) {
     if (finished) {
+      return NoOpSentrySpan();
+    }
+
+    if (startTimestamp?.isBefore(_startTimestamp) ?? false) {
+      _hub.options.logger(
+        SentryLevel.warning,
+        "Start timestamp ($startTimestamp) cannot be before parent span's start timestamp ($_startTimestamp). Returning NoOpSpan.",
+      );
       return NoOpSentrySpan();
     }
 
@@ -103,6 +114,7 @@ class SentrySpan extends ISentrySpan {
       _context.spanId,
       operation,
       description: description,
+      startTimestamp: startTimestamp,
     );
   }
 

--- a/dart/lib/src/sentry.dart
+++ b/dart/lib/src/sentry.dart
@@ -224,6 +224,7 @@ class Sentry {
     String name,
     String operation, {
     String? description,
+    DateTime? startTimestamp,
     bool? bindToScope,
     bool? waitForChildren,
     Duration? autoFinishAfter,
@@ -234,6 +235,7 @@ class Sentry {
         name,
         operation,
         description: description,
+        startTimestamp: startTimestamp,
         bindToScope: bindToScope,
         waitForChildren: waitForChildren,
         autoFinishAfter: autoFinishAfter,
@@ -245,6 +247,7 @@ class Sentry {
   static ISentrySpan startTransactionWithContext(
     SentryTransactionContext transactionContext, {
     Map<String, dynamic>? customSamplingContext,
+    DateTime? startTimestamp,
     bool? bindToScope,
     bool? waitForChildren,
     Duration? autoFinishAfter,
@@ -253,6 +256,7 @@ class Sentry {
       _hub.startTransactionWithContext(
         transactionContext,
         customSamplingContext: customSamplingContext,
+        startTimestamp: startTimestamp,
         bindToScope: bindToScope,
         waitForChildren: waitForChildren,
         autoFinishAfter: autoFinishAfter,

--- a/dart/lib/src/sentry_span_interface.dart
+++ b/dart/lib/src/sentry_span_interface.dart
@@ -25,7 +25,7 @@ abstract class ISentrySpan {
   void removeData(String key);
 
   /// Sets span timestamp marking this span as finished.
-  Future<void> finish({SpanStatus? status}) async {}
+  Future<void> finish({SpanStatus? status, DateTime? endTimestamp}) async {}
 
   /// Gets span status.
   SpanStatus? get status;

--- a/dart/lib/src/sentry_span_interface.dart
+++ b/dart/lib/src/sentry_span_interface.dart
@@ -9,6 +9,7 @@ abstract class ISentrySpan {
   ISentrySpan startChild(
     String operation, {
     String? description,
+    DateTime? startTimestamp,
   });
 
   /// Sets the tag on span or transaction.

--- a/dart/test/default_integrations_test.dart
+++ b/dart/test/default_integrations_test.dart
@@ -234,6 +234,7 @@ class PrintRecursionMockHub extends MockHub {
   ISentrySpan startTransactionWithContext(
     SentryTransactionContext transactionContext, {
     Map<String, dynamic>? customSamplingContext,
+    DateTime? startTimestamp,
     bool? bindToScope,
     bool? waitForChildren,
     Duration? autoFinishAfter,

--- a/dart/test/hub_test.dart
+++ b/dart/test/hub_test.dart
@@ -139,17 +139,21 @@ void main() {
       fixture = Fixture();
     });
 
-    test('start transaction with given name, op and desc', () async {
+    test('start transaction with given name, op, desc and start time',
+        () async {
       final hub = fixture.getSut();
+      final startTime = DateTime.now();
 
       final tr = hub.startTransaction(
         'name',
         'op',
+        startTimestamp: startTime,
         description: 'desc',
       );
 
       expect(tr.context.operation, 'op');
       expect(tr.context.description, 'desc');
+      expect(tr.startTimestamp.isAtSameMomentAs(startTime), true);
       expect((tr as SentryTracer).name, 'name');
     });
 

--- a/flutter/test/mocks.dart
+++ b/flutter/test/mocks.dart
@@ -14,6 +14,7 @@ ISentrySpan startTransactionShim(
   String? name,
   String? operation, {
   String? description,
+  DateTime? startTimestamp,
   bool? bindToScope,
   bool? waitForChildren,
   Duration? autoFinishAfter,

--- a/flutter/test/mocks.mocks.dart
+++ b/flutter/test/mocks.mocks.dart
@@ -86,8 +86,10 @@ class MockNoOpSentrySpan extends _i1.Mock implements _i2.NoOpSentrySpan {
       super.noSuchMethod(Invocation.setter(#status, status),
           returnValueForMissingStub: null);
   @override
-  _i7.Future<void> finish({_i3.SpanStatus? status}) =>
-      (super.noSuchMethod(Invocation.method(#finish, [], {#status: status}),
+  _i7.Future<void> finish({_i3.SpanStatus? status, DateTime? endTimestamp}) =>
+      (super.noSuchMethod(
+          Invocation.method(
+              #finish, [], {#status: status, #endTimestamp: endTimestamp}),
           returnValue: Future<void>.value(),
           returnValueForMissingStub: Future<void>.value()) as _i7.Future<void>);
   @override

--- a/flutter/test/mocks.mocks.dart
+++ b/flutter/test/mocks.mocks.dart
@@ -107,10 +107,11 @@ class MockNoOpSentrySpan extends _i1.Mock implements _i2.NoOpSentrySpan {
       super.noSuchMethod(Invocation.method(#setTag, [key, value]),
           returnValueForMissingStub: null);
   @override
-  _i2.ISentrySpan startChild(String? operation, {String? description}) =>
+  _i2.ISentrySpan startChild(String? operation,
+          {String? description, DateTime? startTimestamp}) =>
       (super.noSuchMethod(
-          Invocation.method(
-              #startChild, [operation], {#description: description}),
+          Invocation.method(#startChild, [operation],
+              {#description: description, #startTimestamp: startTimestamp}),
           returnValue: _FakeISentrySpan_2()) as _i2.ISentrySpan);
   @override
   _i3.SentryTraceHeader toSentryTrace() =>
@@ -211,6 +212,7 @@ class MockHub extends _i1.Mock implements _i5.Hub {
   @override
   _i2.ISentrySpan startTransaction(String? name, String? operation,
           {String? description,
+          DateTime? startTimestamp,
           bool? bindToScope,
           bool? waitForChildren,
           Duration? autoFinishAfter,
@@ -222,6 +224,7 @@ class MockHub extends _i1.Mock implements _i5.Hub {
                 operation
               ], {
                 #description: description,
+                #startTimestamp: startTimestamp,
                 #bindToScope: bindToScope,
                 #waitForChildren: waitForChildren,
                 #autoFinishAfter: autoFinishAfter,
@@ -230,6 +233,7 @@ class MockHub extends _i1.Mock implements _i5.Hub {
               }),
               returnValue: _i11.startTransactionShim(name, operation,
                   description: description,
+                  startTimestamp: startTimestamp,
                   bindToScope: bindToScope,
                   waitForChildren: waitForChildren,
                   autoFinishAfter: autoFinishAfter,
@@ -240,6 +244,7 @@ class MockHub extends _i1.Mock implements _i5.Hub {
   _i2.ISentrySpan startTransactionWithContext(
           _i2.SentryTransactionContext? transactionContext,
           {Map<String, dynamic>? customSamplingContext,
+          DateTime? startTimestamp,
           bool? bindToScope,
           bool? waitForChildren,
           Duration? autoFinishAfter,
@@ -249,6 +254,7 @@ class MockHub extends _i1.Mock implements _i5.Hub {
             transactionContext
           ], {
             #customSamplingContext: customSamplingContext,
+            #startTimestamp: startTimestamp,
             #bindToScope: bindToScope,
             #waitForChildren: waitForChildren,
             #autoFinishAfter: autoFinishAfter,


### PR DESCRIPTION
## :scroll: Description
Allows to set `startTimestamp`(while creating) and `endTimestamp`(while finishing) manually to `SentrySpan`

## :bulb: Motivation and Context
- It will allow to trace events which Sentry does not have control over starting point of that events. 

	e.g. When a 3rd party SDK returns only duration of an internal execution which is wanted to trace.
	
    p.s. It's already implemented (`startTimestamp`) on [sentry-java](https://github.com/getsentry/sentry-java/blob/3ec06985c47758ec9cf8d33592349bd5137d5620/sentry/src/main/java/io/sentry/Sentry.java#L661) with the motivation of tracing app-start time where Sentry not initialized yet

- It will give more control over transactions in terms of creating&finishing them.

	It might be desired to decide whether to start a transaction or not conditionally which will be clear at a later time after starting the operation.

## :green_heart: How did you test it?
Unit tests 

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
