### PR TITLE
Send DidBecomeActiveNotification when OOM enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Send DidBecomeActiveNotification when OOM enabled (#905)
+
 ## 6.6.1
 
 ### Fixes

--- a/flutter/ios/Classes/SentryFlutterPluginApple.swift
+++ b/flutter/ios/Classes/SentryFlutterPluginApple.swift
@@ -222,10 +222,9 @@ public class SentryFlutterPluginApple: NSObject, FlutterPlugin {
             }
         }
 
-      // checking enableAutoSessionTracking is actually not necessary, but we'd spare the sent bits.
-       if didReceiveDidBecomeActiveNotification && sentryOptions?.enableAutoSessionTracking == true {
-            // we send a SentryHybridSdkDidBecomeActive to the Sentry Cocoa SDK, so the SDK will mimics
-            // the didBecomeActiveNotification notification and start a session if not yet.
+       if didReceiveDidBecomeActiveNotification && (sentryOptions?.enableAutoSessionTracking == true || sentryOptions?.enableOutOfMemoryTracking == true) {
+            // We send a SentryHybridSdkDidBecomeActive to the Sentry Cocoa SDK, so the SDK will mimics
+            // the didBecomeActiveNotification notification. This is needed for session and OOM tracking.
            NotificationCenter.default.post(name: Notification.Name("SentryHybridSdkDidBecomeActive"), object: nil)
            // we reset the flag for the sake of correctness
            didReceiveDidBecomeActiveNotification = false

--- a/flutter/ios/Classes/SentryFlutterPluginApple.swift
+++ b/flutter/ios/Classes/SentryFlutterPluginApple.swift
@@ -222,8 +222,8 @@ public class SentryFlutterPluginApple: NSObject, FlutterPlugin {
             }
         }
 
-       if (didReceiveDidBecomeActiveNotification &&
-          (sentryOptions?.enableAutoSessionTracking == true || sentryOptions?.enableOutOfMemoryTracking == true)) {
+       if didReceiveDidBecomeActiveNotification &&
+          (sentryOptions?.enableAutoSessionTracking == true || sentryOptions?.enableOutOfMemoryTracking == true) {
             // We send a SentryHybridSdkDidBecomeActive to the Sentry Cocoa SDK, so the SDK will mimics
             // the didBecomeActiveNotification notification. This is needed for session and OOM tracking.
            NotificationCenter.default.post(name: Notification.Name("SentryHybridSdkDidBecomeActive"), object: nil)

--- a/flutter/ios/Classes/SentryFlutterPluginApple.swift
+++ b/flutter/ios/Classes/SentryFlutterPluginApple.swift
@@ -222,7 +222,8 @@ public class SentryFlutterPluginApple: NSObject, FlutterPlugin {
             }
         }
 
-       if didReceiveDidBecomeActiveNotification && (sentryOptions?.enableAutoSessionTracking == true || sentryOptions?.enableOutOfMemoryTracking == true) {
+       if (didReceiveDidBecomeActiveNotification &&
+          (sentryOptions?.enableAutoSessionTracking == true || sentryOptions?.enableOutOfMemoryTracking == true)) {
             // We send a SentryHybridSdkDidBecomeActive to the Sentry Cocoa SDK, so the SDK will mimics
             // the didBecomeActiveNotification notification. This is needed for session and OOM tracking.
            NotificationCenter.default.post(name: Notification.Name("SentryHybridSdkDidBecomeActive"), object: nil)


### PR DESCRIPTION


## :scroll: Description

The OOM code of the Cocoa SDK also relies on the
SentryHybridSdkDidBecomeActive to work properly.
If a user has enableAutoSessionTracking disabled wrong
OOM events would be created.


## :bulb: Motivation and Context
Came up when investigating https://github.com/getsentry/sentry-cocoa/issues/1852.


## :green_heart: How did you test it?
Hard to test as there are no unit tests.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
