### PR TITLE
Make scheduler binding return null instead of throwing if not initialised

### DIFF
--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -131,7 +131,11 @@ mixin SentryFlutter {
       integrations.add(NativeAppStartIntegration(
         SentryNative(),
         () {
-          return SchedulerBinding.instance;
+          try {
+            /// Flutter >= 2.12 throws if SchedulerBinding.instance isn't initialized.
+            return SchedulerBinding.instance;
+          } catch (_) {}
+          return null;
         },
       ));
     }


### PR DESCRIPTION
_#skip-changelog_