### PR TITLE
Pass processed `Breadcrumb` to scope observer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#6131)
   - [diff](https://github.com/getsentry/sentry-java/compare/6.13.0...6.13.1)
 
+### Fixes
+
+- Pass processed Breadcrumb to scope observer ([#1298](https://github.com/getsentry/sentry-dart/pull/1298))
+
 ## 6.20.1
 
 ### Fixes

--- a/dart/lib/src/scope.dart
+++ b/dart/lib/src/scope.dart
@@ -155,10 +155,10 @@ class Scope {
 
   Scope(this._options);
 
-  bool _addBreadCrumbSync(Breadcrumb breadcrumb, {dynamic hint}) {
+  Breadcrumb? _addBreadCrumbSync(Breadcrumb breadcrumb, {dynamic hint}) {
     // bail out if maxBreadcrumbs is zero
     if (_options.maxBreadcrumbs == 0) {
-      return false;
+      return null;
     }
 
     Breadcrumb? processedBreadcrumb = breadcrumb;
@@ -174,7 +174,7 @@ class Scope {
             SentryLevel.info,
             'Breadcrumb was dropped by beforeBreadcrumb',
           );
-          return false;
+          return null;
         }
       } catch (exception, stackTrace) {
         _options.logger(
@@ -193,14 +193,15 @@ class Scope {
       }
       _breadcrumbs.add(processedBreadcrumb);
     }
-    return true;
+    return processedBreadcrumb;
   }
 
   /// Adds a breadcrumb to the breadcrumbs queue
   Future<void> addBreadcrumb(Breadcrumb breadcrumb, {dynamic hint}) async {
-    if (_addBreadCrumbSync(breadcrumb, hint: hint)) {
+    final addedBreadcrumb = _addBreadCrumbSync(breadcrumb, hint: hint);
+    if (addedBreadcrumb != null) {
       await _callScopeObservers((scopeObserver) async =>
-          await scopeObserver.addBreadcrumb(breadcrumb));
+          await scopeObserver.addBreadcrumb(addedBreadcrumb));
     }
   }
 

--- a/dart/test/mocks/mock_scope_observer.dart
+++ b/dart/test/mocks/mock_scope_observer.dart
@@ -1,6 +1,7 @@
 import 'package:sentry/sentry.dart';
 
 class MockScopeObserver extends ScopeObserver {
+  List<Breadcrumb> addedBreadcrumbs = [];
   bool calledAddBreadcrumb = false;
   bool calledClearBreadcrumbs = false;
   bool calledRemoveContexts = false;
@@ -25,6 +26,7 @@ class MockScopeObserver extends ScopeObserver {
   Future<void> addBreadcrumb(Breadcrumb breadcrumb) async {
     calledAddBreadcrumb = true;
     numberOfAddBreadcrumbCalls += 1;
+    addedBreadcrumbs.add(breadcrumb);
   }
 
   @override

--- a/dart/test/scope_test.dart
+++ b/dart/test/scope_test.dart
@@ -611,6 +611,22 @@ void main() {
     expect(true, fixture.mockScopeObserver.calledAddBreadcrumb);
   });
 
+  test('addBreadcrumb passes processed breadcrumb to scope observers',
+      () async {
+    final sut = fixture.getSut(
+      scopeObserver: fixture.mockScopeObserver,
+      beforeBreadcrumbCallback: (
+        Breadcrumb? breadcrumb, {
+        dynamic hint,
+      }) {
+        return breadcrumb?.copyWith(message: "modified");
+      },
+    );
+    await sut.addBreadcrumb(Breadcrumb());
+
+    expect(fixture.mockScopeObserver.addedBreadcrumbs[0].message, "modified");
+  });
+
   test('clearBreadcrumbs should call scope observers', () async {
     final sut = fixture.getSut(scopeObserver: fixture.mockScopeObserver);
     await sut.clearBreadcrumbs();


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

- Pass processed breadcrumbs to scope oberver.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #1296

## :green_heart: How did you test it?

Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
