### PR TITLE
LoadImageListIntegration won't throw bad state if there is no exceptions in the event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- LoadImageListIntegration won't throw bad state if there is no exceptions in the event ([#1339](https://github.com/getsentry/sentry-dart/pull/1339))
+
 ## 7.1.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- LoadImageListIntegration won't throw bad state if there is no exceptions in the event ([#1339](https://github.com/getsentry/sentry-dart/pull/1339))
+- LoadImageListIntegration won't throw bad state if there is no exceptions in the event ([#1347](https://github.com/getsentry/sentry-dart/pull/1347))
 
 ## 7.1.0
 

--- a/flutter/lib/src/integrations/load_image_list_integration.dart
+++ b/flutter/lib/src/integrations/load_image_list_integration.dart
@@ -22,9 +22,16 @@ class LoadImageListIntegration extends Integration<SentryFlutterOptions> {
 
 extension _NeedsSymbolication on SentryEvent {
   bool needsSymbolication() {
-    if (this is SentryTransaction) return false;
+    if (this is SentryTransaction) {
+      return false;
+    }
+    if (exceptions?.isNotEmpty == false) {
+      return false;
+    }
     final frames = exceptions?.first.stackTrace?.frames;
-    if (frames == null) return false;
+    if (frames == null) {
+      return false;
+    }
     return frames.any((frame) => 'native' == frame.platform);
   }
 }

--- a/flutter/test/integrations/load_image_list_test.dart
+++ b/flutter/test/integrations/load_image_list_test.dart
@@ -154,6 +154,26 @@ void main() {
           expect('e77c5713-5311-28c2-ecf0-eb73fc39f450', image.debugId);
           expect('test', image.debugFile);
         });
+
+        test('Native layer is not called as there is no exceptions',
+            () async {
+          var called = false;
+
+          final sut = fixture.getSut();
+          fixture.channel
+              .setMockMethodCallHandler((MethodCall methodCall) async {
+            called = true;
+            return imageList;
+          });
+
+          sut.call(fixture.hub, fixture.options);
+
+          expect(fixture.options.eventProcessors.length, 1);
+
+          await fixture.hub.captureMessage('error');
+
+          expect(called, false);
+        });
       });
     }
   });


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-dart/issues/1345


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
