### PR TITLE
Improve (Dio)Error stackTrace and cause extraction

### DIFF
--- a/dart/lib/src/recursive_exception_cause_extractor.dart
+++ b/dart/lib/src/recursive_exception_cause_extractor.dart
@@ -17,7 +17,7 @@ class RecursiveExceptionCauseExtractor {
 
     var currentException = exception;
     ExceptionCause? currentExceptionCause =
-        ExceptionCause(exception, stackTrace);
+        ExceptionCause(exception, stackTrace ?? (exception is Error) ? (exception as Error).stackTrace : null);
 
     while (currentException != null &&
         currentExceptionCause != null &&

--- a/dio/lib/src/dio_error_extractor.dart
+++ b/dio/lib/src/dio_error_extractor.dart
@@ -5,12 +5,13 @@ import 'package:sentry/sentry.dart';
 class DioErrorExtractor extends ExceptionCauseExtractor<DioError> {
   @override
   ExceptionCause? cause(DioError error) {
-    if (error.stackTrace == null) {
+    final cause = error.error;
+    if (cause == null) {
       return null;
     }
     return ExceptionCause(
-      error.error ?? 'DioError inner stacktrace',
-      error.stackTrace,
+      cause,
+      (cause is Error) ? cause.stackTrace : null,
     );
   }
 }


### PR DESCRIPTION
## :scroll: Description
This is just a very quick idea idea of how to address https://github.com/getsentry/sentry-dart/issues/1322 and also by default support `Error.stackTrace`.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/getsentry/sentry-dart/issues/1322

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
