### PR TITLE
Fix back compatibility for OnErrorIntegration integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+* Fix back compatibility for OnErrorIntegration integration ([#932](https://github.com/getsentry/sentry-dart/pull/932))
+
 ## 6.8.1
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-* Fix back compatibility for OnErrorIntegration integration ([#932](https://github.com/getsentry/sentry-dart/pull/932))
+* Fix back compatibility for OnErrorIntegration integration ([#965](https://github.com/getsentry/sentry-dart/pull/965))
 
 ## 6.8.1
 

--- a/flutter/lib/src/integrations/on_error_integration.dart
+++ b/flutter/lib/src/integrations/on_error_integration.dart
@@ -3,6 +3,7 @@ import 'dart:ui';
 
 import 'package:flutter/widgets.dart';
 import 'package:sentry/sentry.dart';
+import '../binding_utils.dart';
 import '../sentry_flutter_options.dart';
 
 typedef ErrorCallback = bool Function(Object exception, StackTrace stackTrace);
@@ -28,9 +29,15 @@ class OnErrorIntegration implements Integration<SentryFlutterOptions> {
   @override
   void call(Hub hub, SentryFlutterOptions options) {
     _options = options;
+    final binding = BindingUtils.getWidgetsBindingInstance();
+
+    if (binding == null) {
+      return;
+    }
+
+    // WidgetsBinding works with WidgetsFlutterBinding and other custom bindings
     final wrapper = dispatchWrapper ??
-        // WidgetsBinding works with WidgetsFlutterBinding and other custom bindings
-        PlatformDispatcherWrapper(WidgetsBinding.instance.platformDispatcher);
+        PlatformDispatcherWrapper(binding.platformDispatcher);
 
     if (!wrapper.isOnErrorSupported(options)) {
       return;

--- a/flutter/test/integrations/mock_platform_dispatcher.dart
+++ b/flutter/test/integrations/mock_platform_dispatcher.dart
@@ -1,0 +1,20 @@
+import 'dart:ui';
+
+import 'package:sentry_flutter/src/integrations/on_error_integration.dart';
+
+class MockPlatformDispatcher implements PlatformDispatcher {
+  ErrorCallback? onErrorHandler;
+
+  @override
+  // ignore: override_on_non_overriding_member
+  ErrorCallback? get onError => onErrorHandler;
+
+  @override
+  // ignore: override_on_non_overriding_member
+  set onError(ErrorCallback? onError) {
+    onErrorHandler = onError;
+  }
+
+  @override
+  void noSuchMethod(Invocation invocation) {}
+}

--- a/flutter/test/integrations/on_error_integration_no_binding_test.dart
+++ b/flutter/test/integrations/on_error_integration_no_binding_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:sentry/sentry.dart';
+import 'package:sentry_flutter/src/integrations/on_error_integration.dart';
+import 'package:sentry_flutter/src/sentry_flutter_options.dart';
+
+import '../mocks.dart';
+import '../mocks.mocks.dart';
+import 'mock_platform_dispatcher.dart';
+
+void main() {
+  // Not calling: TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Fixture fixture;
+
+  setUp(() {
+    fixture = Fixture();
+  });
+
+  void _reportError({
+    required Object exception,
+    required StackTrace stackTrace,
+    ErrorCallback? handler,
+  }) {
+    fixture.platformDispatcherWrapper.onError = handler ??
+        (_, __) {
+          return fixture.onErrorReturnValue;
+        };
+
+    when(fixture.hub.captureEvent(captureAny,
+            stackTrace: captureAnyNamed('stackTrace')))
+        .thenAnswer((_) => Future.value(SentryId.empty()));
+
+    OnErrorIntegration(dispatchWrapper: fixture.platformDispatcherWrapper)(
+      fixture.hub,
+      fixture.options,
+    );
+
+    fixture.platformDispatcherWrapper.onError?.call(exception, stackTrace);
+  }
+
+  test('onError does not capture errors when binding is null', () async {
+    final exception = StateError('error');
+
+    _reportError(exception: exception, stackTrace: StackTrace.current);
+
+    verifyNever(await fixture.hub
+        .captureEvent(captureAny, stackTrace: captureAnyNamed('stackTrace')));
+  });
+}
+
+class Fixture {
+  final hub = MockHub();
+  final options = SentryFlutterOptions(dsn: fakeDsn);
+  late final platformDispatcherWrapper =
+      PlatformDispatcherWrapper(MockPlatformDispatcher());
+
+  bool onErrorReturnValue = true;
+}

--- a/flutter/test/integrations/on_error_integration_test.dart
+++ b/flutter/test/integrations/on_error_integration_test.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:sentry/sentry.dart';
@@ -8,6 +6,7 @@ import 'package:sentry_flutter/src/sentry_flutter_options.dart';
 
 import '../mocks.dart';
 import '../mocks.mocks.dart';
+import 'mock_platform_dispatcher.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -140,21 +139,4 @@ class Fixture {
       PlatformDispatcherWrapper(MockPlatformDispatcher());
 
   bool onErrorReturnValue = true;
-}
-
-class MockPlatformDispatcher implements PlatformDispatcher {
-  ErrorCallback? onErrorHandler;
-
-  @override
-  // ignore: override_on_non_overriding_member
-  ErrorCallback? get onError => onErrorHandler;
-
-  @override
-  // ignore: override_on_non_overriding_member
-  set onError(ErrorCallback? onError) {
-    onErrorHandler = onError;
-  }
-
-  @override
-  void noSuchMethod(Invocation invocation) {}
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
Fix https://github.com/getsentry/sentry-dart/issues/964


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
https://github.com/getsentry/sentry-dart/pull/966