### PR TITLE
Fix web deploy GH pages

### DIFF
--- a/dart/example_web/web/index.html
+++ b/dart/example_web/web/index.html
@@ -2,6 +2,21 @@
 
 <html>
 <head>
+    <!--
+      If you are serving your web app in a path other than the root, change the
+      href value below to reflect the base path you are serving from.
+
+      The path provided below has to start and end with a slash "/" in order for
+      it to work correctly.
+
+      For more details:
+      * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base
+
+      This is a placeholder for base href that will be replaced by the value of
+      the `--base-href` argument provided to `flutter build`.
+    -->
+    <base href="$FLUTTER_BASE_HREF">
+
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/flutter/example/web/index.html
+++ b/flutter/example/web/index.html
@@ -2,6 +2,21 @@
 <html>
 
 <head>
+  <!--
+    If you are serving your web app in a path other than the root, change the
+    href value below to reflect the base path you are serving from.
+
+    The path provided below has to start and end with a slash "/" in order for
+    it to work correctly.
+
+    For more details:
+    * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base
+
+    This is a placeholder for base href that will be replaced by the value of
+    the `--base-href` argument provided to `flutter build`.
+  -->
+  <base href="$FLUTTER_BASE_HREF">
+
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta name="description" content="Demonstrates how to use the sentry_flutter plugin.">


### PR DESCRIPTION
## :scroll: Description
https://docs.flutter.dev/ui/navigation/url-strategies
_#skip-changelog_

## :bulb: Motivation and Context
GH web pages is broken for 6 months
https://github.com/getsentry/sentry-dart/actions/runs/4806460022/jobs/8554006880

> Couldn't find the placeholder for base href. Please add `<base href="$FLUTTER_BASE_HREF">` to web/index.html



## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
