### PR TITLE
Fix: Only call method channels on native platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Fix: Only call method channels on native platforms ([#1196](https://github.com/getsentry/sentry-dart/pull/1196))
+
 ### Dependencies
 
 - Bump Android SDK from v6.9.2 to v6.10.0 ([#1194](https://github.com/getsentry/sentry-dart/pull/1194))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix: Only call method channels on native platforms ([#1196](https://github.com/getsentry/sentry-dart/pull/1196))
+
 ## 6.18.1
 
 ### Fixes

--- a/flutter/ios/Classes/SentryFlutterPluginApple.swift
+++ b/flutter/ios/Classes/SentryFlutterPluginApple.swift
@@ -86,6 +86,11 @@ public class SentryFlutterPluginApple: NSObject, FlutterPlugin {
             let value = arguments?["value"] as? Any
             setContexts(key: key, value: value, result: result)
 
+        case "removeContexts":
+            let arguments = call.arguments as? [String: Any?]
+            let key = arguments?["key"] as? String
+            removeContexts(key: key, result: result)
+
         case "setUser":
             let arguments = call.arguments as? [String: Any?]
             let user = arguments?["user"] as? [String: Any?]

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -97,6 +97,7 @@ mixin SentryFlutter {
     // Not all platforms have a native integration.
     if (options.platformChecker.hasNativeIntegration) {
       options.transport = FileSystemTransport(channel, options);
+      options.addScopeObserver(NativeScopeObserver(SentryNative()));
     }
 
     var flutterEventProcessor =
@@ -106,7 +107,6 @@ mixin SentryFlutter {
     if (options.platformChecker.platform.isAndroid) {
       options
           .addEventProcessor(AndroidPlatformExceptionEventProcessor(options));
-      options.addScopeObserver(NativeScopeObserver(SentryNative()));
     }
 
     _setSdk(options);

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -47,8 +47,10 @@ mixin SentryFlutter {
     }
 
     final nativeChannel = SentryNativeChannel(channel, flutterOptions);
-    final native = SentryNative();
-    native.setNativeChannel(nativeChannel);
+    if (flutterOptions.platformChecker.hasNativeIntegration) {
+      final native = SentryNative();
+      native.nativeChannel = nativeChannel;
+    }
 
     final platformDispatcher = PlatformDispatcher.instance;
     final wrapper = PlatformDispatcherWrapper(platformDispatcher);

--- a/flutter/lib/src/sentry_native.dart
+++ b/flutter/lib/src/sentry_native.dart
@@ -19,8 +19,10 @@ class SentryNative {
     return _instance;
   }
 
+  SentryNativeChannel? get nativeChannel => _instance._nativeChannel;
+
   /// Provide [nativeChannel] for native communication.
-  void setNativeChannel(SentryNativeChannel nativeChannel) {
+  set nativeChannel(SentryNativeChannel? nativeChannel) {
     _instance._nativeChannel = nativeChannel;
   }
 

--- a/flutter/test/integrations/native_app_start_integration_test.dart
+++ b/flutter/test/integrations/native_app_start_integration_test.dart
@@ -104,7 +104,7 @@ class Fixture {
   late final native = SentryNative();
 
   Fixture() {
-    native.setNativeChannel(wrapper);
+    native.nativeChannel = wrapper;
     native.reset();
     when(hub.options).thenReturn(options);
   }

--- a/flutter/test/mocks.mocks.dart
+++ b/flutter/test/mocks.mocks.dart
@@ -391,6 +391,14 @@ class MockSentryTracer extends _i1.Mock implements _i8.SentryTracer {
         ),
         returnValueForMissingStub: null,
       );
+  @override
+  void scheduleFinish() => super.noSuchMethod(
+        Invocation.method(
+          #scheduleFinish,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
 }
 
 /// A class which mocks [MethodChannel].
@@ -496,19 +504,19 @@ class MockSentryNative extends _i1.Mock implements _i10.SentryNative {
         returnValueForMissingStub: null,
       );
   @override
+  set nativeChannel(_i11.SentryNativeChannel? nativeChannel) =>
+      super.noSuchMethod(
+        Invocation.setter(
+          #nativeChannel,
+          nativeChannel,
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
   bool get didFetchAppStart => (super.noSuchMethod(
         Invocation.getter(#didFetchAppStart),
         returnValue: false,
       ) as bool);
-  @override
-  void setNativeChannel(_i11.SentryNativeChannel? nativeChannel) =>
-      super.noSuchMethod(
-        Invocation.method(
-          #setNativeChannel,
-          [nativeChannel],
-        ),
-        returnValueForMissingStub: null,
-      );
   @override
   _i6.Future<_i11.NativeAppStart?> fetchNativeAppStart() => (super.noSuchMethod(
         Invocation.method(

--- a/flutter/test/sentry_flutter_test.dart
+++ b/flutter/test/sentry_flutter_test.dart
@@ -56,11 +56,14 @@ void main() {
       List<Integration> integrations = [];
       Transport transport = MockTransport();
 
+      SentryFlutterOptions? sentryFlutterOptions;
+
       await SentryFlutter.init(
         (options) async {
           options.dsn = fakeDsn;
           integrations = options.integrations;
           transport = options.transport;
+          sentryFlutterOptions = options;
         },
         appRunner: appRunner,
         packageLoader: loadTestPackage,
@@ -71,6 +74,9 @@ void main() {
         transport: transport,
         hasFileSystemTransport: true,
       );
+
+      testScopeObserver(
+          options: sentryFlutterOptions!, hasNativeScopeObserver: true);
 
       testConfiguration(
           integrations: integrations,
@@ -98,12 +104,14 @@ void main() {
     test('iOS', () async {
       List<Integration> integrations = [];
       Transport transport = MockTransport();
+      SentryFlutterOptions? sentryFlutterOptions;
 
       await SentryFlutter.init(
         (options) async {
           options.dsn = fakeDsn;
           integrations = options.integrations;
           transport = options.transport;
+          sentryFlutterOptions = options;
         },
         appRunner: appRunner,
         packageLoader: loadTestPackage,
@@ -114,6 +122,9 @@ void main() {
         transport: transport,
         hasFileSystemTransport: true,
       );
+
+      testScopeObserver(
+          options: sentryFlutterOptions!, hasNativeScopeObserver: true);
 
       testConfiguration(
         integrations: integrations,
@@ -139,12 +150,14 @@ void main() {
     test('macOS', () async {
       List<Integration> integrations = [];
       Transport transport = MockTransport();
+      SentryFlutterOptions? sentryFlutterOptions;
 
       await SentryFlutter.init(
         (options) async {
           options.dsn = fakeDsn;
           integrations = options.integrations;
           transport = options.transport;
+          sentryFlutterOptions = options;
         },
         appRunner: appRunner,
         packageLoader: loadTestPackage,
@@ -155,6 +168,9 @@ void main() {
         transport: transport,
         hasFileSystemTransport: true,
       );
+
+      testScopeObserver(
+          options: sentryFlutterOptions!, hasNativeScopeObserver: true);
 
       testConfiguration(
         integrations: integrations,
@@ -180,12 +196,14 @@ void main() {
     test('Windows', () async {
       List<Integration> integrations = [];
       Transport transport = MockTransport();
+      SentryFlutterOptions? sentryFlutterOptions;
 
       await SentryFlutter.init(
         (options) async {
           options.dsn = fakeDsn;
           integrations = options.integrations;
           transport = options.transport;
+          sentryFlutterOptions = options;
         },
         appRunner: appRunner,
         packageLoader: loadTestPackage,
@@ -196,6 +214,9 @@ void main() {
         transport: transport,
         hasFileSystemTransport: false,
       );
+
+      testScopeObserver(
+          options: sentryFlutterOptions!, hasNativeScopeObserver: false);
 
       testConfiguration(
         integrations: integrations,
@@ -223,12 +244,14 @@ void main() {
     test('Linux', () async {
       List<Integration> integrations = [];
       Transport transport = MockTransport();
+      SentryFlutterOptions? sentryFlutterOptions;
 
       await SentryFlutter.init(
         (options) async {
           options.dsn = fakeDsn;
           integrations = options.integrations;
           transport = options.transport;
+          sentryFlutterOptions = options;
         },
         appRunner: appRunner,
         packageLoader: loadTestPackage,
@@ -239,6 +262,9 @@ void main() {
         transport: transport,
         hasFileSystemTransport: false,
       );
+
+      testScopeObserver(
+          options: sentryFlutterOptions!, hasNativeScopeObserver: false);
 
       testConfiguration(
         integrations: integrations,
@@ -266,12 +292,14 @@ void main() {
     test('Web', () async {
       List<Integration> integrations = [];
       Transport transport = MockTransport();
+      SentryFlutterOptions? sentryFlutterOptions;
 
       await SentryFlutter.init(
         (options) async {
           options.dsn = fakeDsn;
           integrations = options.integrations;
           transport = options.transport;
+          sentryFlutterOptions = options;
         },
         appRunner: appRunner,
         packageLoader: loadTestPackage,
@@ -285,6 +313,9 @@ void main() {
         transport: transport,
         hasFileSystemTransport: false,
       );
+
+      testScopeObserver(
+          options: sentryFlutterOptions!, hasNativeScopeObserver: false);
 
       testConfiguration(
         integrations: integrations,

--- a/flutter/test/sentry_flutter_test.dart
+++ b/flutter/test/sentry_flutter_test.dart
@@ -6,6 +6,7 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:sentry_flutter/src/integrations/integrations.dart';
 import 'package:sentry_flutter/src/integrations/screenshot_integration.dart';
 import 'package:sentry_flutter/src/renderer/renderer.dart';
+import 'package:sentry_flutter/src/sentry_native.dart';
 import 'package:sentry_flutter/src/version.dart';
 import 'mocks.dart';
 import 'mocks.mocks.dart';
@@ -46,6 +47,9 @@ void main() {
   group('Test platform integrations', () {
     setUp(() async {
       await Sentry.close();
+      final sentryNative = SentryNative();
+      sentryNative.nativeChannel = null;
+      sentryNative.reset();
     });
 
     test('Android', () async {
@@ -86,6 +90,8 @@ void main() {
           beforeIntegration: WidgetsFlutterBindingIntegration,
           afterIntegration: OnErrorIntegration);
 
+      expect(SentryNative().nativeChannel, isNotNull);
+
       await Sentry.close();
     }, testOn: 'vm');
 
@@ -125,6 +131,8 @@ void main() {
           beforeIntegration: WidgetsFlutterBindingIntegration,
           afterIntegration: OnErrorIntegration);
 
+      expect(SentryNative().nativeChannel, isNotNull);
+
       await Sentry.close();
     }, testOn: 'vm');
 
@@ -163,6 +171,8 @@ void main() {
           integrations: integrations,
           beforeIntegration: WidgetsFlutterBindingIntegration,
           afterIntegration: OnErrorIntegration);
+
+      expect(SentryNative().nativeChannel, isNotNull);
 
       await Sentry.close();
     }, testOn: 'vm');
@@ -205,6 +215,8 @@ void main() {
           beforeIntegration: WidgetsFlutterBindingIntegration,
           afterIntegration: OnErrorIntegration);
 
+      expect(SentryNative().nativeChannel, isNull);
+
       await Sentry.close();
     }, testOn: 'vm');
 
@@ -245,6 +257,8 @@ void main() {
           integrations: integrations,
           beforeIntegration: WidgetsFlutterBindingIntegration,
           afterIntegration: OnErrorIntegration);
+
+      expect(SentryNative().nativeChannel, isNull);
 
       await Sentry.close();
     }, testOn: 'vm');
@@ -287,6 +301,8 @@ void main() {
           integrations: Sentry.currentHub.options.integrations,
           beforeIntegration: RunZonedGuardedIntegration,
           afterIntegration: WidgetsFlutterBindingIntegration);
+
+      expect(SentryNative().nativeChannel, isNull);
 
       await Sentry.close();
     });

--- a/flutter/test/sentry_flutter_test.dart
+++ b/flutter/test/sentry_flutter_test.dart
@@ -76,7 +76,7 @@ void main() {
       );
 
       testScopeObserver(
-          options: sentryFlutterOptions!, hasNativeScopeObserver: true);
+          options: sentryFlutterOptions!, expectedHasNativeScopeObserver: true);
 
       testConfiguration(
           integrations: integrations,
@@ -124,7 +124,7 @@ void main() {
       );
 
       testScopeObserver(
-          options: sentryFlutterOptions!, hasNativeScopeObserver: true);
+          options: sentryFlutterOptions!, expectedHasNativeScopeObserver: true);
 
       testConfiguration(
         integrations: integrations,
@@ -170,7 +170,7 @@ void main() {
       );
 
       testScopeObserver(
-          options: sentryFlutterOptions!, hasNativeScopeObserver: true);
+          options: sentryFlutterOptions!, expectedHasNativeScopeObserver: true);
 
       testConfiguration(
         integrations: integrations,
@@ -216,7 +216,8 @@ void main() {
       );
 
       testScopeObserver(
-          options: sentryFlutterOptions!, hasNativeScopeObserver: false);
+          options: sentryFlutterOptions!,
+          expectedHasNativeScopeObserver: false);
 
       testConfiguration(
         integrations: integrations,
@@ -264,7 +265,8 @@ void main() {
       );
 
       testScopeObserver(
-          options: sentryFlutterOptions!, hasNativeScopeObserver: false);
+          options: sentryFlutterOptions!,
+          expectedHasNativeScopeObserver: false);
 
       testConfiguration(
         integrations: integrations,
@@ -315,7 +317,8 @@ void main() {
       );
 
       testScopeObserver(
-          options: sentryFlutterOptions!, hasNativeScopeObserver: false);
+          options: sentryFlutterOptions!,
+          expectedHasNativeScopeObserver: false);
 
       testConfiguration(
         integrations: integrations,

--- a/flutter/test/sentry_flutter_util.dart
+++ b/flutter/test/sentry_flutter_util.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:sentry_flutter/src/file_system_transport.dart';
+import 'package:sentry_flutter/src/native_scope_observer.dart';
 
 void testTransport({
   required Transport transport,
@@ -11,6 +12,18 @@ void testTransport({
     hasFileSystemTransport,
     reason: '$FileSystemTransport was wrongly set',
   );
+}
+
+void testScopeObserver(
+    {required SentryFlutterOptions options,
+    required bool hasNativeScopeObserver}) {
+  try {
+    options.scopeObservers
+        .firstWhere((element) => element.runtimeType == NativeScopeObserver);
+    expect(true, hasNativeScopeObserver);
+  } catch (_) {
+    expect(false, hasNativeScopeObserver);
+  }
 }
 
 void testConfiguration({

--- a/flutter/test/sentry_flutter_util.dart
+++ b/flutter/test/sentry_flutter_util.dart
@@ -16,14 +16,15 @@ void testTransport({
 
 void testScopeObserver(
     {required SentryFlutterOptions options,
-    required bool hasNativeScopeObserver}) {
-  try {
-    options.scopeObservers
-        .firstWhere((element) => element.runtimeType == NativeScopeObserver);
-    expect(true, hasNativeScopeObserver);
-  } catch (_) {
-    expect(false, hasNativeScopeObserver);
+    required bool expectedHasNativeScopeObserver}) {
+  var actualHasNativeScopeObserver = false;
+  for (final scopeObserver in options.scopeObservers) {
+    if (scopeObserver.runtimeType == NativeScopeObserver) {
+      actualHasNativeScopeObserver = true;
+      break;
+    }
   }
+  expect(actualHasNativeScopeObserver, expectedHasNativeScopeObserver);
 }
 
 void testConfiguration({

--- a/flutter/test/sentry_native_test.dart
+++ b/flutter/test/sentry_native_test.dart
@@ -136,7 +136,7 @@ class Fixture {
 
   SentryNative getSut() {
     final sut = SentryNative();
-    sut.setNativeChannel(channel);
+    sut.nativeChannel = channel;
     return sut;
   }
 }

--- a/flutter/test/sentry_navigator_observer_test.dart
+++ b/flutter/test/sentry_navigator_observer_test.dart
@@ -48,7 +48,7 @@ void main() {
       final mockHub = _MockHub();
       final native = SentryNative();
       final mockNativeChannel = MockNativeChannel();
-      native.setNativeChannel(mockNativeChannel);
+      native.nativeChannel = mockNativeChannel;
 
       final tracer = getMockSentryTracer();
       _whenAnyStart(mockHub, tracer);
@@ -75,7 +75,7 @@ void main() {
       mockNativeChannel.nativeFrames = nativeFrames;
 
       final mockNative = SentryNative();
-      mockNative.setNativeChannel(mockNativeChannel);
+      mockNative.nativeChannel = mockNativeChannel;
 
       final sut = fixture.getSut(
         hub: hub,


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Closes #1176

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- Only call native cannels on native platforms
- Also call native scope observers on iOS & macOS

## :green_heart: How did you test it?

Unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes