### PR TITLE
ci: Make sure that CI builds are always run using local sentry dep

### DIFF
--- a/.github/workflows/dio.yml
+++ b/.github/workflows/dio.yml
@@ -35,6 +35,8 @@ jobs:
         # coverage with 'chrome' platform hangs the build
         - name: Test (VM and browser)
           run: |
+            dart pub remove sentry
+            dart pub add sentry --path ../dart
             dart pub get
             dart test -p chrome
             dart test -p vm --coverage=coverage
@@ -64,6 +66,8 @@ jobs:
           sdk: stable
       - uses: actions/checkout@v2
       - run: |
+          dart pub remove sentry
+          dart pub add sentry --path ../dart
           dart pub get
           dart analyze --fatal-infos
           dart format --set-exit-if-changed ./

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -72,6 +72,8 @@ jobs:
           if: runner.os != 'macOS'
           run: |
             cd flutter
+            flutter pub remove sentry
+            flutter pub add sentry --path ../dart
             flutter pub get
             flutter test --platform chrome
             flutter test --coverage
@@ -127,6 +129,8 @@ jobs:
       - uses: subosito/flutter-action@v2
       - run: |
           cd flutter
+          flutter pub remove sentry
+          flutter pub add sentry --path ../dart
           flutter pub get
           flutter format -n --set-exit-if-changed ./
           flutter analyze

--- a/.github/workflows/logging.yml
+++ b/.github/workflows/logging.yml
@@ -35,6 +35,8 @@ jobs:
         # coverage with 'chrome' platform hangs the build
         - name: Test (VM and browser)
           run: |
+            dart pub remove sentry
+            dart pub add sentry --path ../dart
             dart pub get
             dart test -p chrome
             dart test -p vm --coverage=coverage
@@ -64,6 +66,8 @@ jobs:
           sdk: stable
       - uses: actions/checkout@v2
       - run: |
+          dart pub remove sentry
+          dart pub add sentry --path ../dart
           dart pub get
           dart analyze --fatal-infos
           dart format --set-exit-if-changed ./


### PR DESCRIPTION
Crafts pre-publish step removes `dependencies_override` from the `pubspec.yaml` files, which prevents release builds from every succeeding.
This makes sure that we always use local version of sentry, even when it's not overridden in the `yaml`.
Note that it has to be removed first before adding back.

#skip-changelog