### PR TITLE
Add fragment to HTTP Client errors and fix user sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Add missing `fragment` for HTTP Client Errors ([#1102](https://github.com/getsentry/sentry-dart/pull/1102))
+- Sync user name and geo for Android ([#1102](https://github.com/getsentry/sentry-dart/pull/1102))
+
 ## 6.14.0
 
 ### Features

--- a/dart/lib/src/http_client/failed_request_client.dart
+++ b/dart/lib/src/http_client/failed_request_client.dart
@@ -157,9 +157,14 @@ class FailedRequestClient extends BaseClient {
   }) async {
     // As far as I can tell there's no way to get the uri without the query part
     // so we replace it with an empty string.
-    final urlWithoutQuery = request.url.replace(query: '').toString();
+    final urlWithoutQuery = request.url
+        .replace(query: '', fragment: '')
+        .toString()
+        .replaceAll('?', '')
+        .replaceAll('#', '');
 
     final query = request.url.query.isEmpty ? null : request.url.query;
+    final fragment = request.url.fragment.isEmpty ? null : request.url.fragment;
 
     final sentryRequest = SentryRequest(
       method: request.method,
@@ -172,6 +177,7 @@ class FailedRequestClient extends BaseClient {
         'content_length': request.contentLength.toString(),
         'duration': requestDuration.toString(),
       },
+      fragment: fragment,
     );
 
     final mechanism = Mechanism(

--- a/dart/test/http_client/failed_request_client_test.dart
+++ b/dart/test/http_client/failed_request_client_test.dart
@@ -9,7 +9,7 @@ import '../mocks.dart';
 import '../mocks/mock_hub.dart';
 import '../mocks/mock_transport.dart';
 
-final requestUri = Uri.parse('https://example.com?foo=bar');
+final requestUri = Uri.parse('https://example.com?foo=bar#myFragment');
 
 void main() {
   group(FailedRequestClient, () {
@@ -53,8 +53,9 @@ void main() {
       final request = eventCall.request;
       expect(request, isNotNull);
       expect(request?.method, 'GET');
-      expect(request?.url, 'https://example.com?');
+      expect(request?.url, 'https://example.com');
       expect(request?.queryString, 'foo=bar');
+      expect(request?.fragment, 'myFragment');
       expect(request?.cookies, 'foo=bar');
       expect(request?.headers, {'Cookie': 'foo=bar'});
       // ignore: deprecated_member_use_from_same_package
@@ -112,8 +113,9 @@ void main() {
       final request = eventCall.request;
       expect(request, isNotNull);
       expect(request?.method, 'GET');
-      expect(request?.url, 'https://example.com?');
+      expect(request?.url, 'https://example.com');
       expect(request?.queryString, 'foo=bar');
+      expect(request?.fragment, 'myFragment');
       expect(request?.cookies, 'foo=bar');
       expect(request?.headers, {'Cookie': 'foo=bar'});
       // ignore: deprecated_member_use_from_same_package

--- a/dio/lib/src/dio_event_processor.dart
+++ b/dio/lib/src/dio_event_processor.dart
@@ -119,9 +119,17 @@ class DioEventProcessor implements EventProcessor {
     final options = dioError.requestOptions;
     // As far as I can tell there's no way to get the uri without the query part
     // so we replace it with an empty string.
-    final urlWithoutQuery = options.uri.replace(query: '').toString();
+    final urlWithoutQuery = options.uri
+        .replace(query: '', fragment: '')
+        .toString()
+        .replaceAll('?', '')
+        .replaceAll('#', '');
 
     final query = options.uri.query.isEmpty ? null : options.uri.query;
+
+    // future proof, Dio does not support it yet and even if passing in the path,
+    // the parsing of the uri returns empty.
+    final fragment = options.uri.fragment.isEmpty ? null : options.uri.fragment;
 
     final headers = options.headers
         .map((key, dynamic value) => MapEntry(key, value?.toString() ?? ''));
@@ -132,6 +140,7 @@ class DioEventProcessor implements EventProcessor {
       url: urlWithoutQuery,
       queryString: query,
       data: _getRequestData(dioError.requestOptions.data),
+      fragment: fragment,
     );
   }
 

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -262,6 +262,7 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     }
   }
 
+  @Suppress("ComplexMethod")
   private fun setUser(user: Map<String, Any?>?, result: Result) {
     if (user == null) {
       Sentry.setUser(null)

--- a/flutter/ios/Classes/SentryFlutterPluginApple.swift
+++ b/flutter/ios/Classes/SentryFlutterPluginApple.swift
@@ -527,7 +527,7 @@ public class SentryFlutterPluginApple: NSObject, FlutterPlugin {
           }
         }
 
-        // TODO: missing name and geo
+        // missing name and geo
         // Should be solved by https://github.com/getsentry/team-mobile/issues/59
         // or https://github.com/getsentry/team-mobile/issues/56
 

--- a/flutter/ios/Classes/SentryFlutterPluginApple.swift
+++ b/flutter/ios/Classes/SentryFlutterPluginApple.swift
@@ -527,6 +527,10 @@ public class SentryFlutterPluginApple: NSObject, FlutterPlugin {
           }
         }
 
+        // TODO: missing name and geo
+        // Should be solved by https://github.com/getsentry/team-mobile/issues/59
+        // or https://github.com/getsentry/team-mobile/issues/56
+
         SentrySDK.setUser(userInstance)
       } else {
         SentrySDK.setUser(nil)


### PR DESCRIPTION
## :scroll: Description
Add fragments to HTTP Client errors
Fix user sync


## :bulb: Motivation and Context
Mixed up 3 PRs together
https://github.com/getsentry/sentry-dart/issues/1057, https://github.com/getsentry/sentry-dart/issues/1054 and https://github.com/getsentry/sentry-dart/issues/1065


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
