### PR TITLE
Update package_info_plus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Avoid dependency conflict with package_info_plus v3 ([#1084](https://github.com/getsentry/sentry-dart/pull/1084))
+
 ## 6.13.0
 
 ### Features

--- a/flutter/example/pubspec.yaml
+++ b/flutter/example/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   provider: ^6.0.0
   dio: ^4.0.0
   logging: ^1.0.2
-  package_info_plus: ^2.0.0
+  package_info_plus: ^3.0.0
 
 dev_dependencies:
   pedantic: ^1.11.1

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   sentry: 6.13.0
-  package_info_plus: '>=1.0.0 <3.0.0'
+  package_info_plus: '>=1.0.0 <4.0.0'
   meta: ^1.3.0
 
 dev_dependencies:


### PR DESCRIPTION
## :scroll: Description
This PR allows `package_info_plus` to be used in its newest version `3.0.0`.


## :bulb: Motivation and Context
The federated two-package refactor can now be used together with `sentry_flutter`.


## :green_heart: How did you test it?
All the workflows went through and the Sentry functionality in my app still works perfectly fine with the new version.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes
