### PR TITLE
Sync `connectionTimeout` and `readTimeout` to Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Sync `connectionTimeout` and `readTimeout` to Android ([#1397](https://github.com/getsentry/sentry-dart/pull/1397))
+
 ### Fixes
 
 - Do not report only async gap frames for logging calls ([#1398](https://github.com/getsentry/sentry-dart/pull/1398))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Sync `connectionTimeout` and `readTimeout` to Android ([#1397](https://github.com/getsentry/sentry-dart/pull/1397))
+
 ## 7.4.2
 
 ### Fixes

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -186,6 +186,9 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         event
       }
 
+      args.getIfNotNull<Int>("connectionTimeoutMillis") { options.connectionTimeoutMillis = it }
+      args.getIfNotNull<Int>("readTimeoutMillis") { options.connectionTimeoutMillis = it }
+
       // missing proxy
     }
     result.success("")

--- a/flutter/lib/src/integrations/native_sdk_integration.dart
+++ b/flutter/lib/src/integrations/native_sdk_integration.dart
@@ -49,6 +49,8 @@ class NativeSdkIntegration extends Integration<SentryFlutterOptions> {
         'maxAttachmentSize': options.maxAttachmentSize,
         'captureFailedRequests': options.captureFailedRequests,
         'enableAppHangTracking': options.enableAppHangTracking,
+        'connectionTimeoutMillis': options.connectionTimeout.inMilliseconds,
+        'readTimeoutMillis': options.readTimeout.inMilliseconds,
       });
 
       options.sdk.addIntegration('nativeSdkIntegration');

--- a/flutter/lib/src/native_scope_observer.dart
+++ b/flutter/lib/src/native_scope_observer.dart
@@ -46,7 +46,7 @@ class NativeScopeObserver implements ScopeObserver {
 
   @override
   Future<void> setTag(String key, String value) async {
-    await _sentryNative.setExtra(key, value);
+    await _sentryNative.setTag(key, value);
   }
 
   @override

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -199,6 +199,12 @@ class SentryFlutterOptions extends SentryOptions {
   /// Only available on iOS and macOS.
   bool enableAppHangTracking = true;
 
+  /// Connection timeout. This will only be synced to the Android native SDK.
+  Duration connectionTimeout = Duration(seconds: 5);
+
+  /// Read timeout. This will only be synced to the Android native SDK.
+  Duration readTimeout = Duration(seconds: 5);
+
   /// By using this, you are disabling native [Breadcrumb] tracking and instead
   /// you are just tracking [Breadcrumb]s which result from events available
   /// in the current Flutter environment.

--- a/flutter/test/integrations/init_native_sdk_integration_test.dart
+++ b/flutter/test/integrations/init_native_sdk_integration_test.dart
@@ -60,6 +60,8 @@ void main() {
         'maxAttachmentSize': 20 * 1024 * 1024,
         'captureFailedRequests': true,
         'enableAppHangTracking': true,
+        'connectionTimeoutMillis': 5000,
+        'readTimeoutMillis': 5000,
       });
     });
 
@@ -96,7 +98,9 @@ void main() {
         ..proguardUuid = fakeProguardUuid
         ..maxAttachmentSize = 10
         ..captureFailedRequests = false
-        ..enableAppHangTracking = false;
+        ..enableAppHangTracking = false
+        ..connectionTimeout = Duration(milliseconds: 9001)
+        ..readTimeout = Duration(milliseconds: 9002);
 
       options.sdk.addIntegration('foo');
       options.sdk.addPackage('bar', '1');
@@ -137,6 +141,8 @@ void main() {
         'maxAttachmentSize': 10,
         'captureFailedRequests': false,
         'enableAppHangTracking': false,
+        'connectionTimeoutMillis': 9001,
+        'readTimeoutMillis': 9002,
       });
     });
 

--- a/flutter/test/mocks.dart
+++ b/flutter/test/mocks.dart
@@ -156,6 +156,117 @@ class NoOpHub with NoSuchMethodProvider implements Hub {
   bool get isEnabled => false;
 }
 
