### PR TITLE
fix: Scope.clone incorrectly accesses tags

### DIFF
--- a/dart/lib/src/scope.dart
+++ b/dart/lib/src/scope.dart
@@ -416,7 +416,7 @@ class Scope {
 
     final tags = List.from(_tags.keys);
     for (final tag in tags) {
-      final value = tags[tag];
+      final value = _tags[tag];
       if (value != null) {
         clone._setTagSync(tag, value);
       }


### PR DESCRIPTION
## :scroll: Description
fixed Scope.clone, incorrectly accesses tags and therefore crashes. Main branch currently extracts the keys from _tags to iterate over. This is all fine but it the tries to access the values via the keys-list which makes no sense, it's a list of strings, not a map where you could actually use the keys. I guess it's simply a typo due to "not so optimal" naming.

## :bulb: Motivation and Context

Sentry crashing, error reporting with tags does not work. The following code will crash (current main branch):

```dart
Sentry.configureScope((scope) async {
  await scope.setTag('some.tag', 'value');
});

await Sentry.captureException(
  error,
  stackTrace: stackTrace,
  hint: 'here goes an error',
  withScope: (scope) async {
    try {
      await scope.setTag('class', className);
    } catch (err, stack) {
      print('ERROR: failed to add class in sentry: $err\n$stack');
    }
  },
);
```

## :green_heart: How did you test it?

running in production just fine :) currently using it via a pubspec.yaml git reference:

```dart
 sentry: # also remove override when fixed
    git:
      url: https://github.com/quaaantumdev/sentry-dart.git
      path: dart
```

would like to upgrade back to the official version once fixed


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps

let's make sentry great again ;-)

_#skip-changelog_