### PR TITLE
tracePropagationTargets ignores invalid Regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixes
 
 - Handle traces sampler exception ([#1040](https://github.com/getsentry/sentry-dart/pull/1040))
-- tracePropagationTargets ignores invalid Regex ([#1040](https://github.com/getsentry/sentry-dart/pull/1040))
+- tracePropagationTargets ignores invalid Regex ([#1043](https://github.com/getsentry/sentry-dart/pull/1043))
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Handle traces sampler exception ([#1040](https://github.com/getsentry/sentry-dart/pull/1040))
+- tracePropagationTargets ignores invalid Regex ([#1040](https://github.com/getsentry/sentry-dart/pull/1040))
 
 ### Features
 

--- a/dart/lib/src/utils/tracing_utils.dart
+++ b/dart/lib/src/utils/tracing_utils.dart
@@ -51,7 +51,7 @@ bool containsTracePropagationTarget(
     }
     try {
       final regExp = RegExp(target, caseSensitive: false);
-      if (url.contains(target) || regExp.hasMatch(url)) {
+      if (regExp.hasMatch(url)) {
         return true;
       }
     } on FormatException {

--- a/dart/lib/src/utils/tracing_utils.dart
+++ b/dart/lib/src/utils/tracing_utils.dart
@@ -46,9 +46,17 @@ bool containsTracePropagationTarget(
     return false;
   }
   for (final target in tracePropagationTargets) {
-    final regExp = RegExp(target, caseSensitive: false);
-    if (url.contains(target) || regExp.hasMatch(url)) {
+    if (url.contains(target)) {
       return true;
+    }
+    try {
+      final regExp = RegExp(target, caseSensitive: false);
+      if (url.contains(target) || regExp.hasMatch(url)) {
+        return true;
+      }
+    } on FormatException {
+      // ignore invalid regex
+      continue;
     }
   }
   return false;

--- a/dart/test/utils/tracing_utils_test.dart
+++ b/dart/test/utils/tracing_utils_test.dart
@@ -35,7 +35,15 @@ void main() {
           isTrue);
       expect(
           containsTracePropagationTarget(origins, 'ftp://api.foo.bar:8080/foo'),
-          false);
+          isFalse);
+    });
+
+    test('invalid regex do not throw', () {
+      expect(
+          containsTracePropagationTarget(
+              ['AABB???', '^(http|https)://api\\..*\$'],
+              'http://api.foo.bar:8080/foo'),
+          isTrue);
     });
 
     test('when no origins are defined, returns false for every url', () {


### PR DESCRIPTION
## :scroll: Description
Ignores invalid regex


## :bulb: Motivation and Context
https://github.com/getsentry/sentry-dotnet/pull/1953/files#r986546256


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
