### PR TITLE
Enha: Replace flutter default root name '/' with 'root'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Enha: Replace flutter default root name '/' with 'root' (#678)
+
 # 6.3.0-alpha.1
 
 * Feat: Automatically create transactions when navigating between screens (#643)

--- a/flutter/README.md
+++ b/flutter/README.md
@@ -66,6 +66,9 @@ Future<void> main() async {
 In order to track navigation events you have to add the 
 `SentryNavigatorObserver` to your `MaterialApp`, `WidgetsApp` or `CupertinoApp`.
 
+You should provide a name to route settings: `RouteSettings(name: 'Your Route Name')`. The root 
+route name `/` will be replaced by `root "/"` for clarity's sake.
+
 ```dart
 import 'package:flutter/material.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';

--- a/flutter/lib/src/navigation/sentry_navigator_observer.dart
+++ b/flutter/lib/src/navigation/sentry_navigator_observer.dart
@@ -131,6 +131,9 @@ class SentryNavigatorObserver extends RouteObserver<PageRoute<dynamic>> {
     if (name == null) {
       return;
     }
+    if (name == '/') {
+      name = 'root';
+    }
     _transaction = _hub.startTransaction(
       name,
       'ui.load',

--- a/flutter/lib/src/navigation/sentry_navigator_observer.dart
+++ b/flutter/lib/src/navigation/sentry_navigator_observer.dart
@@ -132,7 +132,7 @@ class SentryNavigatorObserver extends RouteObserver<PageRoute<dynamic>> {
       return;
     }
     if (name == '/') {
-      name = 'root';
+      name = 'root ("/")';
     }
     _transaction = _hub.startTransaction(
       name,

--- a/flutter/test/sentry_navigator_observer_test.dart
+++ b/flutter/test/sentry_navigator_observer_test.dart
@@ -219,6 +219,28 @@ void main() {
 
       verify(span.setData('route_settings_arguments', arguments));
     });
+
+    test('flutter root name is replaced', () {
+      final rootRoute = route(RouteSettings(name: '/'));
+
+      final hub = _MockHub();
+      final span = MockNoOpSentrySpan();
+      _whenAnyStart(hub, span);
+      final sut = fixture.getSut(hub: hub);
+
+      sut.didPush(rootRoute, null);
+
+      verify(hub.startTransaction(
+        'root',
+        'ui.load',
+        waitForChildren: true,
+        autoFinishAfter: Duration(seconds: 3),
+      ));
+
+      hub.configureScope((scope) {
+        expect(scope.span, span);
+      });
+    });
   });
 
   group('RouteObserverBreadcrumb', () {

--- a/flutter/test/sentry_navigator_observer_test.dart
+++ b/flutter/test/sentry_navigator_observer_test.dart
@@ -231,7 +231,7 @@ void main() {
       sut.didPush(rootRoute, null);
 
       verify(hub.startTransaction(
-        'root',
+        'root ("/")',
         'ui.load',
         waitForChildren: true,
         autoFinishAfter: Duration(seconds: 3),

--- a/flutter/test/sentry_navigator_observer_test.dart
+++ b/flutter/test/sentry_navigator_observer_test.dart
@@ -232,7 +232,7 @@ void main() {
 
       verify(hub.startTransaction(
         'root ("/")',
-        'ui.load',
+        'navigation',
         waitForChildren: true,
         autoFinishAfter: Duration(seconds: 3),
       ));


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

- Replace default flutter root `/` name in navigation with `root`. 

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- This should make the route more clear when viewing transactions on `sentry.io`

## :green_heart: How did you test it?

- Added unit test.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes

