### PR TITLE
Fix: captureTransaction should return emptyId when transaction is discarded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Fix: captureTransaction should return emptyId when transaction is discarded (#)
+
 # 6.3.0-beta.3
 
 * Feat: Auto transactions duration trimming (#702)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-* Fix: captureTransaction should return emptyId when transaction is discarded (#)
+* Fix: captureTransaction should return emptyId when transaction is discarded (#713)
 
 # 6.3.0-beta.3
 

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -261,7 +261,7 @@ class SentryClient {
 
     final id = await captureEnvelope(
         SentryEnvelope.fromTransaction(preparedTransaction, _options.sdk));
-    return id!;
+    return id ?? SentryId.empty();
   }
 
   /// Reports the [envelope] to Sentry.io.

--- a/dart/test/sentry_client_test.dart
+++ b/dart/test/sentry_client_test.dart
@@ -348,7 +348,6 @@ void main() {
     });
 
     test('should return empty for when transaction is discarded', () async {
-
       final client = fixture.getSut(eventProcessor: DropAllEventProcessor());
       final tr = SentryTransaction(fixture.tracer);
       final id = await client.captureTransaction(tr);

--- a/dart/test/sentry_client_test.dart
+++ b/dart/test/sentry_client_test.dart
@@ -346,6 +346,15 @@ void main() {
 
       expect(capturedEvent['exception'], isNull);
     });
+
+    test('should return empty for when transaction is discarded', () async {
+
+      final client = fixture.getSut(eventProcessor: DropAllEventProcessor());
+      final tr = SentryTransaction(fixture.tracer);
+      final id = await client.captureTransaction(tr);
+
+      expect(id, SentryId.empty());
+    });
   });
 
   group('SentryClient : apply scope to the captured event', () {


### PR DESCRIPTION
## :scroll: Description
Fix: captureTransaction should return emptyId when transaction is discarded


## :bulb: Motivation and Context
Fix https://github.com/getsentry/sentry-dart/issues/712


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
