### PR TITLE
Add a way to extract stacktraces from custom exception types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Exception StackTrace Extractor ([#1335](https://github.com/getsentry/sentry-dart/pull/1335))
+
 ### Dependencies
 
 - Bump Cocoa SDK from v8.0.0 to v8.3.1 ([#1331](https://github.com/getsentry/sentry-dart/pull/1331))

--- a/dart/lib/sentry.dart
+++ b/dart/lib/sentry.dart
@@ -35,6 +35,7 @@ export 'src/type_check_hint.dart';
 // exception extraction
 export 'src/exception_cause_extractor.dart';
 export 'src/exception_cause.dart';
+export 'src/exception_stacktrace_extractor.dart';
 // Isolates
 export 'src/sentry_isolate_extension.dart';
 export 'src/sentry_isolate.dart';

--- a/dart/lib/src/exception_stacktrace_extractor.dart
+++ b/dart/lib/src/exception_stacktrace_extractor.dart
@@ -17,12 +17,12 @@ import 'sentry_options.dart';
 /// class ExceptionWithInner {
 ///   ExceptionWithInner(this.innerException, this.innerStackTrace);
 ///   Object innerException;
-///   StackTrace innerStackTrace;
+///   dynamic innerStackTrace;
 /// }
 ///
 /// class ExceptionWithInnerStackTraceExtractor extends ExceptionStackTraceExtractor<ExceptionWithInner>  {
 ///   @override
-///   StackTrace? cause(ExceptionWithInner error) {
+///   dynamic cause(ExceptionWithInner error) {
 ///     return error.innerStackTrace;
 ///   }
 /// }
@@ -30,6 +30,6 @@ import 'sentry_options.dart';
 /// options.addExceptionStackTraceExtractor(ExceptionWithInnerStackTraceExtractor());
 /// ```
 abstract class ExceptionStackTraceExtractor<T> {
-  StackTrace? stackTrace(T error);
+  dynamic stackTrace(T error);
   Type get exceptionType => T;
 }

--- a/dart/lib/src/exception_stacktrace_extractor.dart
+++ b/dart/lib/src/exception_stacktrace_extractor.dart
@@ -1,0 +1,35 @@
+import 'protocol.dart';
+import 'sentry_options.dart';
+
+/// Sentry handles [Error.stackTrace] by default. For other cases
+/// extend this abstract class and return a custom [StackTrace] of your
+/// exceptions.
+///
+/// Implementing an extractor and providing it through
+/// [SentryOptions.addExceptionStackTraceExtractor] will enable the framework to
+/// extract the inner stacktrace and add it to [SentryException] when no other
+/// stacktrace was provided while capturing the event.
+///
+/// For an example on how to use the API refer to dio/DioStackTraceExtractor or the
+/// code below:
+///
+/// ```dart
+/// class ExceptionWithInner {
+///   ExceptionWithInner(this.innerException, this.innerStackTrace);
+///   Object innerException;
+///   StackTrace innerStackTrace;
+/// }
+///
+/// class ExceptionWithInnerStackTraceExtractor extends ExceptionStackTraceExtractor<ExceptionWithInner>  {
+///   @override
+///   StackTrace? cause(ExceptionWithInner error) {
+///     return error.innerStackTrace;
+///   }
+/// }
+///
+/// options.addExceptionStackTraceExtractor(ExceptionWithInnerStackTraceExtractor());
+/// ```
+abstract class ExceptionStackTraceExtractor<T> {
+  StackTrace? stackTrace(T error);
+  Type get exceptionType => T;
+}

--- a/dart/lib/src/sentry_exception_factory.dart
+++ b/dart/lib/src/sentry_exception_factory.dart
@@ -30,6 +30,10 @@ class SentryExceptionFactory {
     if (throwable is Error) {
       stackTrace ??= throwable.stackTrace;
     }
+    stackTrace ??= _options
+        .exceptionStackTraceExtractor(throwable.runtimeType)
+        ?.stackTrace(throwable);
+
     // throwable.stackTrace is null if its an exception that was never thrown
     // hence we check again if stackTrace is null and if not, read the current stack trace
     // but only if attachStacktrace is enabled

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -331,16 +331,28 @@ class SentryOptions {
   /// The default is 3 seconds.
   Duration? idleTimeout = Duration(seconds: 3);
 
-  final _extractorsByType = <Type, ExceptionCauseExtractor>{};
+  final _causeExtractorsByType = <Type, ExceptionCauseExtractor>{};
+
+  final _stackTraceExtractorsByType = <Type, ExceptionStackTraceExtractor>{};
 
   /// Returns a previously added [ExceptionCauseExtractor] by type
   ExceptionCauseExtractor? exceptionCauseExtractor(Type type) {
-    return _extractorsByType[type];
+    return _causeExtractorsByType[type];
   }
 
   /// Adds [ExceptionCauseExtractor] in order to extract inner exceptions
   void addExceptionCauseExtractor(ExceptionCauseExtractor extractor) {
-    _extractorsByType[extractor.exceptionType] = extractor;
+    _causeExtractorsByType[extractor.exceptionType] = extractor;
+  }
+
+  /// Returns a previously added [ExceptionStackTraceExtractor] by type
+  ExceptionStackTraceExtractor? exceptionStackTraceExtractor(Type type) {
+    return _stackTraceExtractorsByType[type];
+  }
+
+  /// Adds [ExceptionStackTraceExtractor] in order to extract inner exceptions
+  void addExceptionStackTraceExtractor(ExceptionStackTraceExtractor extractor) {
+    _stackTraceExtractorsByType[extractor.exceptionType] = extractor;
   }
 
   /// Changed SDK behaviour when set to true:

--- a/dio/lib/src/dio_stacktrace_extractor.dart
+++ b/dio/lib/src/dio_stacktrace_extractor.dart
@@ -1,0 +1,10 @@
+import 'package:dio/dio.dart';
+import 'package:sentry/sentry.dart';
+
+/// Extracts the inner stacktrace from [DioError]
+class DioStackTraceExtractor extends ExceptionStackTraceExtractor<DioError> {
+  @override
+  StackTrace? stackTrace(DioError error) {
+    return error.stackTrace;
+  }
+}

--- a/dio/lib/src/sentry_dio_extension.dart
+++ b/dio/lib/src/sentry_dio_extension.dart
@@ -2,6 +2,7 @@ import 'package:dio/dio.dart';
 import 'package:sentry/sentry.dart';
 import 'dio_error_extractor.dart';
 import 'dio_event_processor.dart';
+import 'dio_stacktrace_extractor.dart';
 import 'failed_request_interceptor.dart';
 import 'sentry_transformer.dart';
 import 'sentry_dio_client_adapter.dart';
@@ -50,9 +51,14 @@ extension SentryDioExtension on Dio {
     // ignore: invalid_use_of_internal_member
     final options = hub.options;
 
-    // Add to get inner exception & stacktrace
+    // Add to get inner exception
     if (options.exceptionCauseExtractor(DioError) == null) {
       options.addExceptionCauseExtractor(DioErrorExtractor());
+    }
+
+    // Add to get inner stacktrace
+    if (options.exceptionStackTraceExtractor(DioError) == null) {
+      options.addExceptionStackTraceExtractor(DioStackTraceExtractor());
     }
 
     // Add DioEventProcessor when it's not already present

--- a/dio/test/dio_stacktrace_extractor_test.dart
+++ b/dio/test/dio_stacktrace_extractor_test.dart
@@ -1,5 +1,4 @@
 import 'package:dio/dio.dart';
-import 'package:sentry_dio/src/dio_error_extractor.dart';
 import 'package:sentry_dio/src/dio_stacktrace_extractor.dart';
 import 'package:test/test.dart';
 

--- a/dio/test/dio_stacktrace_extractor_test.dart
+++ b/dio/test/dio_stacktrace_extractor_test.dart
@@ -1,0 +1,50 @@
+import 'package:dio/dio.dart';
+import 'package:sentry_dio/src/dio_error_extractor.dart';
+import 'package:sentry_dio/src/dio_stacktrace_extractor.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late Fixture fixture;
+
+  setUp(() {
+    fixture = Fixture();
+  });
+
+  group(DioStackTraceExtractor, () {
+    test('extracts stacktrace', () {
+      final sut = fixture.getSut();
+      final exception = Exception('foo bar');
+      final stacktrace = StackTrace.current;
+
+      final dioError = DioError(
+        error: exception,
+        requestOptions: RequestOptions(path: '/foo/bar'),
+        stackTrace: stacktrace,
+      );
+
+      final result = sut.stackTrace(dioError);
+
+      expect(result, stacktrace);
+    });
+
+    test('extracts nothing with missing stacktrace', () {
+      final sut = fixture.getSut();
+      final exception = Exception('foo bar');
+
+      final dioError = DioError(
+        error: exception,
+        requestOptions: RequestOptions(path: '/foo/bar'),
+      );
+
+      final result = sut.stackTrace(dioError);
+
+      expect(result, isNull);
+    });
+  });
+}
+
+class Fixture {
+  DioStackTraceExtractor getSut() {
+    return DioStackTraceExtractor();
+  }
+}

--- a/dio/test/sentry_dio_extension_test.dart
+++ b/dio/test/sentry_dio_extension_test.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:sentry_dio/sentry_dio.dart';
 import 'package:sentry_dio/src/dio_error_extractor.dart';
+import 'package:sentry_dio/src/dio_stacktrace_extractor.dart';
 import 'package:sentry_dio/src/sentry_dio_client_adapter.dart';
 import 'package:sentry_dio/src/sentry_dio_extension.dart';
 import 'package:sentry_dio/src/sentry_transformer.dart';
@@ -65,6 +66,17 @@ void main() {
 
       expect(
         fixture.hub.options.exceptionCauseExtractor(DioError),
+        isNotNull,
+      );
+    });
+
+    test('addSentry adds $DioStackTraceExtractor', () {
+      final dio = fixture.getSut();
+
+      dio.addSentry(hub: fixture.hub);
+
+      expect(
+        fixture.hub.options.exceptionStackTraceExtractor(DioError),
         isNotNull,
       );
     });


### PR DESCRIPTION
## :scroll: Description
* add `ExceptionStackTraceExtractor` and use as fallback in `SentryExceptionFactory`
* add `DioStackTraceExtractor` to the dio module which extracts `DioError.stackTrace`



## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See discussion in https://github.com/getsentry/sentry-dart/pull/1323
Fixes #1322

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps

CC @ueman @marandaneto 