### PR TITLE
Fix: addBreadcrumb throws on Android API < 24 because of NewApi usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Fix: addBreadcrumb throws on Android API < 24 because of NewApi usage ([#900](https://github.com/getsentry/sentry-dart/pull/900))
+* Fix: addBreadcrumb throws on Android API < 24 because of NewApi usage ([#923](https://github.com/getsentry/sentry-dart/pull/923))
 * [`sentry_dio`](https://pub.dev/packages/sentry_dio) is promoted to GA and not experimental anymore ([#914](https://github.com/getsentry/sentry-dart/pull/914))
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Fix: addBreadcrumb throws on Android API < 24 because of NewApi usage ([#900](https://github.com/getsentry/sentry-dart/pull/900))
+
 ### Features
 
 - Bump Android SDK to v6.1.4 ([#900](https://github.com/getsentry/sentry-dart/pull/900))

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -277,7 +277,7 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     (user["ip_address"] as? String)?.let { userInstance.ipAddress = it }
     (user["extras"] as? Map<String, Any?>)?.let { extras ->
       val others = mutableMapOf<String, String>()
-      extras.forEach { key, value ->
+      for ((key, value) in extras.entries) {
         if (value != null) {
           others[key] = value.toString()
         }
@@ -311,7 +311,7 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
       }
     }
     (breadcrumb["data"] as? Map<String, Any?>)?.let { data ->
-      data.forEach { key, value ->
+      for ((key, value) in data.entries) {
         breadcrumbInstance.data[key] = value
       }
     }


### PR DESCRIPTION
## :scroll: Description
Fix: addBreadcrumb throws on Android API < 24 because of NewApi usage


## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-dart/issues/916


## :green_heart: How did you test it?
Running it

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
Tests for NewApi