### PR TITLE
Implement `loadStructuredBinaryData` from updated AssetBundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Implement `loadStructuredBinaryData` from updated AssetBundle ([#1272](https://github.com/getsentry/sentry-dart/pull/1272))
+
 ### Dependencies
 
 - Bump Android SDK from v6.13.0 to v6.13.1 ([#1273](https://github.com/getsentry/sentry-dart/pull/1273))

--- a/flutter/lib/src/sentry_asset_bundle.dart
+++ b/flutter/lib/src/sentry_asset_bundle.dart
@@ -339,20 +339,24 @@ class SentryAssetBundle implements AssetBundle {
     return _loadStructuredBinaryDataWrapper<T>(key, parser);
   }
 
-  // helper method to have a "typesafe" method
+  // Helper method that emulates the loadStructuredBinaryData method present on
+  // Flutter 3.8 and later, but not on earlier versions. This is equivalent to
+  // the following code:
+  //
+  //   Future<T> loadStructuredBinaryData<T>(
+  //     String key,
+  //     FutureOr<T> Function(ByteData data) parser,
+  //   ) async {
+  //     return (_bundle as dynamic).loadStructuredBinaryData<T>(key, parser) as Future<T>;
+  //   }
+  //
+  // but it works on all Flutter versions. Can be safely refactored back to the
+  // above code once we drop support for Flutter versions < 3.8.
   Future<T> _loadStructuredBinaryDataWrapper<T>(
     String key,
     FutureOr<T> Function(ByteData data) parser,
   ) async {
-    // The loadStructuredBinaryData method exists as of Flutter greater than 3.8
-    // Previous versions don't have it, but later versions do.
-    // We can't use `extends` in order to provide this method because this is
-    // a wrapper and thus the method call must be forwarded.
-    // On Flutter versions <=3.8 we can't forward this call.
-    // On later version the call gets correctly forwarded.
-    // The error doesn't need to handled since it can't be called on earlier versions,
-    // and it's correctly forwarded on later versions.
-    return (_bundle as dynamic).loadStructuredBinaryData<T>(key, parser)
-        as Future<T>;
+    final ByteData data = await load(key);
+    return parser(data);
   }
 }

--- a/flutter/lib/src/sentry_asset_bundle.dart
+++ b/flutter/lib/src/sentry_asset_bundle.dart
@@ -339,24 +339,20 @@ class SentryAssetBundle implements AssetBundle {
     return _loadStructuredBinaryDataWrapper<T>(key, parser);
   }
 
-  // Helper method that emulates the loadStructuredBinaryData method present on
-  // Flutter 3.8 and later, but not on earlier versions. This is equivalent to
-  // the following code:
-  //
-  //   Future<T> loadStructuredBinaryData<T>(
-  //     String key,
-  //     FutureOr<T> Function(ByteData data) parser,
-  //   ) async {
-  //     return (_bundle as dynamic).loadStructuredBinaryData<T>(key, parser) as Future<T>;
-  //   }
-  //
-  // but it works on all Flutter versions. Can be safely refactored back to the
-  // above code once we drop support for Flutter versions < 3.8.
+  // helper method to have a "typesafe" method
   Future<T> _loadStructuredBinaryDataWrapper<T>(
     String key,
     FutureOr<T> Function(ByteData data) parser,
   ) async {
-    final ByteData data = await load(key);
-    return parser(data);
+    // The loadStructuredBinaryData method exists as of Flutter greater than 3.8
+    // Previous versions don't have it, but later versions do.
+    // We can't use `extends` in order to provide this method because this is
+    // a wrapper and thus the method call must be forwarded.
+    // On Flutter versions <=3.8 we can't forward this call.
+    // On later version the call gets correctly forwarded.
+    // The error doesn't need to handled since it can't be called on earlier versions,
+    // and it's correctly forwarded on later versions.
+    return (_bundle as dynamic).loadStructuredBinaryData<T>(key, parser)
+        as Future<T>;
   }
 }

--- a/flutter/test/sentry_asset_bundle_test.dart
+++ b/flutter/test/sentry_asset_bundle_test.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: invalid_use_of_internal_member
 // The lint above is okay, because we're using another Sentry package
+import 'dart:async';
 import 'dart:convert';
 // backcompatibility for Flutter < 3.3
 // ignore: unnecessary_import
@@ -544,6 +545,20 @@ class Fixture {
 class TestAssetBundle extends CachingAssetBundle {
   bool throwException = false;
   String? evictKey;
+
+  @override
+  // ignore: override_on_non_overriding_member
+  Future<T> loadStructuredBinaryData<T>(
+      String key, FutureOr<T> Function(ByteData data) parser) async {
+    if (throwException) {
+      throw Exception('exception thrown for testing purposes');
+    }
+    if (key == _testFileName) {
+      return parser(ByteData.view(
+          Uint8List.fromList(utf8.encode('Hello World!')).buffer));
+    }
+    return parser(ByteData(0));
+  }
 
   @override
   Future<ByteData> load(String key) async {

--- a/flutter/test/sentry_asset_bundle_test.dart
+++ b/flutter/test/sentry_asset_bundle_test.dart
@@ -334,7 +334,7 @@ void main() {
     );
 
     test(
-      'loadStructuredBinaryData: does not create any spans and just forwords the call to the underlying assetbundle if disabled',
+      'loadStructuredBinaryData: does not create any spans and just forwards the call to the underlying assetbundle if disabled',
       () async {
         final sut = fixture.getSut(structuredDataTracing: false);
         final tr = fixture._hub.startTransaction(
@@ -355,7 +355,7 @@ void main() {
 
         final tracer = (tr as SentryTracer);
 
-        expect(tracer.children.length, 0);
+        expect(tracer.children.length, 1);
       },
     );
 
@@ -417,7 +417,7 @@ void main() {
         final tracer = (tr as SentryTracer);
         var span = tracer.children.first;
 
-        expect(tracer.children.length, 2);
+        expect(tracer.children.length, 3);
 
         expect(span.status, SpanStatus.internalError());
         expect(span.finished, true);
@@ -428,7 +428,7 @@ void main() {
           'AssetBundle.loadStructuredBinaryData<String>: test.txt',
         );
 
-        span = tracer.children[1];
+        span = tracer.children.last;
 
         expect(span.status, SpanStatus.internalError());
         expect(span.finished, true);
@@ -463,7 +463,7 @@ void main() {
         final tracer = (tr as SentryTracer);
         var span = tracer.children.first;
 
-        expect(tracer.children.length, 2);
+        expect(tracer.children.length, 3);
 
         expect(span.status, SpanStatus.ok());
         expect(span.finished, true);
@@ -473,7 +473,7 @@ void main() {
           'AssetBundle.loadStructuredBinaryData<String>: test.txt',
         );
 
-        span = tracer.children[1];
+        span = tracer.children.last;
 
         expect(span.status, SpanStatus.ok());
         expect(span.finished, true);

--- a/flutter/test/sentry_asset_bundle_test.dart
+++ b/flutter/test/sentry_asset_bundle_test.dart
@@ -334,7 +334,7 @@ void main() {
     );
 
     test(
-      'loadStructuredBinaryData: does not create any spans and just forwards the call to the underlying assetbundle if disabled',
+      'loadStructuredBinaryData: does not create any spans and just forwords the call to the underlying assetbundle if disabled',
       () async {
         final sut = fixture.getSut(structuredDataTracing: false);
         final tr = fixture._hub.startTransaction(
@@ -355,7 +355,7 @@ void main() {
 
         final tracer = (tr as SentryTracer);
 
-        expect(tracer.children.length, 1);
+        expect(tracer.children.length, 0);
       },
     );
 
@@ -417,7 +417,7 @@ void main() {
         final tracer = (tr as SentryTracer);
         var span = tracer.children.first;
 
-        expect(tracer.children.length, 3);
+        expect(tracer.children.length, 2);
 
         expect(span.status, SpanStatus.internalError());
         expect(span.finished, true);
@@ -428,7 +428,7 @@ void main() {
           'AssetBundle.loadStructuredBinaryData<String>: test.txt',
         );
 
-        span = tracer.children.last;
+        span = tracer.children[1];
 
         expect(span.status, SpanStatus.internalError());
         expect(span.finished, true);
@@ -463,7 +463,7 @@ void main() {
         final tracer = (tr as SentryTracer);
         var span = tracer.children.first;
 
-        expect(tracer.children.length, 3);
+        expect(tracer.children.length, 2);
 
         expect(span.status, SpanStatus.ok());
         expect(span.finished, true);
@@ -473,7 +473,7 @@ void main() {
           'AssetBundle.loadStructuredBinaryData<String>: test.txt',
         );
 
-        span = tracer.children.last;
+        span = tracer.children[1];
 
         expect(span.status, SpanStatus.ok());
         expect(span.finished, true);


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Implements `loadStructuredBinaryData`, which is a new method added to Flutter's abstract AssetBundle class in flutter/flutter#119277.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change has to be included in order to support what is now the master channel of Flutter and what will hit stable down the road.

## :green_heart: How did you test it?
Duped and tweaked the tests for `loadStructuredData`.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
