### PR TITLE
Fix: maxRequestBodySize should be never by default when using the FailedRequestClientAdapter directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-* Fix: `maxRequestBodySize` should be `never` by default when using the FailedRequestClientAdapter directly (#)
+* Fix: `maxRequestBodySize` should be `never` by default when using the FailedRequestClientAdapter directly (#701)
 
 # 6.3.0-beta.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Fix: `maxRequestBodySize` should be `never` by default when using the FailedRequestClientAdapter directly (#)
+
 # 6.3.0-beta.2
 
 * Feat: Improve configuration options of `SentryNavigatorObserver` (#684)

--- a/dart/lib/src/http_client/failed_request_client.dart
+++ b/dart/lib/src/http_client/failed_request_client.dart
@@ -65,7 +65,7 @@ import 'sentry_http_client.dart';
 /// ```
 class FailedRequestClient extends BaseClient {
   FailedRequestClient({
-    this.maxRequestBodySize = MaxRequestBodySize.small,
+    this.maxRequestBodySize = MaxRequestBodySize.never,
     this.failedRequestStatusCodes = const [],
     this.captureFailedRequests = true,
     this.sendDefaultPii = false,

--- a/dio/lib/src/failed_request_client_adapter.dart
+++ b/dio/lib/src/failed_request_client_adapter.dart
@@ -26,7 +26,7 @@ class FailedRequestClientAdapter extends HttpClientAdapter {
   // ignore: public_member_api_docs
   FailedRequestClientAdapter({
     required HttpClientAdapter client,
-    this.maxRequestBodySize = MaxRequestBodySize.small,
+    this.maxRequestBodySize = MaxRequestBodySize.never,
     this.failedRequestStatusCodes = const [],
     this.captureFailedRequests = true,
     this.sendDefaultPii = false,


### PR DESCRIPTION
## :scroll: Description
Fix: maxRequestBodySize should be never by default when using the FailedRequestClientAdapter directly


## :bulb: Motivation and Context
Not considered a breaking change because people don't use the `FailedRequest` adapter/client directly but rather the higher level `SentryHttp` client/adapter.


## :green_heart: How did you test it?
Tests don't fail because we're always passing the optional parameter in tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
