### PR TITLE
intl is now more version permissive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- intl is now more version permissive (>=0.17.0 <1.0.0) ([#1202](https://github.com/getsentry/sentry-dart/pull/1202))
+
 ### Breaking Changes:
 
 - sentry_file now requires Dart >= 2.19 ([#1240](https://github.com/getsentry/sentry-dart/pull/1240))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- intl is now more version permissive (>=0.17.0 <1.0.0) ([#1202](https://github.com/getsentry/sentry-dart/pull/1202))
+- intl is now more version permissive (>=0.17.0 <1.0.0) ([#1247](https://github.com/getsentry/sentry-dart/pull/1247))
 
 ### Breaking Changes:
 

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   meta: ^1.3.0
   stack_trace: ^1.10.0
   uuid: ^3.0.0
-  intl: ^0.17.0
+  intl: '>=0.17.0 <1.0.0'
 
 dev_dependencies:
   mockito: ^5.1.0


### PR DESCRIPTION
## :scroll: Description
pub has an [addendun](https://pub.dev/packages/pub_semver) to sem ver and 0.x versions can be not compatible, using the `> and <` for now solves the problem, but we'd work on https://github.com/getsentry/sentry-dart/issues/1241 next.


## :bulb: Motivation and Context
https://github.com/getsentry/sentry-dart/pull/1202 and https://github.com/dart-lang/pub/issues/3747



## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
https://github.com/getsentry/sentry-dart/issues/1241