### PR TITLE
Chore: Only await futures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Don't await `FutureOr<T>` if it's not a future. This should marginally improve the performance.
+
 ## 7.0.0-rc.1
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+### Enhancements
+
 - Don't await `FutureOr<T>` if it's not a future. This should marginally improve the performance ([#1310](https://github.com/getsentry/sentry-dart/pull/1310))
 
 ## 7.0.0-rc.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Don't await `FutureOr<T>` if it's not a future. This should marginally improve the performance.
+- Don't await `FutureOr<T>` if it's not a future. This should marginally improve the performance ([#1310](https://github.com/getsentry/sentry-dart/pull/1310))
 
 ## 7.0.0-rc.1
 

--- a/dart/lib/src/hub.dart
+++ b/dart/lib/src/hub.dart
@@ -306,7 +306,10 @@ class Hub {
     } else {
       // close integrations
       for (final integration in _options.integrations) {
-        await integration.close();
+        final close = integration.close();
+        if (close is Future) {
+          await close;
+        }
       }
 
       final item = _peek();

--- a/dart/lib/src/hub.dart
+++ b/dart/lib/src/hub.dart
@@ -81,7 +81,13 @@ class Hub {
       );
     } else {
       final item = _peek();
-      final scope = await _cloneAndRunWithScope(item.scope, withScope);
+      late Scope scope;
+      final s = _cloneAndRunWithScope(item.scope, withScope);
+      if (s is Future<Scope>) {
+        scope = await s;
+      } else {
+        scope = s;
+      }
 
       try {
         if (_options.isTracingEnabled()) {
@@ -129,7 +135,13 @@ class Hub {
       );
     } else {
       final item = _peek();
-      final scope = await _cloneAndRunWithScope(item.scope, withScope);
+      late Scope scope;
+      final s = _cloneAndRunWithScope(item.scope, withScope);
+      if (s is Future<Scope>) {
+        scope = await s;
+      } else {
+        scope = s;
+      }
 
       try {
         var event = SentryEvent(
@@ -185,7 +197,13 @@ class Hub {
       );
     } else {
       final item = _peek();
-      final scope = await _cloneAndRunWithScope(item.scope, withScope);
+      late Scope scope;
+      final s = _cloneAndRunWithScope(item.scope, withScope);
+      if (s is Future<Scope>) {
+        scope = await s;
+      } else {
+        scope = s;
+      }
 
       try {
         sentryId = await item.client.captureMessage(
@@ -239,12 +257,15 @@ class Hub {
     }
   }
 
-  Future<Scope> _cloneAndRunWithScope(
+  FutureOr<Scope> _cloneAndRunWithScope(
       Scope scope, ScopeCallback? withScope) async {
     if (withScope != null) {
       try {
         scope = scope.clone();
-        await withScope(scope);
+        final s = withScope(scope);
+        if (s is Future) {
+          await s;
+        }
       } catch (exception, stackTrace) {
         _options.logger(
           SentryLevel.error,

--- a/dart/lib/src/hub_adapter.dart
+++ b/dart/lib/src/hub_adapter.dart
@@ -85,8 +85,8 @@ class HubAdapter implements Hub {
   Future<void> close() => Sentry.close();
 
   @override
-  FutureOr<void> configureScope(ScopeCallback callback) async =>
-      await Sentry.configureScope(callback);
+  FutureOr<void> configureScope(ScopeCallback callback) =>
+      Sentry.configureScope(callback);
 
   @override
   bool get isEnabled => Sentry.isEnabled;

--- a/dart/lib/src/scope.dart
+++ b/dart/lib/src/scope.dart
@@ -316,7 +316,12 @@ class Scope {
     SentryEvent? processedEvent = event;
     for (final processor in _eventProcessors) {
       try {
-        processedEvent = await processor.apply(processedEvent!, hint: hint);
+        final e = processor.apply(processedEvent!, hint: hint);
+        if (e is Future) {
+          processedEvent = await e;
+        } else {
+          processedEvent = e;
+        }
       } catch (exception, stackTrace) {
         _options.logger(
           SentryLevel.error,

--- a/dart/lib/src/sentry.dart
+++ b/dart/lib/src/sentry.dart
@@ -46,7 +46,10 @@ class Sentry {
     await _initDefaultValues(sentryOptions);
 
     try {
-      await optionsConfiguration(sentryOptions);
+      final config = optionsConfiguration(sentryOptions);
+      if (config is Future) {
+        await config;
+      }
     } catch (exception, stackTrace) {
       sentryOptions.logger(
         SentryLevel.error,

--- a/dart/lib/src/sentry.dart
+++ b/dart/lib/src/sentry.dart
@@ -149,7 +149,10 @@ class Sentry {
   static Future<void> _callIntegrations(
       Iterable<Integration> integrations, SentryOptions options) async {
     for (final integration in integrations) {
-      await integration(HubAdapter(), options);
+      final execute = integration(HubAdapter(), options);
+      if (execute is Future) {
+        await execute;
+      }
     }
   }
 
@@ -219,12 +222,12 @@ class Sentry {
   static SentryId get lastEventId => _hub.lastEventId;
 
   /// Adds a breacrumb to the current Scope
-  static Future<void> addBreadcrumb(Breadcrumb crumb, {Hint? hint}) async =>
-      await _hub.addBreadcrumb(crumb, hint: hint);
+  static Future<void> addBreadcrumb(Breadcrumb crumb, {Hint? hint}) =>
+      _hub.addBreadcrumb(crumb, hint: hint);
 
   /// Configures the scope through the callback.
-  static FutureOr<void> configureScope(ScopeCallback callback) async =>
-      await _hub.configureScope(callback);
+  static FutureOr<void> configureScope(ScopeCallback callback) =>
+      _hub.configureScope(callback);
 
   /// Clones the current Hub
   static Hub clone() => _hub.clone();

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -406,7 +406,12 @@ class SentryClient {
     SentryEvent? processedEvent = event;
     for (final processor in eventProcessors) {
       try {
-        processedEvent = await processor.apply(processedEvent!, hint: hint);
+        final e = processor.apply(processedEvent!, hint: hint);
+        if (e is Future) {
+          processedEvent = await e;
+        } else {
+          processedEvent = e;
+        }
       } catch (exception, stackTrace) {
         _options.logger(
           SentryLevel.error,

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -374,9 +374,19 @@ class SentryClient {
     try {
       if (event is SentryTransaction && beforeSendTransaction != null) {
         beforeSendName = 'beforeSendTransaction';
-        eventOrTransaction = await beforeSendTransaction(event);
+        final e = beforeSendTransaction(event);
+        if (e is Future) {
+          eventOrTransaction = await e;
+        } else {
+          eventOrTransaction = e;
+        }
       } else if (beforeSend != null) {
-        eventOrTransaction = await beforeSend(event, hint: hint);
+        final e = beforeSend(event, hint: hint);
+        if (e is Future) {
+          eventOrTransaction = await e;
+        } else {
+          eventOrTransaction = e;
+        }
       }
     } catch (exception, stackTrace) {
       _options.logger(

--- a/dart/lib/src/sentry_envelope_item.dart
+++ b/dart/lib/src/sentry_envelope_item.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'client_reports/client_report.dart';
 import 'protocol.dart';
@@ -25,7 +26,7 @@ class SentryEnvelopeItem {
   }
 
   factory SentryEnvelopeItem.fromAttachment(SentryAttachment attachment) {
-    final cachedItem = _CachedItem(() async => await attachment.bytes);
+    final cachedItem = _CachedItem(() => attachment.bytes);
 
     final header = SentryEnvelopeItemHeader(
       SentryItemType.attachment,
@@ -106,11 +107,16 @@ class SentryEnvelopeItem {
 class _CachedItem {
   _CachedItem(this._dataFactory);
 
-  final Future<List<int>> Function() _dataFactory;
+  final FutureOr<List<int>> Function() _dataFactory;
   List<int>? _data;
 
   Future<List<int>> getData() async {
-    _data ??= await _dataFactory();
+    final data = _dataFactory();
+    if (data is Future) {
+      _data ??= await data;
+    } else {
+      _data ??= data;
+    }
     return _data!;
   }
 

--- a/dart/lib/src/sentry_tracer.dart
+++ b/dart/lib/src/sentry_tracer.dart
@@ -111,7 +111,10 @@ class SentryTracer extends ISentrySpan {
 
       // the callback should run before because if the span is finished,
       // we cannot attach data, its immutable after being finished.
-      await _onFinish?.call(this);
+      final finish = _onFinish?.call(this);
+      if (finish is Future) {
+        await finish;
+      }
       await _rootSpan.finish(endTimestamp: _rootEndTimestamp);
 
       // remove from scope


### PR DESCRIPTION
## :scroll: Description

Fixes #870

By awaiting only futures, the performance can be marginally improved.
I did my best to find all instances, but I'm not sure I got all.


## :bulb: Motivation and Context

My motivation is the strive for a better performance.

## :green_heart: How did you test it?

There are no changes in functionality, just in the implementation. So the existing tests cover these changes.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
