### PR TITLE
set logging to any as sentry_logging has the dep constraint

### DIFF
--- a/flutter/example/pubspec.yaml
+++ b/flutter/example/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   feedback: ^2.0.0
   provider: ^6.0.0
   dio: any # This gets constrained by `sentry_dio`
-  logging: ^1.0.0
+  logging: any # This gets constrained by `sentry_logging`
   package_info_plus: ^3.0.0
   path_provider: ^2.0.0
 

--- a/min_version_test/pubspec.yaml
+++ b/min_version_test/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   sentry_dio:
   sentry_logging:
   dio: any # This gets constrained by `sentry_dio`
-  logging: ^1.0.0
+  logging: any # This gets constrained by `sentry_logging`
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## :scroll: Description
_#skip-changelog_


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
