### PR TITLE
chore: Target cocoapod Sentry/HybridSDK subspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@
 - Bump Android SDK from v6.6.0 to v6.7.0 ([#1105](https://github.com/getsentry/sentry-dart/pull/1105))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#670)
   - [diff](https://github.com/getsentry/sentry-java/compare/6.6.0...6.7.0)
-- Bump Cocoa SDK from v7.30.0 to v7.31.0 ([#1104](https://github.com/getsentry/sentry-dart/pull/1113))
-  - [changelog](https://github.com/getsentry/sentry-cocoa/blob/master/CHANGELOG.md#7310)
-  - [diff](https://github.com/getsentry/sentry-cocoa/compare/7.30.0...7.31.0)
+- Bump Cocoa SDK from v7.30.1 to v7.30.2 ([#1123](https://github.com/getsentry/sentry-dart/pull/1123))
+   - [changelog](https://github.com/getsentry/sentry-cocoa/blob/master/CHANGELOG.md#7302)
+   - [diff](https://github.com/getsentry/sentry-cocoa/compare/7.30.1...7.30.2)
 
 ## 6.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#670)
   - [diff](https://github.com/getsentry/sentry-java/compare/6.6.0...6.7.0)
 - Bump Cocoa SDK from v7.30.0 to v7.30.2 ([#1113](https://github.com/getsentry/sentry-dart/pull/1113))
-   - [changelog](https://github.com/getsentry/sentry-cocoa/blob/master/CHANGELOG.md#7302)
-   - [diff](https://github.com/getsentry/sentry-cocoa/compare/7.30.0...7.30.2)
+  - [changelog](https://github.com/getsentry/sentry-cocoa/blob/master/CHANGELOG.md#7302)
+  - [diff](https://github.com/getsentry/sentry-cocoa/compare/7.30.0...7.30.2)
 
 ## 6.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@
 - Bump Android SDK from v6.6.0 to v6.7.0 ([#1105](https://github.com/getsentry/sentry-dart/pull/1105))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#670)
   - [diff](https://github.com/getsentry/sentry-java/compare/6.6.0...6.7.0)
-- Bump Cocoa SDK from v7.30.1 to v7.30.2 ([#1123](https://github.com/getsentry/sentry-dart/pull/1123))
+- Bump Cocoa SDK from v7.30.0 to v7.30.2 ([#1113](https://github.com/getsentry/sentry-dart/pull/1113))
    - [changelog](https://github.com/getsentry/sentry-cocoa/blob/master/CHANGELOG.md#7302)
-   - [diff](https://github.com/getsentry/sentry-cocoa/compare/7.30.1...7.30.2)
+   - [diff](https://github.com/getsentry/sentry-cocoa/compare/7.30.0...7.30.2)
 
 ## 6.14.0
 

--- a/flutter/ios/sentry_flutter.podspec
+++ b/flutter/ios/sentry_flutter.podspec
@@ -12,7 +12,7 @@ Sentry SDK for Flutter with support to native through sentry-cocoa.
                          :tag => s.version.to_s }
   s.source_files     = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
-  s.dependency 'Sentry/HybridSDK', '~> 7.29.0'
+  s.dependency 'Sentry/HybridSDK', '~> 7.31.0'
   s.ios.dependency 'Flutter'
   s.osx.dependency 'FlutterMacOS'
   s.ios.deployment_target = '9.0'

--- a/flutter/ios/sentry_flutter.podspec
+++ b/flutter/ios/sentry_flutter.podspec
@@ -12,7 +12,7 @@ Sentry SDK for Flutter with support to native through sentry-cocoa.
                          :tag => s.version.to_s }
   s.source_files     = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
-  s.dependency 'Sentry/HybridSDK', '~> 7.30.2'
+  s.dependency 'Sentry/HybridSDK', '7.30.2'
   s.ios.dependency 'Flutter'
   s.osx.dependency 'FlutterMacOS'
   s.ios.deployment_target = '9.0'

--- a/flutter/ios/sentry_flutter.podspec
+++ b/flutter/ios/sentry_flutter.podspec
@@ -12,7 +12,7 @@ Sentry SDK for Flutter with support to native through sentry-cocoa.
                          :tag => s.version.to_s }
   s.source_files     = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
-  s.dependency 'Sentry/HybridSDK', '~> 7.31.0'
+  s.dependency 'Sentry/HybridSDK', '~> 7.30.2'
   s.ios.dependency 'Flutter'
   s.osx.dependency 'FlutterMacOS'
   s.ios.deployment_target = '9.0'

--- a/flutter/ios/sentry_flutter.podspec
+++ b/flutter/ios/sentry_flutter.podspec
@@ -12,7 +12,7 @@ Sentry SDK for Flutter with support to native through sentry-cocoa.
                          :tag => s.version.to_s }
   s.source_files     = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
-  s.dependency 'Sentry', '~> 7.29.0'
+  s.dependency 'Sentry/HybridSDK', '~> 7.29.0'
   s.ios.dependency 'Flutter'
   s.osx.dependency 'FlutterMacOS'
   s.ios.deployment_target = '9.0'

--- a/flutter/scripts/update-cocoa.sh
+++ b/flutter/scripts/update-cocoa.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 cd $(dirname "$0")/../ios
 file='sentry_flutter.podspec'
 content=$(cat $file)
-regex="('Sentry/HybridSDK', *'~> *)([0-9\.]+)'"
+regex="('Sentry/HybridSDK', *'*)([0-9\.]+)'"
 if ! [[ $content =~ $regex ]]; then
     echo "Failed to find the plugin version in $file"
     exit 1

--- a/flutter/scripts/update-cocoa.sh
+++ b/flutter/scripts/update-cocoa.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 cd $(dirname "$0")/../ios
 file='sentry_flutter.podspec'
 content=$(cat $file)
-regex="('Sentry/HybridSDK', *'*)([0-9\.]+)'"
+regex="('Sentry/HybridSDK', *)'([0-9\.]+)'"
 if ! [[ $content =~ $regex ]]; then
     echo "Failed to find the plugin version in $file"
     exit 1

--- a/flutter/scripts/update-cocoa.sh
+++ b/flutter/scripts/update-cocoa.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 cd $(dirname "$0")/../ios
 file='sentry_flutter.podspec'
 content=$(cat $file)
-regex="('Sentry', *'~> *)([0-9\.]+)'"
+regex="('Sentry/HybridSDK', *'~> *)([0-9\.]+)'"
 if ! [[ $content =~ $regex ]]; then
     echo "Failed to find the plugin version in $file"
     exit 1


### PR DESCRIPTION
Add a dependency to Sentry/HybridSDK cocoa subspec, to have access to `PrivateSentrySDKOnly.h`.

We need to release the next iOS version before merging this.

close #1124

_#skip-changelog_

