### PR TITLE
Enha: Replace `StackTrace.empty` with `StackTrace.current`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 - Fix: Remove `SentryOptions` related parameters from classes which also take `Hub` as a parameter (#816)
 
+# Enhancements
+
+- Enha: Replace `StackTrace.empty` with `StackTrace.current` ([#1183](https://github.com/getsentry/sentry-dart/pull/1183))
+
 ### Breaking Changes
 
 - Removed various deprecated fields ([#1036](https://github.com/getsentry/sentry-dart/pull/1036)):

--- a/dart/lib/src/sentry_exception_factory.dart
+++ b/dart/lib/src/sentry_exception_factory.dart
@@ -33,7 +33,9 @@ class SentryExceptionFactory {
     if (_options.attachStacktrace) {
       // TODO: snapshot=true if stackTrace is null
       // Requires a major breaking change because of grouping
-      stackTrace ??= StackTrace.current;
+      if (stackTrace == null || stackTrace == StackTrace.empty) {
+        stackTrace = StackTrace.current;
+      }
     }
 
     SentryStackTrace? sentryStackTrace;

--- a/dart/test/sentry_exception_factory_test.dart
+++ b/dart/test/sentry_exception_factory_test.dart
@@ -85,10 +85,9 @@ void main() {
   }, onPlatform: {'browser': Skip()});
 
   test('getSentryException with not thrown Error and empty frames', () {
-    final sentryException = fixture.getSut().getSentryException(
-      CustomError(),
-      stackTrace: StackTrace.empty
-    );
+    final sentryException = fixture
+        .getSut()
+        .getSentryException(CustomError(), stackTrace: StackTrace.empty);
 
     expect(sentryException.type, 'CustomError');
     expect(sentryException.stackTrace?.frames, isNotEmpty);

--- a/dart/test/sentry_exception_factory_test.dart
+++ b/dart/test/sentry_exception_factory_test.dart
@@ -84,6 +84,18 @@ void main() {
     // skip on browser because [StackTrace.current] still returns null
   }, onPlatform: {'browser': Skip()});
 
+  test('getSentryException with not thrown Error and empty frames', () {
+    final sentryException = fixture.getSut().getSentryException(
+      CustomError(),
+      stackTrace: StackTrace.empty
+    );
+
+    expect(sentryException.type, 'CustomError');
+    expect(sentryException.stackTrace?.frames, isNotEmpty);
+
+    // skip on browser because [StackTrace.current] still returns null
+  }, onPlatform: {'browser': Skip()});
+
   test('reads the snapshot from the mechanism', () {
     final error = StateError('test-error');
     final mechanism = Mechanism(type: 'Mechanism');


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Closes #1083

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps

@marandaneto Any other places we need to replace `` ?
