### PR TITLE
enableUserInteractionTracing sometimes finds the wrong widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- enableUserInteractionTracing sometimes finds the wrong widget ([#1172](https://github.com/getsentry/sentry-dart/pull/1172))
+
 ### Dependencies
 
 - Bump Android SDK from v6.9.2 to v6.11.0 ([#1194](https://github.com/getsentry/sentry-dart/pull/1194), [#1209](https://github.com/getsentry/sentry-dart/pull/1209))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- enableUserInteractionTracing sometimes finds the wrong widget ([#1172](https://github.com/getsentry/sentry-dart/pull/1172))
+- enableUserInteractionTracing sometimes finds the wrong widget ([#1212](https://github.com/getsentry/sentry-dart/pull/1212))
 
 ### Dependencies
 

--- a/flutter/lib/src/user_interaction/sentry_user_interaction_widget.dart
+++ b/flutter/lib/src/user_interaction/sentry_user_interaction_widget.dart
@@ -258,13 +258,12 @@ class _SentryUserInteractionWidgetState
       if (renderObject == null) {
         return;
       }
+      var hitFound = true;
       if (renderObject is RenderPointerListener) {
         final hitResult = BoxHitTestResult();
 
         // Returns false if the hit can continue to other objects below this one.
-        if (!renderObject.hitTest(hitResult, position: position)) {
-          return;
-        }
+        hitFound = renderObject.hitTest(hitResult, position: position);
       }
 
       final transform = renderObject.getTransformTo(rootElement.renderObject);
@@ -277,7 +276,7 @@ class _SentryUserInteractionWidgetState
 
       tappedWidget = _getDescriptionFrom(element);
 
-      if (tappedWidget == null) {
+      if (tappedWidget == null || !hitFound) {
         element.visitChildElements(elementFinder);
       }
     }

--- a/flutter/lib/src/user_interaction/sentry_user_interaction_widget.dart
+++ b/flutter/lib/src/user_interaction/sentry_user_interaction_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:meta/meta.dart';
 
 import '../../sentry_flutter.dart';
@@ -256,6 +257,14 @@ class _SentryUserInteractionWidgetState
       final renderObject = element.renderObject;
       if (renderObject == null) {
         return;
+      }
+      if (renderObject is RenderPointerListener) {
+        final hitResult = BoxHitTestResult();
+
+        // Returns false if the hit can continue to other objects below this one.
+        if (!renderObject.hitTest(hitResult, position: position)) {
+          return;
+        }
       }
 
       final transform = renderObject.getTransformTo(rootElement.renderObject);

--- a/flutter/test/user_interaction/sentry_user_interaction_widget_test.dart
+++ b/flutter/test/user_interaction/sentry_user_interaction_widget_test.dart
@@ -201,7 +201,7 @@ void main() {
           currentTimer = tracer.autoFinishAfterTimer;
         });
 
-        await tapMe(tester, sut, 'btn_1');
+        await tapMe(tester, sut, 'btn_1', pumpWidget: false);
 
         Timer? autoFinishAfterTimer;
         fixture.hub.configureScope((scope) {
@@ -226,7 +226,7 @@ void main() {
           currentTracer = (scope.span as SentryTracer);
         });
 
-        await tapMe(tester, sut, 'btn_2');
+        await tapMe(tester, sut, 'btn_2', pumpWidget: false);
 
         SentryTracer? tracer;
         fixture.hub.configureScope((scope) {
@@ -238,8 +238,15 @@ void main() {
   });
 }
 
-Future<void> tapMe(WidgetTester tester, Widget widget, String key) async {
-  await tester.pumpWidget(widget);
+Future<void> tapMe(
+  WidgetTester tester,
+  Widget widget,
+  String key, {
+  bool pumpWidget = true,
+}) async {
+  if (pumpWidget) {
+    await tester.pumpWidget(widget);
+  }
 
   await tester.tap(find.byKey(Key(key)));
 }
@@ -278,59 +285,96 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Welcome to Flutter',
-      home: Scaffold(
-        appBar: AppBar(
-          title: const Text('Welcome to Flutter'),
+      home: Page1(),
+      routes: {'page2': (context) => const Page2()},
+    );
+  }
+}
+
+class Page1 extends StatelessWidget {
+  const Page1({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          children: [
+            MaterialButton(
+              key: Key('btn_1'),
+              onPressed: () {
+                // print('button pressed');
+              },
+              child: const Text('Button 1'),
+            ),
+            CupertinoButton(
+              key: Key('btn_2'),
+              onPressed: () {
+                // print('button pressed 2');
+              },
+              child: const Text('Button 2'),
+            ),
+            IconButton(
+              key: Key('btn_3'),
+              onPressed: () {
+                // print('button pressed 3');
+              },
+              icon: Icon(
+                Icons.dark_mode,
+                semanticLabel: 'My Icon',
+              ),
+            ),
+            Card(
+              child: GestureDetector(
+                key: Key('btn_4'),
+                onTap: () => {
+                  // print('button pressed 4'),
+                },
+                child: Stack(
+                  children: [
+                    //fancy card layout
+                    ElevatedButton(
+                      key: Key('btn_5'),
+                      onPressed: () => {
+                        // print('button pressed 5'),
+                      },
+                      child: const Text('Button 5'),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            MaterialButton(
+              key: Key('btn_go_to_page2'),
+              onPressed: () {
+                Navigator.of(context).pushNamed('page2');
+              },
+              child: const Text('Go to page 2'),
+            ),
+          ],
         ),
-        body: Center(
-          child: Column(
-            children: [
-              MaterialButton(
-                key: Key('btn_1'),
-                onPressed: () {
-                  // print('button pressed');
-                },
-                child: const Text('Button 1'),
-              ),
-              CupertinoButton(
-                key: Key('btn_2'),
-                onPressed: () {
-                  // print('button pressed 2');
-                },
-                child: const Text('Button 2'),
-              ),
-              IconButton(
-                key: Key('btn_3'),
-                onPressed: () {
-                  // print('button pressed 3');
-                },
-                icon: Icon(
-                  Icons.dark_mode,
-                  semanticLabel: 'My Icon',
-                ),
-              ),
-              Card(
-                child: GestureDetector(
-                  key: Key('btn_4'),
-                  onTap: () => {
-                    // print('button pressed 4'),
-                  },
-                  child: Stack(
-                    children: [
-                      //fancy card layout
-                      ElevatedButton(
-                        key: Key('btn_5'),
-                        onPressed: () => {
-                          // print('button pressed 5'),
-                        },
-                        child: const Text('Button 5'),
-                      ),
-                    ],
-                  ),
-                ),
-              )
-            ],
-          ),
+      ),
+    );
+  }
+}
+
+class Page2 extends StatelessWidget {
+  const Page2({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          children: [
+            MaterialButton(
+              key: Key('btn_page_2'),
+              onPressed: () {
+                // print('button page 2 pressed');
+              },
+              child: const Text('Button Page 2'),
+            ),
+          ],
         ),
       ),
     );


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
Fix https://github.com/getsentry/sentry-dart/issues/1208


## :green_heart: How did you test it?
Running the given example in the [issue](https://github.com/getsentry/sentry-dart/issues/1208).
The WidgetTester finds the right widget but testing behaves differently due to custom `HitTestBehavior` most likely.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
