### PR TITLE
Export `SentryBaggage`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fix Dart web builds breaking due to `dart:io` imports when using `SentryIsolate` or `SentryIsolateExtension` ([#1371](https://github.com/getsentry/sentry-dart/pull/1371))
   - When using `SentryIsolate` or `SentryIsolateExtension`, import `sentry_io.dart`.
+- Export `SentryBaggage` ([#1377](https://github.com/getsentry/sentry-dart/pull/1377))
 
 ## 7.4.0
 

--- a/dart/lib/sentry.dart
+++ b/dart/lib/sentry.dart
@@ -32,6 +32,7 @@ export 'src/utils/tracing_utils.dart';
 export 'src/tracing.dart';
 export 'src/hint.dart';
 export 'src/type_check_hint.dart';
+export 'src/sentry_baggage.dart';
 // exception extraction
 export 'src/exception_cause_extractor.dart';
 export 'src/exception_cause.dart';

--- a/dart/lib/src/utils/tracing_utils.dart
+++ b/dart/lib/src/utils/tracing_utils.dart
@@ -1,5 +1,4 @@
 import '../../sentry.dart';
-import '../sentry_baggage.dart';
 
 void addSentryTraceHeader(ISentrySpan span, Map<String, dynamic> headers) {
   final traceHeader = span.toSentryTrace();

--- a/dart/test/protocol/sentry_baggage_header_test.dart
+++ b/dart/test/protocol/sentry_baggage_header_test.dart
@@ -1,5 +1,4 @@
 import 'package:sentry/sentry.dart';
-import 'package:sentry/src/sentry_baggage.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/dart/test/sentry_tracer_test.dart
+++ b/dart/test/sentry_tracer_test.dart
@@ -1,5 +1,4 @@
 import 'package:sentry/sentry.dart';
-import 'package:sentry/src/sentry_baggage.dart';
 import 'package:sentry/src/sentry_tracer.dart';
 import 'package:sentry/src/utils.dart';
 import 'package:test/test.dart';

--- a/dart/test/sentry_transaction_context_test.dart
+++ b/dart/test/sentry_transaction_context_test.dart
@@ -1,5 +1,4 @@
 import 'package:sentry/sentry.dart';
-import 'package:sentry/src/sentry_baggage.dart';
 import 'package:test/test.dart';
 
 void main() {


### PR DESCRIPTION
## :scroll: Description

This should be exported in order to use `SentryBaggage.fromHeader()` when starting traces from a header:

```dart
SentryTransactionContext.fromSentryTrace(
  description,
  'http.client',
  SentryTraceHeader.fromTraceHeader(traceHeaderValue),
  baggage: SentryBaggage.fromHeader(),
);
```


## :bulb: Motivation and Context
See above


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
