### PR TITLE
feat: SentryUserFeedback.name verification on captureUserFeedback()

### DIFF
--- a/dart/lib/src/hub.dart
+++ b/dart/lib/src/hub.dart
@@ -225,6 +225,13 @@ class Hub {
       );
       return;
     }
+    if (userFeedback.name == null || (userFeedback.name?.isEmpty ?? true)) {
+      _options.logger(
+        SentryLevel.warning,
+        'Name is empty, dropping the feedback',
+      );
+      return;
+    }
     try {
       final item = _peek();
 

--- a/dart/lib/src/sentry.dart
+++ b/dart/lib/src/sentry.dart
@@ -159,6 +159,7 @@ class Sentry {
         withScope: withScope,
       );
 
+  /// Reports a [message] to Sentry.io.
   static Future<SentryId> captureMessage(
     String? message, {
     SentryLevel? level = SentryLevel.info,
@@ -176,6 +177,8 @@ class Sentry {
         withScope: withScope,
       );
 
+  /// This method is used to capture user feedback events. In order to work,
+  /// first capture an event and use the [SentryId] to create a [UserFeedback]
   static Future<void> captureUserFeedback(SentryUserFeedback userFeedback) =>
       _hub.captureUserFeedback(userFeedback);
 


### PR DESCRIPTION
## :scroll: Description
I added some documentation regardless to the `Sentry.captureUserFeedback();` method and error handling for it.


## :bulb: Motivation and Context
I was trying to implement the `Sentry.captureUserFeedback();` method and it wasn't adding the feedback into my sentry feedback, and every time the method was called I received an error in the debug console saying that the envelope header was null, and I wasn't really sure what was the problem, and after adding the name to the `SentryUserFeedback()` class it worked, and it was confusing cause the name parameter is not required and nullable.


## :green_heart: How did you test it?
Because this only occurs when we don't pass a name to the  `SentryUserFeedback()` and the method per se it's working, this PR is testless, the only thing I added was an extra if statement verifying that the name wasn't null nor empty, and if it is we log the error and return.

![image](https://user-images.githubusercontent.com/49735945/186818876-5a9c13f8-c71a-4cac-b60d-442aad1f10f6.png)

This would really save me a couple hours of debugging.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
