### PR TITLE
Fix: Do not throw when Throwable type is not supported for associating errors to a transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # 6.3.0-alpha.1
 
 * Feat: Automatically create transactions when navigating between screens (#643)
+* Fix: Do not throw when Throwable type is not supported for associating errors to a transaction (#)
 
 # 6.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 # 6.3.0-alpha.1
 
 * Feat: Automatically create transactions when navigating between screens (#643)
-* Fix: Do not throw when Throwable type is not supported for associating errors to a transaction (#)
+* Fix: Do not throw when Throwable type is not supported for associating errors to a transaction (#692)
 
 # 6.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 * Fix: Use 'navigation' instead of 'ui.load' for auto transaction operation (#675)
 * Fix: Use correct data/extras type in tracer (#693)
+* Fix: Do not throw when Throwable type is not supported for associating errors to a transaction (#692)
 
 # 6.3.0-alpha.1
 
 * Feat: Automatically create transactions when navigating between screens (#643)
-* Fix: Do not throw when Throwable type is not supported for associating errors to a transaction (#692)
 
 # 6.2.2
 

--- a/dart/test/hub_test.dart
+++ b/dart/test/hub_test.dart
@@ -110,6 +110,26 @@ void main() {
       expect(capturedEvent.event.transaction, 'test');
       expect(capturedEvent.event.contexts.trace, isNotNull);
     });
+
+    test('Expando does not throw when exception type is not supported',
+        () async {
+      final hub = fixture.getSut();
+
+      try {
+        throw 'string error';
+      } catch (exception, _) {
+        final event = SentryEvent(throwable: exception);
+        final span = NoOpSentrySpan();
+        hub.setSpanContext(exception, span, 'test');
+
+        await hub.captureEvent(event);
+      }
+
+      final capturedEvent = fixture.client.captureEventCalls.first;
+
+      expect(capturedEvent.event.transaction, isNull);
+      expect(capturedEvent.event.contexts.trace, isNull);
+    });
   });
 
   group('Hub captures', () {


### PR DESCRIPTION
## :scroll: Description
Fix: Do not throw when Throwable type is not supported for associating errors to a transaction


## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-dart/issues/680


## :green_heart: How did you test it?

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
