### PR TITLE
Enable enableNdkScopeSync by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+- Enable enableNdkScopeSync by default ([#1276](https://github.com/getsentry/sentry-dart/pull/1276))
+
 ## 6.21.0
 
 ### Features
@@ -24,10 +28,6 @@
 ### Fixes
 
 - Set client name with version in Android SDK ([#1274](https://github.com/getsentry/sentry-dart/pull/1274))
-
-### Breaking Changes
-
-- Enable enableNdkScopeSync by default ([#1276](https://github.com/getsentry/sentry-dart/pull/1276))
 
 ## 7.0.0-beta.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Breaking Changes
 
-- Enable enableNdkScopeSync by default ([#1274](https://github.com/getsentry/sentry-dart/pull/1274))
+- Enable enableNdkScopeSync by default ([#1276](https://github.com/getsentry/sentry-dart/pull/1276))
 
 ## 7.0.0-beta.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### Fixes
 
-- Enable enableNdkScopeSync by default ([#1274](https://github.com/getsentry/sentry-dart/pull/1274))
+- Set client name with version in Android SDK ([#1274](https://github.com/getsentry/sentry-dart/pull/1274))
 
 ### Breaking Changes
 
-- Rename APM tracking feature flags to tracing ([#1222](https://github.com/getsentry/sentry-dart/pull/1222))
+- Enable enableNdkScopeSync by default ([#1274](https://github.com/getsentry/sentry-dart/pull/1274))
 
 ## 7.0.0-beta.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### Fixes
 
-- Set client name with version in Android SDK ([#1274](https://github.com/getsentry/sentry-dart/pull/1274))
+- Enable enableNdkScopeSync by default ([#1274](https://github.com/getsentry/sentry-dart/pull/1274))
+
+### Breaking Changes
+
+- Rename APM tracking feature flags to tracing ([#1222](https://github.com/getsentry/sentry-dart/pull/1222))
 
 ## 7.0.0-beta.4
 

--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -49,7 +49,6 @@ Future<void> setupSentry(AppRunner appRunner, String dsn) async {
     options.addIntegration(LoggingIntegration());
     options.sendDefaultPii = true;
     options.reportSilentFlutterErrors = true;
-    options.enableNdkScopeSync = true;
     options.attachScreenshot = true;
     options.attachViewHierarchy = true;
     // We can enable Sentry debug logging during development. This is likely

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -144,7 +144,7 @@ class SentryFlutterOptions extends SentryOptions {
 
   /// Enable scope sync from Java to NDK.
   /// Only available on Android.
-  bool enableNdkScopeSync = false;
+  bool enableNdkScopeSync = true;
 
   /// Enable auto performance tracking by default.
   bool enableAutoPerformanceTracing = true;

--- a/flutter/test/integrations/init_native_sdk_integration_test.dart
+++ b/flutter/test/integrations/init_native_sdk_integration_test.dart
@@ -90,7 +90,6 @@ void main() {
         ..maxCacheItems = 0
         ..sendDefaultPii = true
         ..enableWatchdogTerminationTracking = false
-        ..enableNdkScopeSync = true
         ..enableAutoPerformanceTracing = false
         ..sendClientReports = false;
 

--- a/flutter/test/integrations/init_native_sdk_integration_test.dart
+++ b/flutter/test/integrations/init_native_sdk_integration_test.dart
@@ -53,7 +53,7 @@ void main() {
         'maxCacheItems': 30,
         'sendDefaultPii': false,
         'enableWatchdogTerminationTracking': true,
-        'enableNdkScopeSync': false,
+        'enableNdkScopeSync': true,
         'enableAutoPerformanceTracing': true,
         'sendClientReports': true,
         'sdk': {

--- a/min_version_test/lib/main.dart
+++ b/min_version_test/lib/main.dart
@@ -35,7 +35,6 @@ Future<void> setupSentry(AppRunner appRunner) async {
     options.addIntegration(LoggingIntegration());
     options.sendDefaultPii = true;
     options.reportSilentFlutterErrors = true;
-    options.enableNdkScopeSync = true;
     options.attachScreenshot = true;
     options.attachViewHierarchy = true;
     // We can enable Sentry debug logging during development. This is likely


### PR DESCRIPTION
## :scroll: Description
`enableNdkScopeSync` enabled by default


## :bulb: Motivation and Context
This is a feature that should be enabled by default.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [X] [I updated the docs if needed](https://github.com/getsentry/sentry-docs/pull/6402)
- [X] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
