### PR TITLE
Support package_info_plus 4.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Fix battery level convertion for iOS 16.4 ([#1433](https://github.com/getsentry/sentry-dart/pull/1433))
+- Fix battery level conversion for iOS 16.4 ([#1433](https://github.com/getsentry/sentry-dart/pull/1433))
 - Adds a namespace for compatibility with AGP 8.0. ([#1427](https://github.com/getsentry/sentry-dart/pull/1427))
 
 ## 7.5.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Fix battery level conversion for iOS 16.4 ([#1433](https://github.com/getsentry/sentry-dart/pull/1433))
 - Adds a namespace for compatibility with AGP 8.0. ([#1427](https://github.com/getsentry/sentry-dart/pull/1427))
 
+### Breaking Changes
+
+- Support `package_info_plus` versions `4.x` which require `min_sdk_version` `>=19` and iOS `11`
+
 ## 7.5.2
 
 ### Fixes

--- a/flutter/android/build.gradle
+++ b/flutter/android/build.gradle
@@ -34,7 +34,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 33
 
         ndk {

--- a/flutter/example/android/app/build.gradle
+++ b/flutter/example/android/app/build.gradle
@@ -48,7 +48,7 @@ android {
 
     defaultConfig {
         applicationId "io.sentry.samples.flutter"
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/flutter/example/pubspec.yaml
+++ b/flutter/example/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   dio: any # This gets constrained by `sentry_dio`
   sqflite: any # This gets constrained by `sentry_sqflite`
   logging: any # This gets constrained by `sentry_logging`
-  package_info_plus: ^3.0.0
+  package_info_plus: ^4.0.0
   path_provider: ^2.0.0
   #sqflite_common_ffi: ^2.0.0
   #sqflite_common_ffi_web: ^0.3.0

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   sentry: 7.5.2
-  package_info_plus: '>=1.0.0 <4.0.0'
+  package_info_plus: '>=1.0.0 <5.0.0'
   meta: ^1.3.0
 
 dev_dependencies:

--- a/min_version_test/android/app/build.gradle
+++ b/min_version_test/android/app/build.gradle
@@ -48,7 +48,7 @@ android {
         applicationId "com.example.minversiontest"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
This PR adds support for `package_info_plus 4.x`


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It fixes compatibility problems when using AGP 8.x by supporting a "fixed" version of package_info_plus.
There might be other libraries which do not support that yet, but they can probably be separately updated later.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
