### PR TITLE
Fix: Add missing return values - dart analyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Fix: Add missing return values - dart analyzer (#)
+
 # 6.3.0
 
 * Feat: Support maxSpan for performance API and expose SentryOptions through Hub (#716)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-* Fix: Add missing return values - dart analyzer (#)
+* Fix: Add missing return values - dart analyzer (#742)
 
 # 6.3.0
 

--- a/dart/lib/src/hub.dart
+++ b/dart/lib/src/hub.dart
@@ -558,5 +558,6 @@ class _WeakMap {
         stackTrace: stackTrace,
       );
     }
+    return null;
   }
 }

--- a/dart/test/sentry_options_test.dart
+++ b/dart/test/sentry_options_test.dart
@@ -89,7 +89,7 @@ void main() {
   test('isTracingEnabled is enabled by theres sampler', () {
     final options = SentryOptions(dsn: fakeDsn);
 
-    double? sampler(SentrySamplingContext samplingContext) {}
+    double? sampler(SentrySamplingContext samplingContext) => 0.0;
 
     options.tracesSampler = sampler;
 


### PR DESCRIPTION
## :scroll: Description
Fix: Add missing return values - dart analyzer


## :bulb: Motivation and Context
   info - lib/src/hub.dart:547:34 - This function has a nullable return type of 'MapEntry<ISentrySpan, String>?', but ends without returning a value. Try adding a return statement, or if no value is ever returned, try changing the return type to 'void'. - body_might_complete_normally_nullable
   info - test/sentry_options_test.dart:92:13 - This function has a nullable return type of 'double?', but ends without returning a value. Try adding a return statement, or if no value is ever returned, try changing the return type to 'void'. - body_might_complete_normally_nullable


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
