### PR TITLE
Enums use its name instead of non exhaustive switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Enums use its name instead of non exhaustive switches ([##1470](https://github.com/getsentry/sentry-dart/pull/#1470))
+- Enums use its name instead of non exhaustive switches ([##1506](https://github.com/getsentry/sentry-dart/pull/#1506))
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Enums use its name instead of non exhaustive switches ([##1470](https://github.com/getsentry/sentry-dart/pull/#1470))
+
 ### Enhancements
 
 - Add http fields to `span.data` ([#1497](https://github.com/getsentry/sentry-dart/pull/1497))

--- a/dart/lib/src/protocol/sentry_device.dart
+++ b/dart/lib/src/protocol/sentry_device.dart
@@ -221,19 +221,6 @@ class SentryDevice {
 
   /// Produces a [Map] that can be serialized to JSON.
   Map<String, dynamic> toJson() {
-    String? orientation;
-
-    switch (this.orientation) {
-      case SentryOrientation.portrait:
-        orientation = 'portait';
-        break;
-      case SentryOrientation.landscape:
-        orientation = 'landscape';
-        break;
-      case null:
-        orientation = null;
-        break;
-    }
     return <String, dynamic>{
       if (name != null) 'name': name,
       if (family != null) 'family': family,
@@ -241,7 +228,7 @@ class SentryDevice {
       if (modelId != null) 'model_id': modelId,
       if (arch != null) 'arch': arch,
       if (batteryLevel != null) 'battery_level': batteryLevel,
-      if (orientation != null) 'orientation': orientation,
+      if (orientation != null) 'orientation': orientation!.name,
       if (manufacturer != null) 'manufacturer': manufacturer,
       if (brand != null) 'brand': brand,
       if (screenWidthPixels != null) 'screen_width_pixels': screenWidthPixels,

--- a/dart/lib/src/protocol/sentry_transaction.dart
+++ b/dart/lib/src/protocol/sentry_transaction.dart
@@ -69,7 +69,7 @@ class SentryTransaction extends SentryEvent {
     );
 
     this.transactionInfo = transactionInfo ??
-        SentryTransactionInfo(_tracer.transactionNameSource.toStringValue());
+        SentryTransactionInfo(_tracer.transactionNameSource.name);
   }
 
   @override

--- a/dart/lib/src/protocol/sentry_transaction_name_source.dart
+++ b/dart/lib/src/protocol/sentry_transaction_name_source.dart
@@ -17,22 +17,3 @@ enum SentryTransactionNameSource {
   /// Name of a background task
   task,
 }
-
-extension SentryTransactionNameSourceExtension on SentryTransactionNameSource {
-  String toStringValue() {
-    switch (this) {
-      case SentryTransactionNameSource.custom:
-        return 'custom';
-      case SentryTransactionNameSource.url:
-        return 'url';
-      case SentryTransactionNameSource.route:
-        return 'route';
-      case SentryTransactionNameSource.view:
-        return 'view';
-      case SentryTransactionNameSource.component:
-        return 'component';
-      case SentryTransactionNameSource.task:
-        return 'task';
-    }
-  }
-}

--- a/flutter/lib/src/event_processor/flutter_enricher_event_processor.dart
+++ b/flutter/lib/src/event_processor/flutter_enricher_event_processor.dart
@@ -143,7 +143,7 @@ class FlutterEnricherEventProcessor implements EventProcessor {
       // Also always fails in tests.
       // See https://github.com/flutter/flutter/issues/83919
       // 'window_is_visible': _window.viewConfiguration.visible,
-      'renderer': _options.rendererWrapper.getRendererAsString()
+      'renderer': _options.rendererWrapper.getRenderer().name,
     };
   }
 

--- a/flutter/lib/src/event_processor/screenshot_event_processor.dart
+++ b/flutter/lib/src/event_processor/screenshot_event_processor.dart
@@ -34,7 +34,7 @@ class ScreenshotEventProcessor implements EventProcessor {
     if (renderer != FlutterRenderer.skia &&
         renderer != FlutterRenderer.canvasKit) {
       _options.logger(SentryLevel.debug,
-          'Cannot take screenshot with ${_options.rendererWrapper.getRendererAsString()} renderer.');
+          'Cannot take screenshot with ${_options.rendererWrapper.getRenderer().name} renderer.');
       return event;
     }
 

--- a/flutter/lib/src/renderer/renderer.dart
+++ b/flutter/lib/src/renderer/renderer.dart
@@ -9,19 +9,6 @@ class RendererWrapper {
   FlutterRenderer getRenderer() {
     return implementation.getRenderer();
   }
-
-  String getRendererAsString() {
-    switch (getRenderer()) {
-      case FlutterRenderer.skia:
-        return 'Skia';
-      case FlutterRenderer.canvasKit:
-        return 'CanvasKit';
-      case FlutterRenderer.html:
-        return 'HTML';
-      case FlutterRenderer.unknown:
-        return 'Unknown';
-    }
-  }
 }
 
 enum FlutterRenderer {

--- a/flutter/lib/src/widgets_binding_observer.dart
+++ b/flutter/lib/src/widgets_binding_observer.dart
@@ -71,7 +71,7 @@ class SentryWidgetsBindingObserver with WidgetsBindingObserver {
       category: 'app.lifecycle',
       type: 'navigation',
       data: <String, String>{
-        'state': _lifecycleToString(state),
+        'state': state.name,
       },
       // ignore: invalid_use_of_internal_member
       timestamp: _options.clock(),
@@ -178,19 +178,6 @@ class SentryWidgetsBindingObserver with WidgetsBindingObserver {
       // ignore: invalid_use_of_internal_member
       timestamp: _options.clock(),
     ));
-  }
-
-  static String _lifecycleToString(AppLifecycleState state) {
-    switch (state) {
-      case AppLifecycleState.resumed:
-        return 'resumed';
-      case AppLifecycleState.inactive:
-        return 'inactive';
-      case AppLifecycleState.paused:
-        return 'paused';
-      case AppLifecycleState.detached:
-        return 'detached';
-    }
   }
 
 /*

--- a/flutter/test/mocks.dart
+++ b/flutter/test/mocks.dart
@@ -354,20 +354,6 @@ class MockRendererWrapper implements RendererWrapper {
   FlutterRenderer getRenderer() {
     return _renderer;
   }
-
-  @override
-  String getRendererAsString() {
-    switch (getRenderer()) {
-      case FlutterRenderer.skia:
-        return 'Skia';
-      case FlutterRenderer.canvasKit:
-        return 'CanvasKit';
-      case FlutterRenderer.html:
-        return 'HTML';
-      case FlutterRenderer.unknown:
-        return 'Unknown';
-    }
-  }
 }
 
 class TestBindingWrapper implements BindingWrapper {


### PR DESCRIPTION
## :scroll: Description
Enums will use its name instead of non-exhaustive switches
Since Dart 2.15 we can use the `name` if they match 1 by 1.


## :bulb: Motivation and Context
https://github.com/getsentry/sentry-dart/pull/1503 and https://github.com/getsentry/sentry-dart/issues/1504
Follow up by @abdelrahmanelmarakby thanks :)


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
