### PR TITLE
Capture Future errors for Flutter Web automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Capture Future errors for Flutter Web automatically ([#1143](https://github.com/getsentry/sentry-dart/pull/1143))
+
 ## 6.16.1
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Capture Future errors for Flutter Web automatically ([#1143](https://github.com/getsentry/sentry-dart/pull/1143))
+- Capture Future errors for Flutter Web automatically ([#1152](https://github.com/getsentry/sentry-dart/pull/1152))
 
 ## 6.16.1
 

--- a/flutter/lib/src/integrations/flutter_error_integration.dart
+++ b/flutter/lib/src/integrations/flutter_error_integration.dart
@@ -60,11 +60,6 @@ class FlutterErrorIntegration extends Integration<SentryFlutterOptions> {
         final mechanism = Mechanism(
           type: 'FlutterError',
           handled: true,
-          data: {
-            if (flutterErrorDetails.isNotEmpty)
-              'hint':
-                  'See "flutter_error_details" down below for more information'
-          },
         );
         final throwableMechanism = ThrowableMechanism(mechanism, exception);
 

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -52,7 +52,13 @@ mixin SentryFlutter {
 
     final platformDispatcher = PlatformDispatcher.instance;
     final wrapper = PlatformDispatcherWrapper(platformDispatcher);
-    final isOnErrorSupported = wrapper.isOnErrorSupported(flutterOptions);
+
+    // Flutter Web don't capture [Future] errors if using [PlatformDispatcher.onError] and not
+    // the [runZonedGuarded].
+    // likely due to https://github.com/flutter/flutter/issues/100277
+    final isOnErrorSupported = flutterOptions.platformChecker.isWeb
+        ? false
+        : wrapper.isOnErrorSupported(flutterOptions);
 
     // first step is to install the native integration and set default values,
     // so we are able to capture future errors.

--- a/flutter/test/integrations/flutter_error_integration_test.dart
+++ b/flutter/test/integrations/flutter_error_integration_test.dart
@@ -56,8 +56,6 @@ void main() {
       final throwableMechanism = event.throwableMechanism as ThrowableMechanism;
       expect(throwableMechanism.mechanism.type, 'FlutterError');
       expect(throwableMechanism.mechanism.handled, true);
-      expect(throwableMechanism.mechanism.data['hint'],
-          'See "flutter_error_details" down below for more information');
       expect(throwableMechanism.throwable, exception);
 
       expect(event.contexts['flutter_error_details']['library'], 'sentry');
@@ -92,8 +90,6 @@ void main() {
       final throwableMechanism = event.throwableMechanism as ThrowableMechanism;
       expect(throwableMechanism.mechanism.type, 'FlutterError');
       expect(throwableMechanism.mechanism.handled, true);
-      expect(throwableMechanism.mechanism.data['hint'],
-          'See "flutter_error_details" down below for more information');
 
       expect(event.contexts['flutter_error_details']['library'], 'sentry');
       expect(event.contexts['flutter_error_details']['context'],

--- a/flutter/test/sentry_flutter_test.dart
+++ b/flutter/test/sentry_flutter_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: invalid_use_of_internal_member
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
@@ -13,10 +15,13 @@ import 'sentry_flutter_util.dart';
 /// They don't depend on the underlying platform.
 final platformAgnosticIntegrations = [
   WidgetsFlutterBindingIntegration,
-  OnErrorIntegration,
   FlutterErrorIntegration,
   LoadReleaseIntegration,
   DebugPrintIntegration,
+];
+
+final nonWebIntegrations = [
+  OnErrorIntegration,
 ];
 
 // These should only be added to Android
@@ -69,6 +74,7 @@ void main() {
             ...androidIntegrations,
             ...nativeIntegrations,
             ...platformAgnosticIntegrations,
+            ...nonWebIntegrations,
           ],
           shouldNotHaveIntegrations: iOsAndMacOsIntegrations);
 
@@ -109,6 +115,7 @@ void main() {
           ...iOsAndMacOsIntegrations,
           ...nativeIntegrations,
           ...platformAgnosticIntegrations,
+          ...nonWebIntegrations,
         ],
         shouldNotHaveIntegrations: androidIntegrations,
       );
@@ -147,6 +154,7 @@ void main() {
           ...iOsAndMacOsIntegrations,
           ...nativeIntegrations,
           ...platformAgnosticIntegrations,
+          ...nonWebIntegrations,
         ],
         shouldNotHaveIntegrations: androidIntegrations,
       );
@@ -181,7 +189,10 @@ void main() {
 
       testConfiguration(
         integrations: integrations,
-        shouldHaveIntegrations: platformAgnosticIntegrations,
+        shouldHaveIntegrations: [
+          ...platformAgnosticIntegrations,
+          ...nonWebIntegrations,
+        ],
         shouldNotHaveIntegrations: [
           ...androidIntegrations,
           ...iOsAndMacOsIntegrations,
@@ -219,7 +230,10 @@ void main() {
 
       testConfiguration(
         integrations: integrations,
-        shouldHaveIntegrations: platformAgnosticIntegrations,
+        shouldHaveIntegrations: [
+          ...platformAgnosticIntegrations,
+          ...nonWebIntegrations,
+        ],
         shouldNotHaveIntegrations: [
           ...androidIntegrations,
           ...iOsAndMacOsIntegrations,
@@ -265,13 +279,14 @@ void main() {
           ...androidIntegrations,
           ...iOsAndMacOsIntegrations,
           ...nativeIntegrations,
+          ...nonWebIntegrations,
         ],
       );
 
       testBefore(
-          integrations: integrations,
-          beforeIntegration: WidgetsFlutterBindingIntegration,
-          afterIntegration: OnErrorIntegration);
+          integrations: Sentry.currentHub.options.integrations,
+          beforeIntegration: RunZonedGuardedIntegration,
+          afterIntegration: WidgetsFlutterBindingIntegration);
 
       await Sentry.close();
     });
@@ -308,13 +323,14 @@ void main() {
           ...androidIntegrations,
           ...iOsAndMacOsIntegrations,
           ...nativeIntegrations,
+          ...nonWebIntegrations,
         ],
       );
 
       testBefore(
-          integrations: integrations,
-          beforeIntegration: WidgetsFlutterBindingIntegration,
-          afterIntegration: OnErrorIntegration);
+          integrations: Sentry.currentHub.options.integrations,
+          beforeIntegration: RunZonedGuardedIntegration,
+          afterIntegration: WidgetsFlutterBindingIntegration);
 
       await Sentry.close();
     });
@@ -351,13 +367,14 @@ void main() {
           ...androidIntegrations,
           ...iOsAndMacOsIntegrations,
           ...nativeIntegrations,
+          ...nonWebIntegrations,
         ],
       );
 
       testBefore(
-          integrations: integrations,
-          beforeIntegration: WidgetsFlutterBindingIntegration,
-          afterIntegration: OnErrorIntegration);
+          integrations: Sentry.currentHub.options.integrations,
+          beforeIntegration: RunZonedGuardedIntegration,
+          afterIntegration: WidgetsFlutterBindingIntegration);
 
       await Sentry.close();
     });
@@ -393,13 +410,14 @@ void main() {
           ...androidIntegrations,
           ...iOsAndMacOsIntegrations,
           ...nativeIntegrations,
+          ...nonWebIntegrations,
         ],
       );
 
       testBefore(
-          integrations: integrations,
-          beforeIntegration: WidgetsFlutterBindingIntegration,
-          afterIntegration: OnErrorIntegration);
+          integrations: Sentry.currentHub.options.integrations,
+          beforeIntegration: RunZonedGuardedIntegration,
+          afterIntegration: WidgetsFlutterBindingIntegration);
 
       await Sentry.close();
     });


### PR DESCRIPTION
## :scroll: Description
Capture Future errors for Flutter Web automatically


## :bulb: Motivation and Context
https://github.com/flutter/flutter/issues/100277#issuecomment-1327478616


## :green_heart: How did you test it?
Running Flutter Web and non-Web, throwing `Future` errors, and checking the error handlers.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
