### PR TITLE
Fix authority redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Fix `event.origin` and `event.environment` on unhandled exceptions ([#1419](https://github.com/getsentry/sentry-dart/pull/1419))
+- Fix authority redaction ([#1424](https://github.com/getsentry/sentry-dart/pull/1424))
 
 ### Dependencies
 

--- a/dart/lib/src/utils/http_sanitizer.dart
+++ b/dart/lib/src/utils/http_sanitizer.dart
@@ -36,7 +36,7 @@ class HttpSanitizer {
     } else {
       try {
         final uri = Uri.parse(url);
-        final urlWithAuthRemoved = _urlWithAuthRemoved(uri._url());
+        final urlWithAuthRemoved = uri._urlWithAuthRemoved();
         return UrlDetails(
             url: urlWithAuthRemoved.isEmpty ? null : urlWithAuthRemoved,
             query: uri.query.isEmpty ? null : uri.query,
@@ -59,29 +59,18 @@ class HttpSanitizer {
     });
     return sanitizedHeaders;
   }
-
-  static String _urlWithAuthRemoved(String url) {
-    final userInfoMatch = _authRegExp.firstMatch(url);
-    if (userInfoMatch != null && userInfoMatch.groupCount == 3) {
-      final userInfoString = userInfoMatch.group(2) ?? '';
-      final replacementString = userInfoString.contains(":")
-          ? "[Filtered]:[Filtered]@"
-          : "[Filtered]@";
-      return '${userInfoMatch.group(1) ?? ''}$replacementString${userInfoMatch.group(3) ?? ''}';
-    } else {
-      return url;
-    }
-  }
 }
 
 extension UriPath on Uri {
-  String _url() {
+  String _urlWithAuthRemoved() {
     var buffer = '';
     if (scheme.isNotEmpty) {
       buffer += '$scheme://';
     }
     if (userInfo.isNotEmpty) {
-      buffer += '$userInfo@';
+      buffer += userInfo.contains(":")
+          ? "[Filtered]:[Filtered]@"
+          : "[Filtered]@";
     }
     buffer += host;
     if (path.isNotEmpty) {

--- a/dart/lib/src/utils/http_sanitizer.dart
+++ b/dart/lib/src/utils/http_sanitizer.dart
@@ -68,9 +68,8 @@ extension UriPath on Uri {
       buffer += '$scheme://';
     }
     if (userInfo.isNotEmpty) {
-      buffer += userInfo.contains(":")
-          ? "[Filtered]:[Filtered]@"
-          : "[Filtered]@";
+      buffer +=
+          userInfo.contains(":") ? "[Filtered]:[Filtered]@" : "[Filtered]@";
     }
     buffer += host;
     if (path.isNotEmpty) {

--- a/dart/lib/src/utils/http_sanitizer.dart
+++ b/dart/lib/src/utils/http_sanitizer.dart
@@ -5,7 +5,6 @@ import 'url_details.dart';
 
 @internal
 class HttpSanitizer {
-  static final RegExp _authRegExp = RegExp("(.+://)(.*@)(.*)");
   static final List<String> _securityHeaders = [
     "X-FORWARDED-FOR",
     "AUTHORIZATION",

--- a/dart/lib/src/utils/http_sanitizer.dart
+++ b/dart/lib/src/utils/http_sanitizer.dart
@@ -35,9 +35,9 @@ class HttpSanitizer {
     } else {
       try {
         final uri = Uri.parse(url);
-        final urlWithAuthRemoved = uri._urlWithAuthRemoved();
+        final urlWithRedactedAuth = uri._urlWithRedactedAuth();
         return UrlDetails(
-            url: urlWithAuthRemoved.isEmpty ? null : urlWithAuthRemoved,
+            url: urlWithRedactedAuth.isEmpty ? null : urlWithRedactedAuth,
             query: uri.query.isEmpty ? null : uri.query,
             fragment: uri.fragment.isEmpty ? null : uri.fragment);
       } catch (_) {
@@ -61,7 +61,7 @@ class HttpSanitizer {
 }
 
 extension UriPath on Uri {
-  String _urlWithAuthRemoved() {
+  String _urlWithRedactedAuth() {
     var buffer = '';
     if (scheme.isNotEmpty) {
       buffer += '$scheme://';

--- a/dart/test/utils/http_sanitizer_test.dart
+++ b/dart/test/utils/http_sanitizer_test.dart
@@ -170,6 +170,15 @@ void main() {
     final details = HttpSanitizer.sanitizeUrl('::Not valid URI::');
     expect(details, isNull);
   });
+
+  test('keeps email address', () {
+    final urlDetails = HttpSanitizer.sanitizeUrl(
+      "https://staging.server.com/api/v4/auth/password/reset/email@example.com"
+    );
+    expect("https://staging.server.com/api/v4/auth/password/reset/email@example.com", urlDetails?.url);
+    expect(urlDetails?.query, isNull);
+    expect(urlDetails?.fragment, isNull);
+  });
 }
 
 extension StringExtension on String {

--- a/dart/test/utils/http_sanitizer_test.dart
+++ b/dart/test/utils/http_sanitizer_test.dart
@@ -173,9 +173,10 @@ void main() {
 
   test('keeps email address', () {
     final urlDetails = HttpSanitizer.sanitizeUrl(
-      "https://staging.server.com/api/v4/auth/password/reset/email@example.com"
-    );
-    expect("https://staging.server.com/api/v4/auth/password/reset/email@example.com", urlDetails?.url);
+        "https://staging.server.com/api/v4/auth/password/reset/email@example.com");
+    expect(
+        "https://staging.server.com/api/v4/auth/password/reset/email@example.com",
+        urlDetails?.url);
     expect(urlDetails?.query, isNull);
     expect(urlDetails?.fragment, isNull);
   });


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Use `Uri` APIs to correctly identify and redact user info (authority). Before emails as prot of paths/queries would incorrectly be identifier as user info.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #1418
Relates to [#2690](https://github.com/getsentry/sentry-java/issues/2690#issuecomment-1538147747)

## :green_heart: How did you test it?

Added test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps

Is there something else we need to check?