### PR TITLE
Fix propagation target regex

### DIFF
--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -291,7 +291,7 @@ class SentryOptions {
   /// requests. If this option is provided, the SDK will match the
   /// request URL of outgoing requests against the items in this
   /// array, and only attach tracing headers if a match was found.
-  final List<String> tracePropagationTargets = ['/.*/'];
+  final List<String> tracePropagationTargets = ['.*'];
 
   SentryOptions({this.dsn, PlatformChecker? checker}) {
     if (checker != null) {

--- a/dart/test/sentry_options_test.dart
+++ b/dart/test/sentry_options_test.dart
@@ -89,6 +89,6 @@ void main() {
   test('SentryOptions has all targets by default', () {
     final options = SentryOptions.empty();
 
-    expect(options.tracePropagationTargets, ['/.*/']);
+    expect(options.tracePropagationTargets, ['.*']);
   });
 }


### PR DESCRIPTION
## :scroll: Description
_#skip-changelog_


## :bulb: Motivation and Context
slashes are just shorthand - not part of actual regex
[Docs](https://develop.sentry.dev/sdk/performance/#tracepropagationtargets) will be patched by @adinauer 


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
