### PR TITLE
ci: don't run metrics on forks

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -2,13 +2,15 @@ name: SDK metrics
 
 on:
   push:
-    branches: [main]
-  pull_request:
     paths:
       - .github/workflows/metrics.yml
       - dart/**
       - flutter/**
       - metrics/**
+    branches-ignore:
+      - deps/**
+      - dependabot/**
+    tags-ignore: [ '**' ]
 
 jobs:
   metrics:


### PR DESCRIPTION
Trying out if this could be a solution to only run metrics on pushes to the repo instead of on forks. Currently, I suspect it may fail because some GHA context var won't be set to an expected value if it's not on a PR.

See also https://github.com/getsentry/sentry-dart/pull/1073#issuecomment-1275767749