### PR TITLE
Bump runner web

### DIFF
--- a/dart/example_web/pubspec.yaml
+++ b/dart/example_web/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
     path: ../../dart
 
 dev_dependencies:
-  build_runner: ^1.12.2
-  build_web_compilers: ^2.16.5
+  build_runner: ^2.1.7
+  build_web_compilers: ^3.2.2
   lints: ^1.0.1
   webdev: ^2.7.6

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   package_info_plus: ^1.0.0
 
 dev_dependencies:
-  build_runner: ^2.1.5
+  build_runner: ^2.1.7
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0


### PR DESCRIPTION
## :scroll: Description
_#skip-changelog_


## :bulb: Motivation and Context
Getting warnings from https://github.com/getsentry/sentry-dart/runs/5050190241?check_suite_focus=true

Warning:  build_web_compilers:entrypoint on web/main.dart: Your current `analyzer` version may not fully support your current SDK version.

Analyzer language version: 2.14.0
SDK language version: 2.15.0

Please update to the latest `analyzer` version (3.2.0) by running
`pub upgrade`.

If you are not getting the latest version by running the above command, you
can try adding a constraint like the following to your pubspec to start
diagnosing why you can't get the latest version:

dev_dependencies:
  analyzer: ^3.2.0


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
