### PR TITLE
Fix: Add user setter back in the scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Fix: Add user setter back in the scope #
+
 ## 6.6.0-beta.1
 
 * Feat: Sync Scope to Native (#858)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Fix: Add user setter back in the scope #
+* Fix: Add user setter back in the scope (#883)
 
 ## 6.6.0-beta.1
 

--- a/dart/lib/src/scope.dart
+++ b/dart/lib/src/scope.dart
@@ -58,7 +58,7 @@ class Scope {
   /// This method will be removed in the future.
   /// The breaking change is due to the [enableScopeSync] feature that
   /// requires returning a [Future].
-  @Deprecated('Use setUser(user) instead')
+  @Deprecated('Use [setUser(user)] instead')
   set user(SentryUser? user) {
     _user = user;
   }

--- a/dart/lib/src/scope.dart
+++ b/dart/lib/src/scope.dart
@@ -65,8 +65,7 @@ class Scope {
 
   /// Set the current user.
   Future<void> setUser(SentryUser? user) async {
-    // ignore: deprecated_member_use_from_same_package
-    this.user = user;
+    _user = user;
     await _callScopeObservers(
         (scopeObserver) async => await scopeObserver.setUser(user));
   }

--- a/dart/lib/src/scope.dart
+++ b/dart/lib/src/scope.dart
@@ -53,9 +53,20 @@ class Scope {
   /// Get the current user.
   SentryUser? get user => _user;
 
+  /// Sets the current user
+  /// This method is deprecated, use the [setUser(user)] instead.
+  /// This method will be removed in the future.
+  /// The breaking change is due to the [enableScopeSync] feature that
+  /// requires returning a [Future].
+  @Deprecated('Use setUser(user) instead')
+  set user(SentryUser? user) {
+    _user = user;
+  }
+
   /// Set the current user.
   Future<void> setUser(SentryUser? user) async {
-    _user = user;
+    // ignore: deprecated_member_use_from_same_package
+    this.user = user;
     await _callScopeObservers(
         (scopeObserver) async => await scopeObserver.setUser(user));
   }
@@ -135,7 +146,7 @@ class Scope {
 
   List<SentryAttachment> get attachments => List.unmodifiable(_attachments);
 
-  @Deprecated('Use attachments instead')
+  @Deprecated('Use [attachments] instead')
   List<SentryAttachment> get attachements => attachments;
 
   Scope(this._options);


### PR DESCRIPTION
## :scroll: Description
Fix: Add user setter back in the scope


## :bulb: Motivation and Context
`scope.user = user` was removed in favor of `setUser`


## :green_heart: How did you test it?
Tests already exists for `setUser`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
