### PR TITLE
Fix SentryUserInteractionWidget throwing when Sentry is not enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Fixes
 
 - Sync missing properties to the Native SDKs ([#1354](https://github.com/getsentry/sentry-dart/pull/1354))
+- Fix `SentryUserInteractionWidget` throwing when Sentry is not enabled ([#1363](https://github.com/getsentry/sentry-dart/pull/1363))
 
 ## 7.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix `SentryUserInteractionWidget` throwing when Sentry is not enabled ([#1363](https://github.com/getsentry/sentry-dart/pull/1363))
+
 ## 7.3.0
 
 ### Features
@@ -15,7 +21,6 @@
 ### Fixes
 
 - Sync missing properties to the Native SDKs ([#1354](https://github.com/getsentry/sentry-dart/pull/1354))
-- Fix `SentryUserInteractionWidget` throwing when Sentry is not enabled ([#1363](https://github.com/getsentry/sentry-dart/pull/1363))
 
 ## 7.2.0
 

--- a/flutter/lib/src/user_interaction/sentry_user_interaction_widget.dart
+++ b/flutter/lib/src/user_interaction/sentry_user_interaction_widget.dart
@@ -251,7 +251,10 @@ class SentryUserInteractionWidget extends StatefulWidget {
 
   SentryFlutterOptions? get _options =>
       // ignore: invalid_use_of_internal_member
-      _hub.options as SentryFlutterOptions?;
+      _hub.options is SentryFlutterOptions
+          // ignore: invalid_use_of_internal_member
+          ? _hub.options as SentryFlutterOptions
+          : null;
 
   @override
   StatefulElement createElement() {

--- a/flutter/test/user_interaction/sentry_user_interaction_widget_test.dart
+++ b/flutter/test/user_interaction/sentry_user_interaction_widget_test.dart
@@ -1,5 +1,4 @@
 @TestOn('vm')
-
 // ignore_for_file: invalid_use_of_internal_member
 
 import 'dart:async';
@@ -14,13 +13,26 @@ import '../mocks.dart';
 import '../mocks.mocks.dart';
 
 void main() {
-  group('$SentryUserInteractionWidget crumbs', () {
-    late Fixture fixture;
-    setUp(() async {
-      fixture = Fixture();
-      TestWidgetsFlutterBinding.ensureInitialized();
-    });
+  late Fixture fixture;
+  setUp(() async {
+    fixture = Fixture();
+    TestWidgetsFlutterBinding.ensureInitialized();
+  });
 
+  testWidgets(
+    '$SentryUserInteractionWidget does not throw cast exception when Sentry is disabled',
+    (tester) async {
+      await tester.runAsync(() async {
+        await tester.pumpWidget(
+          SentryUserInteractionWidget(
+            child: MaterialApp(),
+          ),
+        );
+      });
+    },
+  );
+
+  group('$SentryUserInteractionWidget crumbs', () {
     testWidgets('Add crumb for MaterialButton', (tester) async {
       await tester.runAsync(() async {
         final sut = fixture.getSut();


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
`SentryUserInteractionWidget` always attempts to cast the `hub.options` to `SentryFlutterOptions`- this cast can fail if `Sentry.isEnabled` is false or due do bad configuration. A simple type check was added to avoid this.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
Not sure what more to test.