### PR TITLE
Set client name with version in sentry-android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Set client name with version in Android SDK ([#1274](https://github.com/getsentry/sentry-dart/pull/1274))
+
 ## 7.0.0-beta.4
 
 ### Features
@@ -17,7 +23,6 @@
 - Bump Android SDK from v6.12.1 to v6.13.0 ([#1250](https://github.com/getsentry/sentry-dart/pull/1250))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#6130)
   - [diff](https://github.com/getsentry/sentry-java/compare/6.12.1...6.13.0)
-- Set client name with version in Android SDK ([#1274](https://github.com/getsentry/sentry-dart/pull/1274))
 
 ## 7.0.0-beta.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - View hierarchy reads size from RenderBox only ([#1258](https://github.com/getsentry/sentry-dart/pull/1258))
+- Set client name with version in Android SDK ([#1274](https://github.com/getsentry/sentry-dart/pull/1274))
 
 ## 7.0.0-beta.1
 

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -169,7 +169,7 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         val version = sdk["version"] as? String
         if (name != null && version != null) {
           val sdkVersion = SdkVersion(name, version)
-          options.setSentryClientName(name)
+          options.setSentryClientName(name + "/" + version)
           options.setSdkVersion(sdkVersion)
         }
       }

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -169,7 +169,7 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         val version = sdk["version"] as? String
         if (name != null && version != null) {
           val sdkVersion = SdkVersion(name, version)
-          options.setSentryClientName(name + "/" + version)
+          options.setSentryClientName("$name/$version")
           options.setSdkVersion(sdkVersion)
         }
       }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
`sentry_client` should include the version
https://develop.sentry.dev/sdk/overview/#authentication

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- https://github.com/getsentry/team-mobile/issues/48

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
