### PR TITLE
Remove split-debug-info limitation from readme

### DIFF
--- a/flutter/README.md
+++ b/flutter/README.md
@@ -110,7 +110,6 @@ Please see the instructions [here](https://pub.dev/packages/sentry).
 
 ##### Known limitations
 
-- Flutter `split-debug-info` and `obfuscate` flags aren't supported on iOS yet, but only on Android, if this feature is enabled, Dart stack traces are not human readable
 - If you enable the `split-debug-info` feature, you must upload the Debug Symbols manually.
 - Layout related errors are only caught by [FlutterError.onError](https://api.flutter.dev/flutter/foundation/FlutterError/onError.html) in debug mode. In release mode, they are removed by the Flutter framework. See [Flutter build modes](https://flutter.dev/docs/testing/build-modes).
 


### PR DESCRIPTION
## :scroll: Description
_#skip-changelog_


## :bulb: Motivation and Context
Relates to https://github.com/getsentry/sentry-dart/issues/1281


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
