### PR TITLE
Enha: Don't supress error logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Don't suppress error logs ([#1228](https://github.com/getsentry/sentry-dart/pull/1228))
+
 ### Breaking Changes
 
 - Remove deprecated fields ([#1227](https://github.com/getsentry/sentry-dart/pull/1227))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Don't suppress error logs ([#1228](https://github.com/getsentry/sentry-dart/pull/1228))
+
 ## 7.0.0-alpha.3
 
 ### Breaking Changes

--- a/dart/lib/src/run_zoned_guarded_integration.dart
+++ b/dart/lib/src/run_zoned_guarded_integration.dart
@@ -70,6 +70,7 @@ class RunZonedGuardedIntegration extends Integration {
       },
       (exception, stackTrace) async {
         await captureError(hub, options, exception, stackTrace);
+        Zone.current.handleUncaughtError(exception, stackTrace);
       },
       zoneSpecification: ZoneSpecification(
         print: (self, parent, zone, line) {

--- a/dart/lib/src/run_zoned_guarded_integration.dart
+++ b/dart/lib/src/run_zoned_guarded_integration.dart
@@ -8,6 +8,12 @@ import 'protocol.dart';
 import 'sentry_options.dart';
 import 'throwable_mechanism.dart';
 
+/// Called inside of `runZonedGuarded`
+typedef RunZonedGuardedRunner = Future<void> Function();
+
+/// Caught exception and stacktrace in `runZonedGuarded`
+typedef RunZonedGuardedOnError = FutureOr<void> Function(Object, StackTrace);
+
 /// Integration that runs runner function within `runZonedGuarded` and capture
 /// errors on the `runZonedGuarded` error handler.
 /// See https://api.dart.dev/stable/dart-async/runZonedGuarded.html
@@ -15,9 +21,10 @@ import 'throwable_mechanism.dart';
 /// This integration also records calls to `print()` as Breadcrumbs.
 /// This can be configured with [SentryOptions.enablePrintBreadcrumbs]
 class RunZonedGuardedIntegration extends Integration {
-  RunZonedGuardedIntegration(this._runner);
+  RunZonedGuardedIntegration(this._runner, this._onError);
 
-  final Future<void> Function() _runner;
+  final RunZonedGuardedRunner _runner;
+  final RunZonedGuardedOnError? _onError;
 
   /// Needed to check if we somehow caused a `print()` recursion
   bool _isPrinting = false;
@@ -70,7 +77,10 @@ class RunZonedGuardedIntegration extends Integration {
       },
       (exception, stackTrace) async {
         await captureError(hub, options, exception, stackTrace);
-        Zone.current.handleUncaughtError(exception, stackTrace);
+        final onError = _onError;
+        if (onError != null) {
+          await onError(exception, stackTrace);
+        }
       },
       zoneSpecification: ZoneSpecification(
         print: (self, parent, zone, line) {

--- a/dart/lib/src/sentry.dart
+++ b/dart/lib/src/sentry.dart
@@ -39,6 +39,7 @@ class Sentry {
     OptionsConfiguration optionsConfiguration, {
     AppRunner? appRunner,
     @internal bool callAppRunnerInRunZonedGuarded = true,
+    @internal RunZonedGuardedOnError? runZonedGuardedOnError,
     @internal SentryOptions? options,
   }) async {
     final sentryOptions = options ?? SentryOptions();
@@ -59,7 +60,8 @@ class Sentry {
       throw ArgumentError('DSN is required.');
     }
 
-    await _init(sentryOptions, appRunner, callAppRunnerInRunZonedGuarded);
+    await _init(sentryOptions, appRunner, callAppRunnerInRunZonedGuarded,
+        runZonedGuardedOnError);
   }
 
   static Future<void> _initDefaultValues(SentryOptions options) async {
@@ -101,6 +103,7 @@ class Sentry {
     SentryOptions options,
     AppRunner? appRunner,
     bool callAppRunnerInRunZonedGuarded,
+    RunZonedGuardedOnError? runZonedGuardedOnError,
   ) async {
     if (isEnabled) {
       options.logger(
@@ -126,8 +129,8 @@ class Sentry {
           await appRunner();
         };
 
-        final runZonedGuardedIntegration =
-            RunZonedGuardedIntegration(runIntegrationsAndAppRunner);
+        final runZonedGuardedIntegration = RunZonedGuardedIntegration(
+            runIntegrationsAndAppRunner, runZonedGuardedOnError);
         options.addIntegrationByIndex(0, runZonedGuardedIntegration);
 
         // RunZonedGuardedIntegration will run other integrations and appRunner

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -3,6 +3,7 @@ import 'dart:ui';
 
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
 import '../sentry_flutter.dart';
 import 'event_processor/android_platform_exception_event_processor.dart';
@@ -61,6 +62,16 @@ mixin SentryFlutter {
         ? false
         : wrapper.isOnErrorSupported(flutterOptions);
 
+    final runZonedGuardedOnError = flutterOptions.platformChecker.isWeb
+        ? (Object error, StackTrace stackTrace) async {
+            final errorDetails = FlutterErrorDetails(
+              exception: error,
+              stack: stackTrace,
+            );
+            FlutterError.dumpErrorToConsole(errorDetails, forceReport: true);
+          }
+        : null;
+
     // first step is to install the native integration and set default values,
     // so we are able to capture future errors.
     final defaultIntegrations = _createDefaultIntegrations(
@@ -83,6 +94,8 @@ mixin SentryFlutter {
       options: flutterOptions,
       // ignore: invalid_use_of_internal_member
       callAppRunnerInRunZonedGuarded: !isOnErrorSupported,
+      // ignore: invalid_use_of_internal_member
+      runZonedGuardedOnError: runZonedGuardedOnError,
     );
   }
 

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -63,13 +63,7 @@ mixin SentryFlutter {
         : wrapper.isOnErrorSupported(flutterOptions);
 
     final runZonedGuardedOnError = flutterOptions.platformChecker.isWeb
-        ? (Object error, StackTrace stackTrace) async {
-            final errorDetails = FlutterErrorDetails(
-              exception: error,
-              stack: stackTrace,
-            );
-            FlutterError.dumpErrorToConsole(errorDetails, forceReport: true);
-          }
+        ? _createRunZonedGuardedOnError()
         : null;
 
     // first step is to install the native integration and set default values,
@@ -195,6 +189,16 @@ mixin SentryFlutter {
       ));
     }
     return integrations;
+  }
+
+  static RunZonedGuardedOnError _createRunZonedGuardedOnError() {
+    return (Object error, StackTrace stackTrace) async {
+      final errorDetails = FlutterErrorDetails(
+        exception: error,
+        stack: stackTrace,
+      );
+      FlutterError.dumpErrorToConsole(errorDetails, forceReport: true);
+    };
   }
 
   /// Manually set when your app finished startup. Make sure to set


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Closes #543 

Introduces and `onError` callback in the `RunZonedGuarded` intergrations, so that we can call `FlutterError.dumpToConsole` when an error is caught by the integration.

This is done this way, as it's the recommended way per [flutter documentation](https://docs.flutter.dev/testing/errors).

`Note: Consider calling [FlutterError.presentError](https://api.flutter.dev/flutter/foundation/FlutterError/presentError.html) from your custom error handler in order to see the logs in the console as well.`

On web this does not yield the same output, but the error name and the StackTrace is there.

<img width="1421" alt="Bildschirm­foto 2023-01-23 um 11 03 21" src="https://user-images.githubusercontent.com/3984453/214018528-4b4f651e-5f05-459d-8101-6681f79d9305.png">

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When executing code in custom runZonedGuarded, errors on web are not logged to the console anymore.

## :green_heart: How did you test it?

Added unit test.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

Discuss if we need to handle other cases as well.
