### PR TITLE
Client Reports: Bump and Pass Options (Android)

### DIFF
--- a/flutter/android/build.gradle
+++ b/flutter/android/build.gradle
@@ -54,6 +54,6 @@ android {
 }
 
 dependencies {
-    api 'io.sentry:sentry-android:5.7.0'
+    api 'io.sentry:sentry-android:6.0.0-alpha.6'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 }

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -150,7 +150,7 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         }
       }
 
-      args.getIfNotNull<Boolean>("sendClientReports") { options.setSendClientReports(it)  }
+      args.getIfNotNull<Boolean>("sendClientReports") { options.setSendClientReports(it) }
 
       options.setBeforeSend { event, _ ->
         setEventOriginTag(event)

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -136,7 +136,7 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
       val nativeCrashHandling = (args["enableNativeCrashHandling"] as? Boolean) ?: true
       // nativeCrashHandling has priority over anrEnabled
       if (!nativeCrashHandling) {
-        options.enableUncaughtExceptionHandler = false
+        options.setEnableUncaughtExceptionHandler(false)
         options.isAnrEnabled = false
         // if split symbols are enabled, we need Ndk integration so we can't really offer the option
         // to turn it off
@@ -150,10 +150,7 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         }
       }
 
-      // TODO Set sendClientReports when available on Android
-//      args.getIfNotNull<Boolean>("sendClientReports") { sendClientReports ->
-//        options.sendClientReports = sendClientReports
-//      }
+      args.getIfNotNull<Boolean>("sendClientReports") { options.setSendClientReports(it)  }
 
       options.setBeforeSend { event, _ ->
         setEventOriginTag(event)


### PR DESCRIPTION
_#skip-changelog_

## :scroll: Description
<!--- Describe your changes in detail -->

- Bump sentry-android to `6.0.0.alpha.6`
- Pass `sentClientReports` option

## :green_heart: How did you test it?

- Run from example app.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes
