### PR TITLE
Fix package info broken for older version

### DIFF
--- a/min_version_test/android/app/build.gradle
+++ b/min_version_test/android/app/build.gradle
@@ -49,7 +49,7 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
         minSdkVersion 16
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
 

--- a/min_version_test/android/app/build.gradle
+++ b/min_version_test/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     ndkVersion '21.4.7075529'
 
     compileOptions {

--- a/min_version_test/android/build.gradle
+++ b/min_version_test/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:7.2.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -26,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/min_version_test/android/gradle/wrapper/gradle-wrapper.properties
+++ b/min_version_test/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## :scroll: Description
https://github.com/getsentry/sentry-dart/actions/runs/4807449597/jobs/8556234575?pr=1406

_#skip-changelog_

## :bulb: Motivation and Context
https://github.com/fluttercommunity/plus_plugins/commit/2cd002d025e02f0deed95f31b4d73ad5ad9c959e#diff-c7f0423327ce8d62afcbea390b7a606f8a3c65e678eb09bb11eb55137ec34a7f

* What went wrong:
A problem occurred evaluating project ':package_info_plus'.
> No signature of method: build_5pobc6g32m71evqvv19fi289r.android() is applicable for argument types: (build_5pobc6g32m71evqvv19fi289r$_run_closure2) values: [build_5pobc6g32m71evqvv19fi289r$_run_closure2@5fed17d5]


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
