### PR TITLE
ci: fix windows CI not failing on failed tests

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -8,9 +8,7 @@ on:
     paths-ignore:
       - 'logging/**'
       - 'dio/**'
-defaults:
-  run:
-    shell: bash
+
 jobs:
   build:
     name: Build ${{matrix.sdk}} on ${{matrix.os}}
@@ -18,6 +16,7 @@ jobs:
     timeout-minutes: 30
     defaults:
       run:
+        shell: bash
         working-directory: ./dart
     strategy:
       fail-fast: false

--- a/.github/workflows/dio.yml
+++ b/.github/workflows/dio.yml
@@ -8,9 +8,7 @@ on:
     paths-ignore:
       - 'logging/**'
       - 'flutter/**'
-defaults:
-  run:
-    shell: bash
+
 jobs:
   build:
     name: Build ${{matrix.sdk}} on ${{matrix.os}}
@@ -18,6 +16,7 @@ jobs:
     timeout-minutes: 30
     defaults:
       run:
+        shell: bash
         working-directory: ./dio
     strategy:
       fail-fast: false

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -8,14 +8,15 @@ on:
     paths-ignore:
       - 'logging/**'
       - 'dio/**'
-defaults:
-  run:
-    shell: bash
+
 jobs:
   build:
     name: ${{ matrix.target }} | ${{ matrix.os }} | ${{ matrix.sdk }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: false
       # max-parallel: 4

--- a/.github/workflows/logging.yml
+++ b/.github/workflows/logging.yml
@@ -8,9 +8,7 @@ on:
     paths-ignore:
         - 'dio/**'
         - 'flutter/**'
-defaults:
-  run:
-    shell: bash
+
 jobs:
   build:
     name: Build ${{matrix.sdk}} on ${{matrix.os}}
@@ -18,6 +16,7 @@ jobs:
     timeout-minutes: 30
     defaults:
       run:
+        shell: bash
         working-directory: ./logging
     strategy:
       fail-fast: false

--- a/.github/workflows/min_version_test.yml
+++ b/.github/workflows/min_version_test.yml
@@ -5,9 +5,7 @@ on:
       - main
       - release/**
   pull_request:
-defaults:
-  run:
-    shell: bash
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
#skip-changelog

This PR ensures that when a test fails, the CI fails, same as on other platforms. 

The default powershell runner on Windows doesn't fail if a command fails and should be avoided. The global `defaults` section in a workflow yaml is overwritten by a job-specific `defaults` section, not merged.

We go from [this](https://github.com/getsentry/sentry-dart/runs/8223542693?check_suite_focus=true)
<img width="787" alt="image" src="https://user-images.githubusercontent.com/6349682/188833345-3793acd4-13ee-498f-bb4f-f5401e12ab38.png">

 to [this](https://github.com/getsentry/sentry-dart/runs/8223783749?check_suite_focus=true)
<img width="787" alt="image" src="https://user-images.githubusercontent.com/6349682/188832772-1b0dae7c-42ba-464b-b07b-f750e8a2efa7.png">
