### PR TITLE
Platform Exception Event Processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 6.21.0
+## Unreleased
+
+### Features
+
+- Platform Exception Event Processor ([#1297](https://github.com/getsentry/sentry-dart/pull/1297))
 
 ## 6.21.0
 
@@ -20,10 +24,6 @@
 - Remove duplicated breadcrumbs when syncing with iOS/macOS ([#1283](https://github.com/getsentry/sentry-dart/pull/1283))
 
 ## 6.20.1
-
-### Features
-
-- Platform Exception Event Processor ([#1297](https://github.com/getsentry/sentry-dart/pull/1297))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Platform Exception Event Processor ([#1297](https://github.com/getsentry/sentry-dart/pull/1297))
+
 ### Fixes
 
 - Set client name with version in Android SDK ([#1274](https://github.com/getsentry/sentry-dart/pull/1274))

--- a/flutter/lib/src/event_processor/platform_exception_event_processor.dart
+++ b/flutter/lib/src/event_processor/platform_exception_event_processor.dart
@@ -1,0 +1,36 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:sentry/sentry.dart';
+
+/// Add code & message from [PlatformException] to [SentryException]
+class PlatformExceptionEventProcessor implements EventProcessor {
+  @override
+  FutureOr<SentryEvent?> apply(SentryEvent event, {Hint? hint}) {
+    final exceptions = <SentryException>[];
+
+    for (SentryException exception in (event.exceptions ?? [])) {
+      final platformException = exception.throwable;
+      if (platformException is PlatformException) {
+        exception = _enrich(exception, platformException);
+      }
+      exceptions.add(exception);
+    }
+
+    return event.copyWith(exceptions: exceptions);
+  }
+
+  SentryException _enrich(
+      SentryException sentryException, PlatformException platformException) {
+    final data = Map<String, dynamic>.from(
+      sentryException.mechanism?.data ?? {},
+    );
+    data['platformException'] = {'code': platformException.code};
+    if (platformException.message != null) {
+      data['platformException']['message'] = platformException.message;
+    }
+    return sentryException.copyWith(
+      mechanism: sentryException.mechanism?.copyWith(data: data),
+    );
+  }
+}

--- a/flutter/lib/src/event_processor/platform_exception_event_processor.dart
+++ b/flutter/lib/src/event_processor/platform_exception_event_processor.dart
@@ -25,12 +25,14 @@ class PlatformExceptionEventProcessor implements EventProcessor {
     final data = Map<String, dynamic>.from(
       sentryException.mechanism?.data ?? {},
     );
-    data['platformException'] = {'code': platformException.code};
+    data['platformExceptionCode'] = platformException.code;
     if (platformException.message != null) {
-      data['platformException']['message'] = platformException.message;
+      data['platformExceptionMessage'] = platformException.message;
     }
+    final mechanism =
+        sentryException.mechanism ?? Mechanism(type: "platformException");
     return sentryException.copyWith(
-      mechanism: sentryException.mechanism?.copyWith(data: data),
+      mechanism: mechanism.copyWith(data: data),
     );
   }
 }

--- a/flutter/lib/src/event_processor/platform_exception_event_processor.dart
+++ b/flutter/lib/src/event_processor/platform_exception_event_processor.dart
@@ -25,9 +25,9 @@ class PlatformExceptionEventProcessor implements EventProcessor {
     final data = Map<String, dynamic>.from(
       sentryException.mechanism?.data ?? {},
     );
-    data['platformExceptionCode'] = platformException.code;
+    data['code'] = platformException.code;
     if (platformException.message != null) {
-      data['platformExceptionMessage'] = platformException.message;
+      data['message'] = platformException.message;
     }
     final mechanism =
         sentryException.mechanism ?? Mechanism(type: "platformException");

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -8,6 +8,7 @@ import 'package:meta/meta.dart';
 import '../sentry_flutter.dart';
 import 'event_processor/android_platform_exception_event_processor.dart';
 import 'event_processor/flutter_exception_event_processor.dart';
+import 'event_processor/platform_exception_event_processor.dart';
 import 'integrations/screenshot_integration.dart';
 import 'native_scope_observer.dart';
 import 'renderer/renderer.dart';
@@ -112,6 +113,8 @@ mixin SentryFlutter {
       options
           .addEventProcessor(AndroidPlatformExceptionEventProcessor(options));
     }
+
+    options.addEventProcessor(PlatformExceptionEventProcessor());
 
     _setSdk(options);
   }

--- a/flutter/test/event_processor/platform_exception_event_processor_test.dart
+++ b/flutter/test/event_processor/platform_exception_event_processor_test.dart
@@ -28,10 +28,8 @@ void main() {
       final sut = fixture.getSut();
       event = (await sut.apply(event))!;
 
-      expect(event.exceptions?.first.mechanism?.data["code"],
-          "fixture-code");
-      expect(
-          event.exceptions?.first.mechanism?.data["message"],
+      expect(event.exceptions?.first.mechanism?.data["code"], "fixture-code");
+      expect(event.exceptions?.first.mechanism?.data["message"],
           "fixture-message");
     });
 

--- a/flutter/test/event_processor/platform_exception_event_processor_test.dart
+++ b/flutter/test/event_processor/platform_exception_event_processor_test.dart
@@ -28,10 +28,10 @@ void main() {
       final sut = fixture.getSut();
       event = (await sut.apply(event))!;
 
-      expect(event.exceptions?.first.mechanism?.data["platformExceptionCode"],
+      expect(event.exceptions?.first.mechanism?.data["code"],
           "fixture-code");
       expect(
-          event.exceptions?.first.mechanism?.data["platformExceptionMessage"],
+          event.exceptions?.first.mechanism?.data["message"],
           "fixture-message");
     });
 

--- a/flutter/test/event_processor/platform_exception_event_processor_test.dart
+++ b/flutter/test/event_processor/platform_exception_event_processor_test.dart
@@ -11,7 +11,7 @@ void main() {
       fixture = Fixture();
     });
 
-    test('test', () async {
+    test('applies code and message to mechanism', () async {
       final platformException = PlatformException(
         code: 'fixture-code',
         message: 'fixture-message',
@@ -28,13 +28,29 @@ void main() {
       final sut = fixture.getSut();
       event = (await sut.apply(event))!;
 
-      expect(
-          event.exceptions?.first.mechanism?.data["platformException"]["code"],
+      expect(event.exceptions?.first.mechanism?.data["platformExceptionCode"],
           "fixture-code");
       expect(
-          event.exceptions?.first.mechanism?.data["platformException"]
-              ["message"],
+          event.exceptions?.first.mechanism?.data["platformExceptionMessage"],
           "fixture-message");
+    });
+
+    test('creates fallback mechanism', () async {
+      final platformException = PlatformException(
+        code: 'fixture-code',
+        message: 'fixture-message',
+      );
+      final sentryException = SentryException(
+        type: 'fixture-type',
+        value: 'fixture-value',
+        throwable: platformException,
+      );
+      var event = SentryEvent(exceptions: [sentryException]);
+
+      final sut = fixture.getSut();
+      event = (await sut.apply(event))!;
+
+      expect(event.exceptions?.first.mechanism?.type, "platformException");
     });
   });
 }

--- a/flutter/test/event_processor/platform_exception_event_processor_test.dart
+++ b/flutter/test/event_processor/platform_exception_event_processor_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sentry/sentry.dart';
+import 'package:sentry_flutter/src/event_processor/platform_exception_event_processor.dart';
+
+void main() {
+  group(PlatformExceptionEventProcessor, () {
+    late Fixture fixture;
+
+    setUp(() {
+      fixture = Fixture();
+    });
+
+    test('test', () async {
+      final platformException = PlatformException(
+        code: 'fixture-code',
+        message: 'fixture-message',
+      );
+      final mechanism = Mechanism(type: 'fixture-type');
+      final sentryException = SentryException(
+        type: 'fixture-type',
+        value: 'fixture-value',
+        throwable: platformException,
+        mechanism: mechanism,
+      );
+      var event = SentryEvent(exceptions: [sentryException]);
+
+      final sut = fixture.getSut();
+      event = (await sut.apply(event))!;
+
+      expect(
+          event.exceptions?.first.mechanism?.data["platformException"]["code"],
+          "fixture-code");
+      expect(
+          event.exceptions?.first.mechanism?.data["platformException"]
+              ["message"],
+          "fixture-message");
+    });
+  });
+}
+
+class Fixture {
+  PlatformExceptionEventProcessor getSut() {
+    return PlatformExceptionEventProcessor();
+  }
+}


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

- Adds an event processor that enriches `SentryEvent.mechanism` with `PlatformException` code and message. 

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #1231

## :green_heart: How did you test it?

Unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps

Should we also create a mechanism if it's null on the `SentryException`?