### PR TITLE
Include and set ProGuard uuid in Flutter Options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Add proguard_uui property to SentryFlutterOptions to set proguard information at runtime ([#1312](https://github.com/getsentry/sentry-dart/pull/1312))
+
 ### Fixes
 
 - Change podspec `EXCLUDED_ARCHS` value to allow podfiles to add more excluded architetures ([#1303](https://github.com/getsentry/sentry-dart/pull/1303))

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -279,9 +279,6 @@ class SentryOptions {
   /// If enabled, [scopeObservers] will be called when mutating scope.
   bool enableScopeSync = true;
 
-  /// Sets the ProGuard uuid for Android platform.
-  String? proGuardUuid;
-
   final List<ScopeObserver> _scopeObservers = [];
 
   List<ScopeObserver> get scopeObservers => _scopeObservers;

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -279,6 +279,9 @@ class SentryOptions {
   /// If enabled, [scopeObservers] will be called when mutating scope.
   bool enableScopeSync = true;
 
+  /// Sets the ProGuard uuid for Android platform.
+  String? proGuardUuid;
+
   final List<ScopeObserver> _scopeObservers = [];
 
   List<ScopeObserver> get scopeObservers => _scopeObservers;

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -145,6 +145,7 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
       args.getIfNotNull<Boolean>("anrEnabled") { options.isAnrEnabled = it }
       args.getIfNotNull<Boolean>("sendDefaultPii") { options.isSendDefaultPii = it }
       args.getIfNotNull<Boolean>("enableNdkScopeSync") { options.isEnableScopeSync = it }
+      args.getIfNotNull<String>("proGuardUuid") { options.proguardUuid = it }
 
       val nativeCrashHandling = (args["enableNativeCrashHandling"] as? Boolean) ?: true
       // nativeCrashHandling has priority over anrEnabled

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -145,7 +145,7 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
       args.getIfNotNull<Boolean>("anrEnabled") { options.isAnrEnabled = it }
       args.getIfNotNull<Boolean>("sendDefaultPii") { options.isSendDefaultPii = it }
       args.getIfNotNull<Boolean>("enableNdkScopeSync") { options.isEnableScopeSync = it }
-      args.getIfNotNull<String>("proGuardUuid") { options.proguardUuid = it }
+      args.getIfNotNull<String>("proguardUuid") { options.proguardUuid = it }
 
       val nativeCrashHandling = (args["enableNativeCrashHandling"] as? Boolean) ?: true
       // nativeCrashHandling has priority over anrEnabled

--- a/flutter/config/detekt-bl.xml
+++ b/flutter/config/detekt-bl.xml
@@ -2,7 +2,7 @@
 <SmellBaseline>
   <ManuallySuppressedIssues></ManuallySuppressedIssues>
   <CurrentIssues>
-    <ID>CyclomaticComplexMethod:SentryFlutterPlugin.kt$SentryFlutterPlugin$override fun onMethodCall(call: MethodCall, result: Result)</ID>
+    <ID>ComplexMethod:SentryFlutterPlugin.kt$SentryFlutterPlugin$override fun onMethodCall(call: MethodCall, result: Result)</ID>
     <ID>LongMethod:SentryFlutterPlugin.kt$SentryFlutterPlugin$private fun initNativeSdk(call: MethodCall, result: Result)</ID>
     <ID>MagicNumber:MainActivity.kt$MainActivity$6_000</ID>
     <ID>TooGenericExceptionCaught:MainActivity.kt$MainActivity$e: Exception</ID>

--- a/flutter/config/detekt-bl.xml
+++ b/flutter/config/detekt-bl.xml
@@ -2,7 +2,8 @@
 <SmellBaseline>
   <ManuallySuppressedIssues></ManuallySuppressedIssues>
   <CurrentIssues>
-    <ID>ComplexMethod:SentryFlutterPlugin.kt$SentryFlutterPlugin$override fun onMethodCall(call: MethodCall, result: Result)</ID>
+    <ID>CyclomaticComplexMethod:SentryFlutterPlugin.kt$SentryFlutterPlugin$override fun onMethodCall(call: MethodCall, result: Result)</ID>
+    <ID>LongMethod:SentryFlutterPlugin.kt$SentryFlutterPlugin$private fun initNativeSdk(call: MethodCall, result: Result)</ID>
     <ID>MagicNumber:MainActivity.kt$MainActivity$6_000</ID>
     <ID>TooGenericExceptionCaught:MainActivity.kt$MainActivity$e: Exception</ID>
     <ID>TooGenericExceptionThrown:MainActivity.kt$MainActivity$throw Exception("Catch this java exception thrown from Kotlin thread!")</ID>

--- a/flutter/lib/src/integrations/native_sdk_integration.dart
+++ b/flutter/lib/src/integrations/native_sdk_integration.dart
@@ -44,7 +44,7 @@ class NativeSdkIntegration extends Integration<SentryFlutterOptions> {
         'enableNdkScopeSync': options.enableNdkScopeSync,
         'enableAutoPerformanceTracking': options.enableAutoPerformanceTracking,
         'sendClientReports': options.sendClientReports,
-        'proGuardUuid': options.proGuardUuid,
+        'proguardUuid': options.proguardUuid,
       });
 
       options.sdk.addIntegration('nativeSdkIntegration');

--- a/flutter/lib/src/integrations/native_sdk_integration.dart
+++ b/flutter/lib/src/integrations/native_sdk_integration.dart
@@ -44,6 +44,7 @@ class NativeSdkIntegration extends Integration<SentryFlutterOptions> {
         'enableNdkScopeSync': options.enableNdkScopeSync,
         'enableAutoPerformanceTracking': options.enableAutoPerformanceTracking,
         'sendClientReports': options.sendClientReports,
+        'proGuardUuid': options.proGuardUuid,
       });
 
       options.sdk.addIntegration('nativeSdkIntegration');

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -202,6 +202,9 @@ class SentryFlutterOptions extends SentryOptions {
   /// runApp(SentryUserInteractionWidget(child: App()));
   bool enableUserInteractionTracing = false;
 
+  /// Sets the Proguard uuid for Android platform.
+  String? proguardUuid;
+
   @internal
   late RendererWrapper rendererWrapper = RendererWrapper();
 

--- a/flutter/test/integrations/init_native_sdk_integration_test.dart
+++ b/flutter/test/integrations/init_native_sdk_integration_test.dart
@@ -56,7 +56,7 @@ void main() {
         'enableNdkScopeSync': false,
         'enableAutoPerformanceTracking': true,
         'sendClientReports': true,
-        'proGuardUuid': null
+        'proguardUuid': null
       });
     });
 
@@ -90,7 +90,7 @@ void main() {
         ..enableNdkScopeSync = true
         ..enableAutoPerformanceTracking = false
         ..sendClientReports = false
-        ..proGuardUuid = fakeProGuardUuid;
+        ..proguardUuid = fakeProguardUuid;
 
       options.sdk.addIntegration('foo');
       options.sdk.addPackage('bar', '1');
@@ -127,7 +127,7 @@ void main() {
         'enableNdkScopeSync': true,
         'enableAutoPerformanceTracking': false,
         'sendClientReports': false,
-        'proGuardUuid': fakeProGuardUuid
+        'proguardUuid': fakeProguardUuid
       });
     });
 

--- a/flutter/test/integrations/init_native_sdk_integration_test.dart
+++ b/flutter/test/integrations/init_native_sdk_integration_test.dart
@@ -55,7 +55,8 @@ void main() {
         'enableOutOfMemoryTracking': true,
         'enableNdkScopeSync': false,
         'enableAutoPerformanceTracking': true,
-        'sendClientReports': true
+        'sendClientReports': true,
+        'proGuardUuid': null
       });
     });
 
@@ -88,7 +89,8 @@ void main() {
         ..enableOutOfMemoryTracking = false
         ..enableNdkScopeSync = true
         ..enableAutoPerformanceTracking = false
-        ..sendClientReports = false;
+        ..sendClientReports = false
+        ..proGuardUuid = fakeProGuardUuid;
 
       options.sdk.addIntegration('foo');
       options.sdk.addPackage('bar', '1');
@@ -124,7 +126,8 @@ void main() {
         'enableOutOfMemoryTracking': false,
         'enableNdkScopeSync': true,
         'enableAutoPerformanceTracking': false,
-        'sendClientReports': false
+        'sendClientReports': false,
+        'proGuardUuid': fakeProGuardUuid
       });
     });
 

--- a/flutter/test/mocks.dart
+++ b/flutter/test/mocks.dart
@@ -17,7 +17,7 @@ import 'mocks.mocks.dart';
 import 'no_such_method_provider.dart';
 
 const fakeDsn = 'https://abc@def.ingest.sentry.io/1234567';
-const fakeProGuardUuid = '3457d982-65ef-576d-a6ad-65b5f30f49a5';
+const fakeProguardUuid = '3457d982-65ef-576d-a6ad-65b5f30f49a5';
 
 // https://github.com/dart-lang/mockito/blob/master/NULL_SAFETY_README.md#fallback-generators
 ISentrySpan startTransactionShim(

--- a/flutter/test/mocks.dart
+++ b/flutter/test/mocks.dart
@@ -17,6 +17,7 @@ import 'mocks.mocks.dart';
 import 'no_such_method_provider.dart';
 
 const fakeDsn = 'https://abc@def.ingest.sentry.io/1234567';
+const fakeProGuardUuid = '3457d982-65ef-576d-a6ad-65b5f30f49a5';
 
 // https://github.com/dart-lang/mockito/blob/master/NULL_SAFETY_README.md#fallback-generators
 ISentrySpan startTransactionShim(


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

I just added a proGuardUuid property to the Options and passed it to Sentry's android native initialization.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Due to the flutter SDK not having support to configure the proguard uuid, it is necessary to perform a large workaround to perform this action.
So this simple modification already makes it possible for Flutter apps to configure the proguard uuid at runtime.

## :green_heart: How did you test it?

created unit tests for testing defaults and custom values

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
