### PR TITLE
Update `sentry_dio` to dio 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 
 - Update `sentry_dio` to dio v5 ([#1282](https://github.com/getsentry/sentry-dart/pull/1282))
+
 ### Dependencies
 
 - Bump Android SDK from v6.13.1 to v6.14.0 ([#1287](https://github.com/getsentry/sentry-dart/pull/1287))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Fixes
 
 - Set client name with version in Android SDK ([#1274](https://github.com/getsentry/sentry-dart/pull/1274))
+
+### Breaking Changes
+
 - Update `sentry_dio` to dio v5 ([#1282](https://github.com/getsentry/sentry-dart/pull/1282))
 
 ## 7.0.0-beta.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Set client name with version in Android SDK ([#1274](https://github.com/getsentry/sentry-dart/pull/1274))
+- Update `sentry_dio` to dio v5 ([#1282](https://github.com/getsentry/sentry-dart/pull/1282))
 
 ## 7.0.0-beta.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+- Update `sentry_dio` to dio v5 ([#1282](https://github.com/getsentry/sentry-dart/pull/1282))
+
 ## 6.21.0
 
 ### Features
@@ -24,10 +28,6 @@
 ### Fixes
 
 - Set client name with version in Android SDK ([#1274](https://github.com/getsentry/sentry-dart/pull/1274))
-
-### Breaking Changes
-
-- Update `sentry_dio` to dio v5 ([#1282](https://github.com/getsentry/sentry-dart/pull/1282))
 
 ## 7.0.0-beta.4
 

--- a/dio/lib/src/breadcrumb_client_adapter.dart
+++ b/dio/lib/src/breadcrumb_client_adapter.dart
@@ -11,7 +11,7 @@ import 'package:sentry/sentry.dart';
 /// Remarks:
 /// If this client is used as a wrapper, a call to close also closes the
 /// given client.
-class BreadcrumbClientAdapter extends HttpClientAdapter {
+class BreadcrumbClientAdapter implements HttpClientAdapter {
   // ignore: public_member_api_docs
   BreadcrumbClientAdapter({required HttpClientAdapter client, Hub? hub})
       : _hub = hub ?? HubAdapter(),

--- a/dio/lib/src/sentry_dio_client_adapter.dart
+++ b/dio/lib/src/sentry_dio_client_adapter.dart
@@ -20,7 +20,7 @@ import 'breadcrumb_client_adapter.dart';
 /// Remarks:
 /// HTTP traffic can contain PII (personal identifiable information).
 /// Read more on data scrubbing [here](https://docs.sentry.io/product/data-management-settings/advanced-datascrubbing/).
-class SentryDioClientAdapter extends HttpClientAdapter {
+class SentryDioClientAdapter implements HttpClientAdapter {
   // ignore: public_member_api_docs
   SentryDioClientAdapter({
     required HttpClientAdapter client,

--- a/dio/lib/src/tracing_client_adapter.dart
+++ b/dio/lib/src/tracing_client_adapter.dart
@@ -8,7 +8,7 @@ import 'package:sentry/sentry.dart';
 /// A [Dio](https://pub.dev/packages/dio)-package compatible HTTP client adapter
 /// which adds support to Sentry Performance feature.
 /// https://develop.sentry.dev/sdk/performance
-class TracingClientAdapter extends HttpClientAdapter {
+class TracingClientAdapter implements HttpClientAdapter {
   // ignore: public_member_api_docs
   TracingClientAdapter({required HttpClientAdapter client, Hub? hub})
       : _hub = hub ?? HubAdapter(),
@@ -54,7 +54,7 @@ class TracingClientAdapter extends HttpClientAdapter {
       }
 
       response = await _client.fetch(options, requestStream, cancelFuture);
-      span?.status = SpanStatus.fromHttpStatusCode(response.statusCode ?? -1);
+      span?.status = SpanStatus.fromHttpStatusCode(response.statusCode);
     } catch (exception) {
       span?.throwable = exception;
       span?.status = const SpanStatus.internalError();

--- a/dio/pubspec.yaml
+++ b/dio/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: '>=2.17.0 <4.0.0'
 
 dependencies:
-  dio: ^4.0.0
+  dio: ^5.0.0
   sentry: 7.0.0-beta.4
 
 dev_dependencies:

--- a/dio/test/breadcrumb_client_adapter_test.dart
+++ b/dio/test/breadcrumb_client_adapter_test.dart
@@ -98,7 +98,7 @@ void main() {
         await sut.get<dynamic>('/');
         fail('Method did not throw');
       } on DioError catch (e) {
-        expect(e.message, 'Exception: test');
+        expect(e.error.toString(), 'Exception: test');
         expect(e.requestOptions.uri, Uri.parse('https://example.com/'));
       }
 

--- a/dio/test/dio_error_extractor_test.dart
+++ b/dio/test/dio_error_extractor_test.dart
@@ -17,7 +17,8 @@ void main() {
     final dioError = DioError(
       error: exception,
       requestOptions: RequestOptions(path: '/foo/bar'),
-    )..stackTrace = stacktrace;
+      stackTrace: stacktrace,
+    );
 
     final cause = sut.cause(dioError);
 
@@ -31,7 +32,8 @@ void main() {
 
     final dioError = DioError(
       requestOptions: RequestOptions(path: '/foo/bar'),
-    )..stackTrace = stacktrace;
+      stackTrace: stacktrace,
+    );
 
     final cause = sut.cause(dioError);
 

--- a/dio/test/dio_event_processor_test.dart
+++ b/dio/test/dio_event_processor_test.dart
@@ -75,7 +75,6 @@ void main() {
       expect(processedEvent.request?.queryString, 'foo=bar');
       expect(processedEvent.request?.headers, <String, String>{
         'foo': 'bar',
-        'content-type': 'application/json; charset=utf-8'
       });
       expect(processedEvent.request?.data, 'foobar');
     });

--- a/dio/test/dio_event_processor_test.dart
+++ b/dio/test/dio_event_processor_test.dart
@@ -195,7 +195,8 @@ void main() {
     final dioError = DioError(
       error: exception,
       requestOptions: requestOptions,
-    )..stackTrace = StackTrace.current;
+      stackTrace: StackTrace.current,
+    );
 
     final extracted =
         fixture.exceptionFactory.extractor.flatten(dioError, null);

--- a/dio/test/mocks/mock_http_client_adapter.dart
+++ b/dio/test/mocks/mock_http_client_adapter.dart
@@ -12,8 +12,9 @@ typedef MockFetchMethod = Future<ResponseBody> Function(
 
 typedef MockCloseMethod = void Function({bool force});
 
-class MockHttpClientAdapter extends HttpClientAdapter
-    with NoSuchMethodProvider {
+class MockHttpClientAdapter
+    with NoSuchMethodProvider
+    implements HttpClientAdapter {
   MockHttpClientAdapter(this.mockFetchMethod, {this.mockCloseMethod});
 
   final MockFetchMethod mockFetchMethod;

--- a/flutter/example/pubspec.yaml
+++ b/flutter/example/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   universal_platform: ^1.0.0
   feedback: ^2.0.0
   provider: ^6.0.0
-  dio: ^4.0.0
+  dio: any # This gets constrained by `sentry_dio`
   logging: ^1.0.0
   package_info_plus: ^3.0.0
   path_provider: ^2.0.0

--- a/min_version_test/pubspec.yaml
+++ b/min_version_test/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
   sentry_flutter:
   sentry_dio:
   sentry_logging:
-  dio: ^4.0.0
+  dio: any # This gets constrained by `sentry_dio`
   logging: ^1.0.0
 
 dev_dependencies:


### PR DESCRIPTION
## :scroll: Description

Dio changed in ownership to the guys behind diox, which previously was forked from dio.
Since the ownership changed, they've published diox v5 also as dio v5.
This PR makes the necessary changes to be compatible.

## :bulb: Motivation and Context
Compatibility with dio v5


## :green_heart: How did you test it?
Tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
