### PR TITLE
Fix: Dio event processor safelly bails if no DioError in the exception list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Fix: Dio event processor safelly bails if no DioError in the exception list (#)
+
 ## 6.5.0-alpha.1
 
 * Feat: Mobile Vitals - Native App Start (#749)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Fix: Dio event processor safelly bails if no DioError in the exception list (#)
+* Fix: Dio event processor safelly bails if no DioError in the exception list (#795)
 
 ## 6.5.0-alpha.1
 

--- a/dio/lib/src/dio_event_processor.dart
+++ b/dio/lib/src/dio_event_processor.dart
@@ -9,6 +9,9 @@ import 'package:sentry/src/sentry_exception_factory.dart';
 /// It adds information about [DioError.response] if present and also about
 /// the inner exceptions.
 class DioEventProcessor implements EventProcessor {
+  // Because of obfuscation, we need to dynamically get the name
+  static final _dioErrorType = (DioError).toString();
+
   /// This is an [EventProcessor], which improves crash reports of [DioError]s.
   DioEventProcessor(this._options, this._maxRequestBodySize);
 
@@ -73,9 +76,13 @@ class DioEventProcessor implements EventProcessor {
     List<SentryException> exceptions,
     DioError dioError,
   ) {
-    var dioSentryException = exceptions
-        .where((element) => element.type == dioError.runtimeType.toString())
-        .first;
+    final dioSentryExceptions =
+        exceptions.where((element) => element.type == _dioErrorType);
+
+    if (dioSentryExceptions.isEmpty) {
+      return exceptions;
+    }
+    var dioSentryException = dioSentryExceptions.first;
 
     final exceptionIndex = exceptions.indexOf(dioSentryException);
     exceptions.remove(dioSentryException);


### PR DESCRIPTION
## :scroll: Description
Fix: Dio event processor safelly bails if no DioError in the exception list


## :bulb: Motivation and Context
Closes https://github.com/getsentry/sentry-dart/issues/790


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