+class MockSentryNative implements SentryNative {
+  @override
+  DateTime? appStartEnd;
+
+  @override
+  SentryNativeChannel? nativeChannel;
+
+  bool _didFetchAppStart = false;
+
+  @override
+  bool get didFetchAppStart => _didFetchAppStart;
+
+  Breadcrumb? breadcrumb;
+  var numberOfAddBreadcrumbCalls = 0;
+  var numberOfBeginNativeFramesCollectionCalls = 0;
+  var numberOfClearBreadcrumbsCalls = 0;
+  var numberOfEndNativeFramesCollectionCalls = 0;
+  var numberOfFetchNativeAppStartCalls = 0;
+  var removeContextsKey = '';
+  var numberOfRemoveContextsCalls = 0;
+  var removeExtraKey = '';
+  var numberOfRemoveExtraCalls = 0;
+  var removeTagKey = '';
+  var numberOfRemoveTagCalls = 0;
+  var numberOfResetCalls = 0;
+  Map<String, dynamic> setContextData = {};
+  var numberOfSetContextsCalls = 0;
+  Map<String, dynamic> setExtraData = {};
+  var numberOfSetExtraCalls = 0;
+  Map<String, String> setTagsData = {};
+  var numberOfSetTagCalls = 0;
+  SentryUser? sentryUser;
+  var numberOfSetUserCalls = 0;
+
+  @override
+  Future<void> addBreadcrumb(Breadcrumb breadcrumb) async {
+    this.breadcrumb = breadcrumb;
+    numberOfAddBreadcrumbCalls++;
+  }
+
+  @override
+  Future<void> beginNativeFramesCollection() async {
+    numberOfBeginNativeFramesCollectionCalls++;
+  }
+
+  @override
+  Future<void> clearBreadcrumbs() async {
+    numberOfClearBreadcrumbsCalls++;
+  }
+
+  @override
+  Future<NativeFrames?> endNativeFramesCollection(SentryId traceId) async {
+    numberOfEndNativeFramesCollectionCalls++;
+    return null;
+  }
+
+  @override
+  Future<NativeAppStart?> fetchNativeAppStart() async {
+    _didFetchAppStart = true;
+    numberOfFetchNativeAppStartCalls++;
+    return null;
+  }
+
+  @override
+  Future<void> removeContexts(String key) async {
+    removeContextsKey = key;
+    numberOfRemoveContextsCalls++;
+  }
+
+  @override
+  Future<void> removeExtra(String key) async {
+    removeExtraKey = key;
+    numberOfRemoveExtraCalls++;
+  }
+
+  @override
+  Future<void> removeTag(String key) async {
+    removeTagKey = key;
+    numberOfRemoveTagCalls++;
+  }
+
+  @override
+  void reset() {
+    numberOfResetCalls++;
+  }
+
+  @override
+  Future<void> setContexts(String key, value) async {
+    setContextData?[key] = value;
+    numberOfSetContextsCalls++;
+  }
+
+  @override
+  Future<void> setExtra(String key, value) async {
+    setExtraData?[key] = value;
+    numberOfSetExtraCalls++;
+  }
+
+  @override
+  Future<void> setTag(String key, String value) async {
+    setTagsData?[key] = value;
+    numberOfSetTagCalls++;
+  }
+
+  @override
+  Future<void> setUser(SentryUser? sentryUser) async {
+    this.sentryUser = sentryUser;
+    numberOfSetUserCalls++;
+  }
+}
+
 class MockNativeChannel implements SentryNativeChannel {
   NativeAppStart? nativeAppStart;
   NativeFrames? nativeFrames;

--- a/flutter/test/mocks.dart
+++ b/flutter/test/mocks.dart
@@ -244,19 +244,19 @@ class MockSentryNative implements SentryNative {
 
   @override
   Future<void> setContexts(String key, value) async {
-    setContextData?[key] = value;
+    setContextData[key] = value;
     numberOfSetContextsCalls++;
   }
 
   @override
   Future<void> setExtra(String key, value) async {
-    setExtraData?[key] = value;
+    setExtraData[key] = value;
     numberOfSetExtraCalls++;
   }
 
   @override
   Future<void> setTag(String key, String value) async {
-    setTagsData?[key] = value;
+    setTagsData[key] = value;
     numberOfSetTagCalls++;
   }
 

--- a/flutter/test/native_scope_observer_test.dart
+++ b/flutter/test/native_scope_observer_test.dart
@@ -1,0 +1,98 @@
+@TestOn('vm')
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sentry/sentry.dart';
+import 'package:sentry_flutter/src/native_scope_observer.dart';
+
+import 'mocks.dart';
+
+void main() {
+  late Fixture fixture;
+
+  setUp(() {
+    fixture = Fixture();
+  });
+
+  test('addBreadcrumbCalls', () async {
+    final sut = fixture.getSut();
+    final breadcrumb = Breadcrumb();
+    await sut.addBreadcrumb(breadcrumb);
+
+    expect(fixture.mock.breadcrumb, breadcrumb);
+    expect(fixture.mock.numberOfAddBreadcrumbCalls, 1);
+  });
+
+  test('clearBreadcrumbsCalls', () async {
+    final sut = fixture.getSut();
+    await sut.clearBreadcrumbs();
+
+    expect(fixture.mock.numberOfClearBreadcrumbsCalls, 1);
+  });
+
+  test('removeContextsCalls', () async {
+    final sut = fixture.getSut();
+    await sut.removeContexts('fixture-key');
+
+    expect(fixture.mock.removeContextsKey, 'fixture-key');
+    expect(fixture.mock.numberOfRemoveContextsCalls, 1);
+  });
+
+  test('removeExtraCalls', () async {
+    final sut = fixture.getSut();
+    await sut.removeExtra('fixture-key');
+
+    expect(fixture.mock.removeExtraKey, 'fixture-key');
+    expect(fixture.mock.numberOfRemoveExtraCalls, 1);
+  });
+
+  test('removeTagCalls', () async {
+    final sut = fixture.getSut();
+    await sut.removeTag('fixture-key');
+
+    expect(fixture.mock.removeTagKey, 'fixture-key');
+    expect(fixture.mock.numberOfRemoveTagCalls, 1);
+  });
+
+  test('setContextsCalls', () async {
+    final sut = fixture.getSut();
+    await sut.setContexts('fixture-key', 'fixture-value');
+
+    expect(fixture.mock.setContextData['fixture-key'], 'fixture-value');
+    expect(fixture.mock.numberOfSetContextsCalls, 1);
+  });
+
+  test('setExtraCalls', () async {
+    final sut = fixture.getSut();
+    await sut.setExtra('fixture-key', 'fixture-value');
+
+    expect(fixture.mock.setExtraData['fixture-key'], 'fixture-value');
+    expect(fixture.mock.numberOfSetExtraCalls, 1);
+  });
+
+  test('setTagCalls', () async {
+    final sut = fixture.getSut();
+    await sut.setTag('fixture-key', 'fixture-value');
+
+    expect(fixture.mock.setTagsData['fixture-key'], 'fixture-value');
+    expect(fixture.mock.numberOfSetTagCalls, 1);
+  });
+
+  test('setUserCalls', () async {
+    final sut = fixture.getSut();
+
+    final user = SentryUser(id: 'foo bar');
+    await sut.setUser(user);
+
+    expect(fixture.mock.sentryUser, user);
+    expect(fixture.mock.numberOfSetUserCalls, 1);
+  });
+}
+
+class Fixture {
+  var mock = MockSentryNative();
+
+  NativeScopeObserver getSut() {
+    final sut = NativeScopeObserver(mock);
+    return sut;
+  }
+}


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Sync `connectionTimeout` and `readTimeout` to Android

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #1149

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes
