### PR TITLE
fix: Reset transaction in scope if span is reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Disable `enableUserInteractionBreadcrumbs` on Android when `enableAutoNativeBreadcrumbs` is disabled ([#1131](https://github.com/getsentry/sentry-dart/pull/1131))
+- Transaction name is reset after the transaction finishes ([#1125](https://github.com/getsentry/sentry-dart/pull/1125))
 
 ### Dependencies
 

--- a/dart/lib/src/scope.dart
+++ b/dart/lib/src/scope.dart
@@ -19,28 +19,22 @@ class Scope {
   /// The name of the transaction which generated this event,
   /// for example, the route name: `"/users/<username>/"`.
   String? get transaction {
-    return ((_span is SentryTracer) ? (_span as SentryTracer?)?.name : null) ??
+    return ((span is SentryTracer) ? (span as SentryTracer?)?.name : null) ??
         _transaction;
   }
 
   set transaction(String? transaction) {
     _transaction = transaction;
 
-    if (_transaction != null && _span != null) {
+    if (_transaction != null && span != null) {
       final currentTransaction =
-          (_span is SentryTracer) ? (_span as SentryTracer?) : null;
+          (span is SentryTracer) ? (span as SentryTracer?) : null;
       currentTransaction?.name = _transaction!;
     }
   }
 
-  ISentrySpan? _span;
-
   /// Returns active transaction or null if there is no active transaction.
-  ISentrySpan? get span => _span;
-
-  set span(ISentrySpan? span) {
-    _span = span;
-  }
+  ISentrySpan? span;
 
   SentryUser? _user;
 
@@ -236,7 +230,7 @@ class Scope {
   Future<void> clear() async {
     clearAttachments();
     level = null;
-    _span = null;
+    span = null;
     _transaction = null;
     _fingerprint = [];
     _tags.clear();
@@ -321,10 +315,10 @@ class Scope {
       }
     });
 
-    final span = _span;
-    if (event.contexts.trace == null && span != null) {
-      event.contexts.trace = span.context.toTraceContext(
-        sampled: span.samplingDecision?.sampled,
+    final newSpan = span;
+    if (event.contexts.trace == null && newSpan != null) {
+      event.contexts.trace = newSpan.context.toTraceContext(
+        sampled: newSpan.samplingDecision?.sampled,
       );
     }
 
@@ -414,7 +408,7 @@ class Scope {
       ..level = level
       ..fingerprint = List.from(fingerprint)
       .._transaction = _transaction
-      .._span = _span;
+      ..span = span;
 
     clone._setUserSync(user);
 

--- a/dart/lib/src/scope.dart
+++ b/dart/lib/src/scope.dart
@@ -40,12 +40,6 @@ class Scope {
 
   set span(ISentrySpan? span) {
     _span = span;
-
-    if (_span != null) {
-      final currentTransaction =
-          (_span is SentryTracer) ? (_span as SentryTracer?) : null;
-      _transaction = currentTransaction?.name ?? _transaction;
-    }
   }
 
   SentryUser? _user;
@@ -297,7 +291,7 @@ class Scope {
     dynamic hint,
   }) async {
     event = event.copyWith(
-      transaction: event.transaction ?? _transaction,
+      transaction: event.transaction ?? transaction,
       user: _mergeUsers(user, event.user),
       breadcrumbs: (event.breadcrumbs?.isNotEmpty ?? false)
           ? event.breadcrumbs

--- a/dart/test/scope_test.dart
+++ b/dart/test/scope_test.dart
@@ -35,8 +35,7 @@ void main() {
   test('sets transaction overwrites span name', () {
     final sut = fixture.getSut();
 
-    final tracer = SentryTracer(fixture.context, MockHub());
-    sut.span = tracer;
+    sut.span = fixture.sentryTracer;
     sut.transaction = 'test';
 
     expect(sut.transaction, 'test');
@@ -46,11 +45,29 @@ void main() {
   test('sets span overwrites transaction name', () {
     final sut = fixture.getSut();
 
-    final tracer = SentryTracer(fixture.context, MockHub());
-    sut.span = tracer;
+    sut.span = fixture.sentryTracer;
 
     expect(sut.transaction, 'name');
     expect((sut.span as SentryTracer).name, 'name');
+  });
+
+  test('removing span resets transaction if not set separately', () {
+    final sut = fixture.getSut();
+
+    sut.span = fixture.sentryTracer;
+    sut.span = null;
+
+    expect(sut.transaction, isNull);
+  });
+
+  test('removing span does not reset transaction if set separately', () {
+    final sut = fixture.getSut();
+
+    sut.transaction = 'test';
+    sut.span = fixture.sentryTracer;
+    sut.span = null;
+
+    expect(sut.transaction, 'test');
   });
 
   test('sets $SentryUser', () {
@@ -403,9 +420,9 @@ void main() {
     });
 
     test('apply trace context to event', () async {
-      final tracer = SentryTracer(fixture.context, MockHub());
       final event = SentryEvent();
-      final scope = Scope(SentryOptions(dsn: fakeDsn))..span = tracer;
+      final scope = Scope(SentryOptions(dsn: fakeDsn))
+        ..span = fixture.sentryTracer;
 
       final updatedEvent = await scope.applyToEvent(event);
 
@@ -537,6 +554,16 @@ void main() {
 
       expect(updatedEvent?.level, SentryLevel.error);
     });
+
+    test('should apply the scope transaction from the span', () async {
+      final event = SentryEvent();
+      final scope = Scope(SentryOptions(dsn: fakeDsn))
+        ..span = fixture.sentryTracer;
+
+      final updatedEvent = await scope.applyToEvent(event);
+
+      expect(updatedEvent?.transaction, 'name');
+    });
   });
 
   test('event processor drops the event', () async {
@@ -551,8 +578,7 @@ void main() {
   });
 
   test('should not apply fingerprint if transaction', () async {
-    final tracer = SentryTracer(fixture.context, MockHub());
-    var tr = SentryTransaction(tracer);
+    var tr = SentryTransaction(fixture.sentryTracer);
     final scope = Scope(SentryOptions(dsn: fakeDsn))..fingerprint = ['test'];
 
     final updatedTr = await scope.applyToEvent(tr);
@@ -561,8 +587,7 @@ void main() {
   });
 
   test('should not apply level if transaction', () async {
-    final tracer = SentryTracer(fixture.context, MockHub());
-    var tr = SentryTransaction(tracer);
+    var tr = SentryTransaction(fixture.sentryTracer);
     final scope = Scope(SentryOptions(dsn: fakeDsn))..level = SentryLevel.error;
 
     final updatedTr = await scope.applyToEvent(tr);
@@ -571,8 +596,7 @@ void main() {
   });
 
   test('apply sampled to trace', () async {
-    final tracer = SentryTracer(fixture.context, MockHub());
-    var tr = SentryTransaction(tracer);
+    var tr = SentryTransaction(fixture.sentryTracer);
     final scope = Scope(SentryOptions(dsn: fakeDsn))..level = SentryLevel.error;
 
     final updatedTr = await scope.applyToEvent(tr);
@@ -701,14 +725,18 @@ void main() {
 }
 
 class Fixture {
-  final context = SentryTransactionContext(
-    'name',
-    'op',
-    samplingDecision: SentryTracesSamplingDecision(true),
-  );
   final mockScopeObserver = MockScopeObserver();
 
   final options = SentryOptions(dsn: fakeDsn);
+
+  final sentryTracer = SentryTracer(
+    SentryTransactionContext(
+      'name',
+      'op',
+      samplingDecision: SentryTracesSamplingDecision(true),
+    ),
+    MockHub(),
+  );
 
   SentryLevel? loggedLevel;
   Object? loggedException;


### PR DESCRIPTION
## :scroll: Description

The private `_transaction` is not set anymore when setting a `span` on `Scope`. Instead the code relies on the public getter for `transaction` that already had logic in using the span name as the `transaction` if available. By doing so the `transaction` name is set back to null after a transaction finishes.


## :bulb: Motivation and Context

Previously events had a transaction string set of transactions that already finished earlier. Because after a transaction finished, the `_transaction` field in `Scope`was never reset.


## :green_heart: How did you test it?

Added new new tests. Existing tests still work.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
