### PR TITLE
Fix battery level convertion for iOS 16.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix battery level convertion for iOS 16.4 ([#1424](https://github.com/getsentry/sentry-dart/pull/1424))
+
 ## 7.5.2
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Fix battery level convertion for iOS 16.4 ([#1424](https://github.com/getsentry/sentry-dart/pull/1424))
+- Fix battery level convertion for iOS 16.4 ([#1433](https://github.com/getsentry/sentry-dart/pull/1433))
 - Adds a namespace for compatibility with AGP 8.0. ([#1427](https://github.com/getsentry/sentry-dart/pull/1427))
 
 ## 7.5.2

--- a/dart/lib/src/protocol/sentry_device.dart
+++ b/dart/lib/src/protocol/sentry_device.dart
@@ -178,7 +178,9 @@ class SentryDevice {
         model: data['model'],
         modelId: data['model_id'],
         arch: data['arch'],
-        batteryLevel: data['battery_level'],
+        batteryLevel:
+            (data['battery_level'] is num ? data['battery_level'] as num : null)
+                ?.toDouble(),
         orientation: data['orientation'] == 'portrait'
             ? SentryOrientation.portrait
             : data['orientation'] == 'landscape'

--- a/dart/test/protocol/sentry_device_test.dart
+++ b/dart/test/protocol/sentry_device_test.dart
@@ -115,6 +115,39 @@ void main() {
         true,
       );
     });
+
+    test('batery level converts int to double', () {
+      final map = {'battery_level': 1};
+
+      final sentryDevice = SentryDevice.fromJson(map);
+
+      expect(
+        sentryDevice.batteryLevel,
+        1.0,
+      );
+    });
+
+    test('batery level maps double', () {
+      final map = {'battery_level': 1.0};
+
+      final sentryDevice = SentryDevice.fromJson(map);
+
+      expect(
+        sentryDevice.batteryLevel,
+        1.0,
+      );
+    });
+
+    test('batery level ignores if not a num', () {
+      final map = {'battery_level': 'abc'};
+
+      final sentryDevice = SentryDevice.fromJson(map);
+
+      expect(
+        sentryDevice.batteryLevel,
+        null,
+      );
+    });
   });
 
   group('copyWith', () {


### PR DESCRIPTION
## :scroll: Description
Fix battery level convertion for iOS 16.4


## :bulb: Motivation and Context
Closes https://github.com/getsentry/sentry-dart/issues/1432


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
