### PR TITLE
feat: iOS upload DebugMeta with exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Prepare future support for iOS and macOS obfuscated app symbolication using dSYM (requires Flutter `master` channel) ([#823](https://github.com/getsentry/sentry-dart/pull/823))
 - Bump Android SDK from v6.3.1 to v6.4.1 ([#989](https://github.com/getsentry/sentry-dart/pull/989))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#641)
   - [diff](https://github.com/getsentry/sentry-java/compare/6.3.1...6.4.1)
@@ -458,7 +459,7 @@ This should not break anything since the Dart's min. version is already 2.12.0 a
 ### Breaking Changes:
 
 * Fix: Plugin Registrant class moved to barrel file (#358)
-  * This changed the import from `import 'package:sentry_flutter/src/sentry_flutter_web.dart';` 
+  * This changed the import from `import 'package:sentry_flutter/src/sentry_flutter_web.dart';`
     to `import 'package:sentry_flutter/sentry_flutter_web.dart';`
   * This could lead to breaking changes. Typically it shouldn't because the referencing file is auto-generated.
 * Fix: Prefix classes with Sentry (#357)

--- a/dart/lib/src/protocol/debug_image.dart
+++ b/dart/lib/src/protocol/debug_image.dart
@@ -13,8 +13,11 @@ import 'package:meta/meta.dart';
 class DebugImage {
   final String? uuid;
 
-  /// Required. Type of the debug image. Must be "macho".
+  /// Required. Type of the debug image.
   final String type;
+
+  // Name of the image. Sentry-cocoa only.
+  final String? name;
 
   /// Required. Identifier of the dynamic library or executable. It is the value of the LC_UUID load command in the Mach header, formatted as UUID.
   final String? debugId;
@@ -22,6 +25,10 @@ class DebugImage {
   /// Required. Memory address, at which the image is mounted in the virtual address space of the process.
   /// Should be a string in hex representation prefixed with "0x".
   final String? imageAddr;
+
+  /// Optional. Preferred load address of the image in virtual memory, as declared in the headers of the image.
+  /// When loading an image, the operating system may still choose to place it at a different address.
+  final String? imageVmAddr;
 
   /// Required. The size of the image in virtual memory. If missing, Sentry will assume that the image spans up to the next image, which might lead to invalid stack traces.
   final int? imageSize;
@@ -40,7 +47,9 @@ class DebugImage {
 
   const DebugImage({
     required this.type,
+    this.name,
     this.imageAddr,
+    this.imageVmAddr,
     this.debugId,
     this.debugFile,
     this.imageSize,
@@ -54,7 +63,9 @@ class DebugImage {
   factory DebugImage.fromJson(Map<String, dynamic> json) {
     return DebugImage(
       type: json['type'],
+      name: json['name'],
       imageAddr: json['image_addr'],
+      imageVmAddr: json['image_vmaddr'],
       debugId: json['debug_id'],
       debugFile: json['debug_file'],
       imageSize: json['image_size'],
@@ -79,6 +90,10 @@ class DebugImage {
       json['debug_id'] = debugId;
     }
 
+    if (name != null) {
+      json['name'] = name;
+    }
+
     if (debugFile != null) {
       json['debug_file'] = debugFile;
     }
@@ -89,6 +104,10 @@ class DebugImage {
 
     if (imageAddr != null) {
       json['image_addr'] = imageAddr;
+    }
+
+    if (imageVmAddr != null) {
+      json['image_vmaddr'] = imageVmAddr;
     }
 
     if (imageSize != null) {
@@ -108,22 +127,26 @@ class DebugImage {
 
   DebugImage copyWith({
     String? uuid,
+    String? name,
     String? type,
     String? debugId,
     String? debugFile,
     String? codeFile,
     String? imageAddr,
+    String? imageVmAddr,
     int? imageSize,
     String? arch,
     String? codeId,
   }) =>
       DebugImage(
         uuid: uuid ?? this.uuid,
+        name: name ?? this.name,
         type: type ?? this.type,
         debugId: debugId ?? this.debugId,
         debugFile: debugFile ?? this.debugFile,
         codeFile: codeFile ?? this.codeFile,
         imageAddr: imageAddr ?? this.imageAddr,
+        imageVmAddr: imageVmAddr ?? this.imageVmAddr,
         imageSize: imageSize ?? this.imageSize,
         arch: arch ?? this.arch,
         codeId: codeId ?? this.codeId,

--- a/dart/lib/src/sentry_stack_trace_factory.dart
+++ b/dart/lib/src/sentry_stack_trace_factory.dart
@@ -9,9 +9,8 @@ import 'sentry_options.dart';
 class SentryStackTraceFactory {
   final SentryOptions _options;
 
-  final _absRegex = RegExp('abs +([A-Fa-f0-9]+)');
-  static const _stackTraceViolateDartStandard =
-      'This VM has been configured to produce stack traces that violate the Dart standard.';
+  final _absRegex = RegExp(r'^\s*#[0-9]+ +abs +([A-Fa-f0-9]+)');
+  final _frameRegex = RegExp(r'^\s*#', multiLine: true);
 
   static const _sentryPackagesIdentifier = <String>[
     'sentry',
@@ -24,39 +23,42 @@ class SentryStackTraceFactory {
 
   /// returns the [SentryStackFrame] list from a stackTrace ([StackTrace] or [String])
   List<SentryStackFrame> getStackFrames(dynamic stackTrace) {
-    final chain = (stackTrace is StackTrace)
-        ? Chain.forTrace(stackTrace)
-        : (stackTrace is String)
-            ? Chain.parse(stackTrace)
-            : Chain.parse('');
+    Chain? chain;
+    if (stackTrace is StackTrace) {
+      chain = Chain.forTrace(stackTrace);
+    } else if (stackTrace is String) {
+      // Remove headers (everything before the first line starting with '#').
+      // *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
+      // pid: 19226, tid: 6103134208, name io.flutter.ui
+      // os: macos arch: arm64 comp: no sim: no
+      // isolate_dso_base: 10fa20000, vm_dso_base: 10fa20000
+      // isolate_instructions: 10fa27070, vm_instructions: 10fa21e20
+      //     #00 abs 000000723d6346d7 _kDartIsolateSnapshotInstructions+0x1e26d7
+      //     #01 abs 000000723d637527 _kDartIsolateSnapshotInstructions+0x1e5527
+
+      final match = _frameRegex.firstMatch(stackTrace);
+      if (match != null) {
+        chain = Chain.parse(
+            match.start == 0 ? stackTrace : stackTrace.substring(match.start));
+      }
+    }
+    chain ??= Chain([]);
 
     final frames = <SentryStackFrame>[];
-    var symbolicated = true;
-
     for (var t = 0; t < chain.traces.length; t += 1) {
       final trace = chain.traces[t];
 
       for (final frame in trace.frames) {
         // we don't want to add our own frames
-        if (_sentryPackagesIdentifier.contains(frame.package)) {
+        if (frame.package != null &&
+            _sentryPackagesIdentifier.contains(frame.package)) {
           continue;
         }
 
-        final member = frame.member;
-        // ideally the language would offer us a native way of parsing it.
-        if (member != null && member.contains(_stackTraceViolateDartStandard)) {
-          symbolicated = false;
+        final stackTraceFrame = encodeStackTraceFrame(frame);
+        if (stackTraceFrame != null) {
+          frames.add(stackTraceFrame);
         }
-
-        final stackTraceFrame = encodeStackTraceFrame(
-          frame,
-          symbolicated: symbolicated,
-        );
-
-        if (stackTraceFrame == null) {
-          continue;
-        }
-        frames.add(stackTraceFrame);
       }
 
       // fill asynchronous gap
@@ -70,65 +72,53 @@ class SentryStackTraceFactory {
 
   /// converts [Frame] to [SentryStackFrame]
   @visibleForTesting
-  SentryStackFrame? encodeStackTraceFrame(
-    Frame frame, {
-    bool symbolicated = true,
-  }) {
+  SentryStackFrame? encodeStackTraceFrame(Frame frame) {
     final member = frame.member;
 
-    SentryStackFrame? sentryStackFrame;
-
-    if (symbolicated) {
-      final fileName = frame.uri.pathSegments.isNotEmpty
-          ? frame.uri.pathSegments.last
-          : null;
-
-      final abs = '$eventOrigin${_absolutePathForCrashReport(frame)}';
-
-      sentryStackFrame = SentryStackFrame(
-        absPath: abs,
-        function: member,
-        // https://docs.sentry.io/development/sdk-dev/features/#in-app-frames
-        inApp: isInApp(frame),
-        fileName: fileName,
-        package: frame.package,
-      );
-
-      if (frame.line != null && frame.line! >= 0) {
-        sentryStackFrame = sentryStackFrame.copyWith(lineNo: frame.line);
-      }
-
-      if (frame.column != null && frame.column! >= 0) {
-        sentryStackFrame = sentryStackFrame.copyWith(colNo: frame.column);
-      }
-    } else if (member != null) {
+    if (frame is UnparsedFrame && member != null) {
       // if --split-debug-info is enabled, thats what we see:
-      // warning:  This VM has been configured to produce stack traces that violate the Dart standard.
-      // ***       *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
-      // unparsed  pid: 30930, tid: 30990, name 1.ui
-      // unparsed  build_id: '5346e01103ffeed44e97094ff7bfcc19'
-      // unparsed  isolate_dso_base: 723d447000, vm_dso_base: 723d447000
-      // unparsed  isolate_instructions: 723d452000, vm_instructions: 723d449000
-      // unparsed      #00 abs 000000723d6346d7 virt 00000000001ed6d7 _kDartIsolateSnapshotInstructions+0x1e26d7
-      // unparsed      #01 abs 000000723d637527 virt 00000000001f0527 _kDartIsolateSnapshotInstructions+0x1e5527
-      // unparsed      #02 abs 000000723d4a41a7 virt 000000000005d1a7 _kDartIsolateSnapshotInstructions+0x521a7
-      // unparsed      #03 abs 000000723d624663 virt 00000000001dd663 _kDartIsolateSnapshotInstructions+0x1d2663
-      // unparsed      #04 abs 000000723d4b8c3b virt 0000000000071c3b _kDartIsolateSnapshotInstructions+0x66c3b
+      // *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
+      // pid: 19226, tid: 6103134208, name io.flutter.ui
+      // os: macos arch: arm64 comp: no sim: no
+      // isolate_dso_base: 10fa20000, vm_dso_base: 10fa20000
+      // isolate_instructions: 10fa27070, vm_instructions: 10fa21e20
+      //     #00 abs 000000723d6346d7 _kDartIsolateSnapshotInstructions+0x1e26d7
+      //     #01 abs 000000723d637527 _kDartIsolateSnapshotInstructions+0x1e5527
 
       // we are only interested on the #01, 02... items which contains the 'abs' addresses.
-      final matches = _absRegex.allMatches(member);
-
-      if (matches.isNotEmpty) {
-        final abs = matches.elementAt(0).group(1);
-        if (abs != null) {
-          sentryStackFrame = SentryStackFrame(
-            instructionAddr: '0x$abs',
-            platform: 'native', // to trigger symbolication
-          );
-        }
+      final match = _absRegex.firstMatch(member);
+      if (match != null) {
+        return SentryStackFrame(
+          instructionAddr: '0x${match.group(1)!}',
+          platform: 'native', // to trigger symbolication & native LoadImageList
+        );
       }
+
+      // We shouldn't get here. If we do, it means there's likely an issue in
+      // the parsing so let's fall back and post a stack trace as is, so that at
+      // least we get an indication something's wrong and are able to fix it.
     }
 
+    final fileName =
+        frame.uri.pathSegments.isNotEmpty ? frame.uri.pathSegments.last : null;
+    final abs = '$eventOrigin${_absolutePathForCrashReport(frame)}';
+
+    var sentryStackFrame = SentryStackFrame(
+      absPath: abs,
+      function: member,
+      // https://docs.sentry.io/development/sdk-dev/features/#in-app-frames
+      inApp: isInApp(frame),
+      fileName: fileName,
+      package: frame.package,
+    );
+
+    if (frame.line != null && frame.line! >= 0) {
+      sentryStackFrame = sentryStackFrame.copyWith(lineNo: frame.line);
+    }
+
+    if (frame.column != null && frame.column! >= 0) {
+      sentryStackFrame = sentryStackFrame.copyWith(colNo: frame.column);
+    }
     return sentryStackFrame;
   }
 

--- a/dart/lib/src/sentry_stack_trace_factory.dart
+++ b/dart/lib/src/sentry_stack_trace_factory.dart
@@ -57,6 +57,7 @@ class SentryStackTraceFactory {
 
     // We need to convert to string and split the headers manually, otherwise
     // they end up in the final stack trace as "unparsed" lines.
+    // Note: [Chain.forTrace] would call [stackTrace.toString()] too.
     if (stackTrace is StackTrace) {
       stackTrace = stackTrace.toString();
     }
@@ -71,11 +72,9 @@ class SentryStackTraceFactory {
       //     #00 abs 000000723d6346d7 _kDartIsolateSnapshotInstructions+0x1e26d7
       //     #01 abs 000000723d637527 _kDartIsolateSnapshotInstructions+0x1e5527
 
-      final match = _frameRegex.firstMatch(stackTrace);
-      if (match != null) {
-        return Chain.parse(
-            match.start == 0 ? stackTrace : stackTrace.substring(match.start));
-      }
+      final startOffset = _frameRegex.firstMatch(stackTrace)?.start ?? 0;
+      return Chain.parse(
+          startOffset == 0 ? stackTrace : stackTrace.substring(startOffset));
     }
     return Chain([]);
   }

--- a/dart/lib/src/sentry_stack_trace_factory.dart
+++ b/dart/lib/src/sentry_stack_trace_factory.dart
@@ -23,7 +23,7 @@ class SentryStackTraceFactory {
 
   /// returns the [SentryStackFrame] list from a stackTrace ([StackTrace] or [String])
   List<SentryStackFrame> getStackFrames(dynamic stackTrace) {
-    final chain = parseStackTrace(stackTrace);
+    final chain = _parseStackTrace(stackTrace);
     final frames = <SentryStackFrame>[];
     for (var t = 0; t < chain.traces.length; t += 1) {
       final trace = chain.traces[t];
@@ -50,7 +50,7 @@ class SentryStackTraceFactory {
     return frames.reversed.toList();
   }
 
-  Chain parseStackTrace(dynamic stackTrace) {
+  Chain _parseStackTrace(dynamic stackTrace) {
     if (stackTrace is Chain || stackTrace is Trace) {
       return Chain.forTrace(stackTrace);
     }

--- a/dart/test/protocol/debug_image_test.dart
+++ b/dart/test/protocol/debug_image_test.dart
@@ -64,7 +64,9 @@ void main() {
 
       final copy = data.copyWith(
         type: 'type1',
+        name: 'name',
         imageAddr: 'imageAddr1',
+        imageVmAddr: 'imageVmAddr1',
         debugId: 'debugId1',
         debugFile: 'debugFile1',
         imageSize: 2,

--- a/dart/test/stack_trace_test.dart
+++ b/dart/test/stack_trace_test.dart
@@ -220,7 +220,7 @@ isolate_instructions: 10fa27070, vm_instructions: 10fa21e20
       final frames = Fixture()
           .getSut(considerInAppFramesByDefault: true)
           .getStackFrames('''
-#0 asyncThrows (package:example/main.dart:404)
+#0 asyncThrows (file:/foo/bar/main.dart:404)
 #1 MainScaffold.build.<anonymous closure> (package:example/main.dart:131)
 #2 PlatformDispatcher._dispatchPointerDataPacket (dart:ui/platform_dispatcher.dart:341)
             ''').map((frame) => frame.toJson());
@@ -229,7 +229,7 @@ isolate_instructions: 10fa27070, vm_instructions: 10fa21e20
           'filename': 'platform_dispatcher.dart',
           'function': 'PlatformDispatcher._dispatchPointerDataPacket',
           'lineno': 341,
-          'abs_path': 'dart:ui/platform_dispatcher.dart',
+          'abs_path': '${eventOrigin}dart:ui/platform_dispatcher.dart',
           'in_app': false
         },
         {
@@ -237,15 +237,14 @@ isolate_instructions: 10fa27070, vm_instructions: 10fa21e20
           'package': 'example',
           'function': 'MainScaffold.build.<fn>',
           'lineno': 131,
-          'abs_path': 'package:example/main.dart',
+          'abs_path': '${eventOrigin}package:example/main.dart',
           'in_app': true
         },
         {
           'filename': 'main.dart',
-          'package': 'example',
           'function': 'asyncThrows',
           'lineno': 404,
-          'abs_path': 'package:example/main.dart',
+          'abs_path': '${eventOrigin}main.dart',
           'in_app': true
         }
       ]);

--- a/dart/test/stack_trace_test.dart
+++ b/dart/test/stack_trace_test.dart
@@ -169,50 +169,85 @@ void main() {
       ]);
     });
 
-    test('sets instruction_addr if stack trace violates dart standard', () {
-      final frames = Fixture()
-          .getSut(considerInAppFramesByDefault: true)
-          .getStackFrames('''
-      warning:  This VM has been configured to produce stack traces that violate the Dart standard.
-      unparsed      #00 abs 000000723d6346d7 virt 00000000001ed6d7 _kDartIsolateSnapshotInstructions+0x1e26d7
-      unparsed      #01 abs 000000723d637527 virt 00000000001f0527 _kDartIsolateSnapshotInstructions+0x1e5527
-      ''').map((frame) => frame.toJson());
+    test('parses obfuscated stack trace', () {
+      final stackTraces = [
+        // Older format up to Dart SDK v2.18 (Flutter v3.3)
+        '''
+warning:  This VM has been configured to produce stack traces that violate the Dart standard.
+*** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
+pid: 30930, tid: 30990, name 1.ui
+build_id: '5346e01103ffeed44e97094ff7bfcc19'
+isolate_dso_base: 723d447000, vm_dso_base: 723d447000
+isolate_instructions: 723d452000, vm_instructions: 723d449000
+    #00 abs 000000723d6346d7 virt 00000000001ed6d7 _kDartIsolateSnapshotInstructions+0x1e26d7
+    #01 abs 000000723d637527 virt 00000000001f0527 _kDartIsolateSnapshotInstructions+0x1e5527
+        ''',
+        // Newer format
+        '''
+*** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
+pid: 19226, tid: 6103134208, name io.flutter.ui
+os: macos arch: arm64 comp: no sim: no
+isolate_dso_base: 10fa20000, vm_dso_base: 10fa20000
+isolate_instructions: 10fa27070, vm_instructions: 10fa21e20
+    #00 abs 000000723d6346d7 _kDartIsolateSnapshotInstructions+0x1e26d7
+    #01 abs 000000723d637527 _kDartIsolateSnapshotInstructions+0x1e5527
+        ''',
+      ];
 
-      expect(frames, [
-        {
-          'platform': 'native',
-          'instruction_addr': '0x000000723d637527',
-        },
-        {
-          'platform': 'native',
-          'instruction_addr': '0x000000723d6346d7',
-        },
-      ]);
+      for (var traceString in stackTraces) {
+        final frames = Fixture()
+            .getSut(considerInAppFramesByDefault: true)
+            .getStackFrames(traceString)
+            .map((frame) => frame.toJson());
+
+        expect(
+            frames,
+            [
+              {
+                'platform': 'native',
+                'instruction_addr': '0x000000723d637527',
+              },
+              {
+                'platform': 'native',
+                'instruction_addr': '0x000000723d6346d7',
+              },
+            ],
+            reason: "Failed to parse StackTrace:$traceString");
+      }
     });
 
-    test('sets instruction_addr and ignores noise', () {
+    test('parses normal stack trace', () {
       final frames = Fixture()
           .getSut(considerInAppFramesByDefault: true)
           .getStackFrames('''
-      warning:  This VM has been configured to produce stack traces that violate the Dart standard.
-      ***       *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
-      unparsed  pid: 30930, tid: 30990, name 1.ui
-      unparsed  build_id: '5346e01103ffeed44e97094ff7bfcc19'
-      unparsed  isolate_dso_base: 723d447000, vm_dso_base: 723d447000
-      unparsed  isolate_instructions: 723d452000, vm_instructions: 723d449000
-      unparsed      #00 abs 000000723d6346d7 virt 00000000001ed6d7 _kDartIsolateSnapshotInstructions+0x1e26d7
-      unparsed      #01 abs 000000723d637527 virt 00000000001f0527 _kDartIsolateSnapshotInstructions+0x1e5527
-      ''').map((frame) => frame.toJson());
-
+#0 asyncThrows (package:example/main.dart:404)
+#1 MainScaffold.build.<anonymous closure> (package:example/main.dart:131)
+#2 PlatformDispatcher._dispatchPointerDataPacket (dart:ui/platform_dispatcher.dart:341)
+            ''').map((frame) => frame.toJson());
       expect(frames, [
         {
-          'platform': 'native',
-          'instruction_addr': '0x000000723d637527',
+          'filename': 'platform_dispatcher.dart',
+          'function': 'PlatformDispatcher._dispatchPointerDataPacket',
+          'lineno': 341,
+          'abs_path': 'dart:ui/platform_dispatcher.dart',
+          'in_app': false
         },
         {
-          'platform': 'native',
-          'instruction_addr': '0x000000723d6346d7',
+          'filename': 'main.dart',
+          'package': 'example',
+          'function': 'MainScaffold.build.<fn>',
+          'lineno': 131,
+          'abs_path': 'package:example/main.dart',
+          'in_app': true
         },
+        {
+          'filename': 'main.dart',
+          'package': 'example',
+          'function': 'asyncThrows',
+          'lineno': 404,
+          'abs_path': 'package:example/main.dart',
+          'in_app': true
+        }
       ]);
     });
   });

--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -35,6 +35,14 @@ Future<void> main() async {
       // going to log too much for your app, but can be useful when figuring out
       // configuration issues, e.g. finding out why your events are not uploaded.
       options.debug = true;
+      // Override the logger in release mode in this exmaple. Sentry normally
+      // uses developer.log which doesn't print anything in release mode.
+      if (kReleaseMode) {
+        options.logger = (SentryLevel level, String message,
+            {String? logger, Object? exception, StackTrace? stackTrace}) {
+          print('${DateTime.now().toUtc()} Sentry [${level.name}]: $message');
+        };
+      }
     },
     // Init your App.
     appRunner: () => runApp(

--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -31,6 +31,10 @@ Future<void> main() async {
       options.attachThreads = true;
       options.enableWindowMetricBreadcrumbs = true;
       options.addIntegration(LoggingIntegration());
+      // We can enable Sentry debug logging during development. This is likely
+      // going to log too much for your app, but can be useful when figuring out
+      // configuration issues, e.g. finding out why your events are not uploaded.
+      options.debug = kDebugMode;
     },
     // Init your App.
     appRunner: () => runApp(

--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -34,7 +34,7 @@ Future<void> main() async {
       // We can enable Sentry debug logging during development. This is likely
       // going to log too much for your app, but can be useful when figuring out
       // configuration issues, e.g. finding out why your events are not uploaded.
-      options.debug = kDebugMode;
+      options.debug = true;
     },
     // Init your App.
     appRunner: () => runApp(

--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -35,14 +35,6 @@ Future<void> main() async {
       // going to log too much for your app, but can be useful when figuring out
       // configuration issues, e.g. finding out why your events are not uploaded.
       options.debug = true;
-      // Override the logger in release mode in this exmaple. Sentry normally
-      // uses developer.log which doesn't print anything in release mode.
-      if (kReleaseMode) {
-        options.logger = (SentryLevel level, String message,
-            {String? logger, Object? exception, StackTrace? stackTrace}) {
-          print('${DateTime.now().toUtc()} Sentry [${level.name}]: $message');
-        };
-      }
     },
     // Init your App.
     appRunner: () => runApp(

--- a/flutter/example/run.sh
+++ b/flutter/example/run.sh
@@ -32,6 +32,9 @@ elif [ "$1" == "web" ]; then
     flutter build web --dart-define=SENTRY_RELEASE=$SENTRY_RELEASE --source-maps
     ls -lah $OUTPUT_FOLDER_WEB
     echo -e "[\033[92mrun\033[0m] Built: $OUTPUT_FOLDER_WEB"
+elif [ "$1" == "macos" ]; then
+    flutter build macos --split-debug-info=$symbolsDir --obfuscate
+    ./build/macos/Build/Products/Release/sentry_flutter_example.app/Contents/MacOS/sentry_flutter_example &
 else
     if [ "$1" == "" ]; then
         echo -e "[\033[92mrun\033[0m] Pass the platform you'd like to run: android, ios, web"
@@ -60,5 +63,6 @@ if [ "$1" == "web" ]; then
 else
     echo -e "[\033[92mrun\033[0m] Uploading debug information files"
     # directory 'symbols' contain the Dart debug info files but to include platform ones, use current dir.
-    sentry-cli upload-dif --wait --org $SENTRY_ORG --project $SENTRY_PROJECT .
+    # TODO move actually launching the app after the symbols are uploaded and procesed on the server.
+    sentry-cli upload-dif --wait --org $SENTRY_ORG --project $SENTRY_PROJECT build
 fi

--- a/flutter/ios/Classes/SentryFlutterPluginApple.swift
+++ b/flutter/ios/Classes/SentryFlutterPluginApple.swift
@@ -13,7 +13,6 @@ import AppKit
 public class SentryFlutterPluginApple: NSObject, FlutterPlugin {
 
     private var sentryOptions: Options?
-    let sentryIOSPrivate = PrivateSentrySDKOnly()
 
     // The Cocoa SDK is init. after the notification didBecomeActiveNotification is registered.
     // We need to be able to receive this notification and start a session when the SDK is fully operational.
@@ -180,7 +179,7 @@ public class SentryFlutterPluginApple: NSObject, FlutterPlugin {
             }
 
             if arguments["debugImages"] as? Bool ?? false {
-                let debugImages = self.sentryIOSPrivate.getDebugImages() as [DebugMeta]
+                let debugImages = PrivateSentrySDKOnly.getDebugImages() as [DebugMeta]
                 infos["debugImages"] = debugImages.map { $0.serialize() }
             }
 

--- a/flutter/ios/Classes/SentryFlutterPluginApple.swift
+++ b/flutter/ios/Classes/SentryFlutterPluginApple.swift
@@ -181,16 +181,7 @@ public class SentryFlutterPluginApple: NSObject, FlutterPlugin {
 
             if arguments["debugImages"] as? Bool ?? false {
                 let debugImages = self.sentryIOSPrivate.getDebugImages() as [DebugMeta]
-                infos["debugImages"] = debugImages.map {
-                    [
-                        "uuid": $0.uuid,
-                        "type": $0.type,
-                        "name": $0.name,
-                        "image_size": $0.imageSize,
-                        "image_addr": $0.imageAddress,
-                        "image_vmaddr": $0.imageVmAddress,
-                    ]
-                }
+                infos["debugImages"] = debugImages.map { $0.serialize() }
             }
 
             result(infos)

--- a/flutter/ios/Classes/SentryFlutterPluginApple.swift
+++ b/flutter/ios/Classes/SentryFlutterPluginApple.swift
@@ -59,7 +59,10 @@ public class SentryFlutterPluginApple: NSObject, FlutterPlugin {
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         switch call.method as String {
         case "loadContexts":
-            loadContexts(call, result: result)
+            loadContexts(result: result)
+
+        case "loadImageList":
+            loadImageList(result: result)
 
         case "initNativeSdk":
             initNativeSdk(call, result: result)
@@ -126,13 +129,7 @@ public class SentryFlutterPluginApple: NSObject, FlutterPlugin {
     }
 
     // swiftlint:disable:next cyclomatic_complexity
-    private func loadContexts(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-        guard let arguments = call.arguments as? [String: Any], !arguments.isEmpty else {
-            print("Arguments is null or empty")
-            result(FlutterError(code: "4", message: "Arguments is null or empty", details: nil))
-            return
-        }
-
+    private func loadContexts(result: @escaping FlutterResult) {
         SentrySDK.configureScope { scope in
             let serializedScope = scope.serialize()
             let context = serializedScope["context"]
@@ -178,13 +175,13 @@ public class SentryFlutterPluginApple: NSObject, FlutterPlugin {
                 infos["package"] = ["version": sdkInfo.version, "sdk_name": "cocoapods:sentry-cocoa"]
             }
 
-            if arguments["debugImages"] as? Bool ?? false {
-                let debugImages = PrivateSentrySDKOnly.getDebugImages() as [DebugMeta]
-                infos["debugImages"] = debugImages.map { $0.serialize() }
-            }
-
             result(infos)
         }
+    }
+
+    private func loadImageList(result: @escaping FlutterResult) {
+      let debugImages = PrivateSentrySDKOnly.getDebugImages() as [DebugMeta]
+      result(debugImages.map { $0.serialize() })
     }
 
     private func initNativeSdk(_ call: FlutterMethodCall, result: @escaping FlutterResult) {

--- a/flutter/lib/src/default_integrations.dart
+++ b/flutter/lib/src/default_integrations.dart
@@ -449,14 +449,13 @@ class WidgetsBindingIntegration extends Integration<SentryFlutterOptions> {
 }
 
 /// Loads the native debug image list for stack trace symbolication.
-class LoadImageListIntegration
-    extends Integration<SentryFlutterOptions> {
+class LoadImageListIntegration extends Integration<SentryFlutterOptions> {
   final MethodChannel _channel;
 
   LoadImageListIntegration(this._channel);
 
   static bool supportsPlatform(Platform platform) =>
-    platform.isAndroid || platform.isIOS || platform.isMacOS;
+      platform.isAndroid || platform.isIOS || platform.isMacOS;
 
   @override
   FutureOr<void> call(Hub hub, SentryFlutterOptions options) {
@@ -473,9 +472,7 @@ extension _NeedsSymbolication on SentryEvent {
     if (this is SentryTransaction) return false;
     final frames = exceptions?.first.stackTrace?.frames;
     if (frames == null) return false;
-    return platform.isAndroid
-        ? frames.any((frame) => 'native' == frame.platform)
-        : frames.isNotEmpty;
+    return frames.any((frame) => 'native' == frame.platform);
   }
 }
 

--- a/flutter/lib/src/default_integrations.dart
+++ b/flutter/lib/src/default_integrations.dart
@@ -5,11 +5,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:sentry/sentry.dart';
-// TODO is there a "semi-internal" export we can use instead?
-//      sentry_io.dart looks like that but doesn't have any comments.
-// ignore: implementation_imports
-import 'package:sentry/src/platform/platform.dart';
-
 import 'binding_utils.dart';
 import 'sentry_flutter_options.dart';
 import 'widgets_binding_observer.dart';
@@ -454,9 +449,6 @@ class LoadImageListIntegration extends Integration<SentryFlutterOptions> {
 
   LoadImageListIntegration(this._channel);
 
-  static bool supportsPlatform(Platform platform) =>
-      platform.isAndroid || platform.isIOS || platform.isMacOS;
-
   @override
   FutureOr<void> call(Hub hub, SentryFlutterOptions options) {
     options.addEventProcessor(
@@ -468,7 +460,7 @@ class LoadImageListIntegration extends Integration<SentryFlutterOptions> {
 }
 
 extension _NeedsSymbolication on SentryEvent {
-  bool needsSymbolication(Platform platform) {
+  bool needsSymbolication() {
     if (this is SentryTransaction) return false;
     final frames = exceptions?.first.stackTrace?.frames;
     if (frames == null) return false;
@@ -484,7 +476,7 @@ class _LoadImageListIntegrationEventProcessor extends EventProcessor {
 
   @override
   FutureOr<SentryEvent?> apply(SentryEvent event, {hint}) async {
-    if (event.needsSymbolication(_options.platformChecker.platform)) {
+    if (event.needsSymbolication()) {
       try {
         // we call on every event because the loaded image list is cached
         // and it could be changed on the Native side.

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -98,6 +98,7 @@ mixin SentryFlutter {
     SentryFlutterOptions options,
   ) {
     final integrations = <Integration>[];
+    final platformChecker = options.platformChecker;
 
     // Will call WidgetsFlutterBinding.ensureInitialized() before all other integrations.
     integrations.add(WidgetsFlutterBindingIntegration());
@@ -111,22 +112,22 @@ mixin SentryFlutter {
     // The ordering here matters, as we'd like to first start the native integration.
     // That allow us to send events to the network and then the Flutter integrations.
     // Flutter Web doesn't need that, only Android and iOS.
-    if (options.platformChecker.hasNativeIntegration) {
+    if (platformChecker.hasNativeIntegration) {
       integrations.add(NativeSdkIntegration(channel));
     }
 
     // Will enrich events with device context, native packages and integrations
-    if (options.platformChecker.hasNativeIntegration &&
-        !options.platformChecker.isWeb &&
-        (options.platformChecker.platform.isIOS ||
-            options.platformChecker.platform.isMacOS)) {
+    if (platformChecker.hasNativeIntegration &&
+        !platformChecker.isWeb &&
+        (platformChecker.platform.isIOS ||
+            platformChecker.platform.isMacOS)) {
       integrations.add(LoadContextsIntegration(channel));
     }
 
-    if (options.platformChecker.hasNativeIntegration &&
-        !options.platformChecker.isWeb &&
-        options.platformChecker.platform.isAndroid) {
-      integrations.add(LoadAndroidImageListIntegration(channel));
+    if (platformChecker.hasNativeIntegration &&
+        !platformChecker.isWeb &&
+        LoadImageListIntegration.supportsPlatform(platformChecker.platform)) {
+      integrations.add(LoadImageListIntegration(channel));
     }
 
     integrations.add(DebugPrintIntegration());
@@ -136,7 +137,7 @@ mixin SentryFlutter {
     // in errors.
     integrations.add(LoadReleaseIntegration(packageLoader));
 
-    if (options.platformChecker.hasNativeIntegration) {
+    if (platformChecker.hasNativeIntegration) {
       integrations.add(NativeAppStartIntegration(
         SentryNative(),
         () {

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -99,6 +99,7 @@ mixin SentryFlutter {
   ) {
     final integrations = <Integration>[];
     final platformChecker = options.platformChecker;
+    final platform = platformChecker.platform;
 
     // Will call WidgetsFlutterBinding.ensureInitialized() before all other integrations.
     integrations.add(WidgetsFlutterBindingIntegration());
@@ -119,14 +120,13 @@ mixin SentryFlutter {
     // Will enrich events with device context, native packages and integrations
     if (platformChecker.hasNativeIntegration &&
         !platformChecker.isWeb &&
-        (platformChecker.platform.isIOS ||
-            platformChecker.platform.isMacOS)) {
+        (platform.isIOS || platform.isMacOS)) {
       integrations.add(LoadContextsIntegration(channel));
     }
 
     if (platformChecker.hasNativeIntegration &&
         !platformChecker.isWeb &&
-        LoadImageListIntegration.supportsPlatform(platformChecker.platform)) {
+        (platform.isAndroid || platform.isIOS || platform.isMacOS)) {
       integrations.add(LoadImageListIntegration(channel));
     }
 

--- a/flutter/test/load_image_list_test.dart
+++ b/flutter/test/load_image_list_test.dart
@@ -33,7 +33,7 @@ void main() {
     fixture.channel.setMockMethodCallHandler(null);
   });
 
-  test('$LoadAndroidImageListIntegration adds itself to sdk.integrations',
+  test('$LoadImageListIntegration adds itself to sdk.integrations',
       () async {
     final sut = fixture.getSut();
 
@@ -41,7 +41,7 @@ void main() {
 
     expect(
       fixture.options.sdk.integrations
-          .contains('loadAndroidImageListIntegration'),
+          .contains('loadImageListIntegration'),
       true,
     );
   });
@@ -112,7 +112,7 @@ void main() {
     sut.call(fixture.hub, fixture.options);
 
     final ep = fixture.options.eventProcessors.first;
-    SentryEvent? event = getEvent();
+    SentryEvent? event = _getEvent();
     event = await ep.apply(event);
 
     expect(1, event!.debugMeta!.images.length);
@@ -123,7 +123,7 @@ void main() {
 
     sut.call(fixture.hub, fixture.options);
     final ep = fixture.options.eventProcessors.first;
-    SentryEvent? event = getEvent();
+    SentryEvent? event = _getEvent();
     event = await ep.apply(event);
 
     final image = event!.debugMeta!.images.first;
@@ -138,7 +138,7 @@ void main() {
   });
 }
 
-SentryEvent getEvent({bool symbolicated = false}) {
+SentryEvent _getEvent() {
   final frame = SentryStackFrame(platform: 'native');
   final st = SentryStackTrace(frames: [frame]);
   final ex = SentryException(
@@ -159,7 +159,7 @@ class Fixture {
 
   late Hub hub;
 
-  LoadAndroidImageListIntegration getSut() {
-    return LoadAndroidImageListIntegration(channel);
+  LoadImageListIntegration getSut() {
+    return LoadImageListIntegration(channel);
   }
 }

--- a/flutter/test/load_image_list_test.dart
+++ b/flutter/test/load_image_list_test.dart
@@ -88,7 +88,7 @@ void main() {
         expect(called, false);
       });
 
-      test('Native layer is called as stack traces are not symbolicated',
+      test('Native layer is called because stack traces are not symbolicated',
           () async {
         var called = false;
 
@@ -103,12 +103,12 @@ void main() {
         await fixture.hub.captureException(StateError('error'), stackTrace: '''
       warning:  This VM has been configured to produce stack traces that violate the Dart standard.
       ***       *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
-      unparsed  pid: 30930, tid: 30990, name 1.ui
-      unparsed  build_id: '5346e01103ffeed44e97094ff7bfcc19'
-      unparsed  isolate_dso_base: 723d447000, vm_dso_base: 723d447000
-      unparsed  isolate_instructions: 723d452000, vm_instructions: 723d449000
-      unparsed      #00 abs 000000723d6346d7 virt 00000000001ed6d7 _kDartIsolateSnapshotInstructions+0x1e26d7
-      unparsed      #01 abs 000000723d637527 virt 00000000001f0527 _kDartIsolateSnapshotInstructions+0x1e5527
+      pid: 30930, tid: 30990, name 1.ui
+      build_id: '5346e01103ffeed44e97094ff7bfcc19'
+      isolate_dso_base: 723d447000, vm_dso_base: 723d447000
+      isolate_instructions: 723d452000, vm_instructions: 723d449000
+          #00 abs 000000723d6346d7 virt 00000000001ed6d7 _kDartIsolateSnapshotInstructions+0x1e26d7
+          #01 abs 000000723d637527 virt 00000000001f0527 _kDartIsolateSnapshotInstructions+0x1e5527
       ''');
 
         expect(called, true);

--- a/flutter/test/sentry_flutter_test.dart
+++ b/flutter/test/sentry_flutter_test.dart
@@ -16,11 +16,12 @@ final platformAgnosticIntegrations = [
 
 // These should only be added to Android
 final androidIntegrations = [
-  LoadAndroidImageListIntegration,
+  LoadImageListIntegration,
 ];
 
 // These should be added to iOS and macOS
 final iOsAndMacOsIntegrations = [
+  LoadImageListIntegration,
   LoadContextsIntegration,
 ];
 

--- a/flutter/test/sentry_flutter_util.dart
+++ b/flutter/test/sentry_flutter_util.dart
@@ -8,8 +8,8 @@ import 'package:sentry_flutter/src/sentry_flutter_options.dart';
 import 'mocks.dart';
 
 FutureOr<void> Function(SentryFlutterOptions) getConfigurationTester({
-  required List<Type> shouldHaveIntegrations,
-  required List<Type> shouldNotHaveIntegrations,
+  required Iterable<Type> shouldHaveIntegrations,
+  required Iterable<Type> shouldNotHaveIntegrations,
   required bool hasFileSystemTransport,
 }) =>
     (options) async {
@@ -21,17 +21,18 @@ FutureOr<void> Function(SentryFlutterOptions) getConfigurationTester({
         reason: '$FileSystemTransport was wrongly set',
       );
 
-      for (final type in shouldHaveIntegrations) {
-        final integrations = options.integrations
-            .where((element) => element.runtimeType == type)
-            .toList();
-        expect(integrations.length, 1);
+      final integrations = <Type, int>{};
+      for (var e in options.integrations) {
+        integrations[e.runtimeType] = integrations[e.runtimeType] ?? 0 + 1;
       }
 
+      for (final type in shouldHaveIntegrations) {
+        expect(integrations, containsPair(type, 1));
+      }
+
+      shouldNotHaveIntegrations = Set.of(shouldNotHaveIntegrations)
+          .difference(Set.of(shouldHaveIntegrations));
       for (final type in shouldNotHaveIntegrations) {
-        final integrations = options.integrations
-            .where((element) => element.runtimeType == type)
-            .toList();
-        expect(integrations.isEmpty, true);
+        expect(integrations, isNot(contains(type)));
       }
     };


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

This enables support for loaded-libary-list (a.k.a `DebugMeta`) upload so that Sentry has all the info needed to symbolicate stacktraces. Also fixes StackTrace parsing issues that will come up with the next Flutter version after v3.3.

closes #444 
To actually get any benefit, depends on https://github.com/flutter/flutter/pull/101586. Can be merged before that of course, just won't show anything useful on sentry.io

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Necessary to get symbolication working for #444, but doesn't close the issue - that depends on changes in the [`flutter` tool - PR](https://github.com/flutter/flutter/pull/101586) - which means it will only work with a new flutter version after the PR is eventually merged.

## :green_heart: How did you test it?
Manually on device (requires a local build of the patched `flutter` tool version):
* `cd flutter/example; run.sh ios`
* check the event on Sentry: https://sentry.io/organizations/sentry-sdks/issues/3170309318/events/154a2060d1234899aa217d9254cf0660/?project=5428562

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps

macOS/iOS symbols don't get replaced by their real name on sentry.io - works locally with `flutter symbolize` though... https://sentry.io/organizations/sentry-sdks/issues/3565123989/events/1f1b96a0563443fcbf4b4a4653e24548/?project=5428562
