### PR TITLE
Add SentryRequest context for HttpException and SocketException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Changelog
 
-## 6.15.0
+## Unreleased
+
+### Features
 
 - Add request context to `HttpException` and `SocketException` ([#1118](https://github.com/getsentry/sentry-dart/pull/1118))
 - `SocketException` and `FileSystemException` with `OSError`s report the `OSError` as root exception ([#1118](https://github.com/getsentry/sentry-dart/pull/1118))
+
+## 6.15.0
+
 ### Features
 
 - Feat: Screenshot Attachment ([#1088](https://github.com/getsentry/sentry-dart/pull/1088))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add request context to `HttpException` and `SocketException` ([#1118](https://github.com/getsentry/sentry-dart/pull/1118))
 - `SocketException` and `FileSystemException` with `OSError`s report the `OSError` as root exception ([#1118](https://github.com/getsentry/sentry-dart/pull/1118))
+
 ## 6.15.1
 
 ### Various fixes & improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-- Add request context to `HttpException` and `SocketException`
-- `SocketException` and `FileSystemException` with `OSError`s report the `OSError` as root exception
+- Add request context to `HttpException` and `SocketException` ([#1118](https://github.com/getsentry/sentry-dart/pull/1118))
+- `SocketException` and `FileSystemException` with `OSError`s report the `OSError` as root exception ([#1118](https://github.com/getsentry/sentry-dart/pull/1118))
 ### Features
 
 - Feat: Screenshot Attachment ([#1088](https://github.com/getsentry/sentry-dart/pull/1088))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add request context to `HttpException` and `SocketException`
+- `SocketException` and `FileSystemException` with `OSError`s report the `OSError` as root exception
+
 ### Fixes
 
 - Merging of integrations and packages ([#1111](https://github.com/getsentry/sentry-dart/pull/1111))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Add request context to `HttpException` and `SocketException` ([#1118](https://github.com/getsentry/sentry-dart/pull/1118))
+- Add request context to `HttpException`, `SocketException` and `NetworkImageLoadException` ([#1118](https://github.com/getsentry/sentry-dart/pull/1118))
 - `SocketException` and `FileSystemException` with `OSError`s report the `OSError` as root exception ([#1118](https://github.com/getsentry/sentry-dart/pull/1118))
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add request context to `HttpException` and `SocketException` ([#1118](https://github.com/getsentry/sentry-dart/pull/1118))
 - `SocketException` and `FileSystemException` with `OSError`s report the `OSError` as root exception ([#1118](https://github.com/getsentry/sentry-dart/pull/1118))
+
 ### Fixes
 
 - Disable `enableUserInteractionBreadcrumbs` on Android when `enableAutoNativeBreadcrumbs` is disabled ([#1131](https://github.com/getsentry/sentry-dart/pull/1131))

--- a/dart/lib/src/enricher/enricher_event_processor.dart
+++ b/dart/lib/src/enricher/enricher_event_processor.dart
@@ -1,8 +1,0 @@
-import '../event_processor.dart';
-import '../sentry_options.dart';
-import 'io_enricher_event_processor.dart'
-    if (dart.library.html) 'web_enricher_event_processor.dart';
-
-EventProcessor getEnricherEventProcessor(SentryOptions options) {
-  return enricherEventProcessor(options);
-}

--- a/dart/lib/src/event_processor/enricher/enricher_event_processor.dart
+++ b/dart/lib/src/event_processor/enricher/enricher_event_processor.dart
@@ -1,0 +1,9 @@
+import '../../event_processor.dart';
+import '../../sentry_options.dart';
+import 'io_enricher_event_processor.dart'
+    if (dart.library.html) 'web_enricher_event_processor.dart';
+
+abstract class EnricherEventProcessor implements EventProcessor {
+  factory EnricherEventProcessor(SentryOptions options) =>
+      enricherEventProcessor(options);
+}

--- a/dart/lib/src/event_processor/enricher/io_enricher_event_processor.dart
+++ b/dart/lib/src/event_processor/enricher/io_enricher_event_processor.dart
@@ -2,18 +2,18 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:isolate';
 
-import '../event_processor.dart';
-import '../protocol.dart';
-import '../sentry_options.dart';
+import '../../protocol.dart';
+import '../../sentry_options.dart';
+import 'enricher_event_processor.dart';
 
-EventProcessor enricherEventProcessor(SentryOptions options) {
+EnricherEventProcessor enricherEventProcessor(SentryOptions options) {
   return IoEnricherEventProcessor(options);
 }
 
 /// Enriches [SentryEvents] with various kinds of information.
 /// Uses Darts [Platform](https://api.dart.dev/stable/dart-io/Platform-class.html)
 /// class to read information.
-class IoEnricherEventProcessor extends EventProcessor {
+class IoEnricherEventProcessor implements EnricherEventProcessor {
   IoEnricherEventProcessor(
     this._options,
   );

--- a/dart/lib/src/event_processor/enricher/web_enricher_event_processor.dart
+++ b/dart/lib/src/event_processor/enricher/web_enricher_event_processor.dart
@@ -1,18 +1,18 @@
 import 'dart:async';
 import 'dart:html' as html show window, Window;
 
-import '../event_processor.dart';
-import '../protocol.dart';
-import '../sentry_options.dart';
+import '../../protocol.dart';
+import '../../sentry_options.dart';
+import 'enricher_event_processor.dart';
 
-EventProcessor enricherEventProcessor(SentryOptions options) {
+EnricherEventProcessor enricherEventProcessor(SentryOptions options) {
   return WebEnricherEventProcessor(
     html.window,
     options,
   );
 }
 
-class WebEnricherEventProcessor extends EventProcessor {
+class WebEnricherEventProcessor implements EnricherEventProcessor {
   WebEnricherEventProcessor(
     this._window,
     this._options,

--- a/dart/lib/src/event_processor/exception/exception_event_processor.dart
+++ b/dart/lib/src/event_processor/exception/exception_event_processor.dart
@@ -1,0 +1,7 @@
+import '../../event_processor.dart';
+import 'io_exception_event_processor.dart'
+    if (dart.library.html) 'web_exception_event_processor.dart';
+
+abstract class ExceptionEventProcessor implements EventProcessor {
+  factory ExceptionEventProcessor() => exceptionEventProcessor();
+}

--- a/dart/lib/src/event_processor/exception/exception_event_processor.dart
+++ b/dart/lib/src/event_processor/exception/exception_event_processor.dart
@@ -1,7 +1,9 @@
 import '../../event_processor.dart';
+import '../../sentry_options.dart';
 import 'io_exception_event_processor.dart'
     if (dart.library.html) 'web_exception_event_processor.dart';
 
 abstract class ExceptionEventProcessor implements EventProcessor {
-  factory ExceptionEventProcessor() => exceptionEventProcessor();
+  factory ExceptionEventProcessor(SentryOptions options) =>
+      exceptionEventProcessor(options);
 }

--- a/dart/lib/src/event_processor/exception/io_exception_event_processor.dart
+++ b/dart/lib/src/event_processor/exception/io_exception_event_processor.dart
@@ -1,0 +1,75 @@
+import 'dart:async';
+import 'dart:io';
+
+import '../../protocol.dart';
+import 'exception_event_processor.dart';
+
+ExceptionEventProcessor exceptionEventProcessor() =>
+    IoExceptionEventProcessor();
+
+class IoExceptionEventProcessor implements ExceptionEventProcessor {
+  @override
+  FutureOr<SentryEvent> apply(SentryEvent event, {dynamic hint}) {
+    final throwable = event.throwable;
+    if (throwable is HttpException) {
+      return applyHttpException(throwable, event);
+    }
+    if (throwable is SocketException) {
+      return applySocketException(throwable, event);
+    }
+
+    return event;
+  }
+
+  // https://api.dart.dev/stable/dart-io/HttpException-class.html
+  SentryEvent applyHttpException(HttpException exception, SentryEvent event) {
+    final uri = exception.uri;
+    if (uri == null) {
+      return event;
+    }
+    return event.copyWith(
+      request: event.request ?? SentryRequest.fromUri(uri: uri),
+    );
+  }
+
+  // https://api.dart.dev/stable/dart-io/SocketException-class.html
+  SentryEvent applySocketException(
+    SocketException exception,
+    SentryEvent event,
+  ) {
+    final address = exception.address;
+    if (address == null) {
+      return event;
+    }
+    final osError = exception.osError;
+    try {
+      final uri = Uri.parse(address.host);
+
+      return event.copyWith(
+        request: event.request ?? SentryRequest.fromUri(uri: uri),
+        exceptions: [
+          ...?event.exceptions,
+          // OSError is the underlying error
+          // https://api.dart.dev/stable/dart-io/SocketException/osError.html
+          // https://api.dart.dev/stable/dart-io/OSError-class.html
+          if (osError != null) _sentryExceptionfromOsError(osError),
+        ],
+      );
+    } catch (_) {
+      return event;
+    }
+  }
+}
+
+SentryException _sentryExceptionfromOsError(OSError osError) {
+  return SentryException(
+    type: osError.runtimeType.toString(),
+    value: osError.toString(),
+    mechanism: Mechanism(
+      type: 'OSError',
+      meta: {
+        'code': osError.errorCode,
+      },
+    ),
+  );
+}

--- a/dart/lib/src/event_processor/exception/io_exception_event_processor.dart
+++ b/dart/lib/src/event_processor/exception/io_exception_event_processor.dart
@@ -97,9 +97,7 @@ SentryException _sentryExceptionfromOsError(OSError osError) {
     mechanism: Mechanism(
       type: 'OSError',
       meta: {
-        'signal': {
-          'number': osError.errorCode,
-        },
+        'errno': osError.errorCode,
       },
     ),
   );

--- a/dart/lib/src/event_processor/exception/io_exception_event_processor.dart
+++ b/dart/lib/src/event_processor/exception/io_exception_event_processor.dart
@@ -44,11 +44,11 @@ class IoExceptionEventProcessor implements ExceptionEventProcessor {
     if (address == null) {
       return event.copyWith(
         exceptions: [
-          ...?event.exceptions,
           // OSError is the underlying error
           // https://api.dart.dev/stable/dart-io/SocketException/osError.html
           // https://api.dart.dev/stable/dart-io/OSError-class.html
           if (osError != null) _sentryExceptionfromOsError(osError),
+          ...?event.exceptions,
         ],
       );
     }
@@ -61,11 +61,11 @@ class IoExceptionEventProcessor implements ExceptionEventProcessor {
     return event.copyWith(
       request: event.request ?? request,
       exceptions: [
-        ...?event.exceptions,
         // OSError is the underlying error
         // https://api.dart.dev/stable/dart-io/SocketException/osError.html
         // https://api.dart.dev/stable/dart-io/OSError-class.html
         if (osError != null) _sentryExceptionfromOsError(osError),
+        ...?event.exceptions,
       ],
     );
   }
@@ -78,11 +78,11 @@ class IoExceptionEventProcessor implements ExceptionEventProcessor {
     final osError = exception.osError;
     return event.copyWith(
       exceptions: [
-        ...?event.exceptions,
         // OSError is the underlying error
         // https://api.dart.dev/stable/dart-io/FileSystemException/osError.html
         // https://api.dart.dev/stable/dart-io/OSError-class.html
         if (osError != null) _sentryExceptionfromOsError(osError),
+        ...?event.exceptions,
       ],
     );
   }

--- a/dart/lib/src/event_processor/exception/web_exception_event_processor.dart
+++ b/dart/lib/src/event_processor/exception/web_exception_event_processor.dart
@@ -1,7 +1,8 @@
 import '../../protocol.dart';
+import '../../sentry_options.dart';
 import 'exception_event_processor.dart';
 
-ExceptionEventProcessor exceptionEventProcessor() =>
+ExceptionEventProcessor exceptionEventProcessor(SentryOptions _) =>
     WebExcptionEventProcessor();
 
 class WebExcptionEventProcessor implements ExceptionEventProcessor {

--- a/dart/lib/src/event_processor/exception/web_exception_event_processor.dart
+++ b/dart/lib/src/event_processor/exception/web_exception_event_processor.dart
@@ -1,0 +1,10 @@
+import '../../protocol.dart';
+import 'exception_event_processor.dart';
+
+ExceptionEventProcessor exceptionEventProcessor() =>
+    WebExcptionEventProcessor();
+
+class WebExcptionEventProcessor implements ExceptionEventProcessor {
+  @override
+  SentryEvent apply(SentryEvent event, {dynamic hint}) => event;
+}

--- a/dart/lib/src/http_client/failed_request_client.dart
+++ b/dart/lib/src/http_client/failed_request_client.dart
@@ -155,29 +155,16 @@ class FailedRequestClient extends BaseClient {
     required BaseRequest request,
     required StreamedResponse? response,
   }) async {
-    // As far as I can tell there's no way to get the uri without the query part
-    // so we replace it with an empty string.
-    final urlWithoutQuery = request.url
-        .replace(query: '', fragment: '')
-        .toString()
-        .replaceAll('?', '')
-        .replaceAll('#', '');
-
-    final query = request.url.query.isEmpty ? null : request.url.query;
-    final fragment = request.url.fragment.isEmpty ? null : request.url.fragment;
-
-    final sentryRequest = SentryRequest(
+    final sentryRequest = SentryRequest.fromUri(
       method: request.method,
       headers: sendDefaultPii ? request.headers : null,
-      url: urlWithoutQuery,
-      queryString: query,
+      uri: request.url,
       data: sendDefaultPii ? _getDataFromRequest(request) : null,
       // ignore: deprecated_member_use_from_same_package
       other: {
         'content_length': request.contentLength.toString(),
         'duration': requestDuration.toString(),
       },
-      fragment: fragment,
     );
 
     final mechanism = Mechanism(

--- a/dart/lib/src/protocol/sentry_request.dart
+++ b/dart/lib/src/protocol/sentry_request.dart
@@ -98,6 +98,8 @@ class SentryRequest {
         .replaceAll('?', '')
         .replaceAll('#', '');
 
+    // Future proof, Dio does not support it yet and even if passing in the path,
+    // the parsing of the uri returns empty.
     final query = uri.query.isEmpty ? null : uri.query;
     final fragment = uri.fragment.isEmpty ? null : uri.fragment;
 

--- a/dart/lib/src/protocol/sentry_request.dart
+++ b/dart/lib/src/protocol/sentry_request.dart
@@ -81,6 +81,40 @@ class SentryRequest {
         _env = env != null ? Map.from(env) : null,
         _other = other != null ? Map.from(other) : null;
 
+  factory SentryRequest.fromUri({
+    required Uri uri,
+    String? method,
+    String? cookies,
+    dynamic data,
+    Map<String, String>? headers,
+    Map<String, String>? env,
+    @Deprecated('Will be removed in v7.') Map<String, String>? other,
+  }) {
+    // As far as I can tell there's no way to get the uri without the query part
+    // so we replace it with an empty string.
+    final urlWithoutQuery = uri
+        .replace(query: '', fragment: '')
+        .toString()
+        .replaceAll('?', '')
+        .replaceAll('#', '');
+
+    final query = uri.query.isEmpty ? null : uri.query;
+    final fragment = uri.fragment.isEmpty ? null : uri.fragment;
+
+    return SentryRequest(
+      url: urlWithoutQuery,
+      fragment: fragment,
+      queryString: query,
+      method: method,
+      cookies: cookies,
+      data: data,
+      headers: headers,
+      env: env,
+      // ignore: deprecated_member_use_from_same_package
+      other: other,
+    );
+  }
+
   /// Deserializes a [SentryRequest] from JSON [Map].
   factory SentryRequest.fromJson(Map<String, dynamic> json) {
     return SentryRequest(

--- a/dart/lib/src/sentry.dart
+++ b/dart/lib/src/sentry.dart
@@ -3,9 +3,10 @@ import 'dart:async';
 import 'package:meta/meta.dart';
 
 import 'default_integrations.dart';
-import 'enricher/enricher_event_processor.dart';
+import 'event_processor/enricher/enricher_event_processor.dart';
 import 'environment/environment_variables.dart';
 import 'event_processor/deduplication_event_processor.dart';
+import 'event_processor/exception/exception_event_processor.dart';
 import 'hub.dart';
 import 'hub_adapter.dart';
 import 'integration.dart';
@@ -73,7 +74,8 @@ class Sentry {
       options.addIntegrationByIndex(0, IsolateErrorIntegration());
     }
 
-    options.addEventProcessor(getEnricherEventProcessor(options));
+    options.addEventProcessor(EnricherEventProcessor(options));
+    options.addEventProcessor(ExceptionEventProcessor());
     options.addEventProcessor(DeduplicationEventProcessor(options));
   }
 

--- a/dart/lib/src/sentry.dart
+++ b/dart/lib/src/sentry.dart
@@ -75,7 +75,7 @@ class Sentry {
     }
 
     options.addEventProcessor(EnricherEventProcessor(options));
-    options.addEventProcessor(ExceptionEventProcessor());
+    options.addEventProcessor(ExceptionEventProcessor(options));
     options.addEventProcessor(DeduplicationEventProcessor(options));
   }
 

--- a/dart/test/event_processor/enricher/io_enricher_test.dart
+++ b/dart/test/event_processor/enricher/io_enricher_test.dart
@@ -1,11 +1,11 @@
 @TestOn('vm')
 
 import 'package:sentry/sentry.dart';
-import 'package:sentry/src/enricher/io_enricher_event_processor.dart';
+import 'package:sentry/src/event_processor/enricher/io_enricher_event_processor.dart';
 import 'package:test/test.dart';
 
-import '../mocks.dart';
-import '../mocks/mock_platform_checker.dart';
+import '../../mocks.dart';
+import '../../mocks/mock_platform_checker.dart';
 
 void main() {
   group('io_enricher', () {

--- a/dart/test/event_processor/enricher/web_enricher_test.dart
+++ b/dart/test/event_processor/enricher/web_enricher_test.dart
@@ -2,11 +2,11 @@
 import 'dart:html' as html;
 
 import 'package:sentry/sentry.dart';
-import 'package:sentry/src/enricher/web_enricher_event_processor.dart';
+import 'package:sentry/src/event_processor/enricher/web_enricher_event_processor.dart';
 import 'package:test/test.dart';
 
-import '../mocks.dart';
-import '../mocks/mock_platform_checker.dart';
+import '../../mocks.dart';
+import '../../mocks/mock_platform_checker.dart';
 
 // can be tested on command line with
 // `dart test -p chrome --name web_enricher`

--- a/dart/test/event_processor/exception/io_exception_event_processor_test.dart
+++ b/dart/test/event_processor/exception/io_exception_event_processor_test.dart
@@ -68,7 +68,7 @@ void main() {
         'OS Error: Connection reset by peer, errno = 54',
       );
       expect(event.exceptions?.first.mechanism?.type, 'OSError');
-      expect(event.exceptions?.first.mechanism?.meta['code'], 54);
+      expect(event.exceptions?.first.mechanism?.meta['signal']['number'], 54);
     });
 
     test('adds OSError SentryException for $FileSystemException', () async {
@@ -91,7 +91,7 @@ void main() {
         'OS Error: Oh no :(, errno = 42',
       );
       expect(event.exceptions?.first.mechanism?.type, 'OSError');
-      expect(event.exceptions?.first.mechanism?.meta['code'], 42);
+      expect(event.exceptions?.first.mechanism?.meta['signal']['number'], 42);
     });
   });
 }

--- a/dart/test/event_processor/exception/io_exception_event_processor_test.dart
+++ b/dart/test/event_processor/exception/io_exception_event_processor_test.dart
@@ -1,0 +1,103 @@
+@TestOn('vm')
+
+import 'dart:io';
+
+import 'package:sentry/sentry.dart';
+import 'package:sentry/src/event_processor/exception/io_exception_event_processor.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(IoExceptionEventProcessor, () {
+    late Fixture fixture;
+
+    setUp(() {
+      fixture = Fixture();
+    });
+
+    test('adds $SentryRequest for $HttpException with uris', () async {
+      final enricher = fixture.getSut();
+      final event = enricher.apply(
+        SentryEvent(
+          throwable: HttpException(
+            '',
+            uri: Uri.parse('https://example.org/foo/bar?foo=bar'),
+          ),
+        ),
+      );
+
+      expect(event.request, isNotNull);
+      expect(event.request?.url, 'https://example.org/foo/bar');
+      expect(event.request?.queryString, 'foo=bar');
+    });
+
+    test('no $SentryRequest for $HttpException without uris', () async {
+      final enricher = fixture.getSut();
+      final event = enricher.apply(
+        SentryEvent(
+          throwable: HttpException(''),
+        ),
+      );
+
+      expect(event.request, isNull);
+    });
+
+    test('adds $SentryRequest for $SocketException with addresses', () async {
+      final enricher = fixture.getSut();
+      final event = enricher.apply(
+        SentryEvent(
+          throwable: SocketException(
+            'Exception while connecting',
+            osError: OSError('Connection reset by peer', 54),
+            port: 12345,
+            address: InternetAddress(
+              '127.0.0.1',
+              type: InternetAddressType.IPv4,
+            ),
+          ),
+        ),
+      );
+
+      expect(event.request, isNotNull);
+      expect(event.request?.url, '127.0.0.1');
+
+      // Due to the test setup, there's no SentryException for the SocketException.
+      // And thus only one entry for the added OSError
+      expect(event.exceptions?.first.type, 'OSError');
+      expect(
+        event.exceptions?.first.value,
+        'OS Error: Connection reset by peer, errno = 54',
+      );
+      expect(event.exceptions?.first.mechanism?.type, 'OSError');
+      expect(event.exceptions?.first.mechanism?.meta['code'], 54);
+    });
+
+    test('adds OSError SentryException for $FileSystemException', () async {
+      final enricher = fixture.getSut();
+      final event = enricher.apply(
+        SentryEvent(
+          throwable: FileSystemException(
+            'message',
+            'path',
+            OSError('Oh no :(', 42),
+          ),
+        ),
+      );
+
+      // Due to the test setup, there's no SentryException for the FileSystemException.
+      // And thus only one entry for the added OSError
+      expect(event.exceptions?.first.type, 'OSError');
+      expect(
+        event.exceptions?.first.value,
+        'OS Error: Oh no :(, errno = 42',
+      );
+      expect(event.exceptions?.first.mechanism?.type, 'OSError');
+      expect(event.exceptions?.first.mechanism?.meta['code'], 42);
+    });
+  });
+}
+
+class Fixture {
+  IoExceptionEventProcessor getSut() {
+    return IoExceptionEventProcessor();
+  }
+}

--- a/dart/test/event_processor/exception/io_exception_event_processor_test.dart
+++ b/dart/test/event_processor/exception/io_exception_event_processor_test.dart
@@ -68,7 +68,7 @@ void main() {
         'OS Error: Connection reset by peer, errno = 54',
       );
       expect(event.exceptions?.first.mechanism?.type, 'OSError');
-      expect(event.exceptions?.first.mechanism?.meta['errno'], 54);
+      expect(event.exceptions?.first.mechanism?.meta['errno']['number'], 54);
     });
 
     test('adds OSError SentryException for $FileSystemException', () async {
@@ -91,13 +91,13 @@ void main() {
         'OS Error: Oh no :(, errno = 42',
       );
       expect(event.exceptions?.first.mechanism?.type, 'OSError');
-      expect(event.exceptions?.first.mechanism?.meta['errno'], 42);
+      expect(event.exceptions?.first.mechanism?.meta['errno']['number'], 42);
     });
   });
 }
 
 class Fixture {
   IoExceptionEventProcessor getSut() {
-    return IoExceptionEventProcessor();
+    return IoExceptionEventProcessor(SentryOptions.empty());
   }
 }

--- a/dart/test/event_processor/exception/io_exception_event_processor_test.dart
+++ b/dart/test/event_processor/exception/io_exception_event_processor_test.dart
@@ -68,7 +68,7 @@ void main() {
         'OS Error: Connection reset by peer, errno = 54',
       );
       expect(event.exceptions?.first.mechanism?.type, 'OSError');
-      expect(event.exceptions?.first.mechanism?.meta['signal']['number'], 54);
+      expect(event.exceptions?.first.mechanism?.meta['errno'], 54);
     });
 
     test('adds OSError SentryException for $FileSystemException', () async {
@@ -91,7 +91,7 @@ void main() {
         'OS Error: Oh no :(, errno = 42',
       );
       expect(event.exceptions?.first.mechanism?.type, 'OSError');
-      expect(event.exceptions?.first.mechanism?.meta['signal']['number'], 42);
+      expect(event.exceptions?.first.mechanism?.meta['errno'], 42);
     });
   });
 }

--- a/dart/test/protocol/sentry_request_test.dart
+++ b/dart/test/protocol/sentry_request_test.dart
@@ -76,4 +76,14 @@ void main() {
       expect({'key1': 'value1'}, copy.data);
     });
   });
+
+  test('SentryRequest.fromUri', () {
+    final request = SentryRequest.fromUri(
+      uri: Uri.parse('https://example.org/foo/bar?key=value#fragment'),
+    );
+
+    expect(request.url, 'https://example.org/foo/bar');
+    expect(request.fragment, 'fragment');
+    expect(request.queryString, 'key=value');
+  });
 }

--- a/dio/lib/src/dio_event_processor.dart
+++ b/dio/lib/src/dio_event_processor.dart
@@ -117,30 +117,14 @@ class DioEventProcessor implements EventProcessor {
 
   SentryRequest? _requestFrom(DioError dioError) {
     final options = dioError.requestOptions;
-    // As far as I can tell there's no way to get the uri without the query part
-    // so we replace it with an empty string.
-    final urlWithoutQuery = options.uri
-        .replace(query: '', fragment: '')
-        .toString()
-        .replaceAll('?', '')
-        .replaceAll('#', '');
-
-    final query = options.uri.query.isEmpty ? null : options.uri.query;
-
-    // future proof, Dio does not support it yet and even if passing in the path,
-    // the parsing of the uri returns empty.
-    final fragment = options.uri.fragment.isEmpty ? null : options.uri.fragment;
-
     final headers = options.headers
         .map((key, dynamic value) => MapEntry(key, value?.toString() ?? ''));
 
-    return SentryRequest(
+    return SentryRequest.fromUri(
+      uri: options.uri,
       method: options.method,
       headers: _options.sendDefaultPii ? headers : null,
-      url: urlWithoutQuery,
-      queryString: query,
       data: _getRequestData(dioError.requestOptions.data),
-      fragment: fragment,
     );
   }
 

--- a/flutter/lib/src/event_processor/flutter_exception_event_processor.dart
+++ b/flutter/lib/src/event_processor/flutter_exception_event_processor.dart
@@ -1,17 +1,12 @@
-import 'dart:ui';
-
 import 'package:flutter/rendering.dart';
 import 'package:sentry/sentry.dart';
 
 class FlutterExceptionEventProcessor implements EventProcessor {
   @override
-  SentryEvent? apply(SentryEvent event, {dynamic hint}) {
+  SentryEvent apply(SentryEvent event, {dynamic hint}) {
     final exception = event.throwable;
     if (exception is NetworkImageLoadException) {
       return _applyNetworkImageLoadException(event, exception);
-    }
-    if (exception is PictureRasterizationException) {
-      return _applyPictureRasterizationException(event, exception);
     }
     return event;
   }
@@ -27,12 +22,5 @@ class FlutterExceptionEventProcessor implements EventProcessor {
             SentryResponse(statusCode: exception.statusCode),
       ),
     );
-  }
-
-  SentryEvent _applyPictureRasterizationException(
-    SentryEvent event,
-    PictureRasterizationException exception,
-  ) {
-    return event;
   }
 }

--- a/flutter/lib/src/event_processor/flutter_exception_event_processor.dart
+++ b/flutter/lib/src/event_processor/flutter_exception_event_processor.dart
@@ -1,0 +1,38 @@
+import 'dart:ui';
+
+import 'package:flutter/rendering.dart';
+import 'package:sentry/sentry.dart';
+
+class FlutterExceptionEventProcessor implements EventProcessor {
+  @override
+  SentryEvent? apply(SentryEvent event, {dynamic hint}) {
+    final exception = event.throwable;
+    if (exception is NetworkImageLoadException) {
+      return _applyNetworkImageLoadException(event, exception);
+    }
+    if (exception is PictureRasterizationException) {
+      return _applyPictureRasterizationException(event, exception);
+    }
+    return event;
+  }
+
+  SentryEvent _applyNetworkImageLoadException(
+    SentryEvent event,
+    NetworkImageLoadException exception,
+  ) {
+    return event.copyWith(
+      request: event.request ?? SentryRequest.fromUri(uri: exception.uri),
+      contexts: event.contexts.copyWith(
+        response: event.contexts.response ??
+            SentryResponse(statusCode: exception.statusCode),
+      ),
+    );
+  }
+
+  SentryEvent _applyPictureRasterizationException(
+    SentryEvent event,
+    PictureRasterizationException exception,
+  ) {
+    return event;
+  }
+}

--- a/flutter/lib/src/event_processor/flutter_exception_event_processor.dart
+++ b/flutter/lib/src/event_processor/flutter_exception_event_processor.dart
@@ -11,6 +11,7 @@ class FlutterExceptionEventProcessor implements EventProcessor {
     return event;
   }
 
+  /// https://api.flutter.dev/flutter/painting/NetworkImageLoadException-class.html
   SentryEvent _applyNetworkImageLoadException(
     SentryEvent event,
     NetworkImageLoadException exception,

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -7,6 +7,7 @@ import 'package:meta/meta.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import '../sentry_flutter.dart';
 import 'event_processor/android_platform_exception_event_processor.dart';
+import 'event_processor/flutter_exception_event_processor.dart';
 import 'integrations/screenshot_integration.dart';
 import 'native_scope_observer.dart';
 import 'renderer/renderer.dart';
@@ -83,6 +84,8 @@ mixin SentryFlutter {
     SentryFlutterOptions options,
     MethodChannel channel,
   ) async {
+    options.addEventProcessor(FlutterExceptionEventProcessor());
+
     // Not all platforms have a native integration.
     if (options.platformChecker.hasNativeIntegration) {
       options.transport = FileSystemTransport(channel, options);

--- a/flutter/test/event_processor/flutter_exception_event_processor_test.dart
+++ b/flutter/test/event_processor/flutter_exception_event_processor_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sentry/sentry.dart';
+import 'package:sentry_flutter/src/event_processor/flutter_exception_event_processor.dart';
+
+void main() {
+  group(FlutterExceptionEventProcessor, () {
+    late Fixture fixture;
+
+    setUp(() {
+      fixture = Fixture();
+    });
+
+    test('adds $SentryRequest for $NetworkImageLoadException with uris',
+        () async {
+      final enricher = fixture.getSut();
+      final event = enricher.apply(
+        SentryEvent(
+          throwable: NetworkImageLoadException(
+            statusCode: 401,
+            uri: Uri.parse('https://example.org/foo/bar?foo=bar'),
+          ),
+        ),
+      );
+
+      expect(event.request, isNotNull);
+      expect(event.request?.url, 'https://example.org/foo/bar');
+      expect(event.request?.queryString, 'foo=bar');
+    });
+  });
+}
+
+class Fixture {
+  FlutterExceptionEventProcessor getSut() {
+    return FlutterExceptionEventProcessor();
+  }
+}


### PR DESCRIPTION
## :scroll: Description

Add SentryRequest context for HttpException and SocketException.
Also SocketException and FileSystemException have an underlying OSError, which is now reported as underlying exception.

I've also done some small refactoring of moving the enricher event processors into the event processor folder. I've also added a new constructor to `SentryRequest` and removed duplicated code.


## :bulb: Motivation and Context

HttpExceptions and SocketException can now be filtered via the request context.

## :green_heart: How did you test it?

Added new tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
