### PR TITLE
Log errors from PlatformDispatcher

### DIFF
--- a/flutter/lib/src/integrations/on_error_integration.dart
+++ b/flutter/lib/src/integrations/on_error_integration.dart
@@ -43,7 +43,8 @@ class OnErrorIntegration implements Integration<SentryFlutterOptions> {
     _integrationOnError = (Object exception, StackTrace stackTrace) {
       _options!.logger(
         SentryLevel.error,
-        "Uncaught Exception",
+
+        "Uncaught Platform Error",
         logger: 'sentry.platformError',
         exception: exception,
         stackTrace: stackTrace,

--- a/flutter/lib/src/integrations/on_error_integration.dart
+++ b/flutter/lib/src/integrations/on_error_integration.dart
@@ -41,6 +41,14 @@ class OnErrorIntegration implements Integration<SentryFlutterOptions> {
     _defaultOnError = wrapper.onError;
 
     _integrationOnError = (Object exception, StackTrace stackTrace) {
+      _options!.logger(
+        SentryLevel.error,
+        "Uncaught Exception",
+        logger: 'sentry.platformError',
+        exception: exception,
+        stackTrace: stackTrace,
+      );
+
       final handled = _defaultOnError?.call(exception, stackTrace) ?? true;
 
       // As per docs, the app might crash on some platforms

--- a/flutter/lib/src/integrations/on_error_integration.dart
+++ b/flutter/lib/src/integrations/on_error_integration.dart
@@ -41,7 +41,6 @@ class OnErrorIntegration implements Integration<SentryFlutterOptions> {
     _defaultOnError = wrapper.onError;
 
     _integrationOnError = (Object exception, StackTrace stackTrace) {
-
       _options!.logger(
         SentryLevel.error,
         "Uncaught Platform Error",

--- a/flutter/lib/src/integrations/on_error_integration.dart
+++ b/flutter/lib/src/integrations/on_error_integration.dart
@@ -41,9 +41,9 @@ class OnErrorIntegration implements Integration<SentryFlutterOptions> {
     _defaultOnError = wrapper.onError;
 
     _integrationOnError = (Object exception, StackTrace stackTrace) {
+
       _options!.logger(
         SentryLevel.error,
-
         "Uncaught Platform Error",
         logger: 'sentry.platformError',
         exception: exception,


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

This is similar to how the FlutterErrorIntegration prints caught errors.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1255 

## :green_heart: How did you test it?

See demo app at linked issue. After this change, enabling debug on Sentry options makes an error show up in the logs for each error reported by the PlatformDispatcher.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
