### PR TITLE
Fix `readTimeoutMillis` wrongly configures `connectionTimeoutMillis` instead of the correct field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Align http method to span convention ([#1477](https://github.com/getsentry/sentry-dart/pull/1477))
 - Wrapped methods return a `Future` instead of executing right away ([#1476](https://github.com/getsentry/sentry-dart/pull/1476))
   - Relates to ([#1462](https://github.com/getsentry/sentry-dart/pull/1462))
+- Fix readTimeoutMillis wrongly configures connectionTimeoutMillis instead of the correct field ([#1485](https://github.com/getsentry/sentry-dart/pull/1485))
 
 ### Dependencies
 

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -191,7 +191,7 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
       }
 
       args.getIfNotNull<Int>("connectionTimeoutMillis") { options.connectionTimeoutMillis = it }
-      args.getIfNotNull<Int>("readTimeoutMillis") { options.connectionTimeoutMillis = it }
+      args.getIfNotNull<Int>("readTimeoutMillis") { options.readTimeoutMillis = it }
 
       // missing proxy
     }


### PR DESCRIPTION
Just realized this when reading code. Not tested locally, want to use CI to see whether this is a real bug (i.e. should fix) or not.

## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
