### PR TITLE
Remove craft before release

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -19,4 +19,4 @@ targets:
       pub:sentry_logging:
       pub:sentry_dio:
       pub:sentry_file:
-      pub:sentry_sqflite:
+      #pub:sentry_sqflite:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Sentry SDK for Dart and Flutter
 
 ##### Usage
 
-For detailed usage, check out the inner [dart](https://github.com/getsentry/sentry-dart/tree/main/dart), [flutter](https://github.com/getsentry/sentry-dart/tree/main/flutter), [logging](https://github.com/getsentry/sentry-dart/tree/main/logging), [dio](https://github.com/getsentry/sentry-dart/tree/main/dio) and [file](https://github.com/getsentry/sentry-dart/tree/main/file) `README's` or our `Resources` section below.
+For detailed usage, check out the inner [dart](https://github.com/getsentry/sentry-dart/tree/main/dart), [flutter](https://github.com/getsentry/sentry-dart/tree/main/flutter), [logging](https://github.com/getsentry/sentry-dart/tree/main/logging), [dio](https://github.com/getsentry/sentry-dart/tree/main/dio), [file](https://github.com/getsentry/sentry-dart/tree/main/file) and [sqflite](https://github.com/getsentry/sentry-dart/tree/main/sqflite) `README's` or our `Resources` section below.
 
 #### Blog posts
 


### PR DESCRIPTION
## :scroll: Description
_#skip-changelog_


## :bulb: Motivation and Context
https://github.com/getsentry/sentry-release-registry does not exist yet, will add it after a successful deploy (pub.dev).


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
Add https://github.com/getsentry/sentry-release-registry before next release