### PR TITLE
ci: Disable dart-package-analyzer on release branches

### DIFF
--- a/.github/workflows/dio.yml
+++ b/.github/workflows/dio.yml
@@ -69,6 +69,10 @@ jobs:
           dart format --set-exit-if-changed ./
 
   package-analysis:
+    # `axel-op/dart-package-analyzer` is using `flutter pub upgrade` instead of `get`,
+    # which ignores pubspec.yaml `dependency_overrides`. Because of that, all `release/*` branches are failing,
+    # because the package cannot find the "about to be released" version of our sentry-dart package that it depends on.
+    if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -132,6 +132,10 @@ jobs:
           flutter analyze
 
   package-analysis:
+    # `axel-op/dart-package-analyzer` is using `flutter pub upgrade` instead of `get`,
+    # which ignores pubspec.yaml `dependency_overrides`. Because of that, all `release/*` branches are failing,
+    # because the package cannot find the "about to be released" version of our sentry-dart package that it depends on.
+    if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/.github/workflows/logging.yml
+++ b/.github/workflows/logging.yml
@@ -69,6 +69,10 @@ jobs:
           dart format --set-exit-if-changed ./
 
   package-analysis:
+    # `axel-op/dart-package-analyzer` is using `flutter pub upgrade` instead of `get`,
+    # which ignores pubspec.yaml `dependency_overrides`. Because of that, all `release/*` branches are failing,
+    # because the package cannot find the "about to be released" version of our sentry-dart package that it depends on.
+    if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:


### PR DESCRIPTION
`axel-op/dart-package-analyzer` is using `flutter pub upgrade` instead of `get`, which ignores `pubspec.yaml` `dependency_overrides`.
Because of that, all `release/*` branches are failing, because the package cannot find the "about to be released" version of our sentry-dart package that it depends on.

#skip-changelog