### PR TITLE
Replace `toImage` with `toImageSync` for Flutter >= 3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+- Replace `toImage` with `toImageSync` for Flutter >= 3.7 ([1268](https://github.com/getsentry/sentry-dart/pull/1268))
+
 ### Fixes
 
 - View hierarchy reads size from RenderBox only ([#1258](https://github.com/getsentry/sentry-dart/pull/1258))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 - Replace `toImage` with `toImageSync` for Flutter >= 3.7 ([1268](https://github.com/getsentry/sentry-dart/pull/1268))
+
 ## 6.21.0
 
 ### Features

--- a/flutter/lib/src/event_processor/screenshot_event_processor.dart
+++ b/flutter/lib/src/event_processor/screenshot_event_processor.dart
@@ -83,12 +83,12 @@ class ScreenshotEventProcessor extends EventProcessor {
     return null;
   }
 
-  FutureOr<ui.Image> _getImage(RenderRepaintBoundary repaintBoundary, double pixelRation) {
+  FutureOr<ui.Image> _getImage(RenderRepaintBoundary repaintBoundary, double pixelRatio) {
     // This one is a hack to use https://api.flutter.dev/flutter/rendering/RenderRepaintBoundary/toImage.html on versions older than 3.7 and https://api.flutter.dev/flutter/rendering/RenderRepaintBoundary/toImageSync.html on versions equal or newer than 3.7
     try {
-      return (repaintBoundary as dynamic).toImageSync(pixelRatio: pixelRation);
+      return (repaintBoundary as dynamic).toImageSync(pixelRatio: pixelRatio);
     } on NoSuchMethodError catch (_) {
-      return repaintBoundary.toImage(pixelRatio: pixelRation);
+      return repaintBoundary.toImage(pixelRatio: pixelRatio);
     }
   }
 }

--- a/flutter/lib/src/event_processor/screenshot_event_processor.dart
+++ b/flutter/lib/src/event_processor/screenshot_event_processor.dart
@@ -86,7 +86,7 @@ class ScreenshotEventProcessor extends EventProcessor {
   FutureOr<ui.Image> _getImage(RenderRepaintBoundary repaintBoundary, double pixelRatio) {
     // This one is a hack to use https://api.flutter.dev/flutter/rendering/RenderRepaintBoundary/toImage.html on versions older than 3.7 and https://api.flutter.dev/flutter/rendering/RenderRepaintBoundary/toImageSync.html on versions equal or newer than 3.7
     try {
-      return (repaintBoundary as dynamic).toImageSync(pixelRatio: pixelRatio);
+      return (repaintBoundary as dynamic).toImageSync(pixelRatio: pixelRatio) as ui.Image;
     } on NoSuchMethodError catch (_) {
       return repaintBoundary.toImage(pixelRatio: pixelRatio);
     }

--- a/flutter/lib/src/event_processor/screenshot_event_processor.dart
+++ b/flutter/lib/src/event_processor/screenshot_event_processor.dart
@@ -83,10 +83,12 @@ class ScreenshotEventProcessor extends EventProcessor {
     return null;
   }
 
-  FutureOr<ui.Image> _getImage(RenderRepaintBoundary repaintBoundary, double pixelRatio) {
+  FutureOr<ui.Image> _getImage(
+      RenderRepaintBoundary repaintBoundary, double pixelRatio) {
     // This one is a hack to use https://api.flutter.dev/flutter/rendering/RenderRepaintBoundary/toImage.html on versions older than 3.7 and https://api.flutter.dev/flutter/rendering/RenderRepaintBoundary/toImageSync.html on versions equal or newer than 3.7
     try {
-      return (repaintBoundary as dynamic).toImageSync(pixelRatio: pixelRatio) as ui.Image;
+      return (repaintBoundary as dynamic).toImageSync(pixelRatio: pixelRatio)
+          as ui.Image;
     } on NoSuchMethodError catch (_) {
       return repaintBoundary.toImage(pixelRatio: pixelRatio);
     }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Closes #1246 

## :green_heart: How did you test it?

Ran example app on Flutter 3.3.x and 3.7.x and checked if triggering error attached a screenshot.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes