### PR TITLE
Ref: Error Cause Extractor Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,13 @@
 
 ### Features
 
-- Error Cause Extractor ([#1198](https://github.com/getsentry/sentry-dart/pull/1198))
+- Error Cause Extractor ([#1198](https://github.com/getsentry/sentry-dart/pull/1198), [#1236](https://github.com/getsentry/sentry-dart/pull/1236))
   - Add `throwable` to `SentryException`
 
 ### Fixes
 
 - Don't suppress error logs ([#1228](https://github.com/getsentry/sentry-dart/pull/1228))
 - Fix export for `BindingWrapper` ([#1234](https://github.com/getsentry/sentry-dart/pull/1234))
-
-### Refactoring
-
-- Error Cause Extractor Updates ([#1236](https://github.com/getsentry/sentry-dart/pull/1236))
 
 ## 7.0.0-alpha.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Don't suppress error logs ([#1228](https://github.com/getsentry/sentry-dart/pull/1228))
 - Fix export for `BindingWrapper` ([#1234](https://github.com/getsentry/sentry-dart/pull/1234))
 
+### Refactoring
+
+- Error Cause Extractor Updates ([#1236](https://github.com/getsentry/sentry-dart/pull/1236))
+
 ## 7.0.0-alpha.4
 
 ### Breaking Changes

--- a/dart/lib/src/exception_cause.dart
+++ b/dart/lib/src/exception_cause.dart
@@ -1,3 +1,4 @@
+/// Holds inner exception and stackTrace combinations contained in other exceptions
 class ExceptionCause {
   ExceptionCause(this.exception, this.stackTrace);
 

--- a/dart/lib/src/exception_cause_extractor.dart
+++ b/dart/lib/src/exception_cause_extractor.dart
@@ -1,3 +1,4 @@
+import 'protocol.dart';
 import 'exception_cause.dart';
 import 'sentry_options.dart';
 import 'throwable_mechanism.dart';
@@ -32,8 +33,18 @@ class RecursiveExceptionCauseExtractor {
       final extractor =
           _options.exceptionCauseExtractor(extractionSourceSource.runtimeType);
 
-      currentExceptionCause = extractor?.cause(extractionSourceSource);
-      currentException = currentExceptionCause?.exception;
+      try {
+        currentExceptionCause = extractor?.cause(extractionSourceSource);
+        currentException = currentExceptionCause?.exception;
+      } catch (exception, stackTrace) {
+        _options.logger(
+          SentryLevel.error,
+          'An exception occurred while extracting  exception cause',
+          exception: exception,
+          stackTrace: stackTrace,
+        );
+        break;
+      }
     }
     return allExceptionCauses;
   }

--- a/dart/lib/src/exception_cause_extractor.dart
+++ b/dart/lib/src/exception_cause_extractor.dart
@@ -1,51 +1,34 @@
 import 'protocol.dart';
 import 'exception_cause.dart';
 import 'sentry_options.dart';
-import 'throwable_mechanism.dart';
 
+/// Extend this abstract class and return inner [ExceptionCause] of your
+/// exceptions.
+///
+/// Implementing an extractor and providing it through
+/// [SentryOptions.addExceptionCauseExtractor] will enable the framework to
+/// extract the inner exceptions and add them as [SentryException] to
+/// [SentryEvent.exceptions].
+///
+/// Example:
+///
+/// ```dart
+/// class ExceptionWithInner {
+///   ExceptionWithInner(this.innerException, this.innerStackTrace);
+///   Object innerException;
+///   StackTrace innerStackTrace;
+/// }
+///
+/// class ExceptionWithInnerExtractor extends ExceptionCauseExtractor<ExceptionWithInner>  {
+///   @override
+///   ExceptionCause? cause(ExceptionWithInner error) {
+///     return ExceptionCause(error.innerException, error.innerStackTrace);
+///   }
+/// }
+///
+/// options.addExceptionCauseExtractor(ExceptionWithInnerExtractor());
+/// ```
 abstract class ExceptionCauseExtractor<T> {
   ExceptionCause? cause(T error);
   Type get exceptionType => T;
-}
-
-class RecursiveExceptionCauseExtractor {
-  RecursiveExceptionCauseExtractor(this._options);
-
-  final SentryOptions _options;
-
-  List<ExceptionCause> flatten(exception, stackTrace) {
-    final allExceptionCauses = <ExceptionCause>[];
-    final circularityDetector = <dynamic>{};
-
-    var currentException = exception;
-    ExceptionCause? currentExceptionCause =
-        ExceptionCause(exception, stackTrace);
-
-    while (currentException != null &&
-        currentExceptionCause != null &&
-        circularityDetector.add(currentException)) {
-      allExceptionCauses.add(currentExceptionCause);
-
-      final extractionSourceSource = currentException is ThrowableMechanism
-          ? currentException.throwable
-          : currentException;
-
-      final extractor =
-          _options.exceptionCauseExtractor(extractionSourceSource.runtimeType);
-
-      try {
-        currentExceptionCause = extractor?.cause(extractionSourceSource);
-        currentException = currentExceptionCause?.exception;
-      } catch (exception, stackTrace) {
-        _options.logger(
-          SentryLevel.error,
-          'An exception occurred while extracting  exception cause',
-          exception: exception,
-          stackTrace: stackTrace,
-        );
-        break;
-      }
-    }
-    return allExceptionCauses;
-  }
 }

--- a/dart/lib/src/exception_cause_extractor.dart
+++ b/dart/lib/src/exception_cause_extractor.dart
@@ -10,7 +10,8 @@ import 'sentry_options.dart';
 /// extract the inner exceptions and add them as [SentryException] to
 /// [SentryEvent.exceptions].
 ///
-/// Example:
+/// For an example on how to use the API refer to dio/DioErrorExtractor or the
+/// code below:
 ///
 /// ```dart
 /// class ExceptionWithInner {

--- a/dart/lib/src/recursive_exception_cause_extractor.dart
+++ b/dart/lib/src/recursive_exception_cause_extractor.dart
@@ -1,0 +1,47 @@
+import 'sentry_options.dart';
+import 'throwable_mechanism.dart';
+import 'exception_cause.dart';
+import 'protocol.dart';
+
+/// Extracts inner exceptions recursively
+class RecursiveExceptionCauseExtractor {
+  RecursiveExceptionCauseExtractor(this._options);
+
+  final SentryOptions _options;
+
+  List<ExceptionCause> flatten(exception, stackTrace) {
+    final allExceptionCauses = <ExceptionCause>[];
+    final circularityDetector = <dynamic>{};
+
+    var currentException = exception;
+    ExceptionCause? currentExceptionCause =
+        ExceptionCause(exception, stackTrace);
+
+    while (currentException != null &&
+        currentExceptionCause != null &&
+        circularityDetector.add(currentException)) {
+      allExceptionCauses.add(currentExceptionCause);
+
+      final extractionSourceSource = currentException is ThrowableMechanism
+          ? currentException.throwable
+          : currentException;
+
+      final extractor =
+          _options.exceptionCauseExtractor(extractionSourceSource.runtimeType);
+
+      try {
+        currentExceptionCause = extractor?.cause(extractionSourceSource);
+        currentException = currentExceptionCause?.exception;
+      } catch (exception, stackTrace) {
+        _options.logger(
+          SentryLevel.error,
+          'An exception occurred while extracting  exception cause',
+          exception: exception,
+          stackTrace: stackTrace,
+        );
+        break;
+      }
+    }
+    return allExceptionCauses;
+  }
+}

--- a/dart/lib/src/recursive_exception_cause_extractor.dart
+++ b/dart/lib/src/recursive_exception_cause_extractor.dart
@@ -2,8 +2,10 @@ import 'sentry_options.dart';
 import 'throwable_mechanism.dart';
 import 'exception_cause.dart';
 import 'protocol.dart';
+import 'package:meta/meta.dart';
 
 /// Extracts inner exceptions recursively
+@internal
 class RecursiveExceptionCauseExtractor {
   RecursiveExceptionCauseExtractor(this._options);
 

--- a/dart/lib/src/sentry_exception_factory.dart
+++ b/dart/lib/src/sentry_exception_factory.dart
@@ -1,4 +1,4 @@
-import 'exception_cause_extractor.dart';
+import 'recursive_exception_cause_extractor.dart';
 import 'protocol.dart';
 import 'sentry_options.dart';
 import 'sentry_stack_trace_factory.dart';

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -329,10 +329,12 @@ class SentryOptions {
 
   final _extractorsByType = <Type, ExceptionCauseExtractor>{};
 
+  /// Returns a previously added [ExceptionCauseExtractor] by type
   ExceptionCauseExtractor? exceptionCauseExtractor(Type type) {
     return _extractorsByType[type];
   }
 
+  /// Adds [ExceptionCauseExtractor] in order to extract inner exceptions
   void addExceptionCauseExtractor(ExceptionCauseExtractor extractor) {
     _extractorsByType[extractor.exceptionType] = extractor;
   }

--- a/dart/test/exception_cause_extractor_test.dart
+++ b/dart/test/exception_cause_extractor_test.dart
@@ -19,7 +19,7 @@ void main() {
     final errorA = ExceptionA(errorB);
 
     fixture.options.addExceptionCauseExtractor(
-      ExceptionACauseExtractor(),
+      ExceptionACauseExtractor(false),
     );
 
     fixture.options.addExceptionCauseExtractor(
@@ -61,7 +61,7 @@ void main() {
     final errorA = ExceptionA(errorB);
 
     fixture.options.addExceptionCauseExtractor(
-      ExceptionACauseExtractor(),
+      ExceptionACauseExtractor(false),
     );
 
     fixture.options.addExceptionCauseExtractor(
@@ -76,6 +76,26 @@ void main() {
 
     final actual = flattened.map((exceptionCause) => exceptionCause.exception);
     expect(actual, [throwableMechanism, errorB, errorC]);
+  });
+
+  test('throw during extractions is handled', () {
+    final errorB = ExceptionB(null);
+    final errorA = ExceptionA(errorB);
+
+    fixture.options.addExceptionCauseExtractor(
+      ExceptionACauseExtractor(true),
+    );
+
+    fixture.options.addExceptionCauseExtractor(
+      ExceptionBCauseExtractor(),
+    );
+
+    final sut = fixture.getSut();
+
+    final flattened = sut.flatten(errorA, null);
+    final actual = flattened.map((exceptionCause) => exceptionCause.exception);
+
+    expect(actual, [errorA]);
   });
 }
 
@@ -102,8 +122,15 @@ class ExceptionC {
 }
 
 class ExceptionACauseExtractor extends ExceptionCauseExtractor<ExceptionA> {
+  ExceptionACauseExtractor(this.throwing);
+
+  final bool throwing;
+
   @override
   ExceptionCause? cause(ExceptionA error) {
+    if (throwing) {
+      throw StateError("Unexpected exception");
+    }
     return ExceptionCause(error.other, null);
   }
 }

--- a/dart/test/recursive_exception_cause_extractor_test.dart
+++ b/dart/test/recursive_exception_cause_extractor_test.dart
@@ -1,5 +1,6 @@
 import 'package:sentry/src/exception_cause.dart';
 import 'package:sentry/src/exception_cause_extractor.dart';
+import 'package:sentry/src/recursive_exception_cause_extractor.dart';
 import 'package:sentry/src/protocol/mechanism.dart';
 import 'package:sentry/src/sentry_options.dart';
 import 'package:sentry/src/throwable_mechanism.dart';

--- a/dio/lib/src/sentry_dio_extension.dart
+++ b/dio/lib/src/sentry_dio_extension.dart
@@ -21,7 +21,9 @@ extension SentryDioExtension on Dio {
     final options = hub.options;
 
     // Add to get inner exception & stacktrace
-    options.addExceptionCauseExtractor(DioErrorExtractor());
+    if (options.exceptionCauseExtractor(DioError) == null) {
+      options.addExceptionCauseExtractor(DioErrorExtractor());
+    }
 
     // Add DioEventProcessor when it's not already present
     if (options.eventProcessors.whereType<DioEventProcessor>().isEmpty) {

--- a/dio/test/sentry_dio_extension_test.dart
+++ b/dio/test/sentry_dio_extension_test.dart
@@ -1,5 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:sentry_dio/sentry_dio.dart';
+import 'package:sentry_dio/src/dio_error_extractor.dart';
 import 'package:sentry_dio/src/sentry_dio_client_adapter.dart';
 import 'package:sentry_dio/src/sentry_dio_extension.dart';
 import 'package:sentry_dio/src/sentry_transformer.dart';
@@ -54,6 +55,17 @@ void main() {
             .whereType<DioEventProcessor>()
             .length,
         1,
+      );
+    });
+
+    test('addSentry adds $DioErrorExtractor', () {
+      final dio = fixture.getSut();
+
+      dio.addSentry(hub: fixture.hub);
+
+      expect(
+        fixture.hub.options.exceptionCauseExtractor(DioError),
+        isNotNull,
       );
     });
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Adds remaining feedback from #1198

@marandaneto After documenting the classes, I'm not sure abaut the `Cause` in the naming. Technically an inner exception does not have to be the cause of an exception i guess. So maybe we should replace `Cause` with `Inner`? WDYT?

## :green_heart: How did you test it?

Tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes