### PR TITLE
Pin sentry version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Align span spec for serialize ops ([#1024](https://github.com/getsentry/sentry-dart/pull/1024))
+- Pin sentry version ([#1020](https://github.com/getsentry/sentry-dart/pull/1020))
 
 ## 6.11.0
 

--- a/dio/pubspec.yaml
+++ b/dio/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   dio: ^4.0.0
-  sentry: ^6.11.0
+  sentry: 6.11.0
 
 dev_dependencies:
   meta: ^1.3.0

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  sentry: ^6.11.0
+  sentry: 6.11.0
   package_info_plus: ^1.0.0
   meta: ^1.3.0
 

--- a/logging/pubspec.yaml
+++ b/logging/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   logging: ^1.0.0
-  sentry: ^6.11.0
+  sentry: 6.11.0
 
 dev_dependencies:
   lints: ^2.0.0

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -14,7 +14,7 @@ for pkg in {dart,flutter,logging,dio}; do
   # Bump version in pubspec.yaml
   perl -pi -e "s/^version: .*/version: $NEW_VERSION/" $pkg/pubspec.yaml
   # Bump sentry dependency version in pubspec.yaml
-  perl -pi -e "s/sentry: \^.*/sentry: \^$NEW_VERSION/" $pkg/pubspec.yaml
+  perl -pi -e "s/sentry: .*/sentry: $NEW_VERSION/" $pkg/pubspec.yaml
 done
 
 # Bump version in version.dart


### PR DESCRIPTION
Resolves #1021

`flutter_sentry` and `sentry` packages versions should be in sync. Using caret symbol `^` may cause mismatch of versions and a build fail.

Example:
`sentry_flutter 6.7.0` depends on `sentry: ^6.7.0`

A user has `sentry_flutter: 6.7.0` (without caret symbol) in their pubspec.yaml. 

`sentry_flutter: 6.7.0` depends on `SentryTracer.addMeasurements()`. 
`SentryTracer.addMeasurements()` was removed in `sentry 6.11.0`.
 This means that `sentry_flutter 6.7.0` is incompatible with `sentry 6.11.0`.
