### PR TITLE
Bump: Sentry-Android to 5.6.1 and Sentry-Cocoa to 7.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Feat: Support maxSpan for performance API and expose SentryOptions through Hub (#716)
 * Fix: await ZonedGuard integration to run (#732)
 * Fix: `sentry_logging` incorrectly setting SDK name (#725)
+* Bump: Sentry-Android to 5.6.1 and Sentry-Cocoa to 7.9.0 (#736)
 
 # 6.3.0-beta.4
 

--- a/flutter/android/build.gradle
+++ b/flutter/android/build.gradle
@@ -54,6 +54,6 @@ android {
 }
 
 dependencies {
-    api 'io.sentry:sentry-android:5.5.2'
+    api 'io.sentry:sentry-android:5.6.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 }

--- a/flutter/ios/sentry_flutter.podspec
+++ b/flutter/ios/sentry_flutter.podspec
@@ -12,7 +12,7 @@ Sentry SDK for Flutter with support to native through sentry-cocoa.
                          :tag => s.version.to_s }
   s.source_files     = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
-  s.dependency 'Sentry', '~> 7.8.0'
+  s.dependency 'Sentry', '~> 7.9.0'
   s.ios.dependency 'Flutter'
   s.osx.dependency 'FlutterMacOS'
   s.ios.deployment_target = '9.0'


### PR DESCRIPTION
## :scroll: Description

Bump: Sentry-Android to 5.6.1 and Sentry-Cocoa to 7.9.0

## :bulb: Motivation and Context


Changes upstream seem fixes and non breaking additions, it would be nice to use some of those errors in the dart version.

## :green_heart: How did you test it?

Run the test suite locally, green.

## :pencil: Checklist

- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes

## :crystal_ball: Next steps

Grab a 🍺 😂 