### PR TITLE
Set User `name` and `geo` in native plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Set User `name` and `geo` in native plugins ([#1393](https://github.com/getsentry/sentry-dart/pull/1393))
+
 ### Fixes
 
 - Do not report only async gap frames for logging calls ([#1398](https://github.com/getsentry/sentry-dart/pull/1398))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Set User `name` and `geo` in native plugins ([#1393](https://github.com/getsentry/sentry-dart/pull/1393))
+
 ## 7.4.2
 
 ### Fixes

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -26,6 +26,7 @@ import io.sentry.protocol.DebugImage
 import io.sentry.protocol.SdkVersion
 import io.sentry.protocol.SentryId
 import io.sentry.protocol.User
+import io.sentry.protocol.Geo
 import java.io.File
 import java.lang.ref.WeakReference
 import java.util.Locale
@@ -296,12 +297,14 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     (user["username"] as? String)?.let { userInstance.username = it }
     (user["ip_address"] as? String)?.let { userInstance.ipAddress = it }
     (user["segment"] as? String)?.let { userInstance.segment = it }
-
-    // Not mapped on Android yet, added to the unknown databag that gets serialized correctly anyway
-    // Should be solved by https://github.com/getsentry/team-mobile/issues/59
-    // or https://github.com/getsentry/team-mobile/issues/56
-    (user["name"] as? String)?.let { unknown["name"] = it }
-    (user["geo"] as? Map<String, Any?>)?.let { unknown["geo"] = it }
+    (user["name"] as? String)?.let { userInstance.name = it }
+    (user["geo"] as? Map<String, Any?>)?.let {
+      val geo = Geo()
+      geo.city = it["city"] as? String
+      geo.countryCode = it["country_code"] as? String
+      geo.region = it["region"] as? String
+      userInstance.geo = geo
+    }
 
     (user["extras"] as? Map<String, Any?>)?.let { extras ->
       for ((key, value) in extras.entries) {

--- a/flutter/ios/Classes/SentryFlutterPluginApple.swift
+++ b/flutter/ios/Classes/SentryFlutterPluginApple.swift
@@ -563,10 +563,16 @@ public class SentryFlutterPluginApple: NSObject, FlutterPlugin {
             userInstance.data = data
           }
         }
-
-        // missing name and geo
-        // Should be solved by https://github.com/getsentry/team-mobile/issues/59
-        // or https://github.com/getsentry/team-mobile/issues/56
+        if let name = user["name"] as? String {
+          userInstance.name = name
+        }
+        if let geoData = user["geo"] as? [String: Any] {
+          let geo = Geo()
+          geo.city = geoData["city"] as? String
+          geo.countryCode = geoData["country_code"] as? String
+          geo.region = geoData["region"] as? String
+          userInstance.geo = geo
+        }
 
         SentrySDK.setUser(userInstance)
       } else {

--- a/flutter/ios/Classes/SentryFlutterPluginApple.swift
+++ b/flutter/ios/Classes/SentryFlutterPluginApple.swift
@@ -534,6 +534,7 @@ public class SentryFlutterPluginApple: NSObject, FlutterPlugin {
       }
     }
 
+    // swiftlint:disable:next cyclomatic_complexity
     private func setUser(user: [String: Any?]?, result: @escaping FlutterResult) {
       if let user = user {
         let userInstance = User()


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Set User name and geo in native plugins.

Closes #1065

## :green_heart: How did you test it?

- Run example app.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

As soon as map from user/breadcrumb is merged on native side, this is also not needed anymore.
