### PR TITLE
Fix: `Scope#clone` calls the Native bridges again via the `scopeObserver`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 * Missing OS context for iOS events ([#958](https://github.com/getsentry/sentry-dart/pull/958))
+* Fix: `Scope#clone` calls the Native bridges again via the `scopeObserver` ([#959](https://github.com/getsentry/sentry-dart/pull/959))
 
 ### Features
 

--- a/dart/lib/src/hub.dart
+++ b/dart/lib/src/hub.dart
@@ -242,7 +242,7 @@ class Hub {
   Future<Scope> _cloneAndRunWithScope(
       Scope scope, ScopeCallback? withScope) async {
     if (withScope != null) {
-      scope = await scope.clone();
+      scope = scope.clone();
       await withScope(scope);
     }
     return scope;
@@ -276,13 +276,13 @@ class Hub {
   }
 
   /// Clones the Hub
-  Future<Hub> clone() async {
+  Hub clone() {
     if (!_isEnabled) {
       _options.logger(SentryLevel.warning, 'Disabled Hub cloned.');
     }
     final clone = Hub(_options);
     for (final item in _stack) {
-      clone._stack.add(_StackItem(item.client, await item.scope.clone()));
+      clone._stack.add(_StackItem(item.client, item.scope.clone()));
     }
     return clone;
   }

--- a/dart/lib/src/hub_adapter.dart
+++ b/dart/lib/src/hub_adapter.dart
@@ -78,7 +78,7 @@ class HubAdapter implements Hub {
       );
 
   @override
-  Future<Hub> clone() async => await Sentry.clone();
+  Hub clone() => Sentry.clone();
 
   @override
   Future<void> close() => Sentry.close();

--- a/dart/lib/src/noop_hub.dart
+++ b/dart/lib/src/noop_hub.dart
@@ -57,7 +57,7 @@ class NoOpHub implements Hub {
       SentryId.empty();
 
   @override
-  Future<Hub> clone() async => this;
+  Hub clone() => this;
 
   @override
   Future<void> close() async {}

--- a/dart/lib/src/sentry.dart
+++ b/dart/lib/src/sentry.dart
@@ -201,7 +201,7 @@ class Sentry {
       await _hub.configureScope(callback);
 
   /// Clones the current Hub
-  static Future<Hub> clone() async => await _hub.clone();
+  static Hub clone() => _hub.clone();
 
   /// Binds a different client to the current hub
   static void bindClient(SentryClient client) => _hub.bindClient(client);

--- a/dart/test/mocks/mock_scope_observer.dart
+++ b/dart/test/mocks/mock_scope_observer.dart
@@ -11,7 +11,6 @@ class MockScopeObserver extends ScopeObserver {
   bool calledSetTag = false;
   bool calledSetUser = false;
 
-
   int numberOfAddBreadcrumbCalls = 0;
   int numberOfClearBreadcrumbsCalls = 0;
   int numberOfRemoveContextsCalls = 0;

--- a/dart/test/mocks/mock_scope_observer.dart
+++ b/dart/test/mocks/mock_scope_observer.dart
@@ -11,48 +11,68 @@ class MockScopeObserver extends ScopeObserver {
   bool calledSetTag = false;
   bool calledSetUser = false;
 
+
+  int numberOfAddBreadcrumbCalls = 0;
+  int numberOfClearBreadcrumbsCalls = 0;
+  int numberOfRemoveContextsCalls = 0;
+  int numberOfRemoveExtraCalls = 0;
+  int numberOfRemoveTagCalls = 0;
+  int numberOfSetContextsCalls = 0;
+  int numberOfSetExtraCalls = 0;
+  int numberOfSetTagCalls = 0;
+  int numberOfSetUserCalls = 0;
+
   @override
   Future<void> addBreadcrumb(Breadcrumb breadcrumb) async {
     calledAddBreadcrumb = true;
+    numberOfAddBreadcrumbCalls += 1;
   }
 
   @override
   Future<void> clearBreadcrumbs() async {
     calledClearBreadcrumbs = true;
+    numberOfClearBreadcrumbsCalls += 1;
   }
 
   @override
   Future<void> removeContexts(String key) async {
     calledRemoveContexts = true;
+    numberOfRemoveContextsCalls += 1;
   }
 
   @override
   Future<void> removeExtra(String key) async {
     calledRemoveExtra = true;
+    numberOfRemoveExtraCalls += 1;
   }
 
   @override
   Future<void> removeTag(String key) async {
     calledRemoveTag = true;
+    numberOfRemoveTagCalls += 1;
   }
 
   @override
   Future<void> setContexts(String key, value) async {
     calledSetContexts = true;
+    numberOfSetContextsCalls += 1;
   }
 
   @override
   Future<void> setExtra(String key, value) async {
     calledSetExtra = true;
+    numberOfSetExtraCalls += 1;
   }
 
   @override
   Future<void> setTag(String key, String value) async {
     calledSetTag = true;
+    numberOfSetTagCalls += 1;
   }
 
   @override
   Future<void> setUser(SentryUser? user) async {
     calledSetUser = true;
+    numberOfSetUserCalls += 1;
   }
 }

--- a/dart/test/scope_test.dart
+++ b/dart/test/scope_test.dart
@@ -299,7 +299,7 @@ void main() {
     sut.span = NoOpSentrySpan();
     sut.level = SentryLevel.warning;
 
-    final clone = await sut.clone();
+    final clone = sut.clone();
     expect(sut.user, clone.user);
     expect(sut.transaction, clone.transaction);
     expect(sut.extra, clone.extra);

--- a/dart/test/scope_test.dart
+++ b/dart/test/scope_test.dart
@@ -316,6 +316,32 @@ void main() {
     expect(sut.span, clone.span);
   });
 
+  test('clone does not additionally call observers', () async {
+    final sut = fixture.getSut(scopeObserver: fixture.mockScopeObserver);
+
+    await sut.setContexts("fixture-contexts-key", "fixture-contexts-value");
+    await sut.removeContexts("fixture-contexts-key");
+    await sut.setUser(SentryUser(username: "fixture-username"));
+    await sut.addBreadcrumb(Breadcrumb());
+    await sut.clearBreadcrumbs();
+    await sut.setExtra("fixture-extra-key", "fixture-extra-value");
+    await sut.removeExtra("fixture-extra-key");
+    await sut.setTag("fixture-tag-key", "fixture-tag-value");
+    await sut.removeTag("fixture-tag-key");
+
+    sut.clone();
+
+    expect(1, fixture.mockScopeObserver.numberOfSetContextsCalls);
+    expect(1, fixture.mockScopeObserver.numberOfRemoveContextsCalls);
+    expect(1, fixture.mockScopeObserver.numberOfSetUserCalls);
+    expect(1, fixture.mockScopeObserver.numberOfAddBreadcrumbCalls);
+    expect(1, fixture.mockScopeObserver.numberOfClearBreadcrumbsCalls);
+    expect(1, fixture.mockScopeObserver.numberOfSetExtraCalls);
+    expect(1, fixture.mockScopeObserver.numberOfRemoveExtraCalls);
+    expect(1, fixture.mockScopeObserver.numberOfSetTagCalls);
+    expect(1, fixture.mockScopeObserver.numberOfRemoveTagCalls);
+  });
+
   group('Scope apply', () {
     final scopeUser = SentryUser(
       id: '800',

--- a/flutter/test/mocks.mocks.dart
+++ b/flutter/test/mocks.mocks.dart
@@ -371,9 +371,8 @@ class MockHub extends _i1.Mock implements _i2.Hub {
       super.noSuchMethod(Invocation.method(#bindClient, [client]),
           returnValueForMissingStub: null);
   @override
-  _i6.Future<_i2.Hub> clone() => (super.noSuchMethod(
-      Invocation.method(#clone, []),
-      returnValue: Future<_i2.Hub>.value(_FakeHub_8())) as _i6.Future<_i2.Hub>);
+  _i2.Hub clone() => (super.noSuchMethod(Invocation.method(#clone, []),
+      returnValue: _FakeHub_8()) as _i2.Hub);
   @override
   _i6.Future<void> close() => (super.noSuchMethod(Invocation.method(#close, []),
       returnValue: Future<void>.value(),


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Closes #926

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [ ] No breaking changes
