### PR TITLE
fix: await ZonedGuard integration to run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix: await ZonedGuard integration to run (#732)
 * Fix: `sentry_logging` incorrectly setting SDK name (#725)
 
 # 6.3.0-beta.4

--- a/dart/lib/src/default_integrations.dart
+++ b/dart/lib/src/default_integrations.dart
@@ -22,7 +22,7 @@ class RunZonedGuardedIntegration extends Integration {
 
   @override
   FutureOr<void> call(Hub hub, SentryOptions options) {
-    final completer = Completer();
+    final completer = Completer<void>();
 
     runZonedGuarded(
       () async {

--- a/dart/lib/src/default_integrations.dart
+++ b/dart/lib/src/default_integrations.dart
@@ -22,9 +22,15 @@ class RunZonedGuardedIntegration extends Integration {
 
   @override
   FutureOr<void> call(Hub hub, SentryOptions options) {
+    final completer = Completer();
+
     runZonedGuarded(
       () async {
-        await _runner();
+        try {
+          await _runner();
+        } finally {
+          completer.complete();
+        }
       },
       (exception, stackTrace) async {
         options.logger(
@@ -89,5 +95,7 @@ class RunZonedGuardedIntegration extends Integration {
     );
 
     options.sdk.addIntegration('runZonedGuardedIntegration');
+
+    return completer.future;
   }
 }

--- a/flutter/test/flutter_enricher_test.dart
+++ b/flutter/test/flutter_enricher_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:sentry_flutter/src/flutter_enricher_event_processor.dart';
 
@@ -262,6 +263,7 @@ void main() {
         platformChecker: MockPlatformChecker(
           hasNativeIntegration: false,
         ),
+        packageLoader: loadTestPackage,
       );
       await Sentry.close();
 
@@ -293,4 +295,14 @@ class Fixture {
       binding,
     );
   }
+}
+
+Future<PackageInfo> loadTestPackage() async {
+  return PackageInfo(
+    appName: 'appName',
+    packageName: 'packageName',
+    version: 'version',
+    buildNumber: 'buildNumber',
+    buildSignature: '',
+  );
 }


### PR DESCRIPTION
## :scroll: Description

This change allows users to await the completion of the `appRunner`, that was passed to`Sentry.init`.

## :bulb: Motivation and Context

Closes #730

## :green_heart: How did you test it?

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
