### PR TITLE
fix: windows native method need default result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Maps with Key Object, Object would fail during serialization if not String, Object ([#935](https://github.com/getsentry/sentry-dart/pull/935))
 * Breadcrumbs "Concurrent Modification" ([#948](https://github.com/getsentry/sentry-dart/pull/948))
 * Duplicative Screen size changed breadcrumbs ([#888](https://github.com/getsentry/sentry-dart/pull/888))
+* Fix windows native method need default result ([#943](https://github.com/getsentry/sentry-dart/pull/943))
 
 ### Features
 

--- a/flutter/windows/sentry_flutter_plugin.cpp
+++ b/flutter/windows/sentry_flutter_plugin.cpp
@@ -57,6 +57,7 @@ void SentryFlutterPlugin::HandleMethodCall(
     const flutter::MethodCall<flutter::EncodableValue> &method_call,
     std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
   // Native features will be added in a next release
+  result->NotImplemented();
 }
 
 }  // namespace


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
When flutter is natively connected, the unimplemented logic needs to call back `NotImplemented` by default, otherwise it will be stuck in `await`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Pending line: https://github.com/getsentry/sentry-dart/blob/main/dart/lib/src/sentry_tracer.dart#L102
Link code: [sentry_native_channel](https://github.com/getsentry/sentry-dart/blob/main/flutter/lib/src/sentry_native_channel.dart)

## :green_heart: How did you test it?
- Init set `SentryFlutter.init.options.debug = true`
- Check log print

![image](https://user-images.githubusercontent.com/5964735/178456993-a3ada9df-e8bd-4cac-b5bc-082d9e9d2c56.png)

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
no op

_#skip-changelog_