### PR TITLE
View hierarchy reads size from RenderBox only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- View hierarchy reads size from RenderBox only ([#1249](https://github.com/getsentry/sentry-dart/pull/1249))
+- View hierarchy reads size from RenderBox only ([#1258](https://github.com/getsentry/sentry-dart/pull/1258))
 
 ## 7.0.0-beta.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- View hierarchy reads size from RenderBox only ([#1249](https://github.com/getsentry/sentry-dart/pull/1249))
+
 ## 7.0.0-beta.1
 
 ### Fixes

--- a/flutter/lib/src/view_hierarchy/sentry_tree_walker.dart
+++ b/flutter/lib/src/view_hierarchy/sentry_tree_walker.dart
@@ -52,13 +52,6 @@ class _TreeWalker {
     bool? visible;
     double? alpha;
 
-    // Widget has to be RenderBox to have a size
-    if (widget is RenderBox) {
-      final size = element.size;
-      width = size?.width;
-      height = size?.height;
-    }
-
     final renderObject = element.renderObject;
     if (renderObject is RenderBox) {
       final offset = renderObject.localToGlobal(Offset.zero);
@@ -69,6 +62,12 @@ class _TreeWalker {
         y = offset.dy;
       }
       // no z axes in 2d
+
+      final size = element.size;
+      if (size != null) {
+        width = size.width;
+        height = size.height;
+      }
     }
 
     if (widget is Visibility) {


### PR DESCRIPTION
## :scroll: Description
View hierarchy reads size from RenderBox only


## :bulb: Motivation and Context
The current check works but only if the widget itself is a RenderBox and not its `renderObject`
https://github.com/getsentry/sentry-dart/pull/1189/files#r1080971333


## :green_heart: How did you test it?
Running and checking the result

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
