### PR TITLE
Use new constructor which respects Frame Tracking feature flag

### DIFF
--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -157,7 +157,7 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
       args.getIfNotNull<Boolean>("enableAutoPerformanceTracking") { enableAutoPerformanceTracking ->
         if (enableAutoPerformanceTracking) {
           autoPerformanceTrackingEnabled = true
-          framesTracker = ActivityFramesTracker(LoadClass())
+          framesTracker = ActivityFramesTracker(LoadClass(), options)
         }
       }
 


### PR DESCRIPTION
## :scroll: Description
Frame Tracking can be enabled/disabled in future, this PR adapts the necessary calls into the Android SDK.

## :bulb: Motivation and Context
Related Android PR: https://github.com/getsentry/sentry-java/pull/2314 
https://github.com/getsentry/sentry-java/pull/2314#discussion_r1001420812


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes
- [ ] Android SDK is released (version TBD)
- [ ] New Android SDK is used


## :crystal_ball: Next steps
