### PR TITLE
Remove jcenter from repos

### DIFF
--- a/flutter/android/build.gradle
+++ b/flutter/android/build.gradle
@@ -3,7 +3,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 
     dependencies {
@@ -16,7 +15,6 @@ rootProject.allprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 }
 

--- a/flutter/example/android/build.gradle
+++ b/flutter/example/android/build.gradle
@@ -3,7 +3,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 
     dependencies {
@@ -20,7 +19,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 }
 


### PR DESCRIPTION
## :scroll: Description
_#skip-changelog_


## :bulb: Motivation and Context
jcenter is timing out quite often and we don't depend on anything related to it.
Example https://github.com/getsentry/sentry-dart/runs/4884791320?check_suite_focus=true

> * What went wrong:
> Could not determine the dependencies of task ':app:minifyReleaseWithR8'.
> > Could not resolve all task dependencies for configuration ':app:releaseRuntimeClasspath'.
>    > Could not resolve io.flutter:flutter_embedding_release:1.0.0-63ca99584a1aef79722b2a7c6414570b54416bab.
>      Required by:
>          project :app > project :sentry_flutter
>          project :app > project :package_info_plus
>       > Could not resolve io.flutter:flutter_embedding_release:1.0.0-63ca99584a1aef79722b2a7c6414570b54416bab.
>          > Could not get resource 'jcenter.bintray.com/io/flutter/flutter_embedding_release/1.0.0-63ca99584a1aef79722b2a7c6414570b54416bab/flutter_embedding_release-1.0.0-63ca99584a1aef79722b2a7c6414570b54416bab.pom'.
>             > Could not HEAD 'jcenter.bintray.com/io/flutter/flutter_embedding_release/1.0.0-63ca99584a1aef79722b2a7c6414570b54416bab/flutter_embedding_release-1.0.0-63ca99584a1aef79722b2a7c6414570b54416bab.pom'.
>                > Read timed out


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
