### PR TITLE
Do not allow setting measurement if transaction is finished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Align span spec for serialize ops ([#1024](https://github.com/getsentry/sentry-dart/pull/1024))
 - Pin sentry version ([#1020](https://github.com/getsentry/sentry-dart/pull/1020))
+- Tracer does not allow setting measurement if finished ([#1026](https://github.com/getsentry/sentry-dart/pull/1026))
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Tracer does not allow setting measurement if finished ([#1026](https://github.com/getsentry/sentry-dart/pull/1026))
+
 ## 6.11.1
 
 ### Fixes
 
 - Align span spec for serialize ops ([#1024](https://github.com/getsentry/sentry-dart/pull/1024))
 - Pin sentry version ([#1020](https://github.com/getsentry/sentry-dart/pull/1020))
-- Tracer does not allow setting measurement if finished ([#1026](https://github.com/getsentry/sentry-dart/pull/1026))
 
 ### Features
 

--- a/dart/lib/src/protocol/sentry_span.dart
+++ b/dart/lib/src/protocol/sentry_span.dart
@@ -187,7 +187,7 @@ class SentrySpan extends ISentrySpan {
   void setMeasurement(
     String name,
     num value, {
-    SentryMeasurementUnit? unit,
+    SentryMeasurementUnit? unit = SentryMeasurementUnit.none,
   }) {
     _tracer.setMeasurement(name, value, unit: unit);
   }

--- a/dart/lib/src/protocol/sentry_span.dart
+++ b/dart/lib/src/protocol/sentry_span.dart
@@ -184,7 +184,11 @@ class SentrySpan extends ISentrySpan {
       );
 
   @override
-  void setMeasurement(String name, num value, {SentryMeasurementUnit? unit}) {
+  void setMeasurement(
+    String name,
+    num value, {
+    SentryMeasurementUnit? unit,
+  }) {
     _tracer.setMeasurement(name, value, unit: unit);
   }
 

--- a/dart/lib/src/protocol/sentry_span.dart
+++ b/dart/lib/src/protocol/sentry_span.dart
@@ -19,7 +19,7 @@ class SentrySpan extends ISentrySpan {
 
   SpanStatus? _status;
   final Map<String, String> _tags = {};
-  void Function({DateTime? endTimestamp})? _finishedCallback;
+  Function({DateTime? endTimestamp})? _finishedCallback;
 
   @override
   final SentryTracesSamplingDecision? samplingDecision;
@@ -62,7 +62,7 @@ class SentrySpan extends ISentrySpan {
     if (_throwable != null) {
       _hub.setSpanContext(_throwable, this, _tracer.name);
     }
-    _finishedCallback?.call(endTimestamp: _endTimestamp);
+    await _finishedCallback?.call(endTimestamp: _endTimestamp);
     return super.finish(status: status, endTimestamp: _endTimestamp);
   }
 

--- a/dart/lib/src/protocol/sentry_span.dart
+++ b/dart/lib/src/protocol/sentry_span.dart
@@ -184,11 +184,7 @@ class SentrySpan extends ISentrySpan {
       );
 
   @override
-  void setMeasurement(
-    String name,
-    num value, {
-    SentryMeasurementUnit? unit = SentryMeasurementUnit.none,
-  }) {
+  void setMeasurement(String name, num value, {SentryMeasurementUnit? unit}) {
     _tracer.setMeasurement(name, value, unit: unit);
   }
 

--- a/dart/lib/src/sentry_tracer.dart
+++ b/dart/lib/src/sentry_tracer.dart
@@ -106,8 +106,10 @@ class SentryTracer extends ISentrySpan {
         }
       }
 
-      await _rootSpan.finish(endTimestamp: _rootEndTimestamp);
+      // the callback should run before because if the span is finished,
+      // we cannot attach data, its immutable after being finished.
       await _onFinish?.call(this);
+      await _rootSpan.finish(endTimestamp: _rootEndTimestamp);
 
       // remove from scope
       await _hub.configureScope((scope) {

--- a/dart/lib/src/sentry_tracer.dart
+++ b/dart/lib/src/sentry_tracer.dart
@@ -284,6 +284,9 @@ class SentryTracer extends ISentrySpan {
 
   @override
   void setMeasurement(String name, num value, {SentryMeasurementUnit? unit}) {
+    if (finished) {
+      return;
+    }
     final measurement = SentryMeasurement(name, value, unit: unit);
     _measurements[name] = measurement;
   }

--- a/dart/lib/src/sentry_tracer.dart
+++ b/dart/lib/src/sentry_tracer.dart
@@ -218,19 +218,21 @@ class SentryTracer extends ISentrySpan {
       _hub,
       samplingDecision: _rootSpan.samplingDecision,
       startTimestamp: startTimestamp,
-      finishedCallback: ({
-        DateTime? endTimestamp,
-      }) {
-        final finishStatus = _finishStatus;
-        if (finishStatus.finishing) {
-          finish(status: finishStatus.status, endTimestamp: endTimestamp);
-        }
-      },
+      finishedCallback: _finishedCallback,
     );
 
     _children.add(child);
 
     return child;
+  }
+
+  Future<void> _finishedCallback({
+    DateTime? endTimestamp,
+  }) async {
+    final finishStatus = _finishStatus;
+    if (finishStatus.finishing) {
+      await finish(status: finishStatus.status, endTimestamp: endTimestamp);
+    }
   }
 
   @override

--- a/dart/lib/src/sentry_tracer.dart
+++ b/dart/lib/src/sentry_tracer.dart
@@ -285,11 +285,7 @@ class SentryTracer extends ISentrySpan {
           .isAfter((span.endTimestamp ?? endTimestampCandidate));
 
   @override
-  void setMeasurement(
-    String name,
-    num value, {
-    SentryMeasurementUnit? unit = SentryMeasurementUnit.none,
-  }) {
+  void setMeasurement(String name, num value, {SentryMeasurementUnit? unit}) {
     if (finished) {
       return;
     }

--- a/dart/lib/src/sentry_tracer.dart
+++ b/dart/lib/src/sentry_tracer.dart
@@ -285,7 +285,11 @@ class SentryTracer extends ISentrySpan {
           .isAfter((span.endTimestamp ?? endTimestampCandidate));
 
   @override
-  void setMeasurement(String name, num value, {SentryMeasurementUnit? unit}) {
+  void setMeasurement(
+    String name,
+    num value, {
+    SentryMeasurementUnit? unit = SentryMeasurementUnit.none,
+  }) {
     if (finished) {
       return;
     }

--- a/dart/test/sentry_tracer_test.dart
+++ b/dart/test/sentry_tracer_test.dart
@@ -380,7 +380,6 @@ void main() {
       sut.setMeasurement('key', 1.0);
 
       expect(sut.measurements['key']!.value, 1.0);
-      expect(sut.measurements['key']?.unit, SentryMeasurementUnit.none);
 
       await sut.finish();
     });

--- a/dart/test/sentry_tracer_test.dart
+++ b/dart/test/sentry_tracer_test.dart
@@ -374,6 +374,28 @@ void main() {
       expect(sut.startChild('child3'), isA<NoOpSentrySpan>());
     });
 
+    test('tracer sets measurement', () async {
+      final sut = fixture.getSut();
+
+      sut.setMeasurement('key', 1.0);
+
+      expect(sut.measurements['key']!.value, 1.0);
+      expect(sut.measurements['key']?.unit, SentryMeasurementUnit.none);
+
+      await sut.finish();
+    });
+
+    test('tracer sets custom measurement unit', () async {
+      final sut = fixture.getSut();
+
+      sut.setMeasurement('key', 1.0, unit: SentryMeasurementUnit.hour);
+
+      expect(sut.measurements['key']!.value, 1.0);
+      expect(sut.measurements['key']?.unit, SentryMeasurementUnit.hour);
+
+      await sut.finish();
+    });
+
     test('tracer does not allow setting measurement if finished', () async {
       final sut = fixture.getSut();
 

--- a/dart/test/sentry_tracer_test.dart
+++ b/dart/test/sentry_tracer_test.dart
@@ -373,6 +373,16 @@ void main() {
 
       expect(sut.startChild('child3'), isA<NoOpSentrySpan>());
     });
+
+    test('tracer does not allow setting measurement if finished', () async {
+      final sut = fixture.getSut();
+
+      await sut.finish();
+
+      sut.setMeasurement('key', 1.0);
+
+      expect(sut.measurements.isEmpty, true);
+    });
   });
 
   group('$SentryBaggageHeader', () {

--- a/flutter/lib/src/navigation/sentry_navigator_observer.dart
+++ b/flutter/lib/src/navigation/sentry_navigator_observer.dart
@@ -1,4 +1,3 @@
-// ignore: implementation_imports
 import 'package:flutter/widgets.dart';
 
 import '../../sentry_flutter.dart';

--- a/flutter/lib/src/navigation/sentry_navigator_observer.dart
+++ b/flutter/lib/src/navigation/sentry_navigator_observer.dart
@@ -1,5 +1,4 @@
 // ignore: implementation_imports
-import 'package:sentry/src/sentry_tracer.dart';
 import 'package:flutter/widgets.dart';
 
 import '../../sentry_flutter.dart';
@@ -181,20 +180,17 @@ class SentryNavigatorObserver extends RouteObserver<PageRoute<dynamic>> {
       autoFinishAfter: _autoFinishAfter,
       trimEnd: true,
       onFinish: (transaction) async {
-        // ignore: invalid_use_of_internal_member
-        if (transaction is SentryTracer) {
-          final nativeFrames = await _native
-              .endNativeFramesCollection(transaction.context.traceId);
-          if (nativeFrames != null) {
-            final measurements = nativeFrames.toMeasurements();
-            for (final item in measurements.entries) {
-              final measurement = item.value;
-              transaction.setMeasurement(
-                item.key,
-                measurement.value,
-                unit: measurement.unit,
-              );
-            }
+        final nativeFrames = await _native
+            .endNativeFramesCollection(transaction.context.traceId);
+        if (nativeFrames != null) {
+          final measurements = nativeFrames.toMeasurements();
+          for (final item in measurements.entries) {
+            final measurement = item.value;
+            transaction.setMeasurement(
+              item.key,
+              measurement.value,
+              unit: measurement.unit,
+            );
           }
         }
       },


### PR DESCRIPTION
## :scroll: Description

Related to https://github.com/getsentry/sentry-dart/pull/1011.


## :bulb: Motivation and Context
Does not allow setting measurement if transaction is finished


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
