### PR TITLE
Add doc links to sidebar on pub.dev

### DIFF
--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -6,6 +6,7 @@ description: >
 homepage: https://docs.sentry.io/platforms/dart/
 repository: https://github.com/getsentry/sentry-dart
 issue_tracker: https://github.com/getsentry/sentry-dart/issues
+documentation: https://docs.sentry.io/platforms/dart/
 
 environment:
   sdk: '>=2.12.0 <3.0.0'

--- a/dio/pubspec.yaml
+++ b/dio/pubspec.yaml
@@ -4,6 +4,7 @@ version: 6.18.1
 homepage: https://docs.sentry.io/platforms/dart/
 repository: https://github.com/getsentry/sentry-dart
 issue_tracker: https://github.com/getsentry/sentry-dart/issues
+documentation: https://docs.sentry.io/platforms/dart/performance/instrumentation/automatic-instrumentation/#dio-http-library-instrumentation
 
 environment:
   sdk: '>=2.12.0 <3.0.0'

--- a/dio/pubspec.yaml
+++ b/dio/pubspec.yaml
@@ -4,7 +4,7 @@ version: 6.18.1
 homepage: https://docs.sentry.io/platforms/dart/
 repository: https://github.com/getsentry/sentry-dart
 issue_tracker: https://github.com/getsentry/sentry-dart/issues
-documentation: https://docs.sentry.io/platforms/dart/performance/instrumentation/automatic-instrumentation/#dio-http-library-instrumentation
+documentation: https://docs.sentry.io/platforms/dart/configuration/integrations/dio
 
 environment:
   sdk: '>=2.12.0 <3.0.0'

--- a/dio/pubspec.yaml
+++ b/dio/pubspec.yaml
@@ -4,7 +4,7 @@ version: 6.21.0
 homepage: https://docs.sentry.io/platforms/dart/
 repository: https://github.com/getsentry/sentry-dart
 issue_tracker: https://github.com/getsentry/sentry-dart/issues
-documentation: https://docs.sentry.io/platforms/dart/configuration/integrations/dio
+documentation: https://docs.sentry.io/platforms/dart/configuration/integrations/dio/
 
 environment:
   sdk: '>=2.12.0 <3.0.0'

--- a/file/pubspec.yaml
+++ b/file/pubspec.yaml
@@ -4,7 +4,7 @@ version: 6.21.0
 homepage: https://docs.sentry.io/platforms/dart/
 repository: https://github.com/getsentry/sentry-dart
 issue_tracker: https://github.com/getsentry/sentry-dart/issues
-documentation: https://docs.sentry.io/platforms/dart/configuration/integrations/file
+documentation: https://docs.sentry.io/platforms/dart/configuration/integrations/file/
 
 environment:
   sdk: '>=2.19.0 <3.0.0'

--- a/file/pubspec.yaml
+++ b/file/pubspec.yaml
@@ -4,6 +4,7 @@ version: 6.18.1
 homepage: https://docs.sentry.io/platforms/dart/
 repository: https://github.com/getsentry/sentry-dart
 issue_tracker: https://github.com/getsentry/sentry-dart/issues
+documentation: https://docs.sentry.io/platforms/dart/performance/instrumentation/automatic-instrumentation/#file-io-instrumentation
 
 environment:
   # <2.19 because of https://github.com/dart-lang/sdk/issues/49647 breaking change

--- a/file/pubspec.yaml
+++ b/file/pubspec.yaml
@@ -4,7 +4,7 @@ version: 6.18.1
 homepage: https://docs.sentry.io/platforms/dart/
 repository: https://github.com/getsentry/sentry-dart
 issue_tracker: https://github.com/getsentry/sentry-dart/issues
-documentation: https://docs.sentry.io/platforms/dart/performance/instrumentation/automatic-instrumentation/#file-io-instrumentation
+documentation: https://docs.sentry.io/platforms/dart/configuration/integrations/file
 
 environment:
   # <2.19 because of https://github.com/dart-lang/sdk/issues/49647 breaking change

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -4,6 +4,7 @@ description: Sentry SDK for Flutter. This package aims to support different Flut
 homepage: https://docs.sentry.io/platforms/flutter/
 repository: https://github.com/getsentry/sentry-dart
 issue_tracker: https://github.com/getsentry/sentry-dart/issues
+documentation: https://docs.sentry.io/platforms/flutter/
 
 environment:
   sdk: '>=2.12.0 <3.0.0'

--- a/logging/pubspec.yaml
+++ b/logging/pubspec.yaml
@@ -1,7 +1,7 @@
 name: sentry_logging
 description: An integration which adds support for recording log from the logging package.
 version: 6.18.1
-homepage: https://docs.sentry.io/platforms/flutter/
+homepage: https://docs.sentry.io/platforms/dart/
 repository: https://github.com/getsentry/sentry-dart
 issue_tracker: https://github.com/getsentry/sentry-dart/issues
 documentation: https://docs.sentry.io/platforms/dart/configuration/integrations/logging/

--- a/logging/pubspec.yaml
+++ b/logging/pubspec.yaml
@@ -4,6 +4,7 @@ version: 6.18.1
 homepage: https://docs.sentry.io/platforms/flutter/
 repository: https://github.com/getsentry/sentry-dart
 issue_tracker: https://github.com/getsentry/sentry-dart/issues
+documentation: https://docs.sentry.io/platforms/dart/configuration/integrations/logging/
 
 environment:
   sdk: '>=2.12.0 <3.0.0'


### PR DESCRIPTION
## :scroll: Description

With this change, the links to the Sentry docs are added to the sidebar on pub.dev

#skip-changelog

## :green_heart: How did you test it?

Just doc changes

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
