### PR TITLE
Fix:  hangs if  is empty and SDK NoOp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Fix: `dio.addSentry` hangs if `dsn` is empty and SDK NoOp ([#900](https://github.com/getsentry/sentry-dart/pull/900))
+
 ### Features
 
 - Bump Android SDK to v6.1.4 ([#900](https://github.com/getsentry/sentry-dart/pull/900))
@@ -13,7 +15,7 @@
 
 ### Fixes
 
-- Send DidBecomeActiveNotification when OOM enabled (#905)
+* Send DidBecomeActiveNotification when OOM enabled (#905)
 
 ## 6.6.1
 
@@ -69,8 +71,8 @@
 
 ## 6.6.0-alpha.2
 
-- Fix serialization of threads (#844)
-- Feat: Allow manual init of the Native SDK (#765)
+* Fix serialization of threads (#844)
+* Feat: Allow manual init of the Native SDK (#765)
 
 ## 6.6.0-alpha.1
 
@@ -79,15 +81,15 @@
 
 ### Sentry Self-hosted Compatibility
 
-- Starting with version `6.6.0` of `sentry`, [Sentry's version >= v21.9.0](https://github.com/getsentry/self-hosted/releases) is required or you have to manually disable sending client reports via the `sendClientReports` option. This only applies to self-hosted Sentry. If you are using [sentry.io](https://sentry.io), no action is needed.
+* Starting with version `6.6.0` of `sentry`, [Sentry's version >= v21.9.0](https://github.com/getsentry/self-hosted/releases) is required or you have to manually disable sending client reports via the `sendClientReports` option. This only applies to self-hosted Sentry. If you are using [sentry.io](https://sentry.io), no action is needed.
 
 ## 6.5.1
 
-- Update event contexts (#838)
+* Update event contexts (#838)
 
 ## 6.5.0
 
-- No documented changes.
+* No documented changes.
 
 ## 6.5.0-beta.2
 
@@ -95,7 +97,7 @@
 
 ## 6.5.0-beta.1
 
-- No documented changes.
+* No documented changes.
 
 ## 6.5.0-alpha.3
 
@@ -115,8 +117,8 @@
 
 ### Various fixes & improvements
 
-- Fix: Missing userId on iOS when userId is not set (#782) by @marandaneto
-- Allow to set startTimestamp & endTimestamp manually to SentrySpan (#676) by @fatihergin
+* Fix: Missing userId on iOS when userId is not set (#782) by @marandaneto
+* Allow to set startTimestamp & endTimestamp manually to SentrySpan (#676) by @fatihergin
 
 ## 6.4.0-beta.3
 
@@ -128,7 +130,7 @@
 
 ## 6.4.0-beta.2
 
-- No documented changes.
+* No documented changes.
 
 ## 6.4.0-beta.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Fix: `dio.addSentry` hangs if `dsn` is empty and SDK NoOp ([#900](https://github.com/getsentry/sentry-dart/pull/900))
+* Fix: `dio.addSentry` hangs if `dsn` is empty and SDK NoOp ([#920](https://github.com/getsentry/sentry-dart/pull/920))
 
 ### Features
 

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -292,7 +292,9 @@ class SentryOptions {
   }
 
   @internal
-  SentryOptions.empty();
+  SentryOptions.empty() {
+    sdk = SdkVersion(name: 'noop', version: sdkVersion);
+  }
 
   /// Adds an event processor
   void addEventProcessor(EventProcessor eventProcessor) {

--- a/dart/test/sentry_options_test.dart
+++ b/dart/test/sentry_options_test.dart
@@ -1,4 +1,5 @@
 import 'package:http/http.dart';
+import 'package:meta/meta.dart';
 import 'package:sentry/sentry.dart';
 import 'package:sentry/src/noop_client.dart';
 import 'package:test/test.dart';
@@ -72,5 +73,17 @@ void main() {
     options.tracesSampler = sampler;
 
     expect(options.isTracingEnabled(), true);
+  });
+
+  test('SentryOptions empty inits the late var', () {
+    final options = SentryOptions.empty();
+    options.sdk.addPackage('test', '1.2.3');
+
+    expect(
+        options.sdk.packages
+            .where((element) =>
+                element.name == 'test' && element.version == '1.2.3')
+            .isNotEmpty,
+        true);
   });
 }


### PR DESCRIPTION
## :scroll: Description
Fix: hangs if is empty and SDK NoOp


## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-dart/issues/908
`sdk` is a late var and was not init for the NoOp Hub.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
