### PR TITLE
Feat: Support `Attachment.addToTransactions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Feat: Support Attachment.addToTransactions (#709)
+
 # 6.3.0-beta.3
 
 * Feat: Auto transactions duration trimming (#702)

--- a/dart/lib/src/sentry_attachment/sentry_attachment.dart
+++ b/dart/lib/src/sentry_attachment/sentry_attachment.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:ffi';
 import 'dart:typed_data';
 
 // https://develop.sentry.dev/sdk/features/#attachments
@@ -33,8 +34,10 @@ class SentryAttachment {
     required this.filename,
     String? attachmentType,
     this.contentType,
+    bool? addToTransactions,
   })  : _loader = loader,
-        attachmentType = attachmentType ?? typeAttachmentDefault;
+        attachmentType = attachmentType ?? typeAttachmentDefault,
+        addToTransactions = addToTransactions ?? false;
 
   /// Creates an [SentryAttachment] from a [Uint8List]
   SentryAttachment.fromUint8List(
@@ -42,11 +45,13 @@ class SentryAttachment {
     String fileName, {
     String? contentType,
     String? attachmentType,
+    bool? addToTransactions,
   }) : this.fromLoader(
           attachmentType: attachmentType,
           loader: () => bytes,
           filename: fileName,
           contentType: contentType,
+          addToTransactions: addToTransactions,
         );
 
   /// Creates an [SentryAttachment] from a [List<int>]
@@ -55,11 +60,13 @@ class SentryAttachment {
     String fileName, {
     String? contentType,
     String? attachmentType,
+    bool? addToTransactions,
   }) : this.fromLoader(
           attachmentType: attachmentType,
           loader: () => Uint8List.fromList(bytes),
           filename: fileName,
           contentType: contentType,
+          addToTransactions: addToTransactions,
         );
 
   /// Creates an [SentryAttachment] from [ByteData]
@@ -68,11 +75,13 @@ class SentryAttachment {
     String fileName, {
     String? contentType,
     String? attachmentType,
+    bool? addToTransactions,
   }) : this.fromLoader(
           attachmentType: attachmentType,
           loader: () => bytes.buffer.asUint8List(),
           filename: fileName,
           contentType: contentType,
+          addToTransactions: addToTransactions,
         );
 
   /// Attachment type.
@@ -91,4 +100,8 @@ class SentryAttachment {
   /// Attachment content type.
   /// Inferred by Sentry if it's not given.
   final String? contentType;
+
+  /// If true, attachment should be added to every transaction.
+  /// Defaults to false.
+  final bool addToTransactions;
 }

--- a/dart/lib/src/sentry_attachment/sentry_attachment.dart
+++ b/dart/lib/src/sentry_attachment/sentry_attachment.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:ffi';
 import 'dart:typed_data';
 
 // https://develop.sentry.dev/sdk/features/#attachments

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -114,9 +114,7 @@ class SentryClient {
     final envelope = SentryEnvelope.fromEvent(
       preparedEvent,
       _options.sdk,
-      attachments: scope?.attachements
-          .where((element) => element.addToTransactions)
-          .toList(),
+      attachments: scope?.attachements,
     );
 
     final id = await captureEnvelope(envelope);
@@ -262,7 +260,11 @@ class SentryClient {
     }
 
     final id = await captureEnvelope(
-        SentryEnvelope.fromTransaction(preparedTransaction, _options.sdk));
+      SentryEnvelope.fromTransaction(preparedTransaction, _options.sdk,
+          attachments: scope?.attachements
+              .where((element) => element.addToTransactions)
+              .toList()),
+    );
     return id!;
   }
 

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -114,7 +114,9 @@ class SentryClient {
     final envelope = SentryEnvelope.fromEvent(
       preparedEvent,
       _options.sdk,
-      attachments: scope?.attachements,
+      attachments: scope?.attachements
+          .where((element) => element.addToTransactions)
+          .toList(),
     );
 
     final id = await captureEnvelope(envelope);

--- a/dart/lib/src/sentry_envelope.dart
+++ b/dart/lib/src/sentry_envelope.dart
@@ -47,11 +47,16 @@ class SentryEnvelope {
   /// Create an [SentryEnvelope] with containing one [SentryEnvelopeItem] which holds the [SentryTransaction] data.
   factory SentryEnvelope.fromTransaction(
     SentryTransaction transaction,
-    SdkVersion sdkVersion,
-  ) {
+    SdkVersion sdkVersion, {
+    List<SentryAttachment>? attachments,
+  }) {
     return SentryEnvelope(
       SentryEnvelopeHeader(transaction.eventId, sdkVersion),
-      [SentryEnvelopeItem.fromTransaction(transaction)],
+      [
+        SentryEnvelopeItem.fromTransaction(transaction),
+        if (attachments != null)
+          ...attachments.map((e) => SentryEnvelopeItem.fromAttachment(e))
+      ],
     );
   }
 

--- a/dart/test/sentry_attachment_test.dart
+++ b/dart/test/sentry_attachment_test.dart
@@ -87,7 +87,6 @@ void main() {
   });
 
   group('addToTransactions', () {
-
     test('defaults to false fromLoader', () async {
       final attachment = SentryAttachment.fromLoader(
         loader: () => Uint8List.fromList([0, 0, 0, 0]),
@@ -133,9 +132,9 @@ void main() {
 
     test('defaults to false fromIntList', () async {
       final attachment = SentryAttachment.fromIntList(
-          [0, 0, 0, 0],
-          'test.txt',
-          addToTransactions: true,
+        [0, 0, 0, 0],
+        'test.txt',
+        addToTransactions: true,
       );
 
       expect(attachment.addToTransactions, true);

--- a/dart/test/sentry_attachment_test.dart
+++ b/dart/test/sentry_attachment_test.dart
@@ -85,6 +85,82 @@ void main() {
       );
     });
   });
+
+  group('addToTransactions', () {
+
+    test('defaults to false fromLoader', () async {
+      final attachment = SentryAttachment.fromLoader(
+        loader: () => Uint8List.fromList([0, 0, 0, 0]),
+        filename: 'test.txt',
+      );
+
+      expect(attachment.addToTransactions, false);
+    });
+
+    test('defaults to false fromIntList', () async {
+      final attachment = SentryAttachment.fromIntList([0, 0, 0, 0], 'test.txt');
+
+      expect(attachment.addToTransactions, false);
+    });
+
+    test('defaults to false fromUint8List', () async {
+      final attachment = SentryAttachment.fromUint8List(
+        Uint8List.fromList([0, 0, 0, 0]),
+        'test.txt',
+      );
+
+      expect(attachment.addToTransactions, false);
+    });
+
+    test('defaults to false fromByteData', () async {
+      final attachment = SentryAttachment.fromByteData(
+        ByteData.sublistView(Uint8List.fromList([0, 0, 0, 0])),
+        'test.txt',
+      );
+
+      expect(attachment.addToTransactions, false);
+    });
+
+    test('set fromLoader', () async {
+      final attachment = SentryAttachment.fromLoader(
+        loader: () => Uint8List.fromList([0, 0, 0, 0]),
+        filename: 'test.txt',
+        addToTransactions: true,
+      );
+
+      expect(attachment.addToTransactions, true);
+    });
+
+    test('defaults to false fromIntList', () async {
+      final attachment = SentryAttachment.fromIntList(
+          [0, 0, 0, 0],
+          'test.txt',
+          addToTransactions: true,
+      );
+
+      expect(attachment.addToTransactions, true);
+    });
+
+    test('defaults to false fromUint8List', () async {
+      final attachment = SentryAttachment.fromUint8List(
+        Uint8List.fromList([0, 0, 0, 0]),
+        'test.txt',
+        addToTransactions: true,
+      );
+
+      expect(attachment.addToTransactions, true);
+    });
+
+    test('defaults to false fromByteData', () async {
+      final attachment = SentryAttachment.fromByteData(
+        ByteData.sublistView(Uint8List.fromList([0, 0, 0, 0])),
+        'test.txt',
+        addToTransactions: true,
+      );
+
+      expect(attachment.addToTransactions, true);
+    });
+  });
 }
 
 class Fixture {

--- a/dart/test/sentry_client_test.dart
+++ b/dart/test/sentry_client_test.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:sentry/sentry.dart';
+import 'package:sentry/src/sentry_item_type.dart';
 import 'package:sentry/src/sentry_stack_trace_factory.dart';
 import 'package:sentry/src/sentry_tracer.dart';
 import 'package:test/test.dart';
@@ -345,6 +347,45 @@ void main() {
       final capturedEvent = await transactionFromEnvelope(capturedEnvelope);
 
       expect(capturedEvent['exception'], isNull);
+    });
+
+    test('attachments not added to captured event per default', () async {
+      final attachment = SentryAttachment.fromUint8List(
+        Uint8List.fromList([0, 0, 0, 0]),
+        'test.txt',
+      );
+      final scope = Scope(fixture.options);
+      scope.addAttachment(attachment);
+
+      final client = fixture.getSut();
+      final event = SentryEvent();
+      await client.captureEvent(event, scope: scope);
+
+      final capturedEnvelope = (fixture.transport).envelopes.first;
+      final capturedAttachments = capturedEnvelope.items
+          .where((item) => item.header.type == SentryItemType.attachment);
+
+      expect(capturedAttachments.isEmpty, true);
+    });
+
+    test('attachments added to captured event', () async {
+      final attachment = SentryAttachment.fromUint8List(
+        Uint8List.fromList([0, 0, 0, 0]),
+        'test.txt',
+        addToTransactions: true,
+      );
+      final scope = Scope(fixture.options);
+      scope.addAttachment(attachment);
+
+      final client = fixture.getSut();
+      final event = SentryEvent();
+      await client.captureEvent(event, scope: scope);
+
+      final capturedEnvelope = (fixture.transport).envelopes.first;
+      final capturedAttachments = capturedEnvelope.items
+          .where((item) => item.header.type == SentryItemType.attachment);
+
+      expect(capturedAttachments.isNotEmpty, true);
     });
   });
 

--- a/dart/test/sentry_client_test.dart
+++ b/dart/test/sentry_client_test.dart
@@ -349,7 +349,7 @@ void main() {
       expect(capturedEvent['exception'], isNull);
     });
 
-    test('attachments not added to captured event per default', () async {
+    test('attachments not added to captured transaction per default', () async {
       final attachment = SentryAttachment.fromUint8List(
         Uint8List.fromList([0, 0, 0, 0]),
         'test.txt',
@@ -358,8 +358,8 @@ void main() {
       scope.addAttachment(attachment);
 
       final client = fixture.getSut();
-      final event = SentryEvent();
-      await client.captureEvent(event, scope: scope);
+      final tr = SentryTransaction(fixture.tracer);
+      await client.captureTransaction(tr, scope: scope);
 
       final capturedEnvelope = (fixture.transport).envelopes.first;
       final capturedAttachments = capturedEnvelope.items
@@ -373,6 +373,25 @@ void main() {
         Uint8List.fromList([0, 0, 0, 0]),
         'test.txt',
         addToTransactions: true,
+      );
+      final scope = Scope(fixture.options);
+      scope.addAttachment(attachment);
+
+      final client = fixture.getSut();
+      final tr = SentryTransaction(fixture.tracer);
+      await client.captureTransaction(tr, scope: scope);
+
+      final capturedEnvelope = (fixture.transport).envelopes.first;
+      final capturedAttachments = capturedEnvelope.items
+          .where((item) => item.header.type == SentryItemType.attachment);
+
+      expect(capturedAttachments.isNotEmpty, true);
+    });
+
+    test('attachments added to captured event per default', () async {
+      final attachment = SentryAttachment.fromUint8List(
+        Uint8List.fromList([0, 0, 0, 0]),
+        'test.txt',
       );
       final scope = Scope(fixture.options);
       scope.addAttachment(attachment);

--- a/flutter/lib/src/flutter_sentry_attachment.dart
+++ b/flutter/lib/src/flutter_sentry_attachment.dart
@@ -17,6 +17,7 @@ class FlutterSentryAttachment extends SentryAttachment {
     AssetBundle? bundle,
     String? type,
     String? contentType,
+    bool? addToTransactions,
   }) : super.fromLoader(
           loader: () async {
             final data = await (bundle ?? rootBundle).load(key);
@@ -25,5 +26,6 @@ class FlutterSentryAttachment extends SentryAttachment {
           filename: filename ?? Uri.parse(key).pathSegments.last,
           attachmentType: type,
           contentType: contentType,
+          addToTransactions: addToTransactions,
         );
 }

--- a/flutter/test/flutter_sentry_attachment_test.dart
+++ b/flutter/test/flutter_sentry_attachment_test.dart
@@ -10,11 +10,13 @@ void main() {
     final attachment = FlutterSentryAttachment.fromAsset(
       'foobar.txt',
       bundle: TestAssetBundle(),
+      addToTransactions: true,
     );
 
     expect(attachment.attachmentType, SentryAttachment.typeAttachmentDefault);
     expect(attachment.contentType, isNull);
     expect(attachment.filename, 'foobar.txt');
+    expect(attachment.addToTransactions, true);
     await expectLater(await attachment.bytes, [102, 111, 111, 32, 98, 97, 114]);
   });
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

- Introduce `Attachment.addToTransactions` property.
- Add attachments from scope to transactions where property `addToTransactions` is `true`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #649

## :green_heart: How did you test it?

Added tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
