### PR TITLE
SentryUserInteractionWidget: add support for PopupMenuButton and PopupMenuItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Sanitize sensitive data from URLs (span desc, span data, crumbs, client errors) ([#1327](https://github.com/getsentry/sentry-dart/pull/1327))
+- SentryUserInteractionWidget: add support for PopupMenuButton and PopupMenuItem ([#1361](https://github.com/getsentry/sentry-dart/pull/1361))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- SentryUserInteractionWidget: add support for PopupMenuButton and PopupMenuItem ([#1361](https://github.com/getsentry/sentry-dart/pull/1361))
+
 ## 7.3.0
 
 ### Features
 
 - Sanitize sensitive data from URLs (span desc, span data, crumbs, client errors) ([#1327](https://github.com/getsentry/sentry-dart/pull/1327))
-- SentryUserInteractionWidget: add support for PopupMenuButton and PopupMenuItem ([#1361](https://github.com/getsentry/sentry-dart/pull/1361))
 
 ### Dependencies
 

--- a/flutter/lib/src/user_interaction/sentry_user_interaction_widget.dart
+++ b/flutter/lib/src/user_interaction/sentry_user_interaction_widget.dart
@@ -219,7 +219,7 @@ Element? _clickTrackerElement;
 ///
 /// It's supported by the most common [Widget], for example:
 /// [ButtonStyleButton], [MaterialButton], [CupertinoButton], [InkWell],
-/// and [IconButton].
+/// [IconButton], [PopupMenuButton] and [PopupMenuItem].
 /// Mostly for onPressed, onTap, and onLongPress events
 ///
 /// Example on how to set up:
@@ -537,6 +537,24 @@ class _SentryUserInteractionWidgetState
           description: _findDescriptionOf(element, false),
           type: 'IconButton',
           eventType: 'onPressed',
+        );
+      }
+    } else if (widget is PopupMenuButton) {
+      if (widget.enabled) {
+        return UserInteractionWidget(
+          element: element,
+          description: _findDescriptionOf(element, false),
+          type: 'PopupMenuButton',
+          eventType: 'onTap',
+        );
+      }
+    } else if (widget is PopupMenuItem) {
+      if (widget.enabled) {
+        return UserInteractionWidget(
+          element: element,
+          description: _findDescriptionOf(element, false),
+          type: 'PopupMenuItem',
+          eventType: 'onTap',
         );
       }
     }

--- a/flutter/test/user_interaction/sentry_user_interaction_widget_test.dart
+++ b/flutter/test/user_interaction/sentry_user_interaction_widget_test.dart
@@ -108,6 +108,42 @@ void main() {
         expect(crumb?.data?['label'], 'Button 5');
       });
     });
+
+    testWidgets('Add crumb for PopupMenuButton', (tester) async {
+      await tester.runAsync(() async {
+        final sut = fixture.getSut();
+
+        await tapMe(tester, sut, 'popup_menu_button');
+
+        Breadcrumb? crumb;
+        fixture.hub.configureScope((scope) {
+          crumb = scope.breadcrumbs.last;
+        });
+        expect(crumb?.category, 'ui.click');
+        expect(crumb?.data?['view.id'], 'popup_menu_button');
+        expect(crumb?.data?['view.class'], 'PopupMenuButton');
+      });
+    });
+
+    testWidgets('Add crumb for PopupMenuItem', (tester) async {
+      await tester.runAsync(() async {
+        final sut = fixture.getSut();
+
+        // open the popup menu and wait for the animation to complete
+        await tapMe(tester, sut, 'popup_menu_button');
+        await tester.pumpAndSettle();
+
+        await tapMe(tester, sut, 'popup_menu_item_1');
+
+        Breadcrumb? crumb;
+        fixture.hub.configureScope((scope) {
+          crumb = scope.breadcrumbs.last;
+        });
+        expect(crumb?.category, 'ui.click');
+        expect(crumb?.data?['view.id'], 'popup_menu_item_1');
+        expect(crumb?.data?['view.class'], 'PopupMenuItem');
+      });
+    });
   });
 
   group('$SentryUserInteractionWidget performance', () {
@@ -350,6 +386,15 @@ class Page1 extends StatelessWidget {
                 Navigator.of(context).pushNamed('page2');
               },
               child: const Text('Go to page 2'),
+            ),
+            PopupMenuButton(
+              key: ValueKey('popup_menu_button'),
+              itemBuilder: (_) => [
+                PopupMenuItem<void>(
+                  key: ValueKey('popup_menu_item_1'),
+                  child: Text('first item'),
+                ),
+              ],
             ),
           ],
         ),


### PR DESCRIPTION
## :scroll: Description
This PR adds support for PopupMenuButton and PopupMenuItem in SentryUserInteractionWidget. In this way, interactions with popup menus are automatically tracked.

Fixes #1360 


## :bulb: Motivation and Context
Many widgets are already supported by SentryUserInteractionWidget, but PopupMenuButton and PopupMenuItem currently are not.


## :green_heart: How did you test it?
Running `flutter test`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes

