### PR TITLE
fix: Change podspec `EXCLUDED_ARCHS` value 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Change podspec `EXCLUDED_ARCHS` value to allow podfiles to add more excluded architetures
+- Change podspec `EXCLUDED_ARCHS` value to allow podfiles to add more excluded architetures ([#1303](https://github.com/getsentry/sentry-dart/pull/1303))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Change podspec `EXCLUDED_ARCHS` value to allow podfiles to add more excluded architetures
+
 ### Dependencies
 
 - Bump Android SDK from v6.13.1 to v6.14.0 ([#1287](https://github.com/getsentry/sentry-dart/pull/1287))

--- a/flutter/ios/sentry_flutter.podspec
+++ b/flutter/ios/sentry_flutter.podspec
@@ -19,7 +19,7 @@ Sentry SDK for Flutter with support to native through sentry-cocoa.
   s.osx.deployment_target = '10.11'
 
   # Flutter.framework does not contain a i386 slice.
-  s.ios.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
+  s.ios.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => '$(inherited) i386' }
   s.osx.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
   s.swift_version = '5.0'
 end


### PR DESCRIPTION

## :scroll: Description
Changed podspec `EXCLUDED_ARCHS` value to allow podfiles to add more excluded architetures during setup.

## :bulb: Motivation and Context

close #1300 

## :green_heart: How did you test it?

With samples

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes

