### PR TITLE
Add support to Gradle 8+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fix `event.origin` and `event.environment` on unhandled exceptions ([#1419](https://github.com/getsentry/sentry-dart/pull/1419))
 - Fix authority redaction ([#1424](https://github.com/getsentry/sentry-dart/pull/1424))
+- Adds a namespace for compatibility with AGP 8.0. ([#1427](https://github.com/getsentry/sentry-dart/pull/1427))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Adds a namespace for compatibility with AGP 8.0. ([#1427](https://github.com/getsentry/sentry-dart/pull/1427))
+
 ## 7.5.2
 
 ### Fixes
 
 - Fix `event.origin` and `event.environment` on unhandled exceptions ([#1419](https://github.com/getsentry/sentry-dart/pull/1419))
 - Fix authority redaction ([#1424](https://github.com/getsentry/sentry-dart/pull/1424))
-- Adds a namespace for compatibility with AGP 8.0. ([#1427](https://github.com/getsentry/sentry-dart/pull/1427))
 
 ### Dependencies
 

--- a/flutter/android/build.gradle
+++ b/flutter/android/build.gradle
@@ -26,7 +26,7 @@ android {
 
     // Conditional for compatibility with AGP <4.2.
     if (project.android.hasProperty("namespace")) {
-        namespace 'io.sentry.sentry_flutter'
+        namespace 'io.sentry.flutter'
     }
 
     sourceSets {

--- a/flutter/android/build.gradle
+++ b/flutter/android/build.gradle
@@ -24,6 +24,11 @@ apply plugin: 'kotlin-android'
 android {
     compileSdkVersion 33
 
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'io.sentry.sentry_flutter'
+    }
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Hello, currently the plugin doesn't build when Gradle 8+ is used. That is because the property `namespace` is mandatory.

* I updated the Android example project.
* I included the namespace property with backwards compatibility


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes

