### PR TITLE
Try to avoid ConcurrentModificationError by not using a Future.forEach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Try to avoid ConcurrentModificationError by not using a Future.forEach ([#1247](https://github.com/getsentry/sentry-dart/pull/1247))
+
 ### Dependencies
 
 - Bump Android SDK from v6.12.1 to v6.13.0 ([#1250](https://github.com/getsentry/sentry-dart/pull/1250))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Try to avoid ConcurrentModificationError by not using a Future.forEach ([#1247](https://github.com/getsentry/sentry-dart/pull/1247))
+- Try to avoid ConcurrentModificationError by not using a Future.forEach ([#1259](https://github.com/getsentry/sentry-dart/pull/1259))
 
 ### Dependencies
 

--- a/dart/lib/src/sentry_tracer.dart
+++ b/dart/lib/src/sentry_tracer.dart
@@ -87,11 +87,12 @@ class SentryTracer extends ISentrySpan {
 
       // finish unfinished spans otherwise transaction gets dropped
       final spansToBeFinished = _children.where((span) => !span.finished);
-      await Future.forEach(
-          spansToBeFinished,
-          (SentrySpan span) async => await span.finish(
-              status: SpanStatus.deadlineExceeded(),
-              endTimestamp: commonEndTimestamp));
+      for (final span in spansToBeFinished) {
+        await span.finish(
+          status: SpanStatus.deadlineExceeded(),
+          endTimestamp: commonEndTimestamp,
+        );
+      }
 
       var _rootEndTimestamp = commonEndTimestamp;
       if (_trimEnd && children.isNotEmpty) {


### PR DESCRIPTION
## :scroll: Description
Try to avoid ConcurrentModificationError by not using a `Future.forEach`.
I believe that the event loop has a sort of priority queue and maybe the `future` of finishing a late span is actually executed within the items of `forEach` (more priority in the scheduling) hence causing the `ConcurrentModificationError`, this is a hunch, I can't reproduce it either, let's go with a simple for loop for now.


## :bulb: Motivation and Context
Closes https://github.com/getsentry/sentry-dart/issues/1256


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
