### PR TITLE
Add mechanism to Dio Http Client error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Merging of integrations and packages ([#1111](https://github.com/getsentry/sentry-dart/pull/1111))
 - Add missing `fragment` for HTTP Client Errors ([#1102](https://github.com/getsentry/sentry-dart/pull/1102))
 - Sync user name and geo for Android ([#1102](https://github.com/getsentry/sentry-dart/pull/1102))
+- Add mechanism to Dio Http Client error ([#1114](https://github.com/getsentry/sentry-dart/pull/1114))
 
 ### Dependencies
 

--- a/dart/lib/src/http_client/failed_request_client.dart
+++ b/dart/lib/src/http_client/failed_request_client.dart
@@ -126,8 +126,7 @@ class FailedRequestClient extends BaseClient {
       } else if (failedRequestStatusCodes.containsStatusCode(statusCode)) {
         // Capture an exception if the status code is considered bad
         capture = true;
-        reason =
-            'Event was captured because the request status code was $statusCode';
+        reason = 'HTTP Client Error with status code: $statusCode';
         exception ??= SentryHttpClientError(reason);
       }
       if (capture) {
@@ -178,7 +177,17 @@ class FailedRequestClient extends BaseClient {
       type: 'SentryHttpClient',
       description: reason,
     );
-    final throwableMechanism = ThrowableMechanism(mechanism, exception);
+
+    bool? snapshot;
+    if (exception is SentryHttpClientError) {
+      snapshot = true;
+    }
+
+    final throwableMechanism = ThrowableMechanism(
+      mechanism,
+      exception,
+      snapshot: snapshot,
+    );
 
     final event = SentryEvent(
       throwable: throwableMechanism,

--- a/dart/lib/src/sentry_exception_factory.dart
+++ b/dart/lib/src/sentry_exception_factory.dart
@@ -17,9 +17,11 @@ class SentryExceptionFactory {
   }) {
     var throwable = exception;
     Mechanism? mechanism;
+    bool? snapshot;
     if (exception is ThrowableMechanism) {
       throwable = exception.throwable;
       mechanism = exception.mechanism;
+      snapshot = exception.snapshot;
     }
 
     if (throwable is Error) {
@@ -29,6 +31,8 @@ class SentryExceptionFactory {
     // hence we check again if stackTrace is null and if not, read the current stack trace
     // but only if attachStacktrace is enabled
     if (_options.attachStacktrace) {
+      // TODO: snapshot=true if stackTrace is null
+      // Requires a major breaking change because of grouping
       stackTrace ??= StackTrace.current;
     }
 
@@ -39,6 +43,7 @@ class SentryExceptionFactory {
       if (frames.isNotEmpty) {
         sentryStackTrace = SentryStackTrace(
           frames: frames,
+          snapshot: snapshot,
         );
       }
     }

--- a/dart/lib/src/throwable_mechanism.dart
+++ b/dart/lib/src/throwable_mechanism.dart
@@ -4,10 +4,17 @@ import 'protocol/mechanism.dart';
 class ThrowableMechanism implements Exception {
   final Mechanism _mechanism;
   final dynamic _throwable;
+  final bool? _snapshot;
 
-  ThrowableMechanism(this._mechanism, this._throwable);
+  ThrowableMechanism(
+    this._mechanism,
+    this._throwable, {
+    bool? snapshot,
+  }) : _snapshot = snapshot;
 
   Mechanism get mechanism => _mechanism;
 
   dynamic get throwable => _throwable;
+
+  bool? get snapshot => _snapshot;
 }

--- a/dart/test/http_client/failed_request_client_test.dart
+++ b/dart/test/http_client/failed_request_client_test.dart
@@ -48,6 +48,7 @@ void main() {
       final mechanism = exception?.mechanism;
 
       expect(exception?.stackTrace, isNotNull);
+      expect(exception?.stackTrace!.snapshot, isNull);
       expect(mechanism?.type, 'SentryHttpClient');
 
       final request = eventCall.request;
@@ -100,14 +101,15 @@ void main() {
       expect(mechanism?.type, 'SentryHttpClient');
       expect(
         mechanism?.description,
-        'Event was captured because the request status code was 404',
+        'HTTP Client Error with status code: 404',
       );
 
       expect(exception?.type, 'SentryHttpClientError');
       expect(
         exception?.value,
-        'Exception: Event was captured because the request status code was 404',
+        'Exception: HTTP Client Error with status code: 404',
       );
+      expect(exception?.stackTrace?.snapshot, true);
 
       final request = eventCall.request;
       expect(request, isNotNull);

--- a/dart/test/sentry_exception_factory_test.dart
+++ b/dart/test/sentry_exception_factory_test.dart
@@ -83,6 +83,22 @@ void main() {
 
     // skip on browser because [StackTrace.current] still returns null
   }, onPlatform: {'browser': Skip()});
+
+  test('reads the snapshot from the mechanism', () {
+    final error = StateError('test-error');
+    final mechanism = Mechanism(type: 'Mechanism');
+    final throwableMechanism = ThrowableMechanism(
+      mechanism,
+      error,
+      snapshot: true,
+    );
+
+    SentryException sentryException = fixture.getSut().getSentryException(
+          throwableMechanism,
+        );
+
+    expect(sentryException.stackTrace!.snapshot, true);
+  });
 }
 
 class CustomError extends Error {}

--- a/dart/test/sentry_exception_factory_test.dart
+++ b/dart/test/sentry_exception_factory_test.dart
@@ -93,9 +93,15 @@ void main() {
       snapshot: true,
     );
 
-    SentryException sentryException = fixture.getSut().getSentryException(
-          throwableMechanism,
-        );
+    SentryException sentryException;
+    try {
+      throw throwableMechanism;
+    } catch (err, stackTrace) {
+      sentryException = fixture.getSut().getSentryException(
+            throwableMechanism,
+            stackTrace: stackTrace,
+          );
+    }
 
     expect(sentryException.stackTrace!.snapshot, true);
   });

--- a/dio/lib/src/failed_request_interceptor.dart
+++ b/dio/lib/src/failed_request_interceptor.dart
@@ -13,8 +13,12 @@ class FailedRequestInterceptor extends Interceptor {
     DioError err,
     ErrorInterceptorHandler handler,
   ) async {
+    final mechanism = Mechanism(type: 'SentryDioClientAdapter');
+    final throwableMechanism = ThrowableMechanism(mechanism, err);
+
     _hub.getSpan()?.throwable = err;
-    await _hub.captureException(err);
+
+    await _hub.captureException(throwableMechanism);
 
     handler.next(err);
   }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
Align spec for HTTP Client errors https://develop.sentry.dev/sdk/features/#http-client-errors
Dio events now are possible to be searchable via mechanism.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
