### PR TITLE
Remove parameter from manual setup classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Fix: Remove `SentryOptions` related parameters from classes which also take `Hub` as a parameter
+
 ## 6.5.0-alpha.1
 
 * Feat: Mobile Vitals - Native App Start (#749)

--- a/dart/lib/src/http_client/failed_request_client.dart
+++ b/dart/lib/src/http_client/failed_request_client.dart
@@ -68,7 +68,6 @@ class FailedRequestClient extends BaseClient {
     this.maxRequestBodySize = MaxRequestBodySize.never,
     this.failedRequestStatusCodes = const [],
     this.captureFailedRequests = true,
-    this.sendDefaultPii = false,
     Client? client,
     Hub? hub,
   })  : _hub = hub ?? HubAdapter(),
@@ -93,8 +92,6 @@ class FailedRequestClient extends BaseClient {
   ///
   /// Per default no status code is considered a failed request.
   final List<SentryStatusCode> failedRequestStatusCodes;
-
-  final bool sendDefaultPii;
 
   @override
   Future<StreamedResponse> send(BaseRequest request) async {
@@ -161,10 +158,10 @@ class FailedRequestClient extends BaseClient {
 
     final sentryRequest = SentryRequest(
       method: request.method,
-      headers: sendDefaultPii ? request.headers : null,
+      headers: _hub.options.sendDefaultPii ? request.headers : null,
       url: urlWithoutQuery,
       queryString: query,
-      cookies: sendDefaultPii ? request.headers['Cookie'] : null,
+      cookies: _hub.options.sendDefaultPii ? request.headers['Cookie'] : null,
       data: _getDataFromRequest(request),
       other: {
         'content_length': request.contentLength.toString(),

--- a/dart/lib/src/http_client/sentry_http_client.dart
+++ b/dart/lib/src/http_client/sentry_http_client.dart
@@ -83,7 +83,6 @@ class SentryHttpClient extends BaseClient {
     MaxRequestBodySize maxRequestBodySize = MaxRequestBodySize.never,
     List<SentryStatusCode> failedRequestStatusCodes = const [],
     bool captureFailedRequests = false,
-    bool sendDefaultPii = false,
     bool networkTracing = false,
   }) {
     _hub = hub ?? HubAdapter();
@@ -94,7 +93,6 @@ class SentryHttpClient extends BaseClient {
       failedRequestStatusCodes: failedRequestStatusCodes,
       captureFailedRequests: captureFailedRequests,
       maxRequestBodySize: maxRequestBodySize,
-      sendDefaultPii: sendDefaultPii,
       hub: _hub,
       client: innerClient,
     );

--- a/dart/test/http_client/failed_request_client_test.dart
+++ b/dart/test/http_client/failed_request_client_test.dart
@@ -259,7 +259,6 @@ class Fixture {
       captureFailedRequests: captureFailedRequests,
       failedRequestStatusCodes: badStatusCodes,
       maxRequestBodySize: maxRequestBodySize,
-      sendDefaultPii: sendDefaultPii,
     );
   }
 

--- a/dart/test/http_client/failed_request_client_test.dart
+++ b/dart/test/http_client/failed_request_client_test.dart
@@ -253,9 +253,10 @@ class Fixture {
     bool sendDefaultPii = true,
   }) {
     final mc = client ?? getClient();
+    var hub = _hub..options.sendDefaultPii = sendDefaultPii;
     return FailedRequestClient(
       client: mc,
-      hub: _hub,
+      hub: hub,
       captureFailedRequests: captureFailedRequests,
       failedRequestStatusCodes: badStatusCodes,
       maxRequestBodySize: maxRequestBodySize,


### PR DESCRIPTION
## :scroll: Description
Since the SentryOptions are now accessible via Hub, parameters for the following classes aren't needed anymore, as they can be read from the options.


## :bulb: Motivation and Context
fixes issue #750 


## :green_heart: How did you test it?
Running workflow on my forked repo

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
