### PR TITLE
Use `sentryClientName` instead of `sdk.identifier`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Breaking Changes
+
+- Use `sentryClientName` instead of `sdk.identifier` ([#1135](https://github.com/getsentry/sentry-dart/pull/1135))
+
 ## 7.0.0
 
 ### Fixes
@@ -15,7 +21,6 @@
     - screenResolution
     - theme
   - Removed isolate name from Dart context. It's now reported via the threads interface. It can be enabled via `options.attachThreads`
-- Use `sentryClientName` instead of `sdk.identifier` ([#1135](https://github.com/getsentry/sentry-dart/pull/1135))
 
 ## 6.11.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## Unreleased
-
-### Breaking Changes
-
-- Use `sentryClientName` instead of `sdk.identifier` ([#1135](https://github.com/getsentry/sentry-dart/pull/1135))
-
 ## 7.0.0
 
 ### Fixes
@@ -21,6 +15,7 @@
     - screenResolution
     - theme
   - Removed isolate name from Dart context. It's now reported via the threads interface. It can be enabled via `options.attachThreads`
+- Use `sentryClientName` instead of `sdk.identifier` ([#1135](https://github.com/getsentry/sentry-dart/pull/1135))
 
 ## 6.11.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 7.0.0
 
+### Fixes
+
 - Fix: Remove `SentryOptions` related parameters from classes which also take `Hub` as a parameter (#816)
 
 ### Breaking Changes
@@ -13,6 +15,7 @@
     - screenResolution
     - theme
   - Removed isolate name from Dart context. It's now reported via the threads interface. It can be enabled via `options.attachThreads`
+- Use `sentryClientName` instead of `sdk.identifier` ([#1135](https://github.com/getsentry/sentry-dart/pull/1135))
 
 ## 6.11.1
 

--- a/dart/lib/src/protocol/sdk_version.dart
+++ b/dart/lib/src/protocol/sdk_version.dart
@@ -61,8 +61,6 @@ class SdkVersion {
   /// An immutable list of packages that compose this SDK.
   List<SentryPackage> get packages => List.unmodifiable(_packages);
 
-  String get identifier => '$name/$version';
-
   /// Deserializes a [SdkVersion] from JSON [Map].
   factory SdkVersion.fromJson(Map<String, dynamic> json) {
     final packagesJson = json['packages'] as List<dynamic>?;

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -139,8 +139,7 @@ class SentryOptions {
 
   /// Sentry client name used for the HTTP authHeader and userAgent eg
   /// sentry.{language}.{platform}/{version} eg sentry.java.android/2.0.0 would be a valid case
-  String get sentryClientName =>
-      '${sdkName(platformChecker.isWeb)}/$sdkVersion';
+  String get sentryClientName => '${sdk.name}/${sdk.version}';
 
   /// This function is called with an SDK specific event object and can return a modified event
   /// object or nothing to skip reporting the event

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -139,7 +139,8 @@ class SentryOptions {
 
   /// Sentry client name used for the HTTP authHeader and userAgent eg
   /// sentry.{language}.{platform}/{version} eg sentry.java.android/2.0.0 would be a valid case
-  late String sentryClientName;
+  String get sentryClientName =>
+      '${sdkName(platformChecker.isWeb)}/$sdkVersion';
 
   /// This function is called with an SDK specific event object and can return a modified event
   /// object or nothing to skip reporting the event
@@ -317,18 +318,13 @@ class SentryOptions {
     if (checker != null) {
       platformChecker = checker;
     }
-
-    final name = sdkName(platformChecker.isWeb);
     sdk = SdkVersion(name: sdkName(platformChecker.isWeb), version: sdkVersion);
     sdk.addPackage('pub:sentry', sdkVersion);
-    sentryClientName = '$name/$sdkVersion';
   }
 
   @internal
   SentryOptions.empty() {
-    final name = 'noop';
-    sdk = SdkVersion(name: name, version: sdkVersion);
-    sentryClientName = '$name/$sdkVersion';
+    sdk = SdkVersion(name: 'noop', version: sdkVersion);
   }
 
   /// Adds an event processor

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -139,7 +139,7 @@ class SentryOptions {
 
   /// Sentry client name used for the HTTP authHeader and userAgent eg
   /// sentry.{language}.{platform}/{version} eg sentry.java.android/2.0.0 would be a valid case
-  String? sentryClientName;
+  late String sentryClientName;
 
   /// This function is called with an SDK specific event object and can return a modified event
   /// object or nothing to skip reporting the event
@@ -318,13 +318,17 @@ class SentryOptions {
       platformChecker = checker;
     }
 
+    final name = sdkName(platformChecker.isWeb);
     sdk = SdkVersion(name: sdkName(platformChecker.isWeb), version: sdkVersion);
     sdk.addPackage('pub:sentry', sdkVersion);
+    sentryClientName = '$name/$sdkVersion';
   }
 
   @internal
   SentryOptions.empty() {
-    sdk = SdkVersion(name: 'noop', version: sdkVersion);
+    final name = 'noop';
+    sdk = SdkVersion(name: name, version: sdkVersion);
+    sentryClientName = '$name/$sdkVersion';
   }
 
   /// Adds an event processor

--- a/dart/lib/src/transport/http_transport.dart
+++ b/dart/lib/src/transport/http_transport.dart
@@ -41,11 +41,11 @@ class HttpTransport implements Transport {
         _recorder = _options.recorder,
         _headers = _buildHeaders(
           _options.platformChecker.isWeb,
-          _options.sdk.identifier,
+          _options.sentryClientName,
         ) {
     _credentialBuilder = _CredentialBuilder(
       _dsn,
-      _options.sdk.identifier,
+      _options.sentryClientName,
       _options.clock,
     );
   }

--- a/dart/test/sentry_options_test.dart
+++ b/dart/test/sentry_options_test.dart
@@ -1,6 +1,7 @@
 import 'package:http/http.dart';
 import 'package:sentry/sentry.dart';
 import 'package:sentry/src/noop_client.dart';
+import 'package:sentry/src/version.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';
@@ -90,5 +91,12 @@ void main() {
     final options = SentryOptions.empty();
 
     expect(options.tracePropagationTargets, ['.*']);
+  });
+
+  test('SentryOptions has sentryClientName set', () {
+    final options = SentryOptions(dsn: fakeDsn);
+
+    expect(options.sentryClientName,
+        '${sdkName(options.platformChecker.isWeb)}/$sdkVersion');
   });
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Use `sentryClientName` instead of `sdk.identifier` in `HttpTransport` header.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #584

## :green_heart: How did you test it?

Added test.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [ ] No breaking changes