### PR TITLE
chore: resolve swift lints and compiler warnings

### DIFF
--- a/flutter/ios/Classes/SentryFlutterPluginApple.swift
+++ b/flutter/ios/Classes/SentryFlutterPluginApple.swift
@@ -466,9 +466,9 @@ public class SentryFlutterPluginApple: NSObject, FlutterPlugin {
       }
 
       SentrySDK.configureScope { scope in
-        if let dictionary = value as? Dictionary<String, Any?> {
+        if let dictionary = value as? [String: Any] {
           scope.setContext(value: dictionary, key: key)
-        } else if let string = value as? String? {
+        } else if let string = value as? String {
           scope.setContext(value: ["value": string], key: key)
         } else if let int = value as? Int {
           scope.setContext(value: ["value": int], key: key)
@@ -492,7 +492,7 @@ public class SentryFlutterPluginApple: NSObject, FlutterPlugin {
       }
     }
 
-    private func setUser(user: Dictionary<String, Any?>?, result: @escaping FlutterResult) {
+    private func setUser(user: [String: Any?]?, result: @escaping FlutterResult) {
       if let user = user {
         let userInstance = User()
 
@@ -508,7 +508,7 @@ public class SentryFlutterPluginApple: NSObject, FlutterPlugin {
         if let ipAddress = user["ip_address"] as? String {
           userInstance.ipAddress = ipAddress
         }
-        if let extras = user["extras"] as? Dictionary<String, Any?> {
+        if let extras = user["extras"] as? [String: Any] {
           userInstance.data = extras
         }
 
@@ -520,7 +520,7 @@ public class SentryFlutterPluginApple: NSObject, FlutterPlugin {
     }
 
     // swiftlint:disable:next cyclomatic_complexity
-    private func addBreadcrumb(breadcrumb: Dictionary<String, Any?>?, result: @escaping FlutterResult) {
+    private func addBreadcrumb(breadcrumb: [String: Any?]?, result: @escaping FlutterResult) {
       guard let breadcrumb = breadcrumb else {
         result("")
         return
@@ -553,7 +553,7 @@ public class SentryFlutterPluginApple: NSObject, FlutterPlugin {
           breadcrumbInstance.level = SentryLevel.error
         }
       }
-      if let data = breadcrumb["data"] as? Dictionary<String, Any?> {
+      if let data = breadcrumb["data"] as? [String: Any] {
         breadcrumbInstance.data = data
       }
 


### PR DESCRIPTION
#skip-changelog

closes #867 

resolves the following compiler warnings:
```
/flutter/ios/Classes/SentryFlutterPluginApple.swift:470:35: warning: expression implicitly coerced from 'Dictionary<String, Any?>' to '[String : Any]'
          scope.setContext(value: dictionary, key: key)
                                  ^~~~~~~~~~
          scope.setContext(value: dictionary, key: key)
                                  ^~~~~~~~~~
                                             as [String : Any]
/flutter/ios/Classes/SentryFlutterPluginApple.swift:472:45: warning: expression implicitly coerced from 'String?' to 'Any'
          scope.setContext(value: ["value": string], key: key)
                                            ^~~~~~
          scope.setContext(value: ["value": string], key: key)
                                            ^~~~~~
                                                   ?? <#default value#>
          scope.setContext(value: ["value": string], key: key)
                                            ^~~~~~
                                                  !
          scope.setContext(value: ["value": string], key: key)
                                            ^~~~~~
                                                   as Any
/flutter/ios/Classes/SentryFlutterPluginApple.swift:512:31: warning: expression implicitly coerced from 'Dictionary<String, Any?>' to '[String : Any]'
          userInstance.data = extras
                              ^~~~~~
          userInstance.data = extras
                              ^~~~~~
                                     as [String : Any]
/flutter/ios/Classes/SentryFlutterPluginApple.swift:557:35: warning: expression implicitly coerced from 'Dictionary<String, Any?>' to '[String : Any]'
        breadcrumbInstance.data = data
                                  ^~~~
        breadcrumbInstance.data = data
                                  ^~~~
                                       as [String : Any]
```

and the lints from the CI
<img width="1027" alt="image" src="https://user-images.githubusercontent.com/6349682/188846339-7fcc4fdf-128b-4354-b186-f2b8dc1292db.png">
