### PR TITLE
Remove dio test with no stack trace, field is not nullable now

### DIFF
--- a/dio/test/dio_stacktrace_extractor_test.dart
+++ b/dio/test/dio_stacktrace_extractor_test.dart
@@ -25,20 +25,6 @@ void main() {
 
       expect(result, stacktrace);
     });
-
-    test('extracts nothing with missing stacktrace', () {
-      final sut = fixture.getSut();
-      final exception = Exception('foo bar');
-
-      final dioError = DioError(
-        error: exception,
-        requestOptions: RequestOptions(path: '/foo/bar'),
-      );
-
-      final result = sut.stackTrace(dioError);
-
-      expect(result, isNull);
-    });
   });
 }
 


### PR DESCRIPTION
## :scroll: Description
_#skip-changelog_


## :bulb: Motivation and Context
https://github.com/cfug/dio/pull/1722


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
