### PR TITLE
Fallback Uri parsing to unknown if its invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fallback Uri parsing to `unknown` if its invalid ([#1395](https://github.com/getsentry/sentry-dart/pull/1395))
+
 ## 7.5.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Fallback Uri parsing to `unknown` if its invalid ([#1395](https://github.com/getsentry/sentry-dart/pull/1395))
+- Fallback Uri parsing to `unknown` if its invalid ([#1414](https://github.com/getsentry/sentry-dart/pull/1414))
 
 ## 7.5.0
 

--- a/dart/lib/src/utils/url_details.dart
+++ b/dart/lib/src/utils/url_details.dart
@@ -10,7 +10,10 @@ class UrlDetails {
   final String? query;
   final String? fragment;
 
-  late final urlOrFallback = url ?? 'unknown';
+  static const _unknown = 'unknown';
+
+  late final urlOrFallback =
+      Uri.tryParse(url ?? _unknown)?.toString() ?? _unknown;
 
   void applyToSpan(ISentrySpan? span) {
     if (span == null) {

--- a/dart/test/utils/url_details_test.dart
+++ b/dart/test/utils/url_details_test.dart
@@ -75,6 +75,13 @@ void main() {
     final urlDetails = UrlDetails(url: null);
     expect(urlDetails.urlOrFallback, "unknown");
   });
+
+  test('returns fallback for invalid Uri', () {
+    final urlDetails = UrlDetails(url: 'htttps://[Filtered].com/foobar.txt');
+
+    expect(urlDetails.urlOrFallback, "unknown");
+    expect(Uri.parse(urlDetails.urlOrFallback), isNotNull);
+  });
 }
 
 class MockSpan extends Mock implements SentrySpan {}

--- a/flutter/lib/src/flutter_sentry_attachment.dart
+++ b/flutter/lib/src/flutter_sentry_attachment.dart
@@ -23,7 +23,10 @@ class FlutterSentryAttachment extends SentryAttachment {
             final data = await (bundle ?? rootBundle).load(key);
             return data.buffer.asUint8List();
           },
-          filename: filename ?? Uri.parse(key).pathSegments.last,
+          filename: filename ??
+              ((Uri.tryParse(key)?.pathSegments.isNotEmpty == true)
+                  ? Uri.parse(key).pathSegments.last
+                  : 'unknown'),
           attachmentType: type,
           contentType: contentType,
           addToTransactions: addToTransactions,

--- a/flutter/test/flutter_sentry_attachment_test.dart
+++ b/flutter/test/flutter_sentry_attachment_test.dart
@@ -21,6 +21,16 @@ void main() {
     expect(attachment.addToTransactions, true);
     await expectLater(await attachment.bytes, [102, 111, 111, 32, 98, 97, 114]);
   });
+
+  test('invalid Uri fall back to unknown', () async {
+    final attachment = FlutterSentryAttachment.fromAsset(
+      'htttps://[Filtered].com/foobar.txt',
+      bundle: TestAssetBundle(),
+      addToTransactions: true,
+    );
+
+    expect(attachment.filename, 'unknown');
+  });
 }
 
 class TestAssetBundle extends CachingAssetBundle {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
https://github.com/getsentry/sentry-dart/issues/1412


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
