### PR TITLE
ref: Change how factories are accessed

### DIFF
--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -28,9 +28,9 @@ class SentryClient {
 
   static final _sentryId = Future.value(SentryId.empty());
 
-  late SentryExceptionFactory _exceptionFactory;
+  SentryExceptionFactory get _exceptionFactory => _options.exceptionFactory;
 
-  late SentryStackTraceFactory _stackTraceFactory;
+  SentryStackTraceFactory get _stackTraceFactory => _options.stackTraceFactory;
 
   /// Instantiates a client using [SentryOptions]
   factory SentryClient(SentryOptions options) {
@@ -43,10 +43,7 @@ class SentryClient {
 
   /// Instantiates a client using [SentryOptions]
   SentryClient._(this._options)
-      : _random = _options.sampleRate == null ? null : Random() {
-    _stackTraceFactory = _options.stackTraceFactory;
-    _exceptionFactory = _options.exceptionFactory;
-  }
+      : _random = _options.sampleRate == null ? null : Random();
 
   /// Reports an [event] to Sentry.io.
   Future<SentryId> captureEvent(

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -44,11 +44,8 @@ class SentryClient {
   /// Instantiates a client using [SentryOptions]
   SentryClient._(this._options)
       : _random = _options.sampleRate == null ? null : Random() {
-    _stackTraceFactory = SentryStackTraceFactory(_options);
-    _exceptionFactory = SentryExceptionFactory(
-      _options,
-      _stackTraceFactory,
-    );
+    _stackTraceFactory = _options.stackTraceFactory;
+    _exceptionFactory = _options.exceptionFactory;
   }
 
   /// Reports an [event] to Sentry.io.

--- a/dart/lib/src/sentry_exception_factory.dart
+++ b/dart/lib/src/sentry_exception_factory.dart
@@ -7,9 +7,9 @@ import 'throwable_mechanism.dart';
 class SentryExceptionFactory {
   final SentryOptions _options;
 
-  final SentryStackTraceFactory _stacktraceFactory;
+  SentryStackTraceFactory get _stacktraceFactory => _options.stackTraceFactory;
 
-  SentryExceptionFactory(this._options, this._stacktraceFactory);
+  SentryExceptionFactory(this._options);
 
   SentryException getSentryException(
     dynamic exception, {

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -302,8 +302,7 @@ class SentryOptions {
   }
 
   @internal
-  late SentryExceptionFactory exceptionFactory =
-      SentryExceptionFactory(this, stackTraceFactory);
+  late SentryExceptionFactory exceptionFactory = SentryExceptionFactory(this);
 
   @internal
   late SentryStackTraceFactory stackTraceFactory =

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -3,7 +3,6 @@ import 'dart:developer';
 
 import 'package:meta/meta.dart';
 import 'package:http/http.dart';
-import 'package:meta/meta.dart';
 
 import 'sentry_exception_factory.dart';
 import 'sentry_stack_trace_factory.dart';

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -2,7 +2,10 @@ import 'dart:async';
 import 'dart:developer';
 
 import 'package:http/http.dart';
+import 'package:meta/meta.dart';
 
+import 'sentry_exception_factory.dart';
+import 'sentry_stack_trace_factory.dart';
 import 'diagnostic_logger.dart';
 import 'environment/environment_variables.dart';
 import 'event_processor.dart';
@@ -297,6 +300,14 @@ class SentryOptions {
   bool isTracingEnabled() {
     return tracesSampleRate != null || tracesSampler != null;
   }
+
+  @internal
+  late SentryExceptionFactory exceptionFactory =
+      SentryExceptionFactory(this, stackTraceFactory);
+
+  @internal
+  late SentryStackTraceFactory stackTraceFactory =
+      SentryStackTraceFactory(this);
 }
 
 /// This function is called with an SDK specific event object and can return a modified event

--- a/dart/lib/src/sentry_stack_trace_factory.dart
+++ b/dart/lib/src/sentry_stack_trace_factory.dart
@@ -13,6 +13,13 @@ class SentryStackTraceFactory {
   static const _stackTraceViolateDartStandard =
       'This VM has been configured to produce stack traces that violate the Dart standard.';
 
+  static const _sentryPackagesIdentifier = <String>[
+    'sentry',
+    'sentry_flutter',
+    'sentry_logging',
+    'sentry_dio',
+  ];
+
   SentryStackTraceFactory(this._options);
 
   /// returns the [SentryStackFrame] list from a stackTrace ([StackTrace] or [String])
@@ -31,7 +38,7 @@ class SentryStackTraceFactory {
 
       for (final frame in trace.frames) {
         // we don't want to add our own frames
-        if (frame.package == 'sentry') {
+        if (_sentryPackagesIdentifier.contains(frame.package)) {
           continue;
         }
 

--- a/dart/test/sentry_exception_factory_test.dart
+++ b/dart/test/sentry_exception_factory_test.dart
@@ -1,6 +1,5 @@
 import 'package:sentry/sentry.dart';
 import 'package:sentry/src/sentry_exception_factory.dart';
-import 'package:sentry/src/sentry_stack_trace_factory.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';
@@ -92,9 +91,6 @@ class Fixture {
   final options = SentryOptions(dsn: fakeDsn);
 
   SentryExceptionFactory getSut() {
-    return SentryExceptionFactory(
-      options,
-      SentryStackTraceFactory(options),
-    );
+    return SentryExceptionFactory(options);
   }
 }


### PR DESCRIPTION
## :scroll: Description
This changes how the exception and stacktrace factories are accessed.

__#skip-changelog__

## :bulb: Motivation and Context
Needed for https://github.com/getsentry/sentry-dart/pull/718

## :green_heart: How did you test it?
This is covered by the existing tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
