### PR TITLE
Improve FutureOr usage only when necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Screenshots and View Hierarchy should only be added to errors ([#1385](https://github.com/getsentry/sentry-dart/pull/1385))
+  - View Hierarchy is removed from Web errors since we don't symbolicate minified View Hierarchy yet.
+- More improvements related to not awaiting `FutureOr<T>` if it's not a future ([#1385](https://github.com/getsentry/sentry-dart/pull/1385))
+
 ## 7.4.2
 
 ### Fixes

--- a/dart/example/bin/example.dart
+++ b/dart/example/bin/example.dart
@@ -101,9 +101,9 @@ Future<void> decode() async {
   throw StateError('This is a test error');
 }
 
-class TagEventProcessor extends EventProcessor {
+class TagEventProcessor implements EventProcessor {
   @override
-  FutureOr<SentryEvent?> apply(SentryEvent event, {hint}) {
+  SentryEvent? apply(SentryEvent event, {hint}) {
     return event..tags?.addAll({'page-locale': 'en-us'});
   }
 }

--- a/dart/example_web/web/main.dart
+++ b/dart/example_web/web/main.dart
@@ -127,9 +127,9 @@ Future<void> parseData() async {
   throw StateError('This is a test error');
 }
 
-class TagEventProcessor extends EventProcessor {
+class TagEventProcessor implements EventProcessor {
   @override
-  FutureOr<SentryEvent?> apply(SentryEvent event, {hint}) {
+  SentryEvent? apply(SentryEvent event, {hint}) {
     return event..tags?.addAll({'page-locale': 'en-us'});
   }
 }

--- a/dart/lib/src/event_processor/deduplication_event_processor.dart
+++ b/dart/lib/src/event_processor/deduplication_event_processor.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:collection';
 import '../event_processor.dart';
 import '../hint.dart';
@@ -19,7 +18,7 @@ import '../sentry_options.dart';
 /// var fooTwo = Exception('foo');
 /// ```
 /// because (fooOne == fooTwo) equals false
-class DeduplicationEventProcessor extends EventProcessor {
+class DeduplicationEventProcessor implements EventProcessor {
   DeduplicationEventProcessor(this._options);
 
   // Using a HashSet makes this performant.
@@ -27,7 +26,7 @@ class DeduplicationEventProcessor extends EventProcessor {
   final SentryOptions _options;
 
   @override
-  FutureOr<SentryEvent?> apply(SentryEvent event, {Hint? hint}) {
+  SentryEvent? apply(SentryEvent event, {Hint? hint}) {
     if (event is SentryTransaction) {
       return event;
     }
@@ -39,7 +38,7 @@ class DeduplicationEventProcessor extends EventProcessor {
     return _deduplicate(event);
   }
 
-  FutureOr<SentryEvent?> _deduplicate(SentryEvent event) {
+  SentryEvent? _deduplicate(SentryEvent event) {
     // Cast to `Object?` in order to enable better type checking
     // because `event.throwable` is `dynamic`
     final exception = event.throwable as Object?;

--- a/dart/lib/src/event_processor/enricher/io_enricher_event_processor.dart
+++ b/dart/lib/src/event_processor/enricher/io_enricher_event_processor.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:io';
 
 import '../../../sentry.dart';
@@ -19,7 +18,7 @@ class IoEnricherEventProcessor implements EnricherEventProcessor {
   final SentryOptions _options;
 
   @override
-  FutureOr<SentryEvent> apply(SentryEvent event, {Hint? hint}) {
+  SentryEvent apply(SentryEvent event, {Hint? hint}) {
     // If there's a native integration available, it probably has better
     // information available than Flutter.
 

--- a/dart/lib/src/event_processor/enricher/io_enricher_event_processor.dart
+++ b/dart/lib/src/event_processor/enricher/io_enricher_event_processor.dart
@@ -18,7 +18,7 @@ class IoEnricherEventProcessor implements EnricherEventProcessor {
   final SentryOptions _options;
 
   @override
-  SentryEvent apply(SentryEvent event, {Hint? hint}) {
+  SentryEvent? apply(SentryEvent event, {Hint? hint}) {
     // If there's a native integration available, it probably has better
     // information available than Flutter.
 

--- a/dart/lib/src/event_processor/enricher/web_enricher_event_processor.dart
+++ b/dart/lib/src/event_processor/enricher/web_enricher_event_processor.dart
@@ -21,7 +21,7 @@ class WebEnricherEventProcessor implements EnricherEventProcessor {
   final SentryOptions _options;
 
   @override
-  SentryEvent apply(SentryEvent event, {Hint? hint}) {
+  SentryEvent? apply(SentryEvent event, {Hint? hint}) {
     // Web has no native integration, so no need to check for it
 
     final contexts = event.contexts.copyWith(

--- a/dart/lib/src/event_processor/enricher/web_enricher_event_processor.dart
+++ b/dart/lib/src/event_processor/enricher/web_enricher_event_processor.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:html' as html show window, Window;
 
 import '../../../sentry.dart';
@@ -22,7 +21,7 @@ class WebEnricherEventProcessor implements EnricherEventProcessor {
   final SentryOptions _options;
 
   @override
-  FutureOr<SentryEvent> apply(SentryEvent event, {Hint? hint}) {
+  SentryEvent apply(SentryEvent event, {Hint? hint}) {
     // Web has no native integration, so no need to check for it
 
     final contexts = event.contexts.copyWith(

--- a/dart/lib/src/event_processor/exception/io_exception_event_processor.dart
+++ b/dart/lib/src/event_processor/exception/io_exception_event_processor.dart
@@ -14,7 +14,7 @@ class IoExceptionEventProcessor implements ExceptionEventProcessor {
   final SentryOptions _options;
 
   @override
-  SentryEvent apply(SentryEvent event, {Hint? hint}) {
+  SentryEvent? apply(SentryEvent event, {Hint? hint}) {
     final throwable = event.throwable;
     if (throwable is HttpException) {
       return _applyHttpException(throwable, event);

--- a/dart/lib/src/hub.dart
+++ b/dart/lib/src/hub.dart
@@ -364,7 +364,10 @@ class Hub {
       final item = _peek();
 
       try {
-        await callback(item.scope);
+        final result = callback(item.scope);
+        if (result is Future) {
+          await result;
+        }
       } catch (err) {
         _options.logger(
           SentryLevel.error,

--- a/dart/lib/src/isolate_error_integration.dart
+++ b/dart/lib/src/isolate_error_integration.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:isolate';
 
 import 'hub.dart';
@@ -6,11 +5,11 @@ import 'integration.dart';
 import 'sentry_isolate_extension.dart';
 import 'sentry_options.dart';
 
-class IsolateErrorIntegration extends Integration {
+class IsolateErrorIntegration implements Integration<SentryOptions> {
   RawReceivePort? _receivePort;
 
   @override
-  FutureOr<void> call(Hub hub, SentryOptions options) {
+  void call(Hub hub, SentryOptions options) {
     _receivePort = Isolate.current.addSentryErrorListener();
     options.sdk.addIntegration('isolateErrorIntegration');
   }

--- a/dart/lib/src/noop_isolate_error_integration.dart
+++ b/dart/lib/src/noop_isolate_error_integration.dart
@@ -1,17 +1,15 @@
-import 'dart:async';
-
 import 'hub.dart';
 import 'integration.dart';
 import 'sentry_options.dart';
 
 /// NoOp web integration : isolate doesnt' work in browser
-class IsolateErrorIntegration extends Integration {
+class IsolateErrorIntegration extends Integration<SentryOptions> {
   @override
-  FutureOr<void> call(Hub hub, SentryOptions options) async {}
+  void call(Hub hub, SentryOptions options) {}
 
-  Future<void> handleIsolateError(
+  void handleIsolateError(
     Hub hub,
     SentryOptions options,
     dynamic error,
-  ) async {}
+  ) {}
 }

--- a/dart/lib/src/run_zoned_guarded_integration.dart
+++ b/dart/lib/src/run_zoned_guarded_integration.dart
@@ -20,7 +20,7 @@ typedef RunZonedGuardedOnError = FutureOr<void> Function(Object, StackTrace);
 ///
 /// This integration also records calls to `print()` as Breadcrumbs.
 /// This can be configured with [SentryOptions.enablePrintBreadcrumbs]
-class RunZonedGuardedIntegration extends Integration {
+class RunZonedGuardedIntegration extends Integration<SentryOptions> {
   RunZonedGuardedIntegration(this._runner, this._onError);
 
   final RunZonedGuardedRunner _runner;
@@ -64,7 +64,7 @@ class RunZonedGuardedIntegration extends Integration {
   }
 
   @override
-  FutureOr<void> call(Hub hub, SentryOptions options) {
+  Future<void> call(Hub hub, SentryOptions options) {
     final completer = Completer<void>();
 
     runZonedGuarded(

--- a/dart/lib/src/scope.dart
+++ b/dart/lib/src/scope.dart
@@ -320,7 +320,7 @@ class Scope {
     for (final processor in _eventProcessors) {
       try {
         final e = processor.apply(processedEvent!, hint: hint);
-        if (e is Future) {
+        if (e is Future<SentryEvent?>) {
           processedEvent = await e;
         } else {
           processedEvent = e;

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -366,14 +366,14 @@ class SentryClient {
       if (event is SentryTransaction && beforeSendTransaction != null) {
         beforeSendName = 'beforeSendTransaction';
         final e = beforeSendTransaction(event);
-        if (e is Future) {
+        if (e is Future<SentryTransaction?>) {
           eventOrTransaction = await e;
         } else {
           eventOrTransaction = e;
         }
       } else if (beforeSend != null) {
         final e = beforeSend(event, hint: hint);
-        if (e is Future) {
+        if (e is Future<SentryEvent?>) {
           eventOrTransaction = await e;
         } else {
           eventOrTransaction = e;
@@ -411,7 +411,7 @@ class SentryClient {
     for (final processor in eventProcessors) {
       try {
         final e = processor.apply(processedEvent!, hint: hint);
-        if (e is Future) {
+        if (e is Future<SentryEvent?>) {
           processedEvent = await e;
         } else {
           processedEvent = e;

--- a/dart/lib/src/sentry_envelope_item.dart
+++ b/dart/lib/src/sentry_envelope_item.dart
@@ -112,7 +112,7 @@ class _CachedItem {
 
   Future<List<int>> getData() async {
     final data = _dataFactory();
-    if (data is Future) {
+    if (data is Future<List<int>>) {
       _data ??= await data;
     } else {
       _data ??= data;

--- a/dart/test/event_processor/enricher/io_enricher_test.dart
+++ b/dart/test/event_processor/enricher/io_enricher_test.dart
@@ -17,7 +17,7 @@ void main() {
 
     test('adds dart runtime', () async {
       final enricher = fixture.getSut();
-      final event = await enricher.apply(SentryEvent());
+      final event = enricher.apply(SentryEvent());
 
       expect(event.contexts.runtimes, isNotEmpty);
       final dartRuntime = event.contexts.runtimes
@@ -31,7 +31,7 @@ void main() {
       var event = SentryEvent(contexts: Contexts(runtimes: [runtime]));
       final enricher = fixture.getSut();
 
-      event = await enricher.apply(event);
+      event = enricher.apply(event);
 
       expect(event.contexts.runtimes.contains(runtime), true);
       // second runtime is Dart runtime
@@ -42,7 +42,7 @@ void main() {
         'does not add device, os and culture if native integration is available',
         () async {
       final enricher = fixture.getSut(hasNativeIntegration: true);
-      final event = await enricher.apply(SentryEvent());
+      final event = enricher.apply(SentryEvent());
 
       expect(event.contexts.device, isNull);
       expect(event.contexts.operatingSystem, isNull);
@@ -52,7 +52,7 @@ void main() {
     test('adds device, os and culture if no native integration is available',
         () async {
       final enricher = fixture.getSut(hasNativeIntegration: false);
-      final event = await enricher.apply(SentryEvent());
+      final event = enricher.apply(SentryEvent());
 
       expect(event.contexts.device, isNotNull);
       expect(event.contexts.operatingSystem, isNotNull);
@@ -61,14 +61,14 @@ void main() {
 
     test('device has name', () async {
       final enricher = fixture.getSut();
-      final event = await enricher.apply(SentryEvent());
+      final event = enricher.apply(SentryEvent());
 
       expect(event.contexts.device?.name, isNotNull);
     });
 
     test('culture has locale and timezone', () async {
       final enricher = fixture.getSut();
-      final event = await enricher.apply(SentryEvent());
+      final event = enricher.apply(SentryEvent());
 
       expect(event.contexts.culture?.locale, isNotNull);
       expect(event.contexts.culture?.timezone, isNotNull);
@@ -76,7 +76,7 @@ void main() {
 
     test('os has name and version', () async {
       final enricher = fixture.getSut();
-      final event = await enricher.apply(SentryEvent());
+      final event = enricher.apply(SentryEvent());
 
       expect(event.contexts.operatingSystem?.name, isNotNull);
       expect(event.contexts.operatingSystem?.version, isNotNull);
@@ -84,7 +84,7 @@ void main() {
 
     test('adds Dart context with PII', () async {
       final enricher = fixture.getSut(includePii: true);
-      final event = await enricher.apply(SentryEvent());
+      final event = enricher.apply(SentryEvent());
 
       final dartContext = event.contexts['dart_context'];
       expect(dartContext, isNotNull);
@@ -97,7 +97,7 @@ void main() {
 
     test('adds Dart context without PII', () async {
       final enricher = fixture.getSut(includePii: false);
-      final event = await enricher.apply(SentryEvent());
+      final event = enricher.apply(SentryEvent());
 
       final dartContext = event.contexts['dart_context'];
       expect(dartContext, isNotNull);
@@ -131,7 +131,7 @@ void main() {
         hasNativeIntegration: false,
       );
 
-      final event = await enricher.apply(fakeEvent);
+      final event = enricher.apply(fakeEvent);
 
       // contexts.device
       expect(

--- a/dart/test/event_processor/enricher/io_enricher_test.dart
+++ b/dart/test/event_processor/enricher/io_enricher_test.dart
@@ -15,23 +15,23 @@ void main() {
       fixture = Fixture();
     });
 
-    test('adds dart runtime', () async {
+    test('adds dart runtime', () {
       final enricher = fixture.getSut();
       final event = enricher.apply(SentryEvent());
 
-      expect(event.contexts.runtimes, isNotEmpty);
-      final dartRuntime = event.contexts.runtimes
+      expect(event?.contexts.runtimes, isNotEmpty);
+      final dartRuntime = event?.contexts.runtimes
           .firstWhere((element) => element.name == 'Dart');
-      expect(dartRuntime.name, 'Dart');
-      expect(dartRuntime.rawDescription, isNotNull);
+      expect(dartRuntime?.name, 'Dart');
+      expect(dartRuntime?.rawDescription, isNotNull);
     });
 
-    test('does add to existing runtimes', () async {
+    test('does add to existing runtimes', () {
       final runtime = SentryRuntime(name: 'foo', version: 'bar');
       var event = SentryEvent(contexts: Contexts(runtimes: [runtime]));
       final enricher = fixture.getSut();
 
-      event = enricher.apply(event);
+      event = enricher.apply(event)!;
 
       expect(event.contexts.runtimes.contains(runtime), true);
       // second runtime is Dart runtime
@@ -40,53 +40,53 @@ void main() {
 
     test(
         'does not add device, os and culture if native integration is available',
-        () async {
+        () {
       final enricher = fixture.getSut(hasNativeIntegration: true);
       final event = enricher.apply(SentryEvent());
 
-      expect(event.contexts.device, isNull);
-      expect(event.contexts.operatingSystem, isNull);
-      expect(event.contexts.culture, isNull);
+      expect(event?.contexts.device, isNull);
+      expect(event?.contexts.operatingSystem, isNull);
+      expect(event?.contexts.culture, isNull);
     });
 
     test('adds device, os and culture if no native integration is available',
-        () async {
+        () {
       final enricher = fixture.getSut(hasNativeIntegration: false);
       final event = enricher.apply(SentryEvent());
 
-      expect(event.contexts.device, isNotNull);
-      expect(event.contexts.operatingSystem, isNotNull);
-      expect(event.contexts.culture, isNotNull);
+      expect(event?.contexts.device, isNotNull);
+      expect(event?.contexts.operatingSystem, isNotNull);
+      expect(event?.contexts.culture, isNotNull);
     });
 
-    test('device has name', () async {
+    test('device has name', () {
       final enricher = fixture.getSut();
       final event = enricher.apply(SentryEvent());
 
-      expect(event.contexts.device?.name, isNotNull);
+      expect(event?.contexts.device?.name, isNotNull);
     });
 
-    test('culture has locale and timezone', () async {
+    test('culture has locale and timezone', () {
       final enricher = fixture.getSut();
       final event = enricher.apply(SentryEvent());
 
-      expect(event.contexts.culture?.locale, isNotNull);
-      expect(event.contexts.culture?.timezone, isNotNull);
+      expect(event?.contexts.culture?.locale, isNotNull);
+      expect(event?.contexts.culture?.timezone, isNotNull);
     });
 
-    test('os has name and version', () async {
+    test('os has name and version', () {
       final enricher = fixture.getSut();
       final event = enricher.apply(SentryEvent());
 
-      expect(event.contexts.operatingSystem?.name, isNotNull);
-      expect(event.contexts.operatingSystem?.version, isNotNull);
+      expect(event?.contexts.operatingSystem?.name, isNotNull);
+      expect(event?.contexts.operatingSystem?.version, isNotNull);
     });
 
-    test('adds Dart context with PII', () async {
+    test('adds Dart context with PII', () {
       final enricher = fixture.getSut(includePii: true);
       final event = enricher.apply(SentryEvent());
 
-      final dartContext = event.contexts['dart_context'];
+      final dartContext = event?.contexts['dart_context'];
       expect(dartContext, isNotNull);
       // Getting the executable sometimes throws
       //expect(dartContext['executable'], isNotNull);
@@ -95,11 +95,11 @@ void main() {
       // package_config and executable_arguments are optional
     });
 
-    test('adds Dart context without PII', () async {
+    test('adds Dart context without PII', () {
       final enricher = fixture.getSut(includePii: false);
       final event = enricher.apply(SentryEvent());
 
-      final dartContext = event.contexts['dart_context'];
+      final dartContext = event?.contexts['dart_context'];
       expect(dartContext, isNotNull);
       expect(dartContext['compile_mode'], isNotNull);
       expect(dartContext['executable'], isNull);
@@ -109,7 +109,7 @@ void main() {
       // and Platform is not mockable
     });
 
-    test('does not override event', () async {
+    test('does not override event', () {
       final fakeEvent = SentryEvent(
         contexts: Contexts(
           device: SentryDevice(
@@ -135,25 +135,25 @@ void main() {
 
       // contexts.device
       expect(
-        event.contexts.device?.name,
+        event?.contexts.device?.name,
         fakeEvent.contexts.device?.name,
       );
       // contexts.culture
       expect(
-        event.contexts.culture?.locale,
+        event?.contexts.culture?.locale,
         fakeEvent.contexts.culture?.locale,
       );
       expect(
-        event.contexts.culture?.timezone,
+        event?.contexts.culture?.timezone,
         fakeEvent.contexts.culture?.timezone,
       );
       // contexts.operatingSystem
       expect(
-        event.contexts.operatingSystem?.name,
+        event?.contexts.operatingSystem?.name,
         fakeEvent.contexts.operatingSystem?.name,
       );
       expect(
-        event.contexts.operatingSystem?.version,
+        event?.contexts.operatingSystem?.version,
         fakeEvent.contexts.operatingSystem?.version,
       );
     });

--- a/dart/test/event_processor/enricher/web_enricher_test.dart
+++ b/dart/test/event_processor/enricher/web_enricher_test.dart
@@ -18,29 +18,29 @@ void main() {
       fixture = Fixture();
     });
 
-    test('add path as transaction if transaction is null', () async {
+    test('add path as transaction if transaction is null', () {
       var enricher = fixture.getSut();
       final event = enricher.apply(SentryEvent());
 
-      expect(event.transaction, isNotNull);
+      expect(event?.transaction, isNotNull);
     });
 
-    test("don't overwrite transaction", () async {
+    test("don't overwrite transaction", () {
       var enricher = fixture.getSut();
       final event = enricher.apply(SentryEvent(transaction: 'foobar'));
 
-      expect(event.transaction, 'foobar');
+      expect(event?.transaction, 'foobar');
     });
 
-    test('add request with user-agent header', () async {
+    test('add request with user-agent header', () {
       var enricher = fixture.getSut();
       final event = enricher.apply(SentryEvent());
 
-      expect(event.request?.headers['User-Agent'], isNotNull);
-      expect(event.request?.url, isNotNull);
+      expect(event?.request?.headers['User-Agent'], isNotNull);
+      expect(event?.request?.url, isNotNull);
     });
 
-    test('adds header to request if request already exists', () async {
+    test('adds header to request if request already exists', () {
       var event = SentryEvent(
         request: SentryRequest(
           url: 'foo.bar',
@@ -50,14 +50,14 @@ void main() {
         ),
       );
       var enricher = fixture.getSut();
-      event = enricher.apply(event);
+      event = enricher.apply(event)!;
 
       expect(event.request?.headers['User-Agent'], isNotNull);
       expect(event.request?.headers['foo'], 'bar');
       expect(event.request?.url, 'foo.bar');
     });
 
-    test('does not add auth headers to request', () async {
+    test('does not add auth headers to request', () {
       var event = SentryEvent(
         request: SentryRequest(
           url: 'foo.bar',
@@ -68,13 +68,13 @@ void main() {
         ),
       );
       var enricher = fixture.getSut();
-      event = enricher.apply(event);
+      event = enricher.apply(event)!;
 
       expect(event.request?.headers['Authorization'], isNull);
       expect(event.request?.headers['authorization'], isNull);
     });
 
-    test('user-agent is not overridden if already present', () async {
+    test('user-agent is not overridden if already present', () {
       var event = SentryEvent(
         request: SentryRequest(
           url: 'foo.bar',
@@ -84,43 +84,43 @@ void main() {
         ),
       );
       var enricher = fixture.getSut();
-      event = enricher.apply(event);
+      event = enricher.apply(event)!;
 
       expect(event.request?.headers['User-Agent'], 'best browser agent');
       expect(event.request?.url, 'foo.bar');
     });
 
-    test('adds device and os', () async {
+    test('adds device and os', () {
       var enricher = fixture.getSut();
       final event = enricher.apply(SentryEvent());
 
-      expect(event.contexts.device, isNotNull);
+      expect(event?.contexts.device, isNotNull);
     });
 
-    test('adds Dart context', () async {
+    test('adds Dart context', () {
       final enricher = fixture.getSut();
       final event = enricher.apply(SentryEvent());
 
-      final dartContext = event.contexts['dart_context'];
+      final dartContext = event?.contexts['dart_context'];
       expect(dartContext, isNotNull);
       expect(dartContext['compile_mode'], isNotNull);
     });
 
-    test('device has screendensity', () async {
+    test('device has screendensity', () {
       var enricher = fixture.getSut();
       final event = enricher.apply(SentryEvent());
 
-      expect(event.contexts.device?.screenDensity, isNotNull);
+      expect(event?.contexts.device?.screenDensity, isNotNull);
     });
 
-    test('culture has timezone', () async {
+    test('culture has timezone', () {
       var enricher = fixture.getSut();
       final event = enricher.apply(SentryEvent());
 
-      expect(event.contexts.culture?.timezone, isNotNull);
+      expect(event?.contexts.culture?.timezone, isNotNull);
     });
 
-    test('does not override event', () async {
+    test('does not override event', () {
       final fakeEvent = SentryEvent(
         contexts: Contexts(
           device: SentryDevice(
@@ -146,37 +146,37 @@ void main() {
 
       // contexts.device
       expect(
-        event.contexts.device?.online,
+        event?.contexts.device?.online,
         fakeEvent.contexts.device?.online,
       );
       expect(
-        event.contexts.device?.memorySize,
+        event?.contexts.device?.memorySize,
         fakeEvent.contexts.device?.memorySize,
       );
       expect(
-        event.contexts.device?.orientation,
+        event?.contexts.device?.orientation,
         fakeEvent.contexts.device?.orientation,
       );
       expect(
-        event.contexts.device?.screenHeightPixels,
+        event?.contexts.device?.screenHeightPixels,
         fakeEvent.contexts.device?.screenHeightPixels,
       );
       expect(
-        event.contexts.device?.screenWidthPixels,
+        event?.contexts.device?.screenWidthPixels,
         fakeEvent.contexts.device?.screenWidthPixels,
       );
       expect(
-        event.contexts.device?.screenDensity,
+        event?.contexts.device?.screenDensity,
         fakeEvent.contexts.device?.screenDensity,
       );
       // contexts.culture
       expect(
-        event.contexts.culture?.timezone,
+        event?.contexts.culture?.timezone,
         fakeEvent.contexts.culture?.timezone,
       );
       // contexts.operatingSystem
       expect(
-        event.contexts.operatingSystem?.name,
+        event?.contexts.operatingSystem?.name,
         fakeEvent.contexts.operatingSystem?.name,
       );
     });

--- a/dart/test/event_processor/enricher/web_enricher_test.dart
+++ b/dart/test/event_processor/enricher/web_enricher_test.dart
@@ -20,21 +20,21 @@ void main() {
 
     test('add path as transaction if transaction is null', () async {
       var enricher = fixture.getSut();
-      final event = await enricher.apply(SentryEvent());
+      final event = enricher.apply(SentryEvent());
 
       expect(event.transaction, isNotNull);
     });
 
     test("don't overwrite transaction", () async {
       var enricher = fixture.getSut();
-      final event = await enricher.apply(SentryEvent(transaction: 'foobar'));
+      final event = enricher.apply(SentryEvent(transaction: 'foobar'));
 
       expect(event.transaction, 'foobar');
     });
 
     test('add request with user-agent header', () async {
       var enricher = fixture.getSut();
-      final event = await enricher.apply(SentryEvent());
+      final event = enricher.apply(SentryEvent());
 
       expect(event.request?.headers['User-Agent'], isNotNull);
       expect(event.request?.url, isNotNull);
@@ -50,7 +50,7 @@ void main() {
         ),
       );
       var enricher = fixture.getSut();
-      event = await enricher.apply(event);
+      event = enricher.apply(event);
 
       expect(event.request?.headers['User-Agent'], isNotNull);
       expect(event.request?.headers['foo'], 'bar');
@@ -68,7 +68,7 @@ void main() {
         ),
       );
       var enricher = fixture.getSut();
-      event = await enricher.apply(event);
+      event = enricher.apply(event);
 
       expect(event.request?.headers['Authorization'], isNull);
       expect(event.request?.headers['authorization'], isNull);
@@ -84,7 +84,7 @@ void main() {
         ),
       );
       var enricher = fixture.getSut();
-      event = await enricher.apply(event);
+      event = enricher.apply(event);
 
       expect(event.request?.headers['User-Agent'], 'best browser agent');
       expect(event.request?.url, 'foo.bar');
@@ -92,14 +92,14 @@ void main() {
 
     test('adds device and os', () async {
       var enricher = fixture.getSut();
-      final event = await enricher.apply(SentryEvent());
+      final event = enricher.apply(SentryEvent());
 
       expect(event.contexts.device, isNotNull);
     });
 
     test('adds Dart context', () async {
       final enricher = fixture.getSut();
-      final event = await enricher.apply(SentryEvent());
+      final event = enricher.apply(SentryEvent());
 
       final dartContext = event.contexts['dart_context'];
       expect(dartContext, isNotNull);
@@ -108,14 +108,14 @@ void main() {
 
     test('device has screendensity', () async {
       var enricher = fixture.getSut();
-      final event = await enricher.apply(SentryEvent());
+      final event = enricher.apply(SentryEvent());
 
       expect(event.contexts.device?.screenDensity, isNotNull);
     });
 
     test('culture has timezone', () async {
       var enricher = fixture.getSut();
-      final event = await enricher.apply(SentryEvent());
+      final event = enricher.apply(SentryEvent());
 
       expect(event.contexts.culture?.timezone, isNotNull);
     });
@@ -142,7 +142,7 @@ void main() {
 
       final enricher = fixture.getSut();
 
-      final event = await enricher.apply(fakeEvent);
+      final event = enricher.apply(fakeEvent);
 
       // contexts.device
       expect(

--- a/dart/test/event_processor/exception/io_exception_event_processor_test.dart
+++ b/dart/test/event_processor/exception/io_exception_event_processor_test.dart
@@ -14,7 +14,7 @@ void main() {
       fixture = Fixture();
     });
 
-    test('adds $SentryRequest for $HttpException with uris', () async {
+    test('adds $SentryRequest for $HttpException with uris', () {
       final enricher = fixture.getSut();
       final event = enricher.apply(
         SentryEvent(
@@ -25,12 +25,12 @@ void main() {
         ),
       );
 
-      expect(event.request, isNotNull);
-      expect(event.request?.url, 'https://example.org/foo/bar');
-      expect(event.request?.queryString, 'foo=bar');
+      expect(event?.request, isNotNull);
+      expect(event?.request?.url, 'https://example.org/foo/bar');
+      expect(event?.request?.queryString, 'foo=bar');
     });
 
-    test('no $SentryRequest for $HttpException without uris', () async {
+    test('no $SentryRequest for $HttpException without uris', () {
       final enricher = fixture.getSut();
       final event = enricher.apply(
         SentryEvent(
@@ -38,10 +38,10 @@ void main() {
         ),
       );
 
-      expect(event.request, isNull);
+      expect(event?.request, isNull);
     });
 
-    test('adds $SentryRequest for $SocketException with addresses', () async {
+    test('adds $SentryRequest for $SocketException with addresses', () {
       final enricher = fixture.getSut();
       final event = enricher.apply(
         SentryEvent(
@@ -57,21 +57,21 @@ void main() {
         ),
       );
 
-      expect(event.request, isNotNull);
-      expect(event.request?.url, '127.0.0.1');
+      expect(event?.request, isNotNull);
+      expect(event?.request?.url, '127.0.0.1');
 
       // Due to the test setup, there's no SentryException for the SocketException.
       // And thus only one entry for the added OSError
-      expect(event.exceptions?.first.type, 'OSError');
+      expect(event?.exceptions?.first.type, 'OSError');
       expect(
-        event.exceptions?.first.value,
+        event?.exceptions?.first.value,
         'OS Error: Connection reset by peer, errno = 54',
       );
-      expect(event.exceptions?.first.mechanism?.type, 'OSError');
-      expect(event.exceptions?.first.mechanism?.meta['errno']['number'], 54);
+      expect(event?.exceptions?.first.mechanism?.type, 'OSError');
+      expect(event?.exceptions?.first.mechanism?.meta['errno']['number'], 54);
     });
 
-    test('adds OSError SentryException for $FileSystemException', () async {
+    test('adds OSError SentryException for $FileSystemException', () {
       final enricher = fixture.getSut();
       final event = enricher.apply(
         SentryEvent(
@@ -85,13 +85,13 @@ void main() {
 
       // Due to the test setup, there's no SentryException for the FileSystemException.
       // And thus only one entry for the added OSError
-      expect(event.exceptions?.first.type, 'OSError');
+      expect(event?.exceptions?.first.type, 'OSError');
       expect(
-        event.exceptions?.first.value,
+        event?.exceptions?.first.value,
         'OS Error: Oh no :(, errno = 42',
       );
-      expect(event.exceptions?.first.mechanism?.type, 'OSError');
-      expect(event.exceptions?.first.mechanism?.meta['errno']['number'], 42);
+      expect(event?.exceptions?.first.mechanism?.type, 'OSError');
+      expect(event?.exceptions?.first.mechanism?.meta['errno']['number'], 42);
     });
   });
 }

--- a/dart/test/http_client/failed_request_client_test.dart
+++ b/dart/test/http_client/failed_request_client_test.dart
@@ -295,8 +295,7 @@ void main() {
       final sut = fixture.getSut(client: client);
 
       Hint? eventHint;
-      fixture.options
-          .addEventProcessor(FunctionEventProcessor((event, {hint}) async {
+      fixture.options.addEventProcessor(FunctionEventProcessor((event, {hint}) {
         eventHint = hint;
         return event;
       }));

--- a/dart/test/mocks.dart
+++ b/dart/test/mocks.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:sentry/sentry.dart';
 import 'package:sentry/src/transport/rate_limiter.dart';
 
@@ -97,26 +95,26 @@ final fakeEvent = SentryEvent(
 );
 
 /// Always returns null and thus drops all events
-class DropAllEventProcessor extends EventProcessor {
+class DropAllEventProcessor implements EventProcessor {
   @override
-  FutureOr<SentryEvent?> apply(SentryEvent event, {hint}) {
+  SentryEvent? apply(SentryEvent event, {hint}) {
     return null;
   }
 }
 
-class FunctionEventProcessor extends EventProcessor {
+class FunctionEventProcessor implements EventProcessor {
   FunctionEventProcessor(this.applyFunction);
 
   final EventProcessorFunction applyFunction;
 
   @override
-  FutureOr<SentryEvent?> apply(SentryEvent event, {hint}) {
+  SentryEvent? apply(SentryEvent event, {hint}) {
     return applyFunction(event, hint: hint);
   }
 }
 
-typedef EventProcessorFunction = FutureOr<SentryEvent?>
-    Function(SentryEvent event, {Hint? hint});
+typedef EventProcessorFunction = SentryEvent? Function(SentryEvent event,
+    {Hint? hint});
 
 var fakeEnvelope = SentryEnvelope.fromEvent(
   fakeEvent,

--- a/dart/test/mocks/mock_integration.dart
+++ b/dart/test/mocks/mock_integration.dart
@@ -1,15 +1,15 @@
-import 'dart:async';
-
 import 'package:sentry/sentry.dart';
 
 import 'no_such_method_provider.dart';
 
-class MockIntegration with NoSuchMethodProvider implements Integration {
+class MockIntegration
+    with NoSuchMethodProvider
+    implements Integration<SentryOptions> {
   int closeCalls = 0;
   int callCalls = 0;
 
   @override
-  FutureOr<void> call(Hub hub, SentryOptions options) async {
+  void call(Hub hub, SentryOptions options) {
     callCalls = callCalls + 1;
   }
 

--- a/dart/test/run_zoned_guarded_integration_test.dart
+++ b/dart/test/run_zoned_guarded_integration_test.dart
@@ -49,7 +49,7 @@ void main() {
       };
       final sut = fixture.getSut(runner: runner, onError: onError);
 
-      sut.call(fixture.hub, fixture.options);
+      await sut.call(fixture.hub, fixture.options);
       await Future.delayed(Duration(milliseconds: 10));
 
       expect(onErrorCalled, true);

--- a/dart/test/scope_test.dart
+++ b/dart/test/scope_test.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:collection/collection.dart';
 import 'package:sentry/sentry.dart';
 import 'package:sentry/src/sentry_tracer.dart';
@@ -795,13 +793,13 @@ class Fixture {
   }
 }
 
-class AddTagsEventProcessor extends EventProcessor {
+class AddTagsEventProcessor implements EventProcessor {
   final Map<String, String> tags;
 
   AddTagsEventProcessor(this.tags);
 
   @override
-  FutureOr<SentryEvent?> apply(SentryEvent event, {hint}) {
+  SentryEvent? apply(SentryEvent event, {hint}) {
     return event..tags?.addAll(tags);
   }
 }

--- a/dart/test/sentry_client_test.dart
+++ b/dart/test/sentry_client_test.dart
@@ -1550,18 +1550,18 @@ Future<Map<String, dynamic>> transactionFromEnvelope(
   return envelopeItemJson as Map<String, dynamic>;
 }
 
-FutureOr<SentryEvent?> beforeSendCallbackDropEvent(
+SentryEvent? beforeSendCallbackDropEvent(
   SentryEvent event, {
   Hint? hint,
 }) =>
     null;
 
-FutureOr<SentryTransaction?> beforeSendTransactionCallbackDropEvent(
+SentryTransaction? beforeSendTransactionCallbackDropEvent(
   SentryTransaction event,
 ) =>
     null;
 
-FutureOr<SentryEvent?> asyncBeforeSendCallbackDropEvent(
+Future<SentryEvent?> asyncBeforeSendCallbackDropEvent(
   SentryEvent event, {
   Hint? hint,
 }) async {
@@ -1569,13 +1569,13 @@ FutureOr<SentryEvent?> asyncBeforeSendCallbackDropEvent(
   return null;
 }
 
-FutureOr<SentryTransaction?> asyncBeforeSendTransactionCallbackDropEvent(
+Future<SentryTransaction?> asyncBeforeSendTransactionCallbackDropEvent(
     SentryEvent event) async {
   await Future.delayed(Duration(milliseconds: 200));
   return null;
 }
 
-FutureOr<SentryEvent?> beforeSendCallback(SentryEvent event, {Hint? hint}) {
+SentryEvent? beforeSendCallback(SentryEvent event, {Hint? hint}) {
   return event
     ..tags!.addAll({'theme': 'material'})
     ..extra!['host'] = '0.0.0.1'
@@ -1586,7 +1586,7 @@ FutureOr<SentryEvent?> beforeSendCallback(SentryEvent event, {Hint? hint}) {
     ..sdk!.addPackage('test-pkg', '1.0');
 }
 
-FutureOr<SentryTransaction?> beforeSendTransactionCallback(
+SentryTransaction? beforeSendTransactionCallback(
     SentryTransaction transaction) {
   return transaction
     ..tags!.addAll({'theme': 'material'})
@@ -1649,7 +1649,7 @@ class Fixture {
     return client;
   }
 
-  FutureOr<SentryEvent?> droppingBeforeSend(SentryEvent event,
+  Future<SentryEvent?> droppingBeforeSend(SentryEvent event,
       {Hint? hint}) async {
     return null;
   }

--- a/dio/lib/src/dio_event_processor.dart
+++ b/dio/lib/src/dio_event_processor.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:dio/dio.dart';
 import 'package:sentry/sentry.dart';
 
@@ -13,7 +11,11 @@ class DioEventProcessor implements EventProcessor {
   final SentryOptions _options;
 
   @override
-  FutureOr<SentryEvent?> apply(SentryEvent event, {Hint? hint}) {
+  SentryEvent? apply(SentryEvent event, {Hint? hint}) {
+    if (event is SentryTransaction) {
+      return event;
+    }
+
     DioError? dioError;
 
     for (final exception in event.exceptions ?? []) {
@@ -30,7 +32,7 @@ class DioEventProcessor implements EventProcessor {
 
     final response = _responseFrom(dioError);
 
-    Contexts contexts = event.contexts;
+    var contexts = event.contexts;
     if (event.contexts.response == null) {
       contexts = contexts.copyWith(response: response);
     }

--- a/dio/test/mocks.dart
+++ b/dio/test/mocks.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:sentry/sentry.dart';
 import 'package:sentry/src/transport/rate_limiter.dart';
 
@@ -97,34 +95,36 @@ final fakeEvent = SentryEvent(
 );
 
 /// Doesn't do anything with the events
-class NoOpEventProcessor extends EventProcessor {
+class NoOpEventProcessor implements EventProcessor {
   @override
-  FutureOr<SentryEvent?> apply(SentryEvent event, {Hint? hint}) {
+  SentryEvent? apply(SentryEvent event, {Hint? hint}) {
     return event;
   }
 }
 
 /// Always returns null and thus drops all events
-class DropAllEventProcessor extends EventProcessor {
+class DropAllEventProcessor implements EventProcessor {
   @override
-  FutureOr<SentryEvent?> apply(SentryEvent event, {Hint? hint}) {
+  SentryEvent? apply(SentryEvent event, {Hint? hint}) {
     return null;
   }
 }
 
-class FunctionEventProcessor extends EventProcessor {
+class FunctionEventProcessor implements EventProcessor {
   FunctionEventProcessor(this.applyFunction);
 
   final EventProcessorFunction applyFunction;
 
   @override
-  FutureOr<SentryEvent?> apply(SentryEvent event, {Hint? hint}) {
+  SentryEvent? apply(SentryEvent event, {Hint? hint}) {
     return applyFunction(event, hint: hint);
   }
 }
 
-typedef EventProcessorFunction = FutureOr<SentryEvent?>
-    Function(SentryEvent event, {Hint? hint});
+typedef EventProcessorFunction = SentryEvent? Function(
+  SentryEvent event, {
+  Hint? hint,
+});
 
 var fakeEnvelope = SentryEnvelope.fromEvent(
   fakeEvent,

--- a/flutter/lib/src/event_processor/android_platform_exception_event_processor.dart
+++ b/flutter/lib/src/event_processor/android_platform_exception_event_processor.dart
@@ -19,7 +19,11 @@ class AndroidPlatformExceptionEventProcessor implements EventProcessor {
   static final _platformExceptionType = (PlatformException).toString();
 
   @override
-  FutureOr<SentryEvent?> apply(SentryEvent event, {Hint? hint}) async {
+  Future<SentryEvent?> apply(SentryEvent event, {Hint? hint}) async {
+    if (event is SentryTransaction) {
+      return event;
+    }
+
     final plaformException = event.throwable;
     if (plaformException is! PlatformException) {
       return event;

--- a/flutter/lib/src/event_processor/flutter_enricher_event_processor.dart
+++ b/flutter/lib/src/event_processor/flutter_enricher_event_processor.dart
@@ -12,7 +12,7 @@ typedef WidgetBindingGetter = WidgetsBinding? Function();
 /// Enriches [SentryEvent]s with various kinds of information.
 /// FlutterEnricher only needs to add information which aren't exposed by
 /// the Dart runtime.
-class FlutterEnricherEventProcessor extends EventProcessor {
+class FlutterEnricherEventProcessor implements EventProcessor {
   FlutterEnricherEventProcessor(this._options);
 
   final SentryFlutterOptions _options;
@@ -29,7 +29,7 @@ class FlutterEnricherEventProcessor extends EventProcessor {
   Map<String, String> _packages = {};
 
   @override
-  FutureOr<SentryEvent> apply(
+  Future<SentryEvent?> apply(
     SentryEvent event, {
     Hint? hint,
   }) async {
@@ -70,7 +70,7 @@ class FlutterEnricherEventProcessor extends EventProcessor {
   /// - Only packages with licenses are known
   /// - No version information is available
   /// - Flutter's native dependencies are also included.
-  FutureOr<Map<String, String>?> _getPackages() async {
+  Future<Map<String, String>?> _getPackages() async {
     if (!_options.reportPackages) {
       return null;
     }

--- a/flutter/lib/src/event_processor/flutter_exception_event_processor.dart
+++ b/flutter/lib/src/event_processor/flutter_exception_event_processor.dart
@@ -3,7 +3,11 @@ import 'package:sentry/sentry.dart';
 
 class FlutterExceptionEventProcessor implements EventProcessor {
   @override
-  SentryEvent apply(SentryEvent event, {Hint? hint}) {
+  SentryEvent? apply(SentryEvent event, {Hint? hint}) {
+    if (event is SentryTransaction) {
+      return event;
+    }
+
     final exception = event.throwable;
     if (exception is NetworkImageLoadException) {
       return _applyNetworkImageLoadException(event, exception);

--- a/flutter/lib/src/event_processor/native_app_start_event_processor.dart
+++ b/flutter/lib/src/event_processor/native_app_start_event_processor.dart
@@ -7,7 +7,7 @@ import '../sentry_native_channel.dart';
 
 /// EventProcessor that enriches [SentryTransaction] objects with app start
 /// measurement.
-class NativeAppStartEventProcessor extends EventProcessor {
+class NativeAppStartEventProcessor implements EventProcessor {
   /// We filter out App starts more than 60s
   static const _maxAppStartMillis = 60000;
 
@@ -18,7 +18,7 @@ class NativeAppStartEventProcessor extends EventProcessor {
   final SentryNative _native;
 
   @override
-  FutureOr<SentryEvent?> apply(SentryEvent event, {Hint? hint}) async {
+  Future<SentryEvent?> apply(SentryEvent event, {Hint? hint}) async {
     final appStartEnd = _native.appStartEnd;
 
     if (appStartEnd != null &&

--- a/flutter/lib/src/event_processor/platform_exception_event_processor.dart
+++ b/flutter/lib/src/event_processor/platform_exception_event_processor.dart
@@ -1,12 +1,14 @@
-import 'dart:async';
-
 import 'package:flutter/services.dart';
 import 'package:sentry/sentry.dart';
 
 /// Add code & message from [PlatformException] to [SentryException]
 class PlatformExceptionEventProcessor implements EventProcessor {
   @override
-  FutureOr<SentryEvent?> apply(SentryEvent event, {Hint? hint}) {
+  SentryEvent? apply(SentryEvent event, {Hint? hint}) {
+    if (event is SentryTransaction) {
+      return event;
+    }
+
     final exceptions = <SentryException>[];
 
     for (SentryException exception in (event.exceptions ?? [])) {

--- a/flutter/lib/src/event_processor/screenshot_event_processor.dart
+++ b/flutter/lib/src/event_processor/screenshot_event_processor.dart
@@ -9,7 +9,7 @@ import '../sentry_flutter_options.dart';
 import 'package:flutter/rendering.dart';
 import '../renderer/renderer.dart';
 
-class ScreenshotEventProcessor extends EventProcessor {
+class ScreenshotEventProcessor implements EventProcessor {
   final SentryFlutterOptions _options;
 
   ScreenshotEventProcessor(this._options);
@@ -19,7 +19,11 @@ class ScreenshotEventProcessor extends EventProcessor {
       sentryScreenshotWidgetGlobalKey.currentContext != null;
 
   @override
-  FutureOr<SentryEvent?> apply(SentryEvent event, {Hint? hint}) async {
+  Future<SentryEvent?> apply(SentryEvent event, {Hint? hint}) async {
+    if (event is SentryTransaction) {
+      return event;
+    }
+
     if (event.exceptions == null &&
         event.throwable == null &&
         _hasSentryScreenshotWidget) {

--- a/flutter/lib/src/event_processor/screenshot_event_processor.dart
+++ b/flutter/lib/src/event_processor/screenshot_event_processor.dart
@@ -53,7 +53,7 @@ class ScreenshotEventProcessor implements EventProcessor {
         final pixelRatio = window.devicePixelRatio;
         var imageResult = _getImage(renderObject, pixelRatio);
         Image image;
-        if (imageResult is Future) {
+        if (imageResult is Future<Image>) {
           image = await imageResult;
         } else {
           image = imageResult;
@@ -74,7 +74,7 @@ class ScreenshotEventProcessor implements EventProcessor {
           var ratio = min(ratioWidth, ratioHeight);
           if (ratio > 0.0 && ratio < 1.0) {
             imageResult = _getImage(renderObject, ratio * pixelRatio);
-            if (imageResult is Future) {
+            if (imageResult is Future<Image>) {
               image = await imageResult;
             } else {
               image = imageResult;

--- a/flutter/lib/src/integrations/debug_print_integration.dart
+++ b/flutter/lib/src/integrations/debug_print_integration.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/foundation.dart';
 import 'package:sentry/sentry.dart';
 
@@ -10,20 +8,20 @@ import '../sentry_flutter_options.dart';
 /// add a [Breadcrumb]. [debugPrint] is not outputting to the console anymore!
 /// This integration fixes the issue described in
 /// [#492](https://github.com/getsentry/sentry-dart/issues/492).
-class DebugPrintIntegration extends Integration<SentryFlutterOptions> {
+class DebugPrintIntegration implements Integration<SentryFlutterOptions> {
   DebugPrintCallback? _debugPrintBackup;
   late Hub _hub;
   late SentryFlutterOptions _options;
 
   @override
-  FutureOr<void> call(Hub hub, SentryFlutterOptions options) {
+  void call(Hub hub, SentryFlutterOptions options) {
     _hub = hub;
     _options = options;
 
     final isDebug = options.platformChecker.isDebugMode();
     final enablePrintBreadcrumbs = options.enablePrintBreadcrumbs;
     if (isDebug || !enablePrintBreadcrumbs) {
-      return Future.value();
+      return;
     }
 
     _debugPrintBackup = debugPrint;

--- a/flutter/lib/src/integrations/flutter_error_integration.dart
+++ b/flutter/lib/src/integrations/flutter_error_integration.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/foundation.dart';
 import 'package:sentry/sentry.dart';
 import '../sentry_flutter_options.dart';
@@ -11,7 +9,7 @@ import '../sentry_flutter_options.dart';
 ///     [these](https://flutter.dev/docs/testing/common-errors)) are AssertionErrors
 ///     and are stripped in release mode. See [Flutter build modes](https://flutter.dev/docs/testing/build-modes).
 ///     So they only get caught in debug mode.
-class FlutterErrorIntegration extends Integration<SentryFlutterOptions> {
+class FlutterErrorIntegration implements Integration<SentryFlutterOptions> {
   /// Reference to the original handler.
   FlutterExceptionHandler? _defaultOnError;
 
@@ -106,7 +104,7 @@ class FlutterErrorIntegration extends Integration<SentryFlutterOptions> {
   }
 
   @override
-  FutureOr<void> close() async {
+  void close() {
     /// Restore default if the integration error is still set.
     if (FlutterError.onError == _integrationOnError) {
       FlutterError.onError = _defaultOnError;

--- a/flutter/lib/src/integrations/load_contexts_integration.dart
+++ b/flutter/lib/src/integrations/load_contexts_integration.dart
@@ -25,7 +25,7 @@ class LoadContextsIntegration extends Integration<SentryFlutterOptions> {
   LoadContextsIntegration(this._channel);
 
   @override
-  FutureOr<void> call(Hub hub, SentryFlutterOptions options) async {
+  void call(Hub hub, SentryFlutterOptions options) {
     options.addEventProcessor(
       _LoadContextsIntegrationEventProcessor(_channel, options),
     );
@@ -33,14 +33,14 @@ class LoadContextsIntegration extends Integration<SentryFlutterOptions> {
   }
 }
 
-class _LoadContextsIntegrationEventProcessor extends EventProcessor {
+class _LoadContextsIntegrationEventProcessor implements EventProcessor {
   _LoadContextsIntegrationEventProcessor(this._channel, this._options);
 
   final MethodChannel _channel;
   final SentryFlutterOptions _options;
 
   @override
-  FutureOr<SentryEvent?> apply(SentryEvent event, {Hint? hint}) async {
+  Future<SentryEvent?> apply(SentryEvent event, {Hint? hint}) async {
     try {
       final loadContexts = await _channel.invokeMethod('loadContexts');
 

--- a/flutter/lib/src/integrations/load_image_list_integration.dart
+++ b/flutter/lib/src/integrations/load_image_list_integration.dart
@@ -11,7 +11,7 @@ class LoadImageListIntegration extends Integration<SentryFlutterOptions> {
   LoadImageListIntegration(this._channel);
 
   @override
-  FutureOr<void> call(Hub hub, SentryFlutterOptions options) {
+  void call(Hub hub, SentryFlutterOptions options) {
     options.addEventProcessor(
       _LoadImageListIntegrationEventProcessor(_channel, options),
     );
@@ -36,14 +36,14 @@ extension _NeedsSymbolication on SentryEvent {
   }
 }
 
-class _LoadImageListIntegrationEventProcessor extends EventProcessor {
+class _LoadImageListIntegrationEventProcessor implements EventProcessor {
   _LoadImageListIntegrationEventProcessor(this._channel, this._options);
 
   final MethodChannel _channel;
   final SentryFlutterOptions _options;
 
   @override
-  FutureOr<SentryEvent?> apply(SentryEvent event, {Hint? hint}) async {
+  Future<SentryEvent?> apply(SentryEvent event, {Hint? hint}) async {
     if (event.needsSymbolication()) {
       try {
         // we call on every event because the loaded image list is cached

--- a/flutter/lib/src/integrations/load_release_integration.dart
+++ b/flutter/lib/src/integrations/load_release_integration.dart
@@ -9,7 +9,7 @@ class LoadReleaseIntegration extends Integration<SentryFlutterOptions> {
   LoadReleaseIntegration();
 
   @override
-  FutureOr<void> call(Hub hub, SentryFlutterOptions options) async {
+  Future<void> call(Hub hub, SentryFlutterOptions options) async {
     try {
       if (options.release == null || options.dist == null) {
         final packageInfo = await PackageInfo.fromPlatform();

--- a/flutter/lib/src/integrations/native_app_start_integration.dart
+++ b/flutter/lib/src/integrations/native_app_start_integration.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/scheduler.dart';
 import 'package:sentry/sentry.dart';
 
@@ -16,7 +14,7 @@ class NativeAppStartIntegration extends Integration<SentryFlutterOptions> {
   final SchedulerBindingProvider _schedulerBindingProvider;
 
   @override
-  FutureOr<void> call(Hub hub, SentryFlutterOptions options) {
+  void call(Hub hub, SentryFlutterOptions options) {
     if (options.autoAppStart) {
       final schedulerBinding = _schedulerBindingProvider();
       if (schedulerBinding == null) {

--- a/flutter/lib/src/integrations/native_sdk_integration.dart
+++ b/flutter/lib/src/integrations/native_sdk_integration.dart
@@ -5,14 +5,14 @@ import 'package:sentry/sentry.dart';
 import '../sentry_flutter_options.dart';
 
 /// Enables Sentry's native SDKs (Android and iOS) with options.
-class NativeSdkIntegration extends Integration<SentryFlutterOptions> {
+class NativeSdkIntegration implements Integration<SentryFlutterOptions> {
   NativeSdkIntegration(this._channel);
 
   final MethodChannel _channel;
   SentryFlutterOptions? _options;
 
   @override
-  FutureOr<void> call(Hub hub, SentryFlutterOptions options) async {
+  Future<void> call(Hub hub, SentryFlutterOptions options) async {
     _options = options;
     if (!options.autoInitializeNativeSdk) {
       return;
@@ -63,7 +63,7 @@ class NativeSdkIntegration extends Integration<SentryFlutterOptions> {
   }
 
   @override
-  FutureOr<void> close() async {
+  Future<void> close() async {
     final options = _options;
     if (options != null && !options.autoInitializeNativeSdk) {
       return;

--- a/flutter/lib/src/integrations/on_error_integration.dart
+++ b/flutter/lib/src/integrations/on_error_integration.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:ui';
 
 import 'package:flutter/widgets.dart';
@@ -88,7 +87,7 @@ class OnErrorIntegration implements Integration<SentryFlutterOptions> {
   }
 
   @override
-  void close() async {
+  void close() {
     if (!(dispatchWrapper?.isOnErrorSupported(_options!) == true)) {
       // bail out
       return;

--- a/flutter/lib/src/integrations/screenshot_integration.dart
+++ b/flutter/lib/src/integrations/screenshot_integration.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:sentry/sentry.dart';
 import '../event_processor/screenshot_event_processor.dart';
 import '../sentry_flutter_options.dart';
@@ -10,7 +8,7 @@ class ScreenshotIntegration implements Integration<SentryFlutterOptions> {
   ScreenshotEventProcessor? _screenshotEventProcessor;
 
   @override
-  FutureOr<void> call(Hub hub, SentryFlutterOptions options) {
+  void call(Hub hub, SentryFlutterOptions options) {
     if (options.attachScreenshot) {
       _options = options;
       final screenshotEventProcessor = ScreenshotEventProcessor(options);
@@ -21,7 +19,7 @@ class ScreenshotIntegration implements Integration<SentryFlutterOptions> {
   }
 
   @override
-  FutureOr<void> close() {
+  void close() {
     final screenshotEventProcessor = _screenshotEventProcessor;
     if (screenshotEventProcessor != null) {
       _options?.removeEventProcessor(screenshotEventProcessor);

--- a/flutter/lib/src/integrations/widgets_binding_integration.dart
+++ b/flutter/lib/src/integrations/widgets_binding_integration.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:sentry/sentry.dart';
 import '../sentry_flutter_options.dart';
 import '../widgets_binding_observer.dart';
@@ -8,12 +6,12 @@ import '../widgets_binding_observer.dart';
 /// See also:
 ///   - [SentryWidgetsBindingObserver]
 ///   - [WidgetsBindingObserver](https://api.flutter.dev/flutter/widgets/WidgetsBindingObserver-class.html)
-class WidgetsBindingIntegration extends Integration<SentryFlutterOptions> {
+class WidgetsBindingIntegration implements Integration<SentryFlutterOptions> {
   SentryWidgetsBindingObserver? _observer;
   SentryFlutterOptions? _options;
 
   @override
-  FutureOr<void> call(Hub hub, SentryFlutterOptions options) {
+  void call(Hub hub, SentryFlutterOptions options) {
     _options = options;
     final observer = SentryWidgetsBindingObserver(
       hub: hub,
@@ -32,7 +30,7 @@ class WidgetsBindingIntegration extends Integration<SentryFlutterOptions> {
   }
 
   @override
-  FutureOr<void> close() {
+  void close() {
     final instance = _options?.bindingUtils.instance;
     final observer = _observer;
     if (instance != null && observer != null) {

--- a/flutter/lib/src/integrations/widgets_flutter_binding_integration.dart
+++ b/flutter/lib/src/integrations/widgets_flutter_binding_integration.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/widgets.dart';
 import 'package:sentry/sentry.dart';
 import '../sentry_flutter_options.dart';
@@ -11,7 +9,7 @@ typedef OnWidgetsBinding = WidgetsBinding Function();
 class WidgetsFlutterBindingIntegration
     extends Integration<SentryFlutterOptions> {
   @override
-  FutureOr<void> call(Hub hub, SentryFlutterOptions options) {
+  void call(Hub hub, SentryFlutterOptions options) {
     options.bindingUtils.ensureInitialized();
     options.sdk.addIntegration('widgetsFlutterBindingIntegration');
   }

--- a/flutter/lib/src/sentry_asset_bundle.dart
+++ b/flutter/lib/src/sentry_asset_bundle.dart
@@ -300,7 +300,7 @@ class SentryAssetBundle implements AssetBundle {
     try {
       final result = parser(value);
 
-      if (result is Future) {
+      if (result is Future<T>) {
         data = await result;
       } else {
         data = result;

--- a/flutter/lib/src/sentry_asset_bundle.dart
+++ b/flutter/lib/src/sentry_asset_bundle.dart
@@ -123,7 +123,7 @@ class SentryAssetBundle implements AssetBundle {
     return data;
   }
 
-  FutureOr<T> _loadStructuredBinaryDataWithTracing<T>(
+  Future<T> _loadStructuredBinaryDataWithTracing<T>(
       String key, _ByteParser<T> parser) async {
     final span = _hub.getSpan()?.startChild(
           'file.read',
@@ -298,7 +298,14 @@ class SentryAssetBundle implements AssetBundle {
     );
     T data;
     try {
-      data = await parser(value);
+      final result = parser(value);
+
+      if (result is Future) {
+        data = await result;
+      } else {
+        data = result;
+      }
+
       span?.status = const SpanStatus.ok();
     } catch (e) {
       span?.throwable = e;

--- a/flutter/lib/src/view_hierarchy/view_hierarchy_event_processor.dart
+++ b/flutter/lib/src/view_hierarchy/view_hierarchy_event_processor.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import '../../sentry_flutter.dart';
 import 'sentry_tree_walker.dart';
 
@@ -12,7 +10,13 @@ class SentryViewHierarchyEventProcessor implements EventProcessor {
   final SentryFlutterOptions _options;
 
   @override
-  FutureOr<SentryEvent?> apply(SentryEvent event, {Hint? hint}) async {
+  SentryEvent? apply(SentryEvent event, {Hint? hint}) {
+    // View hierarchy is always minified on Web and we don't support
+    // symbolication of source maps for view hierarchy yet.
+    if (event is SentryTransaction || _options.platformChecker.isWeb) {
+      return event;
+    }
+
     if (event.exceptions == null && event.throwable == null) {
       return event;
     }

--- a/flutter/lib/src/view_hierarchy/view_hierarchy_event_processor.dart
+++ b/flutter/lib/src/view_hierarchy/view_hierarchy_event_processor.dart
@@ -11,9 +11,7 @@ class SentryViewHierarchyEventProcessor implements EventProcessor {
 
   @override
   SentryEvent? apply(SentryEvent event, {Hint? hint}) {
-    // View hierarchy is always minified on Web and we don't support
-    // symbolication of source maps for view hierarchy yet.
-    if (event is SentryTransaction || _options.platformChecker.isWeb) {
+    if (event is SentryTransaction) {
       return event;
     }
 

--- a/flutter/lib/src/view_hierarchy/view_hierarchy_integration.dart
+++ b/flutter/lib/src/view_hierarchy/view_hierarchy_integration.dart
@@ -11,7 +11,9 @@ class SentryViewHierarchyIntegration
 
   @override
   void call(Hub hub, SentryFlutterOptions options) {
-    if (!options.attachViewHierarchy) {
+    // View hierarchy is always minified on Web and we don't support
+    // symbolication of source maps for view hierarchy yet.
+    if (!options.attachViewHierarchy || options.platformChecker.isWeb) {
       return;
     }
     _options = options;

--- a/flutter/lib/src/view_hierarchy/view_hierarchy_integration.dart
+++ b/flutter/lib/src/view_hierarchy/view_hierarchy_integration.dart
@@ -1,19 +1,18 @@
-import 'dart:async';
-
 import '../../sentry_flutter.dart';
 import 'view_hierarchy_event_processor.dart';
 
 /// A [Integration] that renders an ASCII represention of the entire view
 /// hierarchy of the application when an error happens and includes it as an
 /// attachment to the [Hint].
-class SentryViewHierarchyIntegration extends Integration<SentryFlutterOptions> {
+class SentryViewHierarchyIntegration
+    implements Integration<SentryFlutterOptions> {
   SentryViewHierarchyEventProcessor? _eventProcessor;
   SentryFlutterOptions? _options;
 
   @override
-  FutureOr<void> call(Hub hub, SentryFlutterOptions options) {
+  void call(Hub hub, SentryFlutterOptions options) {
     if (!options.attachViewHierarchy) {
-      return Future.value();
+      return;
     }
     _options = options;
     final eventProcessor = SentryViewHierarchyEventProcessor(options);
@@ -23,7 +22,7 @@ class SentryViewHierarchyIntegration extends Integration<SentryFlutterOptions> {
   }
 
   @override
-  FutureOr<void> close() {
+  void close() {
     final eventProcessor = _eventProcessor;
     if (eventProcessor != null) {
       _options?.removeEventProcessor(eventProcessor);

--- a/flutter/test/event_processor/flutter_enricher_event_processor_test.dart
+++ b/flutter/test/event_processor/flutter_enricher_event_processor_test.dart
@@ -37,7 +37,7 @@ void main() {
       debugBrightnessOverride = null;
       debugDefaultTargetPlatformOverride = null;
 
-      final flutterContext = event.contexts['flutter_context'];
+      final flutterContext = event?.contexts['flutter_context'];
       expect(flutterContext, isNotNull);
       expect(flutterContext, isA<Map<String, String>>());
       expect(flutterContext['renderer'], isNotNull);
@@ -50,7 +50,7 @@ void main() {
 
       final event = await enricher.apply(SentryEvent());
 
-      final accessibility = event.contexts['accessibility'];
+      final accessibility = event?.contexts['accessibility'];
 
       expect(accessibility['accessible_navigation'], isNotNull);
       expect(accessibility['bold_text'], isNotNull);
@@ -67,7 +67,7 @@ void main() {
 
       final event = await enricher.apply(SentryEvent());
 
-      final culture = event.contexts.culture;
+      final culture = event?.contexts.culture;
 
       expect(culture?.is24HourFormat, isNotNull);
       expect(culture?.timezone, isNotNull);
@@ -81,7 +81,7 @@ void main() {
       tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
       final event = await enricher.apply(SentryEvent());
 
-      final app = event.contexts.app;
+      final app = event?.contexts.app;
 
       expect(app?.inForeground, true);
     });
@@ -94,7 +94,7 @@ void main() {
       tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
       final event = await enricher.apply(SentryEvent());
 
-      final app = event.contexts.app;
+      final app = event?.contexts.app;
 
       expect(app?.inForeground, false);
     });
@@ -112,7 +112,7 @@ void main() {
 
       final mutatedEvent = await enricher.apply(event);
 
-      final app = mutatedEvent.contexts.app;
+      final app = mutatedEvent?.contexts.app;
 
       expect(app?.inForeground, true);
       expect(app?.name, appName);
@@ -127,7 +127,7 @@ void main() {
 
       final event = await enricher.apply(SentryEvent());
 
-      expect(event.contexts.device, isNull);
+      expect(event?.contexts.device, isNull);
     });
 
     testWidgets('has device when native integration is not available',
@@ -139,7 +139,7 @@ void main() {
 
       final event = await enricher.apply(SentryEvent());
 
-      expect(event.contexts.device, isNotNull);
+      expect(event?.contexts.device, isNotNull);
     });
 
     testWidgets('adds flutter runtime', (WidgetTester tester) async {
@@ -149,10 +149,10 @@ void main() {
 
       final event = await enricher.apply(SentryEvent());
 
-      final flutterRuntime = event.contexts.runtimes
+      final flutterRuntime = event?.contexts.runtimes
           .firstWhere((element) => element.name == 'Flutter');
-      expect(flutterRuntime.name, 'Flutter');
-      expect(flutterRuntime.compiler, isNotNull);
+      expect(flutterRuntime?.name, 'Flutter');
+      expect(flutterRuntime?.compiler, isNotNull);
     });
 
     testWidgets('adds correct flutter runtime', (WidgetTester tester) async {
@@ -172,11 +172,11 @@ void main() {
         );
 
         final event = await enricher.apply(SentryEvent());
-        final flutterRuntime = event.contexts.runtimes
+        final flutterRuntime = event?.contexts.runtimes
             .firstWhere((element) => element.name == 'Flutter');
 
-        expect(flutterRuntime.name, 'Flutter');
-        expect(flutterRuntime.compiler, pair.value);
+        expect(flutterRuntime?.name, 'Flutter');
+        expect(flutterRuntime?.compiler, pair.value);
       }
     });
 
@@ -201,7 +201,7 @@ void main() {
 
       final event = await enricher.apply(SentryEvent());
 
-      expect(event.modules, {
+      expect(event?.modules, {
         'foo_package': 'unknown',
         'bar_package': 'unknown',
       });
@@ -229,7 +229,7 @@ void main() {
 
       final event = await enricher.apply(SentryEvent());
 
-      expect(event.modules, null);
+      expect(event?.modules, null);
     });
 
     testWidgets('adds packages only once', (WidgetTester tester) async {
@@ -253,7 +253,7 @@ void main() {
 
       final event = await enricher.apply(SentryEvent());
 
-      expect(event.modules, {'foo_package': 'unknown'});
+      expect(event?.modules, {'foo_package': 'unknown'});
     });
 
     testWidgets('does not override event', (WidgetTester tester) async {
@@ -280,23 +280,23 @@ void main() {
 
       // contexts.device
       expect(
-        event.contexts.device?.orientation,
+        event?.contexts.device?.orientation,
         fakeEvent.contexts.device?.orientation,
       );
       expect(
-        event.contexts.device?.screenHeightPixels,
+        event?.contexts.device?.screenHeightPixels,
         fakeEvent.contexts.device?.screenHeightPixels,
       );
       expect(
-        event.contexts.device?.screenWidthPixels,
+        event?.contexts.device?.screenWidthPixels,
         fakeEvent.contexts.device?.screenWidthPixels,
       );
       expect(
-        event.contexts.device?.screenDensity,
+        event?.contexts.device?.screenDensity,
         fakeEvent.contexts.device?.screenDensity,
       );
       expect(
-        event.contexts.operatingSystem?.theme,
+        event?.contexts.operatingSystem?.theme,
         fakeEvent.contexts.operatingSystem?.theme,
       );
     });

--- a/flutter/test/event_processor/flutter_exception_event_processor_test.dart
+++ b/flutter/test/event_processor/flutter_exception_event_processor_test.dart
@@ -11,8 +11,7 @@ void main() {
       fixture = Fixture();
     });
 
-    test('adds $SentryRequest for $NetworkImageLoadException with uris',
-        () async {
+    test('adds $SentryRequest for $NetworkImageLoadException with uris', () {
       final enricher = fixture.getSut();
       final event = enricher.apply(
         SentryEvent(
@@ -23,9 +22,9 @@ void main() {
         ),
       );
 
-      expect(event.request, isNotNull);
-      expect(event.request?.url, 'https://example.org/foo/bar');
-      expect(event.request?.queryString, 'foo=bar');
+      expect(event?.request, isNotNull);
+      expect(event?.request?.url, 'https://example.org/foo/bar');
+      expect(event?.request?.queryString, 'foo=bar');
     });
   });
 }

--- a/flutter/test/event_processor/platform_exception_event_processor_test.dart
+++ b/flutter/test/event_processor/platform_exception_event_processor_test.dart
@@ -11,7 +11,7 @@ void main() {
       fixture = Fixture();
     });
 
-    test('applies code and message to mechanism', () async {
+    test('applies code and message to mechanism', () {
       final platformException = PlatformException(
         code: 'fixture-code',
         message: 'fixture-message',
@@ -26,14 +26,14 @@ void main() {
       var event = SentryEvent(exceptions: [sentryException]);
 
       final sut = fixture.getSut();
-      event = (await sut.apply(event))!;
+      event = (sut.apply(event))!;
 
       expect(event.exceptions?.first.mechanism?.data["code"], "fixture-code");
       expect(event.exceptions?.first.mechanism?.data["message"],
           "fixture-message");
     });
 
-    test('creates fallback mechanism', () async {
+    test('creates fallback mechanism', () {
       final platformException = PlatformException(
         code: 'fixture-code',
         message: 'fixture-message',
@@ -46,7 +46,7 @@ void main() {
       var event = SentryEvent(exceptions: [sentryException]);
 
       final sut = fixture.getSut();
-      event = (await sut.apply(event))!;
+      event = (sut.apply(event))!;
 
       expect(event.exceptions?.first.mechanism?.type, "platformException");
     });

--- a/flutter/test/event_processor/screenshot_event_processor_test.dart
+++ b/flutter/test/event_processor/screenshot_event_processor_test.dart
@@ -11,11 +11,11 @@ import '../mocks.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
   late Fixture fixture;
 
   setUp(() {
     fixture = Fixture();
-    TestWidgetsFlutterBinding.ensureInitialized();
   });
 
   Future<void> _addScreenshotAttachment(

--- a/flutter/test/integrations/flutter_error_integration_test.dart
+++ b/flutter/test/integrations/flutter_error_integration_test.dart
@@ -159,7 +159,7 @@ void main() {
 
       final integrationA = fixture.getSut();
       integrationA.call(fixture.hub, fixture.options);
-      await integrationA.close();
+      integrationA.close();
 
       final integrationB = fixture.getSut();
       integrationB.call(fixture.hub, fixture.options);
@@ -172,7 +172,7 @@ void main() {
       expect(numberOfDefaultCalls, 1);
     });
 
-    test('closes restored default onError', () async {
+    test('closes restored default onError', () {
       final defaultOnError = (FlutterErrorDetails errorDetails) async {};
       FlutterError.onError = defaultOnError;
 
@@ -180,11 +180,11 @@ void main() {
       integration.call(fixture.hub, fixture.options);
       expect(false, defaultOnError == FlutterError.onError);
 
-      await integration.close();
+      integration.close();
       expect(FlutterError.onError, defaultOnError);
     });
 
-    test('default is not restored if set after integration', () async {
+    test('default is not restored if set after integration', () {
       final defaultOnError = (FlutterErrorDetails errorDetails) async {};
       FlutterError.onError = defaultOnError;
 
@@ -196,7 +196,7 @@ void main() {
           (FlutterErrorDetails errorDetails) async {};
       FlutterError.onError = afterIntegrationOnError;
 
-      await integration.close();
+      integration.close();
       expect(FlutterError.onError, afterIntegrationOnError);
     });
 

--- a/flutter/test/integrations/load_contexts_integration_test.dart
+++ b/flutter/test/integrations/load_contexts_integration_test.dart
@@ -25,12 +25,12 @@ void main() {
       _channel.setMockMethodCallHandler(null);
     });
 
-    test('loadContextsIntegration adds integration', () async {
+    test('loadContextsIntegration adds integration', () {
       _channel.setMockMethodCallHandler((MethodCall methodCall) async {});
 
       final integration = LoadContextsIntegration(_channel);
 
-      await integration(fixture.hub, fixture.options);
+      integration(fixture.hub, fixture.options);
 
       expect(
           fixture.options.sdk.integrations.contains('loadContextsIntegration'),

--- a/flutter/test/integrations/not_initialized_widgets_binding_test.dart
+++ b/flutter/test/integrations/not_initialized_widgets_binding_test.dart
@@ -13,10 +13,10 @@ void main() {
     fixture = Fixture();
   });
 
-  test('widgetsBindingIntegration does not add integration', () async {
+  test('widgetsBindingIntegration does not add integration', () {
     final integration = WidgetsBindingIntegration();
 
-    await integration(fixture.hub, fixture.options);
+    integration(fixture.hub, fixture.options);
 
     expect(false,
         fixture.options.sdk.integrations.contains('widgetsBindingIntegration'));

--- a/flutter/test/integrations/screenshot_integration_test.dart
+++ b/flutter/test/integrations/screenshot_integration_test.dart
@@ -12,10 +12,10 @@ void main() {
     fixture = Fixture();
   });
 
-  test('screenshotIntegration creates screenshot processor', () async {
+  test('screenshotIntegration creates screenshot processor', () {
     final integration = fixture.getSut();
 
-    await integration(fixture.hub, fixture.options);
+    integration(fixture.hub, fixture.options);
 
     final processors = fixture.options.eventProcessors
         .where((e) => e.runtimeType == ScreenshotEventProcessor);
@@ -25,10 +25,10 @@ void main() {
 
   test(
       'screenshotIntegration does not add screenshot processor if opt out in options',
-      () async {
+      () {
     final integration = fixture.getSut(attachScreenshot: false);
 
-    await integration(fixture.hub, fixture.options);
+    integration(fixture.hub, fixture.options);
 
     final processors = fixture.options.eventProcessors
         .where((e) => e.runtimeType == ScreenshotEventProcessor);
@@ -36,30 +36,29 @@ void main() {
     expect(processors.isEmpty, true);
   });
 
-  test('screenshotIntegration adds integration to the sdk list', () async {
+  test('screenshotIntegration adds integration to the sdk list', () {
     final integration = fixture.getSut();
 
-    await integration(fixture.hub, fixture.options);
+    integration(fixture.hub, fixture.options);
 
     expect(fixture.options.sdk.integrations.contains('screenshotIntegration'),
         true);
   });
 
-  test('screenshotIntegration does not add integration to the sdk list',
-      () async {
+  test('screenshotIntegration does not add integration to the sdk list', () {
     final integration = fixture.getSut(attachScreenshot: false);
 
-    await integration(fixture.hub, fixture.options);
+    integration(fixture.hub, fixture.options);
 
     expect(fixture.options.sdk.integrations.contains('screenshotIntegration'),
         false);
   });
 
-  test('screenshotIntegration close resets processor', () async {
+  test('screenshotIntegration close resets processor', () {
     final integration = fixture.getSut();
 
-    await integration(fixture.hub, fixture.options);
-    await integration.close();
+    integration(fixture.hub, fixture.options);
+    integration.close();
 
     final processors = fixture.options.eventProcessors
         .where((e) => e.runtimeType == ScreenshotEventProcessor);

--- a/flutter/test/integrations/widgets_flutter_binding_integration_test.dart
+++ b/flutter/test/integrations/widgets_flutter_binding_integration_test.dart
@@ -21,9 +21,9 @@ void main() {
     _channel.setMockMethodCallHandler(null);
   });
 
-  test('WidgetsFlutterBindingIntegration adds integration', () async {
+  test('WidgetsFlutterBindingIntegration adds integration', () {
     final integration = WidgetsFlutterBindingIntegration();
-    await integration(fixture.hub, fixture.options);
+    integration(fixture.hub, fixture.options);
 
     expect(
         fixture.options.sdk.integrations
@@ -31,9 +31,9 @@ void main() {
         true);
   });
 
-  test('WidgetsFlutterBindingIntegration calls ensureInitialized', () async {
+  test('WidgetsFlutterBindingIntegration calls ensureInitialized', () {
     final integration = WidgetsFlutterBindingIntegration();
-    await integration(fixture.hub, fixture.options);
+    integration(fixture.hub, fixture.options);
 
     expect(fixture.testBindingUtils.ensureBindingInitializedCalled, true);
   });

--- a/flutter/test/view_hierarchy/view_hierarchy_event_processor_test.dart
+++ b/flutter/test/view_hierarchy/view_hierarchy_event_processor_test.dart
@@ -26,7 +26,7 @@ void main() {
             exceptions: [SentryException(type: 'type', value: 'value')]);
         final hint = Hint();
 
-        await sut.apply(event, hint: hint);
+        sut.apply(event, hint: hint);
 
         expect(hint.viewHierarchy, isNotNull);
       });
@@ -42,7 +42,7 @@ void main() {
         final event = SentryEvent(throwable: StateError('error'));
         final hint = Hint();
 
-        await sut.apply(event, hint: hint);
+        sut.apply(event, hint: hint);
 
         expect(hint.viewHierarchy, isNotNull);
       });
@@ -58,7 +58,7 @@ void main() {
         final event = SentryEvent();
         final hint = Hint();
 
-        await sut.apply(event, hint: hint);
+        sut.apply(event, hint: hint);
 
         expect(hint.viewHierarchy, isNull);
       });
@@ -74,7 +74,7 @@ void main() {
         final event = SentryEvent();
         final hint = Hint();
 
-        await sut.apply(event, hint: hint);
+        sut.apply(event, hint: hint);
 
         expect(hint.viewHierarchy, isNull);
       });

--- a/flutter/test/view_hierarchy/view_hierarchy_integration_test.dart
+++ b/flutter/test/view_hierarchy/view_hierarchy_integration_test.dart
@@ -1,3 +1,5 @@
+@TestOn('vm')
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:sentry_flutter/src/view_hierarchy/view_hierarchy_event_processor.dart';

--- a/flutter/test/view_hierarchy/view_hierarchy_integration_test.dart
+++ b/flutter/test/view_hierarchy/view_hierarchy_integration_test.dart
@@ -12,10 +12,10 @@ void main() {
     fixture = Fixture();
   });
 
-  test('viewHierarchyIntegration creates view hierarchy processor', () async {
+  test('viewHierarchyIntegration creates view hierarchy processor', () {
     final integration = fixture.getSut();
 
-    await integration(fixture.hub, fixture.options);
+    integration(fixture.hub, fixture.options);
 
     final processors = fixture.options.eventProcessors
         .where((e) => e.runtimeType == SentryViewHierarchyEventProcessor);
@@ -25,10 +25,10 @@ void main() {
 
   test(
       'viewHierarchyIntegration does not add view hierarchy processor if opt out in options',
-      () async {
+      () {
     final integration = fixture.getSut(attachViewHierarchy: false);
 
-    await integration(fixture.hub, fixture.options);
+    integration(fixture.hub, fixture.options);
 
     final processors = fixture.options.eventProcessors
         .where((e) => e.runtimeType == SentryViewHierarchyEventProcessor);
@@ -36,11 +36,11 @@ void main() {
     expect(processors.isEmpty, true);
   });
 
-  test('viewHierarchyIntegration close resets processor', () async {
+  test('viewHierarchyIntegration close resets processor', () {
     final integration = fixture.getSut();
 
-    await integration(fixture.hub, fixture.options);
-    await integration.close();
+    integration(fixture.hub, fixture.options);
+    integration.close();
 
     final processors = fixture.options.eventProcessors
         .where((e) => e.runtimeType == SentryViewHierarchyEventProcessor);
@@ -48,21 +48,20 @@ void main() {
     expect(processors.isEmpty, true);
   });
 
-  test('viewHierarchyIntegration adds integration to the sdk list', () async {
+  test('viewHierarchyIntegration adds integration to the sdk list', () {
     final integration = fixture.getSut();
 
-    await integration(fixture.hub, fixture.options);
+    integration(fixture.hub, fixture.options);
 
     expect(
         fixture.options.sdk.integrations.contains('viewHierarchyIntegration'),
         true);
   });
 
-  test('viewHierarchyIntegration does not add integration to the sdk list',
-      () async {
+  test('viewHierarchyIntegration does not add integration to the sdk list', () {
     final integration = fixture.getSut(attachViewHierarchy: false);
 
-    await integration(fixture.hub, fixture.options);
+    integration(fixture.hub, fixture.options);
 
     expect(
         fixture.options.sdk.integrations.contains('viewHierarchyIntegration'),

--- a/logging/lib/src/logging_integration.dart
+++ b/logging/lib/src/logging_integration.dart
@@ -8,7 +8,7 @@ import 'version.dart';
 
 /// An [Integration] which listens to all messages of the
 /// [logging](https://pub.dev/packages/logging) package.
-class LoggingIntegration extends Integration<SentryOptions> {
+class LoggingIntegration implements Integration<SentryOptions> {
   /// Creates the [LoggingIntegration].
   ///
   /// All log events equal or higher than [minBreadcrumbLevel] are recorded as a
@@ -27,7 +27,7 @@ class LoggingIntegration extends Integration<SentryOptions> {
   late Hub _hub;
 
   @override
-  FutureOr<void> call(Hub hub, SentryOptions options) {
+  void call(Hub hub, SentryOptions options) {
     _hub = hub;
     _subscription = Logger.root.onRecord.listen(
       _onLog,

--- a/logging/test/logging_integration_test.dart
+++ b/logging/test/logging_integration_test.dart
@@ -15,7 +15,7 @@ void main() {
 
   test('options.sdk.integrations contains $LoggingIntegration', () async {
     final sut = fixture.createSut();
-    await sut.call(fixture.hub, fixture.options);
+    sut.call(fixture.hub, fixture.options);
     await sut.close();
     expect(
       fixture.options.sdk.integrations.contains('LoggingIntegration'),
@@ -25,7 +25,7 @@ void main() {
 
   test('options.sdk.integrations contains version', () async {
     final sut = fixture.createSut();
-    await sut.call(fixture.hub, fixture.options);
+    sut.call(fixture.hub, fixture.options);
     await sut.close();
 
     final package =
@@ -34,9 +34,9 @@ void main() {
     expect(package.version, sdkVersion);
   });
 
-  test('logger gets recorded if level over minlevel', () async {
+  test('logger gets recorded if level over minlevel', () {
     final sut = fixture.createSut(minBreadcrumbLevel: Level.CONFIG);
-    await sut.call(fixture.hub, fixture.options);
+    sut.call(fixture.hub, fixture.options);
 
     final log = Logger('FooBarLogger');
     log.warning('A log message');
@@ -55,9 +55,9 @@ void main() {
     expect(crumb.type, 'debug');
   });
 
-  test('logger gets recorded if level equal minlevel', () async {
+  test('logger gets recorded if level equal minlevel', () {
     final sut = fixture.createSut(minBreadcrumbLevel: Level.INFO);
-    await sut.call(fixture.hub, fixture.options);
+    sut.call(fixture.hub, fixture.options);
 
     final log = Logger('FooBarLogger');
     log.info('A log message');
@@ -66,12 +66,12 @@ void main() {
     expect(fixture.hub.breadcrumbs.length, 1);
   });
 
-  test('passes log records as hints', () async {
+  test('passes log records as hints', () {
     final sut = fixture.createSut(
       minBreadcrumbLevel: Level.INFO,
       minEventLevel: Level.WARNING,
     );
-    await sut.call(fixture.hub, fixture.options);
+    sut.call(fixture.hub, fixture.options);
     final logger = Logger('FooBarLogger');
 
     logger.info(
@@ -102,9 +102,9 @@ void main() {
     expect(errorHint.stackTrace, stackTrace);
   });
 
-  test('logger gets not recorded if level under minlevel', () async {
+  test('logger gets not recorded if level under minlevel', () {
     final sut = fixture.createSut(minBreadcrumbLevel: Level.SEVERE);
-    await sut.call(fixture.hub, fixture.options);
+    sut.call(fixture.hub, fixture.options);
 
     final log = Logger('FooBarLogger');
     log.warning('A log message');
@@ -113,10 +113,10 @@ void main() {
     expect(fixture.hub.breadcrumbs.length, 0);
   });
 
-  test('Level.Off is never recorded as breadcrumb', () async {
+  test('Level.Off is never recorded as breadcrumb', () {
     // even if everything should be logged, Level.Off is never logged
     final sut = fixture.createSut(minBreadcrumbLevel: Level.ALL);
-    await sut.call(fixture.hub, fixture.options);
+    sut.call(fixture.hub, fixture.options);
 
     final log = Logger('FooBarLogger');
     log.log(Level.OFF, 'A log message');
@@ -126,9 +126,9 @@ void main() {
   });
 
   test('exception is recorded as event if minEventLevel over minlevel',
-      () async {
+      () {
     final sut = fixture.createSut(minEventLevel: Level.INFO);
-    await sut.call(fixture.hub, fixture.options);
+    sut.call(fixture.hub, fixture.options);
 
     final exception = Exception('foo bar');
     final stackTrace = StackTrace.current;
@@ -150,9 +150,9 @@ void main() {
   });
 
   test('exception is recorded as event if minEventLevel equal minlevel',
-      () async {
+      () {
     final sut = fixture.createSut(minEventLevel: Level.INFO);
-    await sut.call(fixture.hub, fixture.options);
+    sut.call(fixture.hub, fixture.options);
 
     final exception = Exception('foo bar');
     final stackTrace = StackTrace.current;
@@ -168,9 +168,9 @@ void main() {
   });
 
   test('exception is not recorded as event if minEventLevel under minlevel',
-      () async {
+      () {
     final sut = fixture.createSut(minEventLevel: Level.SEVERE);
-    await sut.call(fixture.hub, fixture.options);
+    sut.call(fixture.hub, fixture.options);
 
     final exception = Exception('foo bar');
     final stackTrace = StackTrace.current;
@@ -184,10 +184,10 @@ void main() {
     expect(fixture.hub.events.length, 0);
   });
 
-  test('Level.Off is never sent as event', () async {
+  test('Level.Off is never sent as event', () {
     // even if everything should be logged, Level.Off is never logged
     final sut = fixture.createSut(minEventLevel: Level.ALL);
-    await sut.call(fixture.hub, fixture.options);
+    sut.call(fixture.hub, fixture.options);
 
     final exception = Exception('foo bar');
     final stackTrace = StackTrace.current;

--- a/logging/test/logging_integration_test.dart
+++ b/logging/test/logging_integration_test.dart
@@ -125,8 +125,7 @@ void main() {
     expect(fixture.hub.breadcrumbs.length, 0);
   });
 
-  test('exception is recorded as event if minEventLevel over minlevel',
-      () {
+  test('exception is recorded as event if minEventLevel over minlevel', () {
     final sut = fixture.createSut(minEventLevel: Level.INFO);
     sut.call(fixture.hub, fixture.options);
 
@@ -149,8 +148,7 @@ void main() {
     expect(fixture.hub.events.first.stackTrace, stackTrace);
   });
 
-  test('exception is recorded as event if minEventLevel equal minlevel',
-      () {
+  test('exception is recorded as event if minEventLevel equal minlevel', () {
     final sut = fixture.createSut(minEventLevel: Level.INFO);
     sut.call(fixture.hub, fixture.options);
 


### PR DESCRIPTION
## :scroll: Description
We should only use `FutureOr<T>` when we don't know its type.
We should always use `Future<T>` or `T` when we know the return type.
We should only `await` if its a `Future`, we can check the return type of a `FutureOr<T>` method.
We always `implement` an interface and only `extend` when we need to make use of its default methods.
Tests should only be `async` if its awaiting for a Future.
We should always honor the return type of an interface, for example, `SentryEvent?` instead of `SentryEvent`.

## :bulb: Motivation and Context
Also fixes https://github.com/getsentry/sentry-dart/issues/1336
Screenshots and View hierarchy should only be added to errors and not transactions.

## :green_heart: How did you test it?
Tests already exist.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
