### PR TITLE
Breadcrumbs should not be duplicated if there is no mechaism on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-* Breadcrumbs should not be duplicated if there is no mechaism on Android ([#936](https://github.com/getsentry/sentry-dart/pull/936))
+* Breadcrumbs should not be duplicated if there is no mechanism on Android ([#936](https://github.com/getsentry/sentry-dart/pull/936))
 
 ## 6.6.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+* Breadcrumbs should not be duplicated if there is no mechaism ([#925](https://github.com/getsentry/sentry-dart/pull/925))
+
 ## 6.6.3
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-* Breadcrumbs should not be duplicated if there is no mechaism ([#925](https://github.com/getsentry/sentry-dart/pull/925))
+* Breadcrumbs should not be duplicated if there is no mechaism on Android ([#936](https://github.com/getsentry/sentry-dart/pull/936))
 
 ## 6.6.3
 

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -378,12 +378,11 @@ class SentryClient {
   }
 
   SentryEvent _eventWithRemovedBreadcrumbsIfHandled(SentryEvent event) {
-    final exceptions = event.exceptions ?? [];
-    final handled = exceptions.isNotEmpty
-        ? exceptions.first.mechanism?.handled == true
-        : false;
+    final foundNotHandled = event.exceptions
+            ?.any((element) => element.mechanism?.handled == false) ??
+        false;
 
-    if (handled) {
+    if (!foundNotHandled) {
       return event.copyWith(breadcrumbs: []);
     } else {
       return event;

--- a/dart/test/sentry_client_test.dart
+++ b/dart/test/sentry_client_test.dart
@@ -898,6 +898,28 @@ void main() {
       expect((capturedEvent.breadcrumbs ?? []).isEmpty, true);
     });
 
+    test('Clears breadcrumbs on Android if theres no mechanism', () async {
+      fixture.options.enableScopeSync = true;
+      fixture.options.platformChecker =
+          MockPlatformChecker(platform: MockPlatform.android());
+
+      final client = fixture.getSut();
+      final event = SentryEvent(exceptions: [
+        SentryException(
+          type: "type",
+          value: "value",
+        )
+      ], breadcrumbs: [
+        Breadcrumb()
+      ]);
+      await client.captureEvent(event);
+
+      final capturedEnvelope = (fixture.transport).envelopes.first;
+      final capturedEvent = await eventFromEnvelope(capturedEnvelope);
+
+      expect((capturedEvent.breadcrumbs ?? []).isEmpty, true);
+    });
+
     test('Does not clear breadcrumbs on Android if mechanism.handled is false',
         () async {
       fixture.options.enableScopeSync = true;


### PR DESCRIPTION
## :scroll: Description
Breadcrumbs should not be duplicated if there is no mechaism on Android


## :bulb: Motivation and Context
Found by debugging, breadcrumbs were duplicated if there were no mechanism.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
