### PR TITLE
Allow sentry user to control resolution of captured Flutter screenshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Allow sentry user to control resolution of captured Flutter screenshots ([#1288](https://github.com/getsentry/sentry-dart/pull/1288))
+
 ### Fixes
 
 - Set client name with version in Android SDK ([#1274](https://github.com/getsentry/sentry-dart/pull/1274))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Allow sentry user to control resolution of captured Flutter screenshots ([#1288](https://github.com/getsentry/sentry-dart/pull/1288))
+
 ## 6.21.0
 
 ### Features

--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -51,6 +51,7 @@ Future<void> setupSentry(AppRunner appRunner, String dsn) async {
     options.reportSilentFlutterErrors = true;
     options.enableNdkScopeSync = true;
     options.attachScreenshot = true;
+    options.screenshotQuality = SentryScreenshotQuality.low;
     options.attachViewHierarchy = true;
     // We can enable Sentry debug logging during development. This is likely
     // going to log too much for your app, but can be useful when figuring out

--- a/flutter/lib/sentry_flutter.dart
+++ b/flutter/lib/sentry_flutter.dart
@@ -9,5 +9,6 @@ export 'src/flutter_sentry_attachment.dart';
 export 'src/sentry_asset_bundle.dart';
 export 'src/integrations/on_error_integration.dart';
 export 'src/screenshot/sentry_screenshot_widget.dart';
+export 'src/screenshot/sentry_screenshot_quality.dart';
 export 'src/user_interaction/sentry_user_interaction_widget.dart';
 export 'src/binding_wrapper.dart';

--- a/flutter/lib/src/event_processor/screenshot_event_processor.dart
+++ b/flutter/lib/src/event_processor/screenshot_event_processor.dart
@@ -45,10 +45,8 @@ class ScreenshotEventProcessor extends EventProcessor {
 
   Future<Uint8List?> _createScreenshot() async {
     try {
-      final context = sentryScreenshotWidgetGlobalKey.currentContext;
-      final renderObject = context?.findRenderObject();
-
-      if (context != null && renderObject is RenderRepaintBoundary) {
+      final renderObject = sentryScreenshotWidgetGlobalKey.currentContext?.findRenderObject();
+      if (renderObject is RenderRepaintBoundary) {
         final pixelRatio = window.devicePixelRatio;
         var image = await renderObject.toImage(pixelRatio: pixelRatio);
         // At the time of writing there's no other image format available which

--- a/flutter/lib/src/event_processor/screenshot_event_processor.dart
+++ b/flutter/lib/src/event_processor/screenshot_event_processor.dart
@@ -4,7 +4,6 @@ import 'dart:typed_data';
 import 'dart:ui' as ui show ImageByteFormat;
 import 'dart:ui';
 
-import 'package:flutter/widgets.dart';
 import 'package:sentry/sentry.dart';
 import '../screenshot/sentry_screenshot_widget.dart';
 import '../sentry_flutter_options.dart';
@@ -45,7 +44,8 @@ class ScreenshotEventProcessor extends EventProcessor {
 
   Future<Uint8List?> _createScreenshot() async {
     try {
-      final renderObject = sentryScreenshotWidgetGlobalKey.currentContext?.findRenderObject();
+      final renderObject =
+          sentryScreenshotWidgetGlobalKey.currentContext?.findRenderObject();
       if (renderObject is RenderRepaintBoundary) {
         final pixelRatio = window.devicePixelRatio;
         var image = await renderObject.toImage(pixelRatio: pixelRatio);

--- a/flutter/lib/src/event_processor/screenshot_event_processor.dart
+++ b/flutter/lib/src/event_processor/screenshot_event_processor.dart
@@ -49,7 +49,6 @@ class ScreenshotEventProcessor extends EventProcessor {
       final renderObject = context?.findRenderObject();
 
       if (context != null && renderObject is RenderRepaintBoundary) {
-
         final pixelRatio = window.devicePixelRatio;
         var image = await renderObject.toImage(pixelRatio: pixelRatio);
         // At the time of writing there's no other image format available which

--- a/flutter/lib/src/screenshot/sentry_screenshot_quality.dart
+++ b/flutter/lib/src/screenshot/sentry_screenshot_quality.dart
@@ -1,0 +1,19 @@
+enum SentryScreenshotQuality {
+  full,
+  high,
+  medium,
+  low;
+
+  int? targetResolution() {
+    switch (this) {
+      case SentryScreenshotQuality.full:
+        return null; // Keep current scale
+      case SentryScreenshotQuality.high:
+        return 1920;
+      case SentryScreenshotQuality.medium:
+        return 1280;
+      case SentryScreenshotQuality.low:
+        return 854;
+    }
+  }
+}

--- a/flutter/lib/src/screenshot/sentry_screenshot_quality.dart
+++ b/flutter/lib/src/screenshot/sentry_screenshot_quality.dart
@@ -1,3 +1,4 @@
+/// The quality of the attached screenshot
 enum SentryScreenshotQuality {
   full,
   high,

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -4,6 +4,7 @@ import 'package:flutter/widgets.dart';
 
 import 'binding_wrapper.dart';
 import 'renderer/renderer.dart';
+import 'screenshot/sentry_screenshot_quality.dart';
 
 /// This class adds options which are only availble in a Flutter environment.
 /// Note that some of these options require native Sentry integration, which is
@@ -162,6 +163,9 @@ class SentryFlutterOptions extends SentryOptions {
   /// runApp(SentryScreenshotWidget(child: App()));
   /// The [SentryScreenshotWidget] has to be the root widget of the app.
   bool attachScreenshot = false;
+
+  /// The quality of the attached screenshot
+  SentryScreenshotQuality screenshotQuality = SentryScreenshotQuality.high;
 
   /// Enable or disable automatic breadcrumbs for User interactions Using [Listener]
   ///

--- a/flutter/test/event_processor/screenshot_event_processor_test.dart
+++ b/flutter/test/event_processor/screenshot_event_processor_test.dart
@@ -1,5 +1,8 @@
 @Tags(['canvasKit']) // Web renderer where this test can run
 
+import 'dart:math';
+import 'dart:ui';
+
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sentry_flutter/src/event_processor/screenshot_event_processor.dart';
@@ -9,13 +12,15 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 
 void main() {
   late Fixture fixture;
+
   setUp(() {
     fixture = Fixture();
     TestWidgetsFlutterBinding.ensureInitialized();
   });
 
   Future<void> _addScreenshotAttachment(
-      WidgetTester tester, FlutterRenderer renderer, bool added) async {
+      WidgetTester tester, FlutterRenderer renderer, bool added,
+      {int? expectedMaxWidthOrHeight}) async {
     // Run with real async https://stackoverflow.com/a/54021863
     await tester.runAsync(() async {
       final sut = fixture.getSut(renderer);
@@ -30,6 +35,16 @@ void main() {
       await sut.apply(event, hint: hint);
 
       expect(hint.screenshot != null, added);
+      if (expectedMaxWidthOrHeight != null) {
+        final bytes = await hint.screenshot?.bytes;
+        final codec = await instantiateImageCodec(bytes!);
+        final frameInfo = await codec.getNextFrame();
+        final image = frameInfo.image;
+        expect(
+          max(image.width, image.height).toDouble(),
+          moreOrLessEquals(expectedMaxWidthOrHeight.toDouble(), epsilon: 1.0),
+        );
+      }
     });
   }
 
@@ -50,6 +65,30 @@ void main() {
   testWidgets('does not add screenshot attachment with unknown renderer',
       (tester) async {
     await _addScreenshotAttachment(tester, FlutterRenderer.unknown, false);
+  });
+
+  testWidgets('does add screenshot in correct resolution for low',
+      (tester) async {
+    final height = SentryScreenshotQuality.low.targetResolution()!;
+    fixture.options.screenshotQuality = SentryScreenshotQuality.low;
+    await _addScreenshotAttachment(tester, FlutterRenderer.skia, true,
+        expectedMaxWidthOrHeight: height);
+  });
+
+  testWidgets('does add screenshot in correct resolution for medium',
+      (tester) async {
+    final height = SentryScreenshotQuality.medium.targetResolution()!;
+    fixture.options.screenshotQuality = SentryScreenshotQuality.medium;
+    await _addScreenshotAttachment(tester, FlutterRenderer.skia, true,
+        expectedMaxWidthOrHeight: height);
+  });
+
+  testWidgets('does add screenshot in correct resolution for high',
+      (tester) async {
+    final widthOrHeight = SentryScreenshotQuality.high.targetResolution()!;
+    fixture.options.screenshotQuality = SentryScreenshotQuality.high;
+    await _addScreenshotAttachment(tester, FlutterRenderer.skia, true,
+        expectedMaxWidthOrHeight: widthOrHeight);
   });
 }
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

- Introduce `SentryscreenshotQulity`
- Render screenshots according to quality
- We now also support full resolution instead of just rendering logical pixels

Full Quality:
<img width="530" alt="Bildschirm­foto 2023-02-20 um 17 10 12" src="https://user-images.githubusercontent.com/3984453/220157040-df60516b-92f9-47c4-b913-56417c0c70eb.png">

Small Quality:
<img width="584" alt="Bildschirm­foto 2023-02-20 um 17 15 08" src="https://user-images.githubusercontent.com/3984453/220157046-b6299f10-51f1-4c09-85c5-a0b664844d52.png">

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #1200

## :green_heart: How did you test it?

Ran different resolutions with sample app.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes
