### PR TITLE
Filter out app starts with more than 60s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+* Filter out app starts with more than 60s (#)
+
 ## 6.6.0
 
 * Bump: Sentry-Cocoa to 7.18.0 and Sentry-Android to 6.1.2 (#892)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-* Filter out app starts with more than 60s (#)
+* Filter out app starts with more than 60s (#895)
 
 ## 6.6.0
 

--- a/flutter/lib/src/event_processor/native_app_start_event_processor.dart
+++ b/flutter/lib/src/event_processor/native_app_start_event_processor.dart
@@ -8,6 +8,9 @@ import '../sentry_native_channel.dart';
 /// EventProcessor that enriches [SentryTransaction] objects with app start
 /// measurement.
 class NativeAppStartEventProcessor extends EventProcessor {
+  /// We filter out App starts more than 60s
+  static const _maxAppStartMillis = 60000;
+
   NativeAppStartEventProcessor(
     this._native,
   );
@@ -22,9 +25,22 @@ class NativeAppStartEventProcessor extends EventProcessor {
         event is SentryTransaction &&
         !_native.didFetchAppStart) {
       final nativeAppStart = await _native.fetchNativeAppStart();
-      if (nativeAppStart != null) {
-        event.measurements.add(nativeAppStart.toMeasurement(appStartEnd));
+      if (nativeAppStart == null) {
+        return event;
       }
+      final measurement = nativeAppStart.toMeasurement(appStartEnd);
+      // We filter out app start more than 60s.
+      // This could be due to many different reasons.
+      // If you do the manual init and init the SDK too late and it does not
+      // compute the app start end in the very first Screen.
+      // If the process starts but the App isn't in the foreground.
+      // If the system forked the process earlier to accelerate the app start.
+      // And some unknown reasons that could not be reproduced.
+      // We've seen app starts with hours, days and even months.
+      if (measurement.value >= _maxAppStartMillis) {
+        return event;
+      }
+      event.measurements.add(measurement);
     }
     return event;
   }

--- a/flutter/test/integrations/native_app_start_integration_test.dart
+++ b/flutter/test/integrations/native_app_start_integration_test.dart
@@ -79,6 +79,22 @@ void main() {
       expect(secondEnriched.measurements.length, 2);
       expect(secondEnriched.measurements.contains(measurement), true);
     });
+
+    test('native app start measurement not added if more than 60s', () async {
+      fixture.options.autoAppStart = false;
+      fixture.native.appStartEnd = DateTime.fromMillisecondsSinceEpoch(60001);
+      fixture.wrapper.nativeAppStart = NativeAppStart(0, true);
+
+      fixture.getNativeAppStartIntegration().call(MockHub(), fixture.options);
+
+      final tracer = fixture.createTracer();
+      final transaction = SentryTransaction(tracer);
+
+      final processor = fixture.options.eventProcessors.first;
+      final enriched = await processor.apply(transaction) as SentryTransaction;
+
+      expect(enriched.measurements.isEmpty, true);
+    });
   });
 }
 


### PR DESCRIPTION
## :scroll: Description
Filter out app starts with more than 60s


## :bulb: Motivation and Context
https://github.com/getsentry/sentry-cocoa/pull/1899


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
