### PR TITLE
Dio extension flexible

### DIFF
--- a/dio/lib/sentry_dio.dart
+++ b/dio/lib/sentry_dio.dart
@@ -1,3 +1,5 @@
 library sentry_dio;
 
 export 'src/sentry_dio_extension.dart';
+export 'src/sentry_dio_client_adapter.dart';
+export 'src/sentry_transformer.dart';

--- a/dio/lib/src/sentry_dio_extension.dart
+++ b/dio/lib/src/sentry_dio_extension.dart
@@ -16,10 +16,12 @@ extension SentryDioExtension on Dio {
     List<SentryStatusCode> failedRequestStatusCodes = const [],
     bool captureFailedRequests = false,
     bool sendDefaultPii = false,
+    HttpClientAdapter? httpClientAdapter,
+    Transformer? transformer,
   }) {
     // intercept http requests
-    httpClientAdapter = SentryDioClientAdapter(
-      client: httpClientAdapter,
+    this.httpClientAdapter = SentryDioClientAdapter(
+      client: httpClientAdapter ?? this.httpClientAdapter,
       recordBreadcrumbs: recordBreadcrumbs,
       networkTracing: networkTracing,
       maxRequestBodySize: maxRequestBodySize,
@@ -29,6 +31,7 @@ extension SentryDioExtension on Dio {
     );
 
     // intercept transformations
-    transformer = SentryTransformer(transformer: transformer);
+    this.transformer =
+        SentryTransformer(transformer: transformer ?? this.transformer);
   }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
I made the extension more flexible and added the main objects to the export

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Sometimes projects have custom transformers and adapters, for example, an http2 adapter or compute transformer for jsons.
For convenience, need to pass the `HttpClientAdapter` and `Transformer` ​​​​directly in function `addSentry`
And sometimes it's not convenient to use the constructor, you need the ability to directly set dio options

<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?
Check Dio extension

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [ ] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
