### PR TITLE
Add `Sentry.runWithClone` and `Sentry.runWithSpan`

### DIFF
--- a/dart/lib/src/hub.dart
+++ b/dart/lib/src/hub.dart
@@ -433,7 +433,7 @@ class Hub {
   }
 
   /// Runs a function in a new [Zone] in which the given [span] becomes the
-  /// current [ISentrySpan].
+  /// current span.
   ///
   /// In the new [Zone], calls to [getSpan] will return the given [span].
   T runWithSpan<T>(ISentrySpan span, T Function() fn) =>

--- a/dart/lib/src/hub.dart
+++ b/dart/lib/src/hub.dart
@@ -420,13 +420,24 @@ class Hub {
         "Tracing is disabled and this 'getSpan' returns null.",
       );
     } else {
-      final item = _peek();
+      span = Zone.current[#_span] as ISentrySpan?;
 
-      span = item.scope.span;
+      if (span == null) {
+        final item = _peek();
+
+        span = item.scope.span;
+      }
     }
 
     return span;
   }
+
+  /// Runs a function in a new [Zone] in which the given [span] becomes the
+  /// current [ISentrySpan].
+  ///
+  /// In the new [Zone], calls to [getSpan] will return the given [span].
+  T runWithSpan<T>(ISentrySpan span, T Function() fn) =>
+      runZoned(fn, zoneValues: {#_span: span});
 
   @internal
   Future<SentryId> captureTransaction(SentryTransaction transaction) async {

--- a/dart/lib/src/hub_adapter.dart
+++ b/dart/lib/src/hub_adapter.dart
@@ -94,6 +94,10 @@ class HubAdapter implements Hub {
   ISentrySpan? getSpan() => Sentry.currentHub.getSpan();
 
   @override
+  T runWithSpan<T>(ISentrySpan span, T Function() fn) =>
+      Sentry.runWithSpan(span, fn);
+
+  @override
   Future captureUserFeedback(SentryUserFeedback userFeedback) =>
       Sentry.captureUserFeedback(userFeedback);
 

--- a/dart/lib/src/noop_hub.dart
+++ b/dart/lib/src/noop_hub.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+
 import 'hub.dart';
 import 'protocol.dart';
 import 'sentry_client.dart';
@@ -98,6 +99,9 @@ class NoOpHub implements Hub {
 
   @override
   ISentrySpan? getSpan() => null;
+
+  @override
+  T runWithSpan<T>(ISentrySpan span, T Function() fn) => fn();
 
   @override
   void setSpanContext(throwable, ISentrySpan span, String transaction) {}

--- a/dart/lib/src/sentry.dart
+++ b/dart/lib/src/sentry.dart
@@ -207,7 +207,7 @@ class Sentry {
   /// Clones the current Hub
   static Hub clone() => currentHub.clone();
 
-  /// Runs a function in a new [Zone] in which a [clone] of the current [hub]
+  /// Runs a function in a new [Zone] in which a [clone] of the current [Hub]
   /// becomes the new current [Hub].
   static T runWithClone<T>(T Function() fn) =>
       runZoned(fn, zoneValues: {#_hub: clone()});
@@ -272,7 +272,7 @@ class Sentry {
   static ISentrySpan? getSpan() => currentHub.getSpan();
 
   /// Runs a function in a new [Zone] in which the given [span] becomes the
-  /// current [ISentrySpan].
+  /// current span.
   ///
   /// In the new [Zone], calls to [getSpan] will return the given [span].
   static T runWithSpan<T>(ISentrySpan span, T Function() fn) =>

--- a/dart/test/hub_test.dart
+++ b/dart/test/hub_test.dart
@@ -461,6 +461,59 @@ void main() {
       expect(calls[2].formatted, 'foo bar 2');
     });
   });
+
+  group('runWithSpan', () {
+    late Fixture fixture;
+
+    setUp(() {
+      fixture = Fixture();
+    });
+
+    test('without binding span to scope', () {
+      final hub = fixture.getSut();
+
+      final span = hub.startTransaction('a', 'a');
+
+      hub.runWithSpan(span, () {
+        expect(hub.getSpan(), span);
+      });
+
+      expect(hub.getSpan(), isNull);
+    });
+
+    test('override span bound to scope', () {
+      final hub = fixture.getSut();
+
+      expect(hub.getSpan(), isNull);
+      final spanA = hub.startTransaction('a', 'a', bindToScope: true);
+      final spanB = hub.startTransaction('b', 'b');
+
+      hub.runWithSpan(spanB, () {
+        expect(hub.getSpan(), spanB);
+      });
+
+      expect(hub.getSpan(), spanA);
+    });
+
+    test('supports nested calls', () {
+      final hub = fixture.getSut();
+
+      final spanA = hub.startTransaction('a', 'a');
+      final spanB = hub.startTransaction('b', 'b');
+
+      hub.runWithSpan(spanA, () {
+        expect(hub.getSpan(), spanA);
+
+        hub.runWithSpan(spanB, () {
+          expect(hub.getSpan(), spanB);
+        });
+
+        expect(hub.getSpan(), spanA);
+      });
+
+      expect(hub.getSpan(), isNull);
+    });
+  });
 }
 
 class Fixture {

--- a/dart/test/mocks/mock_hub.dart
+++ b/dart/test/mocks/mock_hub.dart
@@ -152,6 +152,11 @@ class MockHub implements Hub {
   }
 
   @override
+  T runWithSpan<T>(ISentrySpan span, T Function() fn) {
+    return fn();
+  }
+
+  @override
   void setSpanContext(throwable, ISentrySpan span, String transaction) {
     spanContextCals++;
   }

--- a/dio/test/mocks/mock_hub.dart
+++ b/dio/test/mocks/mock_hub.dart
@@ -158,6 +158,11 @@ class MockHub implements Hub {
   }
 
   @override
+  T runWithSpan<T>(ISentrySpan span, T Function() fn) {
+    return fn();
+  }
+
+  @override
   void setSpanContext(dynamic throwable, ISentrySpan span, String transaction) {
     spanContextCals++;
   }

--- a/flutter/test/mocks.dart
+++ b/flutter/test/mocks.dart
@@ -214,5 +214,10 @@ class NoOpHub implements Hub {
   }
 
   @override
+  T runWithSpan<T>(ISentrySpan span, T Function() fn) {
+    return fn();
+  }
+
+  @override
   void setSpanContext(throwable, ISentrySpan span, String transaction) {}
 }

--- a/logging/test/mock_hub.dart
+++ b/logging/test/mock_hub.dart
@@ -68,6 +68,11 @@ class MockHub implements Hub {
   ISentrySpan? getSpan() => NoOpSentrySpan();
 
   @override
+  T runWithSpan<T>(ISentrySpan span, T Function() fn) {
+    return fn();
+  }
+
+  @override
   bool get isEnabled => false;
 
   @override


### PR DESCRIPTION
## :scroll: Description

This change adds support for using Sentry with Dart `Zone`s.

`Sentry.runWithClone` allows users to run code in a new `Zone`, in which a clone of the current `Hub` becomes the current `Hub`. This is similar to how [Kotlin coroutines](https://docs.sentry.io/platforms/java/enriching-events/scopes/#kotlin-coroutines) have their own `Hub`s.

`Sentry.runWithSpan` allows users to run code in new `Zone`, in which a provided
span become the current span. In this `Zone` calls to `Sentry.getSpan` and `Hub.getSpan` return this span.

Let me know what you think!

## :bulb: Motivation and Context

Closes #724


## :green_heart: How did you test it?

I added unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
