### PR TITLE
Wrapped methods return a Future instead of executing right away

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fixes
+
+- Wrapped methods return a `Future` instead of executing right away ([#1462](https://github.com/getsentry/sentry-dart/pull/1462))
+  - Relates to ([#1462](https://github.com/getsentry/sentry-dart/pull/1462))
+
 ### Dependencies
 
 - Bump Android SDK from v6.19.0 to v6.19.1 ([#1466](https://github.com/getsentry/sentry-dart/pull/1466))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Wrapped methods return a `Future` instead of executing right away ([#1462](https://github.com/getsentry/sentry-dart/pull/1462))
+- Wrapped methods return a `Future` instead of executing right away ([#1476](https://github.com/getsentry/sentry-dart/pull/1476))
   - Relates to ([#1462](https://github.com/getsentry/sentry-dart/pull/1462))
 
 ### Dependencies

--- a/flutter/lib/src/sentry_asset_bundle.dart
+++ b/flutter/lib/src/sentry_asset_bundle.dart
@@ -54,7 +54,7 @@ class SentryAssetBundle implements AssetBundle {
 
   @override
   Future<ByteData> load(String key) {
-    Future<ByteData> future() async {
+    return Future<ByteData>(() async {
       final span = _hub.getSpan()?.startChild(
             'file.read',
             description: 'AssetBundle.load: ${_fileName(key)}',
@@ -75,9 +75,7 @@ class SentryAssetBundle implements AssetBundle {
         await span?.finish();
       }
       return data;
-    }
-
-    return future();
+    });
   }
 
   @override
@@ -90,7 +88,7 @@ class SentryAssetBundle implements AssetBundle {
 
   Future<T> _loadStructuredDataWithTracing<T>(
       String key, _StringParser<T> parser) {
-    Future<T> future() async {
+    return Future<T>(() async {
       final span = _hub.getSpan()?.startChild(
             'file.read',
             description:
@@ -127,14 +125,12 @@ class SentryAssetBundle implements AssetBundle {
         await span?.finish();
       }
       return data;
-    }
-
-    return future();
+    });
   }
 
   Future<T> _loadStructuredBinaryDataWithTracing<T>(
       String key, _ByteParser<T> parser) {
-    Future<T> future() async {
+    return Future<T>(() async {
       final span = _hub.getSpan()?.startChild(
             'file.read',
             description:
@@ -171,14 +167,12 @@ class SentryAssetBundle implements AssetBundle {
         await span?.finish();
       }
       return data;
-    }
-
-    return future();
+    });
   }
 
   @override
   Future<String> loadString(String key, {bool cache = true}) {
-    Future<String> future() async {
+    return Future<String>(() async {
       final span = _hub.getSpan()?.startChild(
             'file.read',
             description: 'AssetBundle.loadString: ${_fileName(key)}',
@@ -199,9 +193,7 @@ class SentryAssetBundle implements AssetBundle {
         await span?.finish();
       }
       return data;
-    }
-
-    return future();
+    });
   }
 
   void _setDataLength(dynamic data, ISentrySpan? span) {
@@ -238,7 +230,7 @@ class SentryAssetBundle implements AssetBundle {
   // This is an override on Flutter greater than 3.1
   // ignore: override_on_non_overriding_member
   Future<ImmutableBuffer> loadBuffer(String key) {
-    Future<ImmutableBuffer> future() async {
+    return Future<ImmutableBuffer>(() async {
       final span = _hub.getSpan()?.startChild(
             'file.read',
             description: 'AssetBundle.loadBuffer: ${_fileName(key)}',
@@ -259,9 +251,7 @@ class SentryAssetBundle implements AssetBundle {
         await span?.finish();
       }
       return data;
-    }
-
-    return future();
+    });
   }
 
   Future<ImmutableBuffer> _loadBuffer(String key) {

--- a/sqflite/lib/src/sentry_batch.dart
+++ b/sqflite/lib/src/sentry_batch.dart
@@ -40,7 +40,7 @@ class SentryBatch implements Batch {
 
   @override
   Future<List<Object?>> apply({bool? noResult, bool? continueOnError}) {
-    Future<List<Object?>> future() async {
+    return Future<List<Object?>>(() async {
       final currentSpan = _hub.getSpan();
 
       final span = currentSpan?.startChild(
@@ -65,9 +65,7 @@ class SentryBatch implements Batch {
       } finally {
         await span?.finish();
       }
-    }
-
-    return future();
+    });
   }
 
   @override
@@ -76,7 +74,7 @@ class SentryBatch implements Batch {
     bool? noResult,
     bool? continueOnError,
   }) {
-    Future<List<Object?>> future() async {
+    return Future<List<Object?>>(() async {
       final currentSpan = _hub.getSpan();
 
       final span = currentSpan?.startChild(
@@ -102,9 +100,7 @@ class SentryBatch implements Batch {
       } finally {
         await span?.finish();
       }
-    }
-
-    return future();
+    });
   }
 
   @override

--- a/sqflite/lib/src/sentry_database.dart
+++ b/sqflite/lib/src/sentry_database.dart
@@ -54,7 +54,7 @@ class SentryDatabase extends SentryDatabaseExecutor implements Database {
 
   @override
   Future<void> close() {
-    Future<void> future() async {
+    return Future<void>(() async {
       final currentSpan = _hub.getSpan();
       final span = currentSpan?.startChild(
         dbOp,
@@ -73,9 +73,7 @@ class SentryDatabase extends SentryDatabaseExecutor implements Database {
       } finally {
         await span?.finish();
       }
-    }
-
-    return future();
+    });
   }
 
   @override
@@ -105,7 +103,7 @@ class SentryDatabase extends SentryDatabaseExecutor implements Database {
     Future<T> Function(Transaction txn) action, {
     bool? exclusive,
   }) {
-    Future<T> future() async {
+    return Future<T>(() async {
       final currentSpan = _hub.getSpan();
       final span = currentSpan?.startChild(
         _dbSqlOp,
@@ -136,8 +134,6 @@ class SentryDatabase extends SentryDatabaseExecutor implements Database {
       } finally {
         await span?.finish();
       }
-    }
-
-    return future();
+    });
   }
 }

--- a/sqflite/lib/src/sentry_database_executor.dart
+++ b/sqflite/lib/src/sentry_database_executor.dart
@@ -31,7 +31,7 @@ class SentryDatabaseExecutor implements DatabaseExecutor {
 
   @override
   Future<int> delete(String table, {String? where, List<Object?>? whereArgs}) {
-    Future<int> future() async {
+    return Future<int>(() async {
       final currentSpan = _parentSpan ?? _hub.getSpan();
       final builder =
           SqlBuilder.delete(table, where: where, whereArgs: whereArgs);
@@ -55,14 +55,12 @@ class SentryDatabaseExecutor implements DatabaseExecutor {
       } finally {
         await span?.finish();
       }
-    }
-
-    return future();
+    });
   }
 
   @override
   Future<void> execute(String sql, [List<Object?>? arguments]) {
-    Future<void> future() async {
+    return Future<void>(() async {
       final currentSpan = _parentSpan ?? _hub.getSpan();
       final span = currentSpan?.startChild(
         SentryDatabase.dbSqlExecuteOp,
@@ -81,9 +79,7 @@ class SentryDatabaseExecutor implements DatabaseExecutor {
       } finally {
         await span?.finish();
       }
-    }
-
-    return future();
+    });
   }
 
   @override
@@ -93,7 +89,7 @@ class SentryDatabaseExecutor implements DatabaseExecutor {
     String? nullColumnHack,
     ConflictAlgorithm? conflictAlgorithm,
   }) {
-    Future<int> future() async {
+    return Future<int>(() async {
       final currentSpan = _parentSpan ?? _hub.getSpan();
       final builder = SqlBuilder.insert(
         table,
@@ -125,9 +121,7 @@ class SentryDatabaseExecutor implements DatabaseExecutor {
       } finally {
         await span?.finish();
       }
-    }
-
-    return future();
+    });
   }
 
   @override
@@ -143,7 +137,7 @@ class SentryDatabaseExecutor implements DatabaseExecutor {
     int? limit,
     int? offset,
   }) {
-    Future<List<Map<String, Object?>>> future() async {
+    return Future<List<Map<String, Object?>>>(() async {
       final currentSpan = _parentSpan ?? _hub.getSpan();
       final builder = SqlBuilder.query(
         table,
@@ -187,9 +181,7 @@ class SentryDatabaseExecutor implements DatabaseExecutor {
       } finally {
         await span?.finish();
       }
-    }
-
-    return future();
+    });
   }
 
   @override
@@ -206,7 +198,7 @@ class SentryDatabaseExecutor implements DatabaseExecutor {
     int? offset,
     int? bufferSize,
   }) {
-    Future<QueryCursor> future() async {
+    return Future<QueryCursor>(() async {
       final currentSpan = _parentSpan ?? _hub.getSpan();
       final builder = SqlBuilder.query(
         table,
@@ -251,14 +243,12 @@ class SentryDatabaseExecutor implements DatabaseExecutor {
       } finally {
         await span?.finish();
       }
-    }
-
-    return future();
+    });
   }
 
   @override
   Future<int> rawDelete(String sql, [List<Object?>? arguments]) {
-    Future<int> future() async {
+    return Future<int>(() async {
       final currentSpan = _parentSpan ?? _hub.getSpan();
       final span = currentSpan?.startChild(
         SentryDatabase.dbSqlExecuteOp,
@@ -279,14 +269,12 @@ class SentryDatabaseExecutor implements DatabaseExecutor {
       } finally {
         await span?.finish();
       }
-    }
-
-    return future();
+    });
   }
 
   @override
   Future<int> rawInsert(String sql, [List<Object?>? arguments]) {
-    Future<int> future() async {
+    return Future<int>(() async {
       final currentSpan = _parentSpan ?? _hub.getSpan();
       final span = currentSpan?.startChild(
         SentryDatabase.dbSqlExecuteOp,
@@ -307,9 +295,7 @@ class SentryDatabaseExecutor implements DatabaseExecutor {
       } finally {
         await span?.finish();
       }
-    }
-
-    return future();
+    });
   }
 
   @override
@@ -317,7 +303,7 @@ class SentryDatabaseExecutor implements DatabaseExecutor {
     String sql, [
     List<Object?>? arguments,
   ]) {
-    Future<List<Map<String, Object?>>> future() async {
+    return Future<List<Map<String, Object?>>>(() async {
       final currentSpan = _parentSpan ?? _hub.getSpan();
       final span = currentSpan?.startChild(
         SentryDatabase.dbSqlQueryOp,
@@ -338,9 +324,7 @@ class SentryDatabaseExecutor implements DatabaseExecutor {
       } finally {
         await span?.finish();
       }
-    }
-
-    return future();
+    });
   }
 
   @override
@@ -349,7 +333,7 @@ class SentryDatabaseExecutor implements DatabaseExecutor {
     List<Object?>? arguments, {
     int? bufferSize,
   }) {
-    Future<QueryCursor> future() async {
+    return Future<QueryCursor>(() async {
       final currentSpan = _parentSpan ?? _hub.getSpan();
       final span = currentSpan?.startChild(
         SentryDatabase.dbSqlQueryOp,
@@ -374,14 +358,12 @@ class SentryDatabaseExecutor implements DatabaseExecutor {
       } finally {
         await span?.finish();
       }
-    }
-
-    return future();
+    });
   }
 
   @override
   Future<int> rawUpdate(String sql, [List<Object?>? arguments]) {
-    Future<int> future() async {
+    return Future<int>(() async {
       final currentSpan = _parentSpan ?? _hub.getSpan();
       final span = currentSpan?.startChild(
         SentryDatabase.dbSqlExecuteOp,
@@ -402,9 +384,7 @@ class SentryDatabaseExecutor implements DatabaseExecutor {
       } finally {
         await span?.finish();
       }
-    }
-
-    return future();
+    });
   }
 
   @override
@@ -415,7 +395,7 @@ class SentryDatabaseExecutor implements DatabaseExecutor {
     List<Object?>? whereArgs,
     ConflictAlgorithm? conflictAlgorithm,
   }) {
-    Future<int> future() async {
+    return Future<int>(() async {
       final currentSpan = _parentSpan ?? _hub.getSpan();
       final builder = SqlBuilder.update(
         table,
@@ -449,8 +429,6 @@ class SentryDatabaseExecutor implements DatabaseExecutor {
       } finally {
         await span?.finish();
       }
-    }
-
-    return future();
+    });
   }
 }

--- a/sqflite/lib/src/sentry_sqflite.dart
+++ b/sqflite/lib/src/sentry_sqflite.dart
@@ -25,7 +25,7 @@ Future<Database> openDatabaseWithSentry(
   bool singleInstance = true,
   @internal Hub? hub,
 }) {
-  Future<Database> openDatabase() async {
+  return Future<Database>(() async {
     final dbOptions = OpenDatabaseOptions(
       version: version,
       onConfigure: onConfigure,
@@ -61,9 +61,7 @@ Future<Database> openDatabaseWithSentry(
     } finally {
       await span?.finish();
     }
-  }
-
-  return openDatabase();
+  });
 }
 
 /// Opens a database with Sentry support.

--- a/sqflite/lib/src/sentry_sqflite_database_factory.dart
+++ b/sqflite/lib/src/sentry_sqflite_database_factory.dart
@@ -57,7 +57,7 @@ class SentrySqfliteDatabaseFactory with SqfliteDatabaseFactoryMixin {
       return databaseFactory.openDatabase(path, options: options);
     }
 
-    Future<Database> openDatabase() async {
+    return Future<Database>(() async {
       final currentSpan = _hub.getSpan();
       final span = currentSpan?.startChild(
         SentryDatabase.dbOp,
@@ -80,8 +80,6 @@ class SentrySqfliteDatabaseFactory with SqfliteDatabaseFactoryMixin {
       } finally {
         await span?.finish();
       }
-    }
-
-    return openDatabase();
+    });
   }
 }

--- a/sqflite/test/sentry_batch_test.dart
+++ b/sqflite/test/sentry_batch_test.dart
@@ -281,7 +281,7 @@ SELECT * FROM Product''';
 
       batch.insert('Product', <String, Object?>{'title': 'Product 1'});
 
-      expect(() async => await batch.commit(), throwsException);
+      await expectLater(() async => await batch.commit(), throwsException);
 
       final span = fixture.tracer.children.last;
       expect(span.throwable, fixture.exception);
@@ -295,7 +295,7 @@ SELECT * FROM Product''';
 
       batch.insert('Product', <String, Object?>{'title': 'Product 1'});
 
-      expect(() async => await batch.apply(), throwsException);
+      await expectLater(() async => await batch.apply(), throwsException);
 
       final span = fixture.tracer.children.last;
       expect(span.throwable, fixture.exception);

--- a/sqflite/test/sentry_database_test.dart
+++ b/sqflite/test/sentry_database_test.dart
@@ -137,7 +137,7 @@ void main() {
 
       final db = await fixture.getSut(database: fixture.database);
 
-      expect(() async => await db.close(), throwsException);
+      await expectLater(() async => await db.close(), throwsException);
 
       final span = fixture.tracer.children.last;
       expect(span.throwable, fixture.exception);
@@ -150,7 +150,8 @@ void main() {
 
       final db = await fixture.getSut(database: fixture.database);
 
-      expect(() async => await db.transaction((txn) async {}), throwsException);
+      await expectLater(
+          () async => await db.transaction((txn) async {}), throwsException);
 
       final span = fixture.tracer.children.last;
       expect(span.throwable, fixture.exception);
@@ -342,7 +343,7 @@ void main() {
 
       final executor = fixture.getExecutorSut();
 
-      expect(
+      await expectLater(
         () async => await executor.delete('Product'),
         throwsException,
       );
@@ -357,7 +358,7 @@ void main() {
 
       final executor = fixture.getExecutorSut();
 
-      expect(
+      await expectLater(
         () async => await executor.execute('sql'),
         throwsException,
       );
@@ -372,7 +373,7 @@ void main() {
 
       final executor = fixture.getExecutorSut();
 
-      expect(
+      await expectLater(
         () async => await executor
             .insert('Product', <String, Object?>{'title': 'Product 1'}),
         throwsException,
@@ -388,7 +389,7 @@ void main() {
 
       final executor = fixture.getExecutorSut();
 
-      expect(
+      await expectLater(
         () async => await executor.query('sql'),
         throwsException,
       );
@@ -403,7 +404,7 @@ void main() {
 
       final executor = fixture.getExecutorSut();
 
-      expect(
+      await expectLater(
         () async => await executor.queryCursor('sql'),
         throwsException,
       );
@@ -418,7 +419,7 @@ void main() {
 
       final executor = fixture.getExecutorSut();
 
-      expect(
+      await expectLater(
         () async => await executor.rawDelete('sql'),
         throwsException,
       );
@@ -433,7 +434,7 @@ void main() {
 
       final executor = fixture.getExecutorSut();
 
-      expect(
+      await expectLater(
         () async => await executor.rawInsert('sql'),
         throwsException,
       );
@@ -448,7 +449,7 @@ void main() {
 
       final executor = fixture.getExecutorSut();
 
-      expect(
+      await expectLater(
         () async => await executor.rawQuery('sql'),
         throwsException,
       );
@@ -464,7 +465,7 @@ void main() {
 
       final executor = fixture.getExecutorSut();
 
-      expect(
+      await expectLater(
         () async => await executor.rawQueryCursor('sql', []),
         throwsException,
       );
@@ -479,7 +480,7 @@ void main() {
 
       final executor = fixture.getExecutorSut();
 
-      expect(
+      await expectLater(
         () async => await executor.rawUpdate('sql'),
         throwsException,
       );
@@ -494,7 +495,7 @@ void main() {
 
       final executor = fixture.getExecutorSut();
 
-      expect(
+      await expectLater(
         () async => await executor
             .update('Product', <String, Object?>{'title': 'Product 1'}),
         throwsException,

--- a/sqflite/test/sentry_database_test.dart
+++ b/sqflite/test/sentry_database_test.dart
@@ -151,7 +151,9 @@ void main() {
       final db = await fixture.getSut(database: fixture.database);
 
       await expectLater(
-          () async => await db.transaction((txn) async {}), throwsException);
+        () async => await db.transaction((txn) async {}),
+        throwsException,
+      );
 
       final span = fixture.tracer.children.last;
       expect(span.throwable, fixture.exception);


### PR DESCRIPTION
## :scroll: Description
Wrapped methods return a Future instead of executing right away


## :bulb: Motivation and Context
Follow up https://github.com/getsentry/sentry-dart/pull/1462#issuecomment-1559152056
I was calling the declared `Future` function in the return statement with the impression that I was returning the function, my bad.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
