### PR TITLE
Check if the Native SDKs are enabled when using autoInitializeNativeSdk false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Check if the Native SDKs are enabled when using `autoInitializeNativeSdk=false` ([#1477](https://github.com/getsentry/sentry-dart/pull/1477))
+- Check if the Native SDKs are enabled when using `autoInitializeNativeSdk=false` ([#1489](https://github.com/getsentry/sentry-dart/pull/1489))
 - Align http method to span convention ([#1477](https://github.com/getsentry/sentry-dart/pull/1477))
 - Wrapped methods return a `Future` instead of executing right away ([#1476](https://github.com/getsentry/sentry-dart/pull/1476))
   - Relates to ([#1462](https://github.com/getsentry/sentry-dart/pull/1462))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Check if the Native SDKs are enabled when using `autoInitializeNativeSdk=false` ([#1477](https://github.com/getsentry/sentry-dart/pull/1477))
 - Align http method to span convention ([#1477](https://github.com/getsentry/sentry-dart/pull/1477))
 - Wrapped methods return a `Future` instead of executing right away ([#1476](https://github.com/getsentry/sentry-dart/pull/1476))
   - Relates to ([#1462](https://github.com/getsentry/sentry-dart/pull/1462))

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -354,20 +354,25 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
   }
 
   private fun captureEnvelope(call: MethodCall, result: Result) {
+    if (!Sentry.isEnabled()) {
+      result.error("1", "The Sentry Android SDK is disabled", null)
+      return
+    }
+
     val args = call.arguments() as List<Any>? ?: listOf<Any>()
     if (args.isNotEmpty()) {
       val event = args.first() as ByteArray?
 
       if (event != null && event.isNotEmpty()) {
         if (!writeEnvelope(event)) {
-          result.error("3", "SentryOptions or outboxPath are null or empty", null)
+          result.error("2", "SentryOptions or outboxPath are null or empty", null)
         }
         result.success("")
         return
       }
     }
 
-    result.error("2", "Envelope is null or empty", null)
+    result.error("3", "Envelope is null or empty", null)
   }
 
   private fun loadImageList(result: Result) {


### PR DESCRIPTION
## :scroll: Description
Check if the Native SDKs are enabled when using `autoInitializeNativeSdk=false`


## :bulb: Motivation and Context
Relates to https://github.com/getsentry/sentry-dart/issues/1486


## :green_heart: How did you test it?
Running autoInitializeNativeSdk mode and checking logs.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
