### PR TITLE
fix(ios): Add `event.origin` and `event.environment` on unhandled exception on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Fix `event.origin` and `event.environment` on unhandled exception on iOS ([#1419](https://github.com/getsentry/sentry-dart/pull/1419))
+- Fix `event.origin` and `event.environment` on unhandled exceptions ([#1419](https://github.com/getsentry/sentry-dart/pull/1419))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Fix `event.origin` and `event.environment` on unhandled exception on iOS ([#1419](https://github.com/getsentry/sentry-dart/pull/1419))
+
 ### Dependencies
 
 - Bump Android SDK from v6.17.0 to v6.18.1 ([#1415](https://github.com/getsentry/sentry-dart/pull/1415))

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -40,6 +40,10 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
   private var framesTracker: ActivityFramesTracker? = null
   private var autoPerformanceTracingEnabled = false
 
+  private val flutterSdk = "sentry.dart.flutter"
+  private val androidSdk = "sentry.java.android.flutter"
+  private val nativeSdk = "sentry.native.android"
+
   override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
     context = flutterPluginBinding.applicationContext
     channel = MethodChannel(flutterPluginBinding.binaryMessenger, "sentry_flutter")
@@ -169,17 +173,15 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
       args.getIfNotNull<Long>("maxAttachmentSize") { options.maxAttachmentSize = it }
 
-      val name = "sentry.java.android.flutter"
-
       var sdkVersion = options.sdkVersion
       if (sdkVersion == null) {
-        sdkVersion = SdkVersion(name, VERSION_NAME)
+        sdkVersion = SdkVersion(androidSdk, VERSION_NAME)
       } else {
-        sdkVersion.name = name
+        sdkVersion.name = androidSdk
       }
 
       options.sdkVersion = sdkVersion
-      options.sentryClientName = "$name/$VERSION_NAME"
+      options.sentryClientName = "$androidSdk/$VERSION_NAME"
 
       options.setBeforeSend { event, _ ->
         setEventOriginTag(event)
@@ -463,10 +465,6 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
     result.success("")
   }
-
-  private val flutterSdk = "sentry.dart.flutter"
-  private val androidSdk = "sentry.java.android"
-  private val nativeSdk = "sentry.native"
 
   private fun setEventOriginTag(event: SentryEvent) {
     event.sdk?.let {

--- a/flutter/ios/Classes/SentryFlutterPluginApple.swift
+++ b/flutter/ios/Classes/SentryFlutterPluginApple.swift
@@ -12,7 +12,7 @@ import AppKit
 // swiftlint:disable:next type_body_length
 public class SentryFlutterPluginApple: NSObject, FlutterPlugin {
 
-    private static var nativeClientName = "sentry.cocoa.flutter"
+    private static let nativeClientName = "sentry.cocoa.flutter"
 
     // The Cocoa SDK is init. after the notification didBecomeActiveNotification is registered.
     // We need to be able to receive this notification and start a session when the SDK is fully operational.

--- a/flutter/ios/Classes/SentryFlutterPluginApple.swift
+++ b/flutter/ios/Classes/SentryFlutterPluginApple.swift
@@ -12,6 +12,8 @@ import AppKit
 // swiftlint:disable:next type_body_length
 public class SentryFlutterPluginApple: NSObject, FlutterPlugin {
 
+    private static var nativeClientName = "sentry.cocoa.flutter"
+
     // The Cocoa SDK is init. after the notification didBecomeActiveNotification is registered.
     // We need to be able to receive this notification and start a session when the SDK is fully operational.
     private var didReceiveDidBecomeActiveNotification = false
@@ -257,9 +259,8 @@ public class SentryFlutterPluginApple: NSObject, FlutterPlugin {
                 #endif
             }
 
-            let name = "sentry.cocoa.flutter"
             let version = PrivateSentrySDKOnly.getSdkVersionString()
-            PrivateSentrySDKOnly.setSdkName(name, andVersionString: version)
+            PrivateSentrySDKOnly.setSdkName(SentryFlutterPluginApple.nativeClientName, andVersionString: version)
 
             // note : for now, in sentry-cocoa, beforeSend is not called before captureEnvelope
             options.beforeSend = { event in
@@ -409,7 +410,7 @@ public class SentryFlutterPluginApple: NSObject, FlutterPlugin {
         if isValidSdk(sdk: sdk) {
 
             switch sdk["name"] as? String {
-            case "sentry.cocoa":
+            case SentryFlutterPluginApple.nativeClientName:
                 #if os(OSX)
                     let origin = "mac"
                 #elseif os(watchOS)


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Because of the naming change of the native clients, the `event.origin` and `event.environment` tags were missing on unhandled exceptions issues.

## :green_heart: How did you test it?
example flutter app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
