### PR TITLE
Fix auto format GH head ref

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -48,6 +48,7 @@ jobs:
         # we need to pass the current branch, otherwise we can't commit the changes.
         # GITHUB_HEAD_REF is the name of the head branch. GitHub Actions only sets this for PRs.
       - run: ../scripts/commit-formatted-code.sh $GITHUB_HEAD_REF
+        if: $GITHUB_HEAD_REF != null
 
       - name: dart analyze
         uses: invertase/github-action-dart-analyzer@cdd8652b05bf7ed08ffce30f425436780f869f13 # pin@v1

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -48,7 +48,7 @@ jobs:
         # we need to pass the current branch, otherwise we can't commit the changes.
         # GITHUB_HEAD_REF is the name of the head branch. GitHub Actions only sets this for PRs.
       - run: ../scripts/commit-formatted-code.sh $GITHUB_HEAD_REF
-        if: $GITHUB_HEAD_REF != null
+        if: env.GITHUB_HEAD_REF != null
 
       - name: dart analyze
         uses: invertase/github-action-dart-analyzer@cdd8652b05bf7ed08ffce30f425436780f869f13 # pin@v1


### PR DESCRIPTION
## :scroll: Description
_#skip-changelog_


## :bulb: Motivation and Context

> ../scripts/commit-formatted-code.sh: line 4: 1: unbound variable
`GITHUB_HEAD_REF` only exists for PRs and not the main branch.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
