### PR TITLE
Disable enableUserInteractionBreadcrumbs on Android when enableAutoNativeBreadcrumbs is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Disable `enableUserInteractionBreadcrumbs` on Android when `enableAutoNativeBreadcrumbs` is disabled ([#1088](https://github.com/getsentry/sentry-dart/pull/1088))
+- Disable `enableUserInteractionBreadcrumbs` on Android when `enableAutoNativeBreadcrumbs` is disabled ([#1131](https://github.com/getsentry/sentry-dart/pull/1131))
 
 ## 6.15.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,18 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Disable `enableUserInteractionBreadcrumbs` on Android when `enableAutoNativeBreadcrumbs` is disabled ([#1088](https://github.com/getsentry/sentry-dart/pull/1088))
+
 ## 6.15.1
 
-### Various fixes & improvements
+### Dependencies
 
-- chore(deps): update Flutter SDK (metrics) to v3.3.8 (#1121) by @github-actions
+- Bump Cocoa SDK from v7.30.1 to v7.30.2 ([#1113](https://github.com/getsentry/sentry-dart/pull/1113))
+  - [changelog](https://github.com/getsentry/sentry-cocoa/blob/master/CHANGELOG.md#7302)
+  - [diff](https://github.com/getsentry/sentry-cocoa/compare/7.30.1...7.30.2)
 
 ## 6.15.0
 
@@ -24,9 +32,9 @@
 - Bump Android SDK from v6.6.0 to v6.7.0 ([#1105](https://github.com/getsentry/sentry-dart/pull/1105))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#670)
   - [diff](https://github.com/getsentry/sentry-java/compare/6.6.0...6.7.0)
-- Bump Cocoa SDK from v7.30.0 to v7.30.2 ([#1113](https://github.com/getsentry/sentry-dart/pull/1113))
-  - [changelog](https://github.com/getsentry/sentry-cocoa/blob/master/CHANGELOG.md#7302)
-  - [diff](https://github.com/getsentry/sentry-cocoa/compare/7.30.0...7.30.2)
+- Bump Cocoa SDK from v7.30.0 to v7.30.1 ([#1104](https://github.com/getsentry/sentry-dart/pull/1104))
+  - [changelog](https://github.com/getsentry/sentry-cocoa/blob/master/CHANGELOG.md#7301)
+  - [diff](https://github.com/getsentry/sentry-cocoa/compare/7.30.0...7.30.1)
 
 ## 6.14.0
 

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -131,6 +131,7 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         options.isEnableAppLifecycleBreadcrumbs = it
         options.isEnableSystemEventBreadcrumbs = it
         options.isEnableAppComponentBreadcrumbs = it
+        options.isEnableUserInteractionBreadcrumbs = it
       }
       args.getIfNotNull<Int>("maxBreadcrumbs") { options.maxBreadcrumbs = it }
       args.getIfNotNull<Int>("maxCacheItems") { options.maxCacheItems = it }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
New feature was added https://docs.sentry.io/platforms/android/enriching-events/breadcrumbs/#disable-automatic-breadcrumbs but not disabled here.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
