### PR TITLE
Missing handled flag in the mechanism for some events

### DIFF
--- a/dart/lib/src/event_processor/exception/io_exception_event_processor.dart
+++ b/dart/lib/src/event_processor/exception/io_exception_event_processor.dart
@@ -111,6 +111,7 @@ SentryException _sentryExceptionfromOsError(OSError osError) {
       meta: {
         'errno': {'number': osError.errorCode},
       },
+      handled: true,
     ),
   );
 }

--- a/dart/lib/src/http_client/failed_request_client.dart
+++ b/dart/lib/src/http_client/failed_request_client.dart
@@ -173,6 +173,7 @@ class FailedRequestClient extends BaseClient {
     final mechanism = Mechanism(
       type: 'SentryHttpClient',
       description: reason,
+      handled: true,
     );
 
     bool? snapshot;

--- a/dart/test/event_processor/exception/io_exception_event_processor_test.dart
+++ b/dart/test/event_processor/exception/io_exception_event_processor_test.dart
@@ -69,6 +69,7 @@ void main() {
       );
       expect(event.exceptions?.first.mechanism?.type, 'OSError');
       expect(event.exceptions?.first.mechanism?.meta['errno']['number'], 54);
+      expect(event.exceptions?.first.mechanism?.handled, true);
     });
 
     test('adds OSError SentryException for $FileSystemException', () async {

--- a/dart/test/http_client/failed_request_client_test.dart
+++ b/dart/test/http_client/failed_request_client_test.dart
@@ -100,6 +100,7 @@ void main() {
       final mechanism = exception?.mechanism;
 
       expect(mechanism?.type, 'SentryHttpClient');
+      expect(mechanism?.handled, true);
       expect(
         mechanism?.description,
         'HTTP Client Error with status code: 404',

--- a/dio/lib/src/failed_request_interceptor.dart
+++ b/dio/lib/src/failed_request_interceptor.dart
@@ -13,7 +13,10 @@ class FailedRequestInterceptor extends Interceptor {
     DioError err,
     ErrorInterceptorHandler handler,
   ) async {
-    final mechanism = Mechanism(type: 'SentryDioClientAdapter');
+    final mechanism = Mechanism(
+      type: 'SentryDioClientAdapter',
+      handled: true,
+    );
     final throwableMechanism = ThrowableMechanism(mechanism, err);
 
     _hub.getSpan()?.throwable = err;

--- a/dio/test/failed_request_interceptor_test.dart
+++ b/dio/test/failed_request_interceptor_test.dart
@@ -27,6 +27,7 @@ void main() {
     final throwable =
         fixture.hub.captureExceptionCalls.first.throwable as ThrowableMechanism;
     expect(throwable.mechanism.type, 'SentryDioClientAdapter');
+    expect(throwable.mechanism.handled, true);
     expect(throwable.throwable, error);
   });
 }


### PR DESCRIPTION
## :scroll: Description
Missing handled flag in the mechanism for some events
_#skip-changelog_

## :bulb: Motivation and Context
Some events had a mechanism but not the handled flag


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
