### PR TITLE
Update widgets_binding_observer.dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#6210)
   - [diff](https://github.com/getsentry/sentry-java/compare/6.20.0...6.21.0)
 
+
+### Fixes
+ - fix widgets_binding_observer.dart:183:17: ([#1503](https://github.com/getsentry/sentry-dart/pull/1503))  Error: A non-null value must be returned since the return type 'String' doesn't allow null. because switch returns String? not String because there is no default case
+
+
 ## 7.6.3
 
 ### Fixes

--- a/flutter/lib/src/widgets_binding_observer.dart
+++ b/flutter/lib/src/widgets_binding_observer.dart
@@ -181,16 +181,7 @@ class SentryWidgetsBindingObserver with WidgetsBindingObserver {
   }
 
   static String _lifecycleToString(AppLifecycleState state) {
-    switch (state) {
-      case AppLifecycleState.resumed:
-        return 'resumed';
-      case AppLifecycleState.inactive:
-        return 'inactive';
-      case AppLifecycleState.paused:
-        return 'paused';
-      case AppLifecycleState.detached:
-        return 'detached';
-    }
+    return state.name;
   }
 
 /*


### PR DESCRIPTION
fix ```widgets_binding_observer.dart:183:17: Error: A non-null value must be returned since the return type 'String' doesn't allow null.``` because switch returns String? not String because there is no default case

## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
