### PR TITLE
Update dependency `intl` to ^0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Bump Cocoa SDK from v7.31.3 to v7.31.4 ([#1190](https://github.com/getsentry/sentry-dart/pull/1190))
   - [changelog](https://github.com/getsentry/sentry-cocoa/blob/8.0.0/CHANGELOG.md#7314)
   - [diff](https://github.com/getsentry/sentry-cocoa/compare/7.31.3...7.31.4)
+- Bump dependency `intl` to ^0.18.0 ([#1202](https://github.com/getsentry/sentry-dart/pull/1202))
 
 ## 6.18.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Dependencies
+
+- Bump dependency `intl` to ^0.18.0 ([#1202](https://github.com/getsentry/sentry-dart/pull/1202))
+
 ## 6.18.2
 
 ### Fixes
@@ -15,7 +21,6 @@
 - Bump Cocoa SDK from v7.31.3 to v7.31.5 ([#1190](https://github.com/getsentry/sentry-dart/pull/1190), [#1207](https://github.com/getsentry/sentry-dart/pull/1207))
   - [changelog](https://github.com/getsentry/sentry-cocoa/blob/8.0.0/CHANGELOG.md#7315)
   - [diff](https://github.com/getsentry/sentry-cocoa/compare/7.31.3...7.31.5)
-- Bump dependency `intl` to ^0.18.0 ([#1202](https://github.com/getsentry/sentry-dart/pull/1202))
 
 ## 6.18.1
 

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   meta: ^1.3.0
   stack_trace: ^1.10.0
   uuid: ^3.0.0
-  intl: ^0.17.0
+  intl: ^0.18.0
 
 dev_dependencies:
   mockito: ^5.1.0


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Update dependency `intl` to ^0.18.0 - https://pub.dev/packages/intl.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
My project uses both `sentry` and `intl`. Right now, I'm unable to upgrade `intl` to `^0.18.0` in my project because `sentry` depends on `intl: ^0.17.0` and the version resolution would fail.

## :green_heart: How did you test it?
Hoping GitHub Actions will verify that the new version of `intl` is still compatible.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
