### PR TITLE
Fix: Use correct data/extra type in tracer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Fix: Use 'navigation' instead of 'ui.load' for auto transaction operation (#675)
+* Fix: Use correct data/extras type in tracer (#693)
 
 # 6.3.0-alpha.1
 

--- a/dart/lib/src/sentry_tracer.dart
+++ b/dart/lib/src/sentry_tracer.dart
@@ -13,7 +13,7 @@ class SentryTracer extends ISentrySpan {
 
   late final SentrySpan _rootSpan;
   final List<SentrySpan> _children = [];
-  final Map<String, String> _extra = {};
+  final Map<String, dynamic> _extra = {};
   Timer? _autoFinishAfterTimer;
   var _finishStatus = SentryTracerFinishStatus.notFinishing();
 
@@ -81,7 +81,7 @@ class SentryTracer extends ISentrySpan {
   }
 
   @override
-  void setData(String key, value) {
+  void setData(String key, dynamic value) {
     if (finished) {
       return;
     }
@@ -153,7 +153,7 @@ class SentryTracer extends ISentrySpan {
   @override
   DateTime? get endTimestamp => _rootSpan.endTimestamp;
 
-  Map<String, String> get data => Map.unmodifiable(_extra);
+  Map<String, dynamic> get data => Map.unmodifiable(_extra);
 
   @override
   bool get finished => _rootSpan.finished;

--- a/dart/test/sentry_tracer_test.dart
+++ b/dart/test/sentry_tracer_test.dart
@@ -71,6 +71,18 @@ void main() {
     expect(tr.extra?['test'], isNull);
   });
 
+  test('tracer sets non-string data to extra', () async {
+    final sut = fixture.getSut();
+
+    sut.setData('test', {'key': 'value'});
+
+    await sut.finish(status: SpanStatus.aborted());
+
+    final tr = fixture.hub.captureTransactionCalls.first;
+
+    expect(tr.extra?['test'], {'key': 'value'});
+  });
+
   test('tracer starts child', () async {
     final sut = fixture.getSut();
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Fixes #679

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- The internal property `_extra` in the `SentryTracer` is exposed via `data` property and both are of type `Map< string, string>`
- The latter is used when intializing `SentryTransaction`s `extra` property, which is of type `Map<string, dynamic>`
- By changing to `Map<string, dynamic>` we support the correct type and more complex hierarchies can be serialized further downstream.
- Serializing complex objects should work as long as every call of `jsonEncode` is provided `jsonSerializationFallback` implementation, which calls `toString()` on non-null objects.

## :green_heart: How did you test it?

- Added unit test.
- Checked that all calls of `jsonEncode` are provided with `jsonSerializationFallback`. 

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes
