### PR TITLE
Use `sentryClientName` instead of `sdk.identifier`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Use `sentryClientName` instead of `sdk.identifier` ([#1133](https://github.com/getsentry/sentry-dart/pull/1133))
+
 ### Fixes
 
 - Disable `enableUserInteractionBreadcrumbs` on Android when `enableAutoNativeBreadcrumbs` is disabled ([#1131](https://github.com/getsentry/sentry-dart/pull/1131))

--- a/dart/lib/src/protocol/sdk_version.dart
+++ b/dart/lib/src/protocol/sdk_version.dart
@@ -61,8 +61,6 @@ class SdkVersion {
   /// An immutable list of packages that compose this SDK.
   List<SentryPackage> get packages => List.unmodifiable(_packages);
 
-  String get identifier => '$name/$version';
-
   /// Deserializes a [SdkVersion] from JSON [Map].
   factory SdkVersion.fromJson(Map<String, dynamic> json) {
     final packagesJson = json['packages'] as List<dynamic>?;

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -137,7 +137,7 @@ class SentryOptions {
 
   /// Sentry client name used for the HTTP authHeader and userAgent eg
   /// sentry.{language}.{platform}/{version} eg sentry.java.android/2.0.0 would be a valid case
-  String? sentryClientName;
+  late String sentryClientName;
 
   /// This function is called with an SDK specific event object and can return a modified event
   /// object or nothing to skip reporting the event
@@ -304,13 +304,17 @@ class SentryOptions {
       platformChecker = checker;
     }
 
+    final name = sdkName(platformChecker.isWeb);
     sdk = SdkVersion(name: sdkName(platformChecker.isWeb), version: sdkVersion);
     sdk.addPackage('pub:sentry', sdkVersion);
+    sentryClientName = '$name/$sdkVersion';
   }
 
   @internal
   SentryOptions.empty() {
-    sdk = SdkVersion(name: 'noop', version: sdkVersion);
+    final name = 'noop';
+    sdk = SdkVersion(name: name, version: sdkVersion);
+    sentryClientName = '$name/$sdkVersion';
   }
 
   /// Adds an event processor

--- a/dart/lib/src/transport/http_transport.dart
+++ b/dart/lib/src/transport/http_transport.dart
@@ -41,11 +41,11 @@ class HttpTransport implements Transport {
         _recorder = _options.recorder,
         _headers = _buildHeaders(
           _options.platformChecker.isWeb,
-          _options.sdk.identifier,
+          _options.sentryClientName,
         ) {
     _credentialBuilder = _CredentialBuilder(
       _dsn,
-      _options.sdk.identifier,
+      _options.sentryClientName,
       _options.clock,
     );
   }

--- a/dart/test/sentry_options_test.dart
+++ b/dart/test/sentry_options_test.dart
@@ -1,6 +1,7 @@
 import 'package:http/http.dart';
 import 'package:sentry/sentry.dart';
 import 'package:sentry/src/noop_client.dart';
+import 'package:sentry/src/version.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';
@@ -94,5 +95,12 @@ void main() {
     final options = SentryOptions.empty();
 
     expect(options.tracePropagationTargets, ['.*']);
+  });
+
+  test('SentryOptions has sentryClientName set', () {
+    final options = SentryOptions(dsn: fakeDsn);
+
+    expect(options.sentryClientName,
+        '${sdkName(options.platformChecker.isWeb)}/$sdkVersion');
   });
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Use `sentryClientName` instead of `sdk.identifier` in `HttpTransport` header.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #584

## :green_heart: How did you test it?

Added test.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [ ] No breaking changes