### PR TITLE
View hierarchy sets to local instead of global position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - View hierarchy reads size from RenderBox only ([#1258](https://github.com/getsentry/sentry-dart/pull/1258))
+- View hierarchy sets to local instead of global position ([#1258](https://github.com/getsentry/sentry-dart/pull/1258))
 
 ## 7.0.0-beta.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixes
 
 - View hierarchy reads size from RenderBox only ([#1258](https://github.com/getsentry/sentry-dart/pull/1258))
-- View hierarchy sets to local instead of global position ([#1258](https://github.com/getsentry/sentry-dart/pull/1258))
+- View hierarchy sets to local instead of global position ([#1265](https://github.com/getsentry/sentry-dart/pull/1265))
 
 ## 7.0.0-beta.1
 

--- a/flutter/lib/src/view_hierarchy/sentry_tree_walker.dart
+++ b/flutter/lib/src/view_hierarchy/sentry_tree_walker.dart
@@ -54,13 +54,9 @@ class _TreeWalker {
 
     final renderObject = element.renderObject;
     if (renderObject is RenderBox) {
-      final offset = renderObject.localToGlobal(Offset.zero);
-      if (offset.dx > 0) {
-        x = offset.dx;
-      }
-      if (offset.dy > 0) {
-        y = offset.dy;
-      }
+      final offset = renderObject.globalToLocal(Offset.zero);
+      x = offset.dx;
+      y = offset.dy;
       // no z axes in 2d
 
       final size = element.size;

--- a/flutter/lib/src/view_hierarchy/sentry_tree_walker.dart
+++ b/flutter/lib/src/view_hierarchy/sentry_tree_walker.dart
@@ -59,7 +59,12 @@ class _TreeWalker {
       y = offset.dy;
       // no z axes in 2d
 
-      final size = element.size;
+      Size? size;
+      try {
+        size = element.size;
+      } catch (_) {
+        // ignore, can throw FlutterError
+      }
       if (size != null) {
         width = size.width;
         height = size.height;
@@ -73,9 +78,16 @@ class _TreeWalker {
       alpha = widget.opacity;
     }
 
+    int? depth;
+    try {
+      depth = element.depth;
+    } catch (_) {
+      // ignore, can throw FlutterError
+    }
+
     return SentryViewHierarchyElement(
       element.widget.runtimeType.toString(),
-      depth: element.depth,
+      depth: depth,
       identifier: element.widget.key?.toStringValue(),
       width: width,
       height: height,


### PR DESCRIPTION
## :scroll: Description
View hierarchy sets to local instead of global position


## :bulb: Motivation and Context
The position was global but it should be local considering the parent.


## :green_heart: How did you test it?
Debugging and checking the view hierarchy preview

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [X] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
