### PR TITLE
Fix binding wrapper export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - Remove deprecated field from the `SentryFlutterOptions` class.
     - `anrTimeoutIntervalMillis`, using the `anrTimeoutInterval` instead.
     - `autoSessionTrackingIntervalMillis`, using the `autoSessionTrackingInterval` instead.
+- Fix export for `BindingWrapper` ([#1234](https://github.com/getsentry/sentry-dart/pull/1234))
 
 ### Dependencies
 

--- a/flutter/lib/sentry_flutter.dart
+++ b/flutter/lib/sentry_flutter.dart
@@ -10,3 +10,4 @@ export 'src/sentry_asset_bundle.dart';
 export 'src/integrations/on_error_integration.dart';
 export 'src/screenshot/sentry_screenshot_widget.dart';
 export 'src/user_interaction/sentry_user_interaction_widget.dart';
+export 'src/binding_wrapper.dart';

--- a/flutter/lib/src/binding_wrapper.dart
+++ b/flutter/lib/src/binding_wrapper.dart
@@ -6,7 +6,7 @@ import 'package:meta/meta.dart';
 import '../sentry_flutter.dart';
 
 /// The methods and properties are modelled after the the real binding class.
-@internal
+@experimental
 class BindingWrapper {
   final Hub _hub;
 


### PR DESCRIPTION
## :scroll: Description

The binding wrapper wasn't correctly exported, and it was also marked as internal. It should have been marked as `experimental`


## :bulb: Motivation and Context

This allows the binding wrapper to be used in the consumers code.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
