### PR TITLE
feat: Allow `routeNameExtractor` to set transaction names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Bump Cocoa SDK from v7.23.0 to v7.25.0 ([#993](https://github.com/getsentry/sentry-dart/pull/993), [#996](https://github.com/getsentry/sentry-dart/pull/996), [#1000](https://github.com/getsentry/sentry-dart/pull/1000))
   - [changelog](https://github.com/getsentry/sentry-cocoa/blob/master/CHANGELOG.md#7250)
   - [diff](https://github.com/getsentry/sentry-cocoa/compare/7.23.0...7.25.0)
+- Allow routeNameExtractor to set transaction names ([#1005](https://github.com/getsentry/sentry-dart/pull/1005))
 
 ## 6.9.1
 

--- a/flutter/lib/src/navigation/sentry_navigator_observer.dart
+++ b/flutter/lib/src/navigation/sentry_navigator_observer.dart
@@ -86,7 +86,9 @@ class SentryNavigatorObserver extends RouteObserver<PageRoute<dynamic>> {
   void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
     super.didPush(route, previousRoute);
 
-    _setCurrentRoute(route.settings.name);
+    final routeName =
+        (_routeNameExtractor?.call(route.settings) ?? route.settings).name;
+    _setCurrentRoute(routeName);
 
     _addBreadcrumb(
       type: 'didPush',
@@ -101,7 +103,11 @@ class SentryNavigatorObserver extends RouteObserver<PageRoute<dynamic>> {
   @override
   void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
     super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
-    _setCurrentRoute(newRoute?.settings.name);
+
+    final routeName =
+        (_routeNameExtractor?.call(newRoute?.settings) ?? newRoute?.settings)
+            ?.name;
+    _setCurrentRoute(routeName);
     _addBreadcrumb(
       type: 'didReplace',
       from: oldRoute?.settings,
@@ -113,7 +119,10 @@ class SentryNavigatorObserver extends RouteObserver<PageRoute<dynamic>> {
   void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
     super.didPop(route, previousRoute);
 
-    _setCurrentRoute(previousRoute?.settings.name);
+    final routeName = (_routeNameExtractor?.call(previousRoute?.settings) ??
+            previousRoute?.settings)
+        ?.name;
+    _setCurrentRoute(routeName);
     _addBreadcrumb(
       type: 'didPop',
       from: route.settings,

--- a/flutter/test/sentry_navigator_observer_test.dart
+++ b/flutter/test/sentry_navigator_observer_test.dart
@@ -727,6 +727,28 @@ void main() {
         ).data,
       );
     });
+
+    test('route name as transaction with routeNameExtractor', () {
+      final hub = _MockHub();
+      _whenAnyStart(hub, NoOpSentrySpan());
+      final observer = fixture.getSut(
+          hub: hub,
+          setRouteNameAsTransaction: true,
+          routeNameExtractor: (settings) =>
+              settings?.copyWith(name: '${settings.name}_test'));
+
+      final to = routeSettings('to');
+      final previous = routeSettings('previous');
+
+      observer.didPush(route(to), route(previous));
+      expect(hub.scope.transaction, 'to_test');
+
+      observer.didPop(route(to), route(previous));
+      expect(hub.scope.transaction, 'previous_test');
+
+      observer.didReplace(newRoute: route(to), oldRoute: route(previous));
+      expect(hub.scope.transaction, 'to_test');
+    });
   });
 }
 


### PR DESCRIPTION
## :scroll: Description
This PR adds the functionality to have the routeNameExtractor override the route names logged in Sentry, which I personally think makes more sense. It does not make sense to me that this extractor would only affect breadcrumbs, which is the current state, see Motivation. 

Note that this is currently technically a breaking change. I'm open to changing the PR to avoid that, but I'd say the decision on how to proceed there is best left to the maintainers of this project. :)


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Setting the `routeNameExtractor` of the `SentryNavigatorObserver` currently only affects breadcrumbs. For our app, this does not work. We use named routes with IDs to navigate to our pages, e.g. `/movies/1500` to navigate to the detail page of a movie. We want to measure the performance of this whole group of pages instead of the unique instance. We thought we would be able to use the extractor to do this, but sadly not.

As for why I think this makes more sense: `routeNameExtractor` to me says that this functionality will allow you to mutate the route. Intuitively, that means this data will be used throughout the `SentryNavigatorObserver`; nothing about this signifies that this would only affect breadcrumbs. I see no discussion about this in the introducing PR (#684), so hard to say if this was thought about.


## :green_heart: How did you test it?
I used the current tests available for the observer, and added an extra test specific to this functionality since one was missing for the `routeNameExtractor`.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
