### PR TITLE
Fix wrong SDK being reported when sentry_logging is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+* Fix: `sentry_logging` incorrectly setting SDK name
 
 # 6.3.0-beta.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
-* Fix: `sentry_logging` incorrectly setting SDK name
+
+* Fix: `sentry_logging` incorrectly setting SDK name (#725)
 
 # 6.3.0-beta.4
 

--- a/logging/lib/src/version.dart
+++ b/logging/lib/src/version.dart
@@ -1,5 +1,5 @@
 /// The SDK version reported to Sentry.io in the submitted events.
 const String sdkVersion = '6.3.0-beta.5';
 
-/// The default SDK name reported to Sentry.io in the submitted events.
-const String sdkName = 'sentry.dart.logging';
+/// The package name reported to Sentry.io in the submitted events.
+const String packageName = 'pub:sentry_logging';

--- a/logging/test/logging_integration_test.dart
+++ b/logging/test/logging_integration_test.dart
@@ -28,10 +28,9 @@ void main() {
     await sut.call(fixture.hub, fixture.options);
     await sut.close();
 
-    expect(fixture.options.sdk.name, sdkName);
-    final package = fixture.options.sdk.packages
-        .firstWhere((it) => it.name == 'pub:sentry_logging');
-    expect(package.name, 'pub:sentry_logging');
+    final package =
+        fixture.options.sdk.packages.firstWhere((it) => it.name == packageName);
+    expect(package.name, packageName);
     expect(package.version, sdkVersion);
   });
 


### PR DESCRIPTION
## :scroll: Description
Fixes #717 


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?
I checked the Sentry UI, the package doesn't seem to be reported anywhere tho.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
