### PR TITLE
chore: remove unused code

### DIFF
--- a/dart/test/http_client/tracing_client_test.dart
+++ b/dart/test/http_client/tracing_client_test.dart
@@ -194,8 +194,6 @@ MockClient createThrowingClient() {
   );
 }
 
-class CloseableMockClient extends Mock implements BaseClient {}
-
 class Fixture {
   final _options = SentryOptions(dsn: fakeDsn);
   late Hub _hub;

--- a/dart/test/http_client/tracing_client_test.dart
+++ b/dart/test/http_client/tracing_client_test.dart
@@ -1,6 +1,5 @@
 import 'package:http/http.dart';
 import 'package:http/testing.dart';
-import 'package:mockito/mockito.dart';
 import 'package:sentry/sentry.dart';
 import 'package:sentry/src/http_client/tracing_client.dart';
 import 'package:sentry/src/sentry_tracer.dart';

--- a/dart/test/mocks.dart
+++ b/dart/test/mocks.dart
@@ -99,14 +99,6 @@ final fakeEvent = SentryEvent(
   ),
 );
 
-/// Doesn't do anything with the events
-class NoOpEventProcessor extends EventProcessor {
-  @override
-  FutureOr<SentryEvent?> apply(SentryEvent event, {hint}) {
-    return event;
-  }
-}
-
 /// Always returns null and thus drops all events
 class DropAllEventProcessor extends EventProcessor {
   @override

--- a/dart/test/sentry_envelope_test.dart
+++ b/dart/test/sentry_envelope_test.dart
@@ -186,6 +186,4 @@ void main() {
   });
 }
 
-class NonEncodable {
-  final String message = 'Hello World';
-}
+class NonEncodable {}

--- a/dart/test/sentry_user_feedback_test.dart
+++ b/dart/test/sentry_user_feedback_test.dart
@@ -171,15 +171,6 @@ class SentryUserFeedbackWithoutAssert implements SentryUserFeedback {
     this.comments,
   });
 
-  factory SentryUserFeedbackWithoutAssert.fromJson(Map<String, dynamic> json) {
-    return SentryUserFeedbackWithoutAssert(
-      eventId: SentryId.fromId(json['event_id']),
-      name: json['name'],
-      email: json['email'],
-      comments: json['comments'],
-    );
-  }
-
   @override
   final SentryId eventId;
 

--- a/dart/test/transport/http_transport_test.dart
+++ b/dart/test/transport/http_transport_test.dart
@@ -7,7 +7,6 @@ import 'package:sentry/src/client_reports/discard_reason.dart';
 import 'package:sentry/src/sentry_envelope_header.dart';
 import 'package:sentry/src/sentry_envelope_item_header.dart';
 import 'package:sentry/src/sentry_item_type.dart';
-import 'package:sentry/src/sentry_tracer.dart';
 import 'package:sentry/src/transport/data_category.dart';
 import 'package:sentry/src/transport/http_transport.dart';
 import 'package:sentry/src/transport/rate_limiter.dart';
@@ -15,7 +14,6 @@ import 'package:test/test.dart';
 
 import '../mocks.dart';
 import '../mocks/mock_client_report_recorder.dart';
