### PR TITLE
Support `failedRequestTargets` for HTTP Client errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+- Support failedRequestTargets for HTTP Client errors ([#1285](https://github.com/getsentry/sentry-dart/pull/1285))
+  - Captures errors for the default range `500-599` if `captureFailedRequests` is enabled
+
 ### Fixes
 
 - Set client name with version in Android SDK ([#1274](https://github.com/getsentry/sentry-dart/pull/1274))
@@ -12,11 +17,6 @@
 
 - Support beforeSendTransaction ([#1238](https://github.com/getsentry/sentry-dart/pull/1238))
 - Add In Foreground to App context ([#1260](https://github.com/getsentry/sentry-dart/pull/1260))
-
-### Breaking Changes
-
-- Support failedRequestTargets for HTTP Client errors ([#1285](https://github.com/getsentry/sentry-dart/pull/1285))
-  - Captures errors for the default range `500-599` if `captureFailedRequests` is enabled
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Support failedRequestTargets for HTTP Client errors ([#1285](https://github.com/getsentry/sentry-dart/pull/1285))
   - Captures errors for the default range `500-599` if `captureFailedRequests` is enabled
+
 ## 6.21.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-### Breaking Changes
+### Feature
 
 - Support failedRequestTargets for HTTP Client errors ([#1285](https://github.com/getsentry/sentry-dart/pull/1285))
   - Captures errors for the default range `500-599` if `captureFailedRequests` is enabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - Add In Foreground to App context ([#1260](https://github.com/getsentry/sentry-dart/pull/1260))
 
+### Breaking Changes
+
+- Support failedRequestTargets for HTTP Client errors ([#1285](https://github.com/getsentry/sentry-dart/pull/1285))
+  - Captures errors for the default range `500-599` if `captureFailedRequests` is enabled
+
 ### Fixes
 
 - View hierarchy reads size from RenderBox only ([#1258](https://github.com/getsentry/sentry-dart/pull/1258))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,10 @@
 
 ## Unreleased
 
-### Feature
+### Features
 
 - Support failedRequestTargets for HTTP Client errors ([#1285](https://github.com/getsentry/sentry-dart/pull/1285))
   - Captures errors for the default range `500-599` if `captureFailedRequests` is enabled
-### Features
-
 - Sentry Isolate Extension ([#1266](https://github.com/getsentry/sentry-dart/pull/1266))
 - Allow sentry user to control resolution of captured Flutter screenshots ([#1288](https://github.com/getsentry/sentry-dart/pull/1288))
 

--- a/dart/lib/src/http_client/failed_request_client.dart
+++ b/dart/lib/src/http_client/failed_request_client.dart
@@ -139,7 +139,7 @@ class FailedRequestClient extends BaseClient {
       if (!failedRequestStatusCodes.containsStatusCode(statusCode)) {
         return;
       }
-      if (!containsTracePropagationTarget(
+      if (!containsTargetOrMatchesRegExp(
           failedRequestTargets, request.url.toString())) {
         return;
       }

--- a/dart/lib/src/http_client/failed_request_client.dart
+++ b/dart/lib/src/http_client/failed_request_client.dart
@@ -1,7 +1,7 @@
 import 'package:http/http.dart';
-import '../../sentry.dart';
 import '../hint.dart';
 import '../type_check_hint.dart';
+import '../utils/tracing_utils.dart';
 import 'sentry_http_client_error.dart';
 import '../protocol.dart';
 import '../hub.dart';

--- a/dart/lib/src/http_client/failed_request_client.dart
+++ b/dart/lib/src/http_client/failed_request_client.dart
@@ -31,8 +31,6 @@ import 'sentry_http_client.dart';
 /// );
 /// ```
 ///
-///
-///
 /// Remarks:
 /// If this client is used as a wrapper, a call to close also closes the
 /// given client.

--- a/dart/lib/src/http_client/failed_request_client.dart
+++ b/dart/lib/src/http_client/failed_request_client.dart
@@ -31,6 +31,8 @@ import 'sentry_http_client.dart';
 /// );
 /// ```
 ///
+///
+///
 /// Remarks:
 /// If this client is used as a wrapper, a call to close also closes the
 /// given client.
@@ -69,7 +71,7 @@ import 'sentry_http_client.dart';
 class FailedRequestClient extends BaseClient {
   FailedRequestClient({
     this.failedRequestStatusCodes = const [SentryStatusCode.defaultRange()],
-    this.failedRequestTargets = const [".*"],
+    this.failedRequestTargets = const ['.*'],
     Client? client,
     Hub? hub,
   })  : _hub = hub ?? HubAdapter(),

--- a/dart/lib/src/http_client/failed_request_client.dart
+++ b/dart/lib/src/http_client/failed_request_client.dart
@@ -68,8 +68,9 @@ import 'sentry_http_client.dart';
 /// ```
 class FailedRequestClient extends BaseClient {
   FailedRequestClient({
-    this.failedRequestStatusCodes = const [SentryStatusCode.defaultRange()],
-    this.failedRequestTargets = const ['.*'],
+    this.failedRequestStatusCodes =
+        SentryHttpClient.defaultFailedRequestStatusCodes,
+    this.failedRequestTargets = SentryHttpClient.defaultFailedRequestTargets,
     Client? client,
     Hub? hub,
   })  : _hub = hub ?? HubAdapter(),

--- a/dart/lib/src/http_client/sentry_http_client.dart
+++ b/dart/lib/src/http_client/sentry_http_client.dart
@@ -23,6 +23,19 @@ import 'failed_request_client.dart';
 /// );
 /// ```
 ///
+/// If empty request status codes are provided, all failure requests will be
+/// captured. Per default, codes in the range 500-599 are recorded.
+///
+/// If you provide failed request targets, rhe SDK will only capture HTTP
+/// Client errors if the HTTP Request URL is a match for any of the provided
+/// targets.
+///
+/// ```dart
+/// var client = SentryHttpClient(
+///   failedRequestTargets: ['my-api.com'],
+/// );
+/// ```
+///
 /// Remarks: If this client is used as a wrapper, a call to close also closes
 /// the given client.
 ///

--- a/dart/lib/src/http_client/sentry_http_client.dart
+++ b/dart/lib/src/http_client/sentry_http_client.dart
@@ -118,12 +118,12 @@ class SentryHttpClient extends BaseClient {
 }
 
 class SentryStatusCode {
-  static const defaultMin = 500;
-  static const defaultMax = 599;
+  static const _defaultMin = 500;
+  static const _defaultMax = 599;
 
   const SentryStatusCode.defaultRange()
-      : _min = defaultMin,
-        _max = defaultMax;
+      : _min = _defaultMin,
+        _max = _defaultMax;
 
   SentryStatusCode.range(this._min, this._max)
       : assert(_min <= _max),

--- a/dart/lib/src/http_client/sentry_http_client.dart
+++ b/dart/lib/src/http_client/sentry_http_client.dart
@@ -105,6 +105,13 @@ class SentryHttpClient extends BaseClient {
 }
 
 class SentryStatusCode {
+  static const defaultMin = 500;
+  static const defaultMax = 599;
+
+  const SentryStatusCode.defaultRange()
+      : _min = defaultMin,
+        _max = defaultMax;
+
   SentryStatusCode.range(this._min, this._max)
       : assert(_min <= _max),
         assert(_min > 0 && _max > 0);

--- a/dart/lib/src/http_client/sentry_http_client.dart
+++ b/dart/lib/src/http_client/sentry_http_client.dart
@@ -26,7 +26,7 @@ import 'failed_request_client.dart';
 /// If empty request status codes are provided, all failure requests will be
 /// captured. Per default, codes in the range 500-599 are recorded.
 ///
-/// If you provide failed request targets, rhe SDK will only capture HTTP
+/// If you provide failed request targets, the SDK will only capture HTTP
 /// Client errors if the HTTP Request URL is a match for any of the provided
 /// targets.
 ///

--- a/dart/lib/src/http_client/sentry_http_client.dart
+++ b/dart/lib/src/http_client/sentry_http_client.dart
@@ -75,10 +75,17 @@ import 'failed_request_client.dart';
 /// Read more on data scrubbing [here](https://docs.sentry.io/product/data-management-settings/advanced-datascrubbing/).
 /// ```
 class SentryHttpClient extends BaseClient {
+  static const defaultFailedRequestStatusCodes = [
+    SentryStatusCode.defaultRange()
+  ];
+  static const defaultFailedRequestTargets = ['.*'];
+
   SentryHttpClient({
     Client? client,
     Hub? hub,
-    List<SentryStatusCode> failedRequestStatusCodes = const [],
+    List<SentryStatusCode> failedRequestStatusCodes =
+        defaultFailedRequestStatusCodes,
+    List<String> failedRequestTargets = defaultFailedRequestTargets,
   }) {
     _hub = hub ?? HubAdapter();
 
@@ -86,6 +93,7 @@ class SentryHttpClient extends BaseClient {
 
     innerClient = FailedRequestClient(
       failedRequestStatusCodes: failedRequestStatusCodes,
+      failedRequestTargets: failedRequestTargets,
       hub: _hub,
       client: innerClient,
     );

--- a/dart/lib/src/http_client/tracing_client.dart
+++ b/dart/lib/src/http_client/tracing_client.dart
@@ -33,7 +33,7 @@ class TracingClient extends BaseClient {
     StreamedResponse? response;
     try {
       if (span != null) {
-        if (containsTracePropagationTarget(
+        if (containsTargetOrMatchesRegExp(
             _hub.options.tracePropagationTargets, request.url.toString())) {
           addSentryTraceHeader(span, request.headers);
           addBaggageHeader(

--- a/dart/lib/src/utils/tracing_utils.dart
+++ b/dart/lib/src/utils/tracing_utils.dart
@@ -40,7 +40,7 @@ void addBaggageHeader(
   }
 }
 
-bool containsTracePropagationTarget(
+bool containsTargetOrMatchesRegExp(
     List<String> tracePropagationTargets, String url) {
   if (tracePropagationTargets.isEmpty) {
     return false;

--- a/dart/test/utils/tracing_utils_test.dart
+++ b/dart/test/utils/tracing_utils_test.dart
@@ -6,48 +6,48 @@ import '../mocks.dart';
 import '../mocks/mock_sentry_client.dart';
 
 void main() {
-  group('$containsTracePropagationTarget', () {
+  group('$containsTargetOrMatchesRegExp', () {
     final origins = ['localhost', '^(http|https)://api\\..*\$'];
 
     test('origins contains the url when it contains one of the defined origins',
         () {
       expect(
-          containsTracePropagationTarget(origins, 'http://localhost:8080/foo'),
+          containsTargetOrMatchesRegExp(origins, 'http://localhost:8080/foo'),
           isTrue);
       expect(
-          containsTracePropagationTarget(
+          containsTargetOrMatchesRegExp(
               origins, 'http://xxx.localhost:8080/foo'),
           isTrue);
     });
 
     test('origins contain the url when it matches regex', () {
       expect(
-          containsTracePropagationTarget(
+          containsTargetOrMatchesRegExp(
               origins, 'http://api.foo.bar:8080/foo'),
           isTrue);
       expect(
-          containsTracePropagationTarget(
+          containsTargetOrMatchesRegExp(
               origins, 'https://api.foo.bar:8080/foo'),
           isTrue);
       expect(
-          containsTracePropagationTarget(
+          containsTargetOrMatchesRegExp(
               origins, 'http://api.localhost:8080/foo'),
           isTrue);
       expect(
-          containsTracePropagationTarget(origins, 'ftp://api.foo.bar:8080/foo'),
+          containsTargetOrMatchesRegExp(origins, 'ftp://api.foo.bar:8080/foo'),
           isFalse);
     });
 
     test('invalid regex do not throw', () {
       expect(
-          containsTracePropagationTarget(
+          containsTargetOrMatchesRegExp(
               ['AABB???', '^(http|https)://api\\..*\$'],
               'http://api.foo.bar:8080/foo'),
           isTrue);
     });
 
     test('when no origins are defined, returns false for every url', () {
-      expect(containsTracePropagationTarget([], 'api.foo.com'), isFalse);
+      expect(containsTargetOrMatchesRegExp([], 'api.foo.com'), isFalse);
     });
   });
 

--- a/dart/test/utils/tracing_utils_test.dart
+++ b/dart/test/utils/tracing_utils_test.dart
@@ -22,8 +22,7 @@ void main() {
 
     test('origins contain the url when it matches regex', () {
       expect(
-          containsTargetOrMatchesRegExp(
-              origins, 'http://api.foo.bar:8080/foo'),
+          containsTargetOrMatchesRegExp(origins, 'http://api.foo.bar:8080/foo'),
           isTrue);
       expect(
           containsTargetOrMatchesRegExp(

--- a/dio/lib/src/failed_request_interceptor.dart
+++ b/dio/lib/src/failed_request_interceptor.dart
@@ -29,7 +29,9 @@ class FailedRequestInterceptor extends Interceptor {
     final containsStatusCode =
         _failedRequestStatusCodes.containsStatusCode(err.response?.statusCode);
     final containsRequestTarget = containsTargetOrMatchesRegExp(
-        _failedRequestTargets, err.requestOptions.path);
+      _failedRequestTargets,
+      err.requestOptions.path,
+    );
 
     if (captureFailedRequests && containsStatusCode && containsRequestTarget) {
       final mechanism = Mechanism(type: 'SentryDioClientAdapter');

--- a/dio/lib/src/failed_request_interceptor.dart
+++ b/dio/lib/src/failed_request_interceptor.dart
@@ -4,9 +4,10 @@ import 'package:dio/dio.dart';
 import 'package:sentry/sentry.dart';
 
 class FailedRequestInterceptor extends Interceptor {
-  FailedRequestInterceptor(
-      {Hub? hub, List<SentryStatusCode> failedRequestStatusCodes = const []})
-      : _hub = hub ?? HubAdapter(),
+  FailedRequestInterceptor({
+    Hub? hub,
+    List<SentryStatusCode> failedRequestStatusCodes = const [],
+  })  : _hub = hub ?? HubAdapter(),
         _failedRequestStatusCodes = failedRequestStatusCodes;
 
   final Hub _hub;

--- a/dio/lib/src/failed_request_interceptor.dart
+++ b/dio/lib/src/failed_request_interceptor.dart
@@ -28,7 +28,7 @@ class FailedRequestInterceptor extends Interceptor {
 
     final containsStatusCode =
         _failedRequestStatusCodes.containsStatusCode(err.response?.statusCode);
-    final containsRequestTarget = containsTracePropagationTarget(
+    final containsRequestTarget = containsTargetOrMatchesRegExp(
         _failedRequestTargets, err.requestOptions.path);
 
     if (captureFailedRequests && containsStatusCode && containsRequestTarget) {

--- a/dio/lib/src/failed_request_interceptor.dart
+++ b/dio/lib/src/failed_request_interceptor.dart
@@ -4,22 +4,38 @@ import 'package:dio/dio.dart';
 import 'package:sentry/sentry.dart';
 
 class FailedRequestInterceptor extends Interceptor {
-  FailedRequestInterceptor({Hub? hub}) : _hub = hub ?? HubAdapter();
+  FailedRequestInterceptor(
+      {Hub? hub, List<SentryStatusCode> failedRequestStatusCodes = const []})
+      : _hub = hub ?? HubAdapter(),
+        _failedRequestStatusCodes = failedRequestStatusCodes;
 
   final Hub _hub;
+  final List<SentryStatusCode> _failedRequestStatusCodes;
 
   @override
   Future<void> onError(
     DioError err,
     ErrorInterceptorHandler handler,
   ) async {
-    final mechanism = Mechanism(type: 'SentryDioClientAdapter');
-    final throwableMechanism = ThrowableMechanism(mechanism, err);
+    if (_failedRequestStatusCodes.isEmpty ||
+        _failedRequestStatusCodes
+            .containsStatusCode(err.response?.statusCode)) {
+      final mechanism = Mechanism(type: 'SentryDioClientAdapter');
+      final throwableMechanism = ThrowableMechanism(mechanism, err);
 
-    _hub.getSpan()?.throwable = err;
+      _hub.getSpan()?.throwable = err;
 
-    await _hub.captureException(throwableMechanism);
-
+      await _hub.captureException(throwableMechanism);
+    }
     handler.next(err);
+  }
+}
+
+extension _ListX on List<SentryStatusCode> {
+  bool containsStatusCode(int? statusCode) {
+    if (statusCode == null) {
+      return false;
+    }
+    return any((element) => element.isInRange(statusCode));
   }
 }

--- a/dio/lib/src/failed_request_interceptor.dart
+++ b/dio/lib/src/failed_request_interceptor.dart
@@ -6,10 +6,10 @@ import 'package:sentry/sentry.dart';
 class FailedRequestInterceptor extends Interceptor {
   FailedRequestInterceptor({
     Hub? hub,
-    List<SentryStatusCode> failedRequestStatusCodes = const [
-      SentryStatusCode.defaultRange()
-    ],
-    List<String> failedRequestTargets = const ['.*'],
+    List<SentryStatusCode> failedRequestStatusCodes =
+        SentryHttpClient.defaultFailedRequestStatusCodes,
+    List<String> failedRequestTargets =
+        SentryHttpClient.defaultFailedRequestTargets,
   })  : _hub = hub ?? HubAdapter(),
         _failedRequestStatusCodes = failedRequestStatusCodes,
         _failedRequestTargets = failedRequestTargets;

--- a/dio/lib/src/failed_request_interceptor.dart
+++ b/dio/lib/src/failed_request_interceptor.dart
@@ -6,21 +6,32 @@ import 'package:sentry/sentry.dart';
 class FailedRequestInterceptor extends Interceptor {
   FailedRequestInterceptor({
     Hub? hub,
-    List<SentryStatusCode> failedRequestStatusCodes = const [],
+    List<SentryStatusCode> failedRequestStatusCodes = const [
+      SentryStatusCode.defaultRange()
+    ],
+    List<String> failedRequestTargets = const ['.*'],
   })  : _hub = hub ?? HubAdapter(),
-        _failedRequestStatusCodes = failedRequestStatusCodes;
+        _failedRequestStatusCodes = failedRequestStatusCodes,
+        _failedRequestTargets = failedRequestTargets;
 
   final Hub _hub;
   final List<SentryStatusCode> _failedRequestStatusCodes;
+  final List<String> _failedRequestTargets;
 
   @override
   Future<void> onError(
     DioError err,
     ErrorInterceptorHandler handler,
   ) async {
-    if (_failedRequestStatusCodes.isEmpty ||
-        _failedRequestStatusCodes
-            .containsStatusCode(err.response?.statusCode)) {
+    // ignore: invalid_use_of_internal_member
+    final captureFailedRequests = _hub.options.captureFailedRequests;
+
+    final containsStatusCode =
+        _failedRequestStatusCodes.containsStatusCode(err.response?.statusCode);
+    final containsRequestTarget = containsTracePropagationTarget(
+        _failedRequestTargets, err.requestOptions.path);
+
+    if (captureFailedRequests && containsStatusCode && containsRequestTarget) {
       final mechanism = Mechanism(type: 'SentryDioClientAdapter');
       final throwableMechanism = ThrowableMechanism(mechanism, err);
 

--- a/dio/lib/src/sentry_dio_extension.dart
+++ b/dio/lib/src/sentry_dio_extension.dart
@@ -19,14 +19,31 @@ extension SentryDioExtension on Dio {
   ///
   /// ```dart
   /// dio.addSentry(
-  ///   failedRequestStatusCodes: [SentryStatusCode.range(400, 404), SentryStatusCode(500)]
+  ///   failedRequestStatusCodes: [
+  ///     SentryStatusCode.range(400, 404),
+  ///     SentryStatusCode(500),
+  ///   ]
   /// );
   /// ```
   ///
-  /// If not failed request status codes are provided, all failure requests will be captured.
+  /// If empty request status codes are provided, all failure requests will be
+  /// captured. Per default, codes in the range 500-599 are recorded.
+  ///
+  /// If you provide failed request targets, rhe SDK will only capture HTTP
+  /// Client errors if the HTTP Request URL is a match for any of the provided
+  /// targets.
+  ///
+  /// ```dart
+  /// dio.addSentry(
+  ///   failedRequestTargets: ['my-api.com'],
+  /// );
+  /// ```
   void addSentry({
     Hub? hub,
-    List<SentryStatusCode> failedRequestStatusCodes = const [],
+    List<SentryStatusCode> failedRequestStatusCodes = const [
+      SentryStatusCode.defaultRange()
+    ],
+    List<String> failedRequestTargets = const ['.*'],
   }) {
     hub = hub ?? HubAdapter();
 
@@ -51,6 +68,7 @@ extension SentryDioExtension on Dio {
         0,
         FailedRequestInterceptor(
           failedRequestStatusCodes: failedRequestStatusCodes,
+          failedRequestTargets: failedRequestTargets,
         ),
       );
       // ignore: invalid_use_of_internal_member

--- a/dio/lib/src/sentry_dio_extension.dart
+++ b/dio/lib/src/sentry_dio_extension.dart
@@ -40,10 +40,10 @@ extension SentryDioExtension on Dio {
   /// ```
   void addSentry({
     Hub? hub,
-    List<SentryStatusCode> failedRequestStatusCodes = const [
-      SentryStatusCode.defaultRange()
-    ],
-    List<String> failedRequestTargets = const ['.*'],
+    List<SentryStatusCode> failedRequestStatusCodes =
+        SentryHttpClient.defaultFailedRequestStatusCodes,
+    List<String> failedRequestTargets =
+        SentryHttpClient.defaultFailedRequestTargets,
   }) {
     hub = hub ?? HubAdapter();
 

--- a/dio/lib/src/sentry_dio_extension.dart
+++ b/dio/lib/src/sentry_dio_extension.dart
@@ -12,8 +12,21 @@ extension SentryDioExtension on Dio {
   /// as well as request and response transformations.
   /// This must be the last initialization step of the [Dio] setup, otherwise
   /// your configuration of Dio might overwrite the Sentry configuration.
+  ///
+  /// You can also configure specific HTTP response codes to be considered
+  /// as a failed request. In the following example, the status codes 404 and 500
+  /// are considered a failed request.
+  ///
+  /// ```dart
+  /// dio.addSentry(
+  ///   failedRequestStatusCodes: [SentryStatusCode.range(400, 404), SentryStatusCode(500)]
+  /// );
+  /// ```
+  ///
+  /// If not failed request status codes are provided, all failure requests will be captured.
   void addSentry({
     Hub? hub,
+    List<SentryStatusCode> failedRequestStatusCodes = const [],
   }) {
     hub = hub ?? HubAdapter();
 
@@ -34,7 +47,10 @@ extension SentryDioExtension on Dio {
     if (options.captureFailedRequests) {
       // Add FailedRequestInterceptor at index 0, so it's the first interceptor.
       // This ensures that it is called and not skipped by any previous interceptor.
-      interceptors.insert(0, FailedRequestInterceptor());
+      interceptors.insert(
+          0,
+          FailedRequestInterceptor(
+              failedRequestStatusCodes: failedRequestStatusCodes));
       // ignore: invalid_use_of_internal_member
       hub.options.sdk.addIntegration('DioHTTPClientError');
     }

--- a/dio/lib/src/sentry_dio_extension.dart
+++ b/dio/lib/src/sentry_dio_extension.dart
@@ -29,7 +29,7 @@ extension SentryDioExtension on Dio {
   /// If empty request status codes are provided, all failure requests will be
   /// captured. Per default, codes in the range 500-599 are recorded.
   ///
-  /// If you provide failed request targets, rhe SDK will only capture HTTP
+  /// If you provide failed request targets, the SDK will only capture HTTP
   /// Client errors if the HTTP Request URL is a match for any of the provided
   /// targets.
   ///

--- a/dio/lib/src/sentry_dio_extension.dart
+++ b/dio/lib/src/sentry_dio_extension.dart
@@ -48,9 +48,11 @@ extension SentryDioExtension on Dio {
       // Add FailedRequestInterceptor at index 0, so it's the first interceptor.
       // This ensures that it is called and not skipped by any previous interceptor.
       interceptors.insert(
-          0,
-          FailedRequestInterceptor(
-              failedRequestStatusCodes: failedRequestStatusCodes));
+        0,
+        FailedRequestInterceptor(
+          failedRequestStatusCodes: failedRequestStatusCodes,
+        ),
+      );
       // ignore: invalid_use_of_internal_member
       hub.options.sdk.addIntegration('DioHTTPClientError');
     }

--- a/dio/lib/src/tracing_client_adapter.dart
+++ b/dio/lib/src/tracing_client_adapter.dart
@@ -38,7 +38,7 @@ class TracingClientAdapter extends HttpClientAdapter {
     ResponseBody? response;
     try {
       if (span != null) {
-        if (containsTracePropagationTarget(
+        if (containsTargetOrMatchesRegExp(
           // ignore: invalid_use_of_internal_member
           _hub.options.tracePropagationTargets,
           options.uri.toString(),


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

- Introduce a default range for captured http status codes of 500-599, same as `sentry-java`
- Add `failedRequestStatusCodes` & `failedRequestTargets` in dio `FailedRequestInterceptor`
- Add `failedRequestTargets` in `FailedRequestClient`

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #1115

## :green_heart: How did you test it?

Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps

According to documentation the [path](https://pub.dev/documentation/dio/latest/dio/RequestOptions/path.html) is described as:

> If the path starts with 'http(s)', the baseURL will be ignored, otherwise, it will be combined and then resolved with the baseUrl.

Can someone that is familiar with dio errors point me to samples how the path looks in different scenarios? This might affect how we have to match against `failedRequestTargets`.
