### PR TITLE
docs: replace "http://sentry.io" with "https://sentry.io"

### DIFF
--- a/dart/README.md
+++ b/dart/README.md
@@ -21,7 +21,7 @@ That will give you native crash support (for Android and iOS), [release health](
 
 #### Usage
 
-- Sign up for a Sentry.io account and get a DSN at http://sentry.io.
+- Sign up for a Sentry.io account and get a DSN at https://sentry.io.
 
 - Follow the installing instructions on [pub.dev](https://pub.dev/packages/sentry/install).
 

--- a/dio/README.md
+++ b/dio/README.md
@@ -16,7 +16,7 @@ Integration for the [`dio`](https://pub.dev/packages/dio) package.
 
 #### Usage
 
-- Sign up for a Sentry.io account and get a DSN at http://sentry.io.
+- Sign up for a Sentry.io account and get a DSN at https://sentry.io.
 
 - Follow the installing instructions on [pub.dev](https://pub.dev/packages/sentry/install).
 

--- a/flutter/README.md
+++ b/flutter/README.md
@@ -17,7 +17,7 @@ It will capture errors in the native layer, including (Java/Kotlin/C/C++ for And
 
 #### Usage
 
-- Sign up for a Sentry.io account and get a DSN at http://sentry.io.
+- Sign up for a Sentry.io account and get a DSN at https://sentry.io.
 
 - Follow the installing instructions on [pub.dev](https://pub.dev/packages/sentry_flutter/install).
 

--- a/logging/README.md
+++ b/logging/README.md
@@ -16,7 +16,7 @@ Integration for the [`logging`](https://pub.dev/packages/logging) package.
 
 #### Usage
 
-- Sign up for a Sentry.io account and get a DSN at http://sentry.io.
+- Sign up for a Sentry.io account and get a DSN at https://sentry.io.
 
 - Follow the installing instructions on [pub.dev](https://pub.dev/packages/sentry/install).
 


### PR DESCRIPTION
## :scroll: Description

We should use "https" instead of "http". Or was there any reason why http has been used?
_#skip-changelog_


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