-import '../mocks/mock_hub.dart';
 
 void main() {
   SentryEnvelope givenEnvelope() {
@@ -235,16 +233,5 @@ class Fixture {
     options.httpClient = client;
     options.recorder = clientReportRecorder;
     return HttpTransport(options, rateLimiter);
-  }
-
-  SentryTracer createTracer({
-    bool? sampled = true,
-  }) {
-    final context = SentryTransactionContext(
-      'name',
-      'op',
-      samplingDecision: SentryTracesSamplingDecision(sampled!),
-    );
-    return SentryTracer(context, MockHub());
   }
 }

--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -112,13 +112,13 @@ class MainScaffold extends StatelessWidget {
           ),
           IconButton(
             onPressed: () {
-              themeProvider.updatePrimatryColor(Colors.orange);
+              themeProvider.updatePrimaryColor(Colors.orange);
             },
             icon: const Icon(Icons.circle, color: Colors.orange),
           ),
           IconButton(
             onPressed: () {
-              themeProvider.updatePrimatryColor(Colors.green);
+              themeProvider.updatePrimaryColor(Colors.green);
             },
             icon: const Icon(Icons.circle, color: Colors.lime),
           ),
@@ -677,7 +677,7 @@ class ThemeProvider extends ChangeNotifier {
     notifyListeners();
   }
 
-  void updatePrimatryColor(MaterialColor color) {
+  void updatePrimaryColor(MaterialColor color) {
     if (theme.brightness == Brightness.light) {
       theme = ThemeData(primarySwatch: color, brightness: theme.brightness);
     } else {

--- a/flutter/lib/src/jvm/jvm_exception.dart
+++ b/flutter/lib/src/jvm/jvm_exception.dart
@@ -19,14 +19,6 @@ class JvmException {
     return _parse(exception);
   }
 
-  static JvmException? tryParse(String exception) {
-    try {
-      return JvmException.parse(exception);
-    } catch (_) {
-      return null;
-    }
-  }
-
   final String? thread;
   final String? type;
   final String? description;

--- a/flutter/test/integrations/load_release_integration_test.dart
+++ b/flutter/test/integrations/load_release_integration_test.dart
@@ -138,7 +138,6 @@ void main() {
 }
 
 class Fixture {
-  final hub = MockHub();
   final options = SentryFlutterOptions(dsn: fakeDsn);
 
   LoadReleaseIntegration getIntegration({PackageLoader? loader}) {


### PR DESCRIPTION
## :scroll: Description
This PR removes some unused code.
_#skip-changelog_

## :bulb: Motivation and Context
Hello! I'm one of the authors of DCM package and I'm currently testing new unused code check that also checks for methods, fields, etc.

I've noticed that you have an opened issue #949, so decide to submit this PR.

Here is full report for `dart/` folder:

```
✔ Analysis is completed. Preparing the results: 18.3s

dart/lib/src/noop_sentry_client.dart:
    ⚠ unused constructor NoOpSentryClient
      at /Users/dimannich/Desktop/code/sentry-dart/dart/lib/src/noop_sentry_client.dart:15:3

dart/lib/src/protocol/max_body_size.dart:
    ⚠ unused method shouldAddBody
      at /Users/dimannich/Desktop/code/sentry-dart/dart/lib/src/protocol/max_body_size.dart:61:3
    ⚠ unused extension MaxResponseBodySizeX
      at /Users/dimannich/Desktop/code/sentry-dart/dart/lib/src/protocol/max_body_size.dart:60:1

dart/lib/src/sentry_client_stub.dart:
    ⚠ unused function createSentryClient
      at /Users/dimannich/Desktop/code/sentry-dart/dart/lib/src/sentry_client_stub.dart:8:1

dart/lib/src/sentry_item_type.dart:
    ⚠ unused field unknown
      at /Users/dimannich/Desktop/code/sentry-dart/dart/lib/src/sentry_item_type.dart:7:3

dart/lib/src/transport/encode.dart:
    ⚠ unused function compressBody
      at /Users/dimannich/Desktop/code/sentry-dart/dart/lib/src/transport/encode.dart:3:1

dart/lib/src/transport/noop_encode.dart:
    ⚠ unused function compressBody
      at /Users/dimannich/Desktop/code/sentry-dart/dart/lib/src/transport/noop_encode.dart:1:1

dart/test/mocks/mock_hub.dart:
    ⚠ unused method reset
      at /Users/dimannich/Desktop/code/sentry-dart/dart/test/mocks/mock_hub.dart:27:3
    ⚠ unused field stackTrace
      at /Users/dimannich/Desktop/code/sentry-dart/dart/test/mocks/mock_hub.dart:138:3
    ⚠ unused field hint
      at /Users/dimannich/Desktop/code/sentry-dart/dart/test/mocks/mock_hub.dart:139:3
    ⚠ unused field throwable
      at /Users/dimannich/Desktop/code/sentry-dart/dart/test/mocks/mock_hub.dart:145:3
    ⚠ unused field stackTrace
      at /Users/dimannich/Desktop/code/sentry-dart/dart/test/mocks/mock_hub.dart:146:3
    ⚠ unused field hint
      at /Users/dimannich/Desktop/code/sentry-dart/dart/test/mocks/mock_hub.dart:147:3
    ⚠ unused field message
      at /Users/dimannich/Desktop/code/sentry-dart/dart/test/mocks/mock_hub.dart:157:3
    ⚠ unused field level
      at /Users/dimannich/Desktop/code/sentry-dart/dart/test/mocks/mock_hub.dart:158:3
    ⚠ unused field template
      at /Users/dimannich/Desktop/code/sentry-dart/dart/test/mocks/mock_hub.dart:159:3
    ⚠ unused field params
      at /Users/dimannich/Desktop/code/sentry-dart/dart/test/mocks/mock_hub.dart:160:3
    ⚠ unused field hint
      at /Users/dimannich/Desktop/code/sentry-dart/dart/test/mocks/mock_hub.dart:161:3
    ⚠ unused field hint
      at /Users/dimannich/Desktop/code/sentry-dart/dart/test/mocks/mock_hub.dart:174:3

dart/test/mocks/mock_sentry_client.dart:
    ⚠ unused field hint
      at /Users/dimannich/Desktop/code/sentry-dart/dart/test/mocks/mock_sentry_client.dart:98:3
    ⚠ unused field throwable
      at /Users/dimannich/Desktop/code/sentry-dart/dart/test/mocks/mock_sentry_client.dart:109:3
    ⚠ unused field stackTrace
      at /Users/dimannich/Desktop/code/sentry-dart/dart/test/mocks/mock_sentry_client.dart:110:3
    ⚠ unused field scope
      at /Users/dimannich/Desktop/code/sentry-dart/dart/test/mocks/mock_sentry_client.dart:111:3
    ⚠ unused field hint
      at /Users/dimannich/Desktop/code/sentry-dart/dart/test/mocks/mock_sentry_client.dart:112:3
    ⚠ unused field template
      at /Users/dimannich/Desktop/code/sentry-dart/dart/test/mocks/mock_sentry_client.dart:125:3
    ⚠ unused field params
      at /Users/dimannich/Desktop/code/sentry-dart/dart/test/mocks/mock_sentry_client.dart:126:3
    ⚠ unused field hint
      at /Users/dimannich/Desktop/code/sentry-dart/dart/test/mocks/mock_sentry_client.dart:128:3
    ⚠ unused field envelope
      at /Users/dimannich/Desktop/code/sentry-dart/dart/test/mocks/mock_sentry_client.dart:141:3

✖ total unused code (classes, functions, variables, extensions, enums, mixins and type aliases) - 28
```

Here is full report for `flutter/` folder:
```
✔ Analysis is completed. Preparing the results: 10.9s

flutter/lib/src/jvm/jvm_exception.dart:
    ⚠ unused method tryParse
      at /Users/dimannich/Desktop/code/sentry-dart/flutter/lib/src/jvm/jvm_exception.dart:22:3

flutter/lib/src/jvm/jvm_frame.dart:
    ⚠ unused method tryParse
      at /Users/dimannich/Desktop/code/sentry-dart/flutter/lib/src/jvm/jvm_frame.dart:24:3
    ⚠ unused getter unparsed
      at /Users/dimannich/Desktop/code/sentry-dart/flutter/lib/src/jvm/jvm_frame.dart:67:3

flutter/test/integrations/flutter_error_integration_test.dart:
    ⚠ unused method getIntegration
      at /Users/dimannich/Desktop/code/sentry-dart/flutter/test/integrations/flutter_error_integration_test.dart:219:3

flutter/test/integrations/load_contexts_integration_test.dart:
    ⚠ unused method getIntegration
      at /Users/dimannich/Desktop/code/sentry-dart/flutter/test/integrations/load_contexts_integration_test.dart:46:3

flutter/test/integrations/native_sdk_integration_test.dart:
    ⚠ unused method getIntegration
      at /Users/dimannich/Desktop/code/sentry-dart/flutter/test/integrations/native_sdk_integration_test.dart:101:3

flutter/test/integrations/widgets_flutter_binding_integration_test.dart:
    ⚠ unused method getIntegration
      at /Users/dimannich/Desktop/code/sentry-dart/flutter/test/integrations/widgets_flutter_binding_integration_test.dart:53:3

flutter/test/mocks.dart:
    ⚠ unused constructor MockPlatform.fuchsia
      at /Users/dimannich/Desktop/code/sentry-dart/flutter/test/mocks.dart:77:3

flutter/test/mocks.mocks.dart:
    ⚠ unused constructor MockSentryNative
      at /Users/dimannich/Desktop/code/sentry-dart/flutter/test/mocks.mocks.dart:494:3
    ⚠ unused class MockSentryNative
      at /Users/dimannich/Desktop/code/sentry-dart/flutter/test/mocks.mocks.dart:490:1

flutter/test/sentry_navigator_observer_test.dart:
    ⚠ unused method mockContext
      at /Users/dimannich/Desktop/code/sentry-dart/flutter/test/sentry_navigator_observer_test.dart:750:3

✖ total unused code (classes, functions, variables, extensions, enums, mixins and type aliases) - 11
```

**Note:** I've removed only some reported code, anything above is not touched. If you consider anything above worth removing, please let me know and I'll update the PR.

## :green_heart: How did you test it?
With `dcm`.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps

Waiting for your feedback / comments 🙂.
