### PR TITLE
Fix: clear method sets all properties synchronously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Fix: clear method sets all properties synchronously (#)
+
 ## 6.6.0-beta.1
 
 * Feat: Sync Scope to Native (#858)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Fix: clear method sets all properties synchronously (#)
+* Fix: clear method sets all properties synchronously (#882)
 
 ## 6.6.0-beta.1
 

--- a/dart/lib/src/scope.dart
+++ b/dart/lib/src/scope.dart
@@ -53,9 +53,13 @@ class Scope {
   /// Get the current user.
   SentryUser? get user => _user;
 
+  void _setUserSync(SentryUser? user) {
+    _user = user;
+  }
+
   /// Set the current user.
   Future<void> setUser(SentryUser? user) async {
-    _user = user;
+    _setUserSync(user);
     await _callScopeObservers(
         (scopeObserver) async => await scopeObserver.setUser(user));
   }
@@ -184,10 +188,13 @@ class Scope {
     _attachments.clear();
   }
 
+  void _clearBreadcrumbsSync() {
+    _breadcrumbs.clear();
+  }
+
   /// Clear all the breadcrumbs
   Future<void> clearBreadcrumbs() async {
-    _breadcrumbs.clear();
-
+    _clearBreadcrumbsSync();
     await _callScopeObservers(
         (scopeObserver) async => await scopeObserver.clearBreadcrumbs());
   }
@@ -199,16 +206,20 @@ class Scope {
 
   /// Resets the Scope to its default state
   Future<void> clear() async {
-    await clearBreadcrumbs();
     clearAttachments();
     level = null;
     _span = null;
     _transaction = null;
-    await setUser(null);
     _fingerprint = [];
     _tags.clear();
     _extra.clear();
     _eventProcessors.clear();
+
+    _clearBreadcrumbsSync();
+    _setUserSync(null);
+
+    await clearBreadcrumbs();
+    await setUser(null);
   }
 
   /// Sets a tag to the Scope

--- a/dart/test/scope_test.dart
+++ b/dart/test/scope_test.dart
@@ -165,7 +165,7 @@ void main() {
     expect(sut.breadcrumbs.length, maxBreadcrumbs);
   });
 
-  test('clears $Breadcrumb list', () async {
+  test('clears $Breadcrumb list', () {
     final sut = fixture.getSut();
 
     final breadcrumb1 = Breadcrumb(
@@ -173,7 +173,7 @@ void main() {
       timestamp: DateTime.utc(2019),
     );
     sut.addBreadcrumb(breadcrumb1);
-    await sut.clear();
+    sut.clear();
 
     expect(sut.breadcrumbs.length, 0);
   });
@@ -188,13 +188,13 @@ void main() {
     expect(sut.attachments.length, 1);
   });
 
-  test('clear() removes all $SentryAttachment', () async {
+  test('clear() removes all $SentryAttachment', () {
     final sut = fixture.getSut();
 
     final attachment = SentryAttachment.fromIntList([0, 0, 0, 0], 'test.txt');
     sut.addAttachment(attachment);
     expect(sut.attachments.length, 1);
-    await sut.clear();
+    sut.clear();
 
     expect(sut.attachments.length, 0);
   });
@@ -244,7 +244,7 @@ void main() {
     expect(sut.extra['test'], null);
   });
 
-  test('clears $Scope', () async {
+  test('clears $Scope', () {
     final sut = fixture.getSut();
 
     final breadcrumb1 = Breadcrumb(
@@ -268,7 +268,7 @@ void main() {
 
     sut.addEventProcessor(fixture.processor);
 
-    await sut.clear();
+    sut.clear();
 
     expect(sut.breadcrumbs.length, 0);
 


### PR DESCRIPTION
## :scroll: Description
Fix: clear method sets all properties synchronously


## :bulb: Motivation and Context
`clear` method had a side effect if not awaiting its future.


## :green_heart: How did you test it?
There are tests in place for it already

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
