### PR TITLE
Split `min_version_test.yml` Android and iOS in different jobs

### DIFF
--- a/.github/workflows/min_version_test.yml
+++ b/.github/workflows/min_version_test.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-  test-android:
+  build-android:
     runs-on: macos-latest
     timeout-minutes: 30
 

--- a/.github/workflows/min_version_test.yml
+++ b/.github/workflows/min_version_test.yml
@@ -15,8 +15,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-  build:
-    name: Build
+  test-android:
     runs-on: macos-latest
     timeout-minutes: 30
 
@@ -32,9 +31,25 @@ jobs:
         with:
           flutter-version: '3.0.0'
       # Add flutter build web (missing index)
-      - name: Build
+      - name: Build Android
+        run: |
+          cd min_version_test
+          flutter pub get
+          flutter build appbundle
+
+  build-ios:
+    runs-on: macos-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: subosito/flutter-action@dbf1fa04f4d2e52c33185153d06cdb5443aa189d # pin@v2
+        with:
+          flutter-version: '3.0.0'
+      # Add flutter build web (missing index)
+      - name: Build iOS
         run: |
           cd min_version_test
           flutter pub get
           flutter build ios --no-codesign
-          flutter build appbundle


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->

Split workflow into iOS and Android jobs.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #1318

## :green_heart: How did you test it?

Running on CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes