### PR TITLE
Align method http span convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Align http method to span convention ([#1477](https://github.com/getsentry/sentry-dart/pull/1477))
+
 ### Dependencies
 
 - Bump Android SDK from v6.19.0 to v6.19.1 ([#1466](https://github.com/getsentry/sentry-dart/pull/1466))
@@ -17,10 +21,6 @@
 ### Features
 
 - Support `http` >= 1.0.0 ([#1475](https://github.com/getsentry/sentry-dart/pull/1475))
-
-### Fixes
-
-- Align http method to span convention ([#1477](https://github.com/getsentry/sentry-dart/pull/1477))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Support `http` >= 1.0.0 ([#1475](https://github.com/getsentry/sentry-dart/pull/1475))
 
+### Fixes
+
+- Align http method to span convention ([#1477](https://github.com/getsentry/sentry-dart/pull/1477))
+
 ### Dependencies
 
 - Bump Android SDK from v6.18.1 to v6.19.0 ([#1455](https://github.com/getsentry/sentry-dart/pull/1455))

--- a/dart/lib/src/http_client/tracing_client.dart
+++ b/dart/lib/src/http_client/tracing_client.dart
@@ -39,7 +39,7 @@ class TracingClient extends BaseClient {
       span = null;
     }
 
-    span?.setData('method', request.method);
+    span?.setData('http.method', request.method);
     urlDetails?.applyToSpan(span);
 
     StreamedResponse? response;

--- a/dart/lib/src/protocol/sentry_response.dart
+++ b/dart/lib/src/protocol/sentry_response.dart
@@ -5,7 +5,7 @@ import '../utils/iterable_extension.dart';
 /// The response interface contains information on a HTTP request related to the event.
 @immutable
 class SentryResponse {
-  /// The tpye of this class in the [Contexts] field
+  /// The type of this class in the [Contexts] field
   static const String type = 'response';
 
   /// The size of the response body.

--- a/dart/test/http_client/tracing_client_test.dart
+++ b/dart/test/http_client/tracing_client_test.dart
@@ -38,7 +38,7 @@ void main() {
       expect(span.status, SpanStatus.ok());
       expect(span.context.operation, 'http.client');
       expect(span.context.description, 'GET https://example.com');
-      expect(span.data['method'], 'GET');
+      expect(span.data['http.method'], 'GET');
       expect(span.data['url'], 'https://example.com');
       expect(span.data['http.query'], 'foo=bar');
       expect(span.data['http.fragment'], 'baz');

--- a/dio/lib/src/sentry_transformer.dart
+++ b/dio/lib/src/sentry_transformer.dart
@@ -27,7 +27,7 @@ class SentryTransformer implements Transformer {
           description: description,
         );
 
-    span?.setData('method', options.method);
+    span?.setData('http.method', options.method);
     urlDetails?.applyToSpan(span);
 
     String? request;
@@ -62,7 +62,7 @@ class SentryTransformer implements Transformer {
           description: description,
         );
 
-    span?.setData('method', options.method);
+    span?.setData('http.method', options.method);
     urlDetails?.applyToSpan(span);
 
     dynamic transformedResponse;

--- a/dio/lib/src/tracing_client_adapter.dart
+++ b/dio/lib/src/tracing_client_adapter.dart
@@ -43,7 +43,7 @@ class TracingClientAdapter implements HttpClientAdapter {
       span = null;
     }
 
-    span?.setData('method', options.method);
+    span?.setData('http.method', options.method);
     urlDetails?.applyToSpan(span);
 
     ResponseBody? response;

--- a/dio/test/sentry_transformer_test.dart
+++ b/dio/test/sentry_transformer_test.dart
@@ -39,7 +39,7 @@ void main() {
       expect(span.status, SpanStatus.ok());
       expect(span.context.operation, 'serialize.http.client');
       expect(span.context.description, 'GET https://example.com');
-      expect(span.data['method'], 'GET');
+      expect(span.data['http.method'], 'GET');
       expect(span.data['url'], 'https://example.com');
       expect(span.data['http.query'], 'foo=bar');
       expect(span.data['http.fragment'], 'baz');
@@ -65,7 +65,7 @@ void main() {
       expect(span.status, SpanStatus.internalError());
       expect(span.context.operation, 'serialize.http.client');
       expect(span.context.description, 'GET https://example.com');
-      expect(span.data['method'], 'GET');
+      expect(span.data['http.method'], 'GET');
       expect(span.data['url'], 'https://example.com');
       expect(span.data['http.query'], 'foo=bar');
       expect(span.data['http.fragment'], 'baz');
@@ -93,7 +93,7 @@ void main() {
       expect(span.status, SpanStatus.ok());
       expect(span.context.operation, 'serialize.http.client');
       expect(span.context.description, 'GET https://example.com');
-      expect(span.data['method'], 'GET');
+      expect(span.data['http.method'], 'GET');
       expect(span.data['url'], 'https://example.com');
       expect(span.data['http.query'], 'foo=bar');
       expect(span.data['http.fragment'], 'baz');
@@ -122,7 +122,7 @@ void main() {
       expect(span.status, SpanStatus.internalError());
       expect(span.context.operation, 'serialize.http.client');
       expect(span.context.description, 'GET https://example.com');
-      expect(span.data['method'], 'GET');
+      expect(span.data['http.method'], 'GET');
       expect(span.data['url'], 'https://example.com');
       expect(span.data['http.query'], 'foo=bar');
       expect(span.data['http.fragment'], 'baz');

--- a/dio/test/tracing_client_adapter_test.dart
+++ b/dio/test/tracing_client_adapter_test.dart
@@ -42,7 +42,7 @@ void main() {
       expect(span.status, SpanStatus.ok());
       expect(span.context.operation, 'http.client');
       expect(span.context.description, 'GET https://example.com');
-      expect(span.data['method'], 'GET');
+      expect(span.data['http.method'], 'GET');
       expect(span.data['url'], 'https://example.com');
       expect(span.data['http.query'], 'foo=bar');
       expect(span.data['http.fragment'], 'baz');


### PR DESCRIPTION
## :scroll: Description
`method` was changed to `http.method` in http spans


## :bulb: Motivation and Context
We want to align to our [convention](https://develop.sentry.dev/sdk/performance/span-data-conventions/)
Closes https://github.com/getsentry/sentry-dart/issues/1422


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
