### PR TITLE
Revert "chore(deps): update Flutter SDK (metrics) to v3.12.0"

### DIFF
--- a/metrics/flutter.properties
+++ b/metrics/flutter.properties
@@ -1,2 +1,2 @@
-version = 3.12.0
+version = 3.10.3
 repo = https://github.com/flutter/flutter


### PR DESCRIPTION
Reverts getsentry/sentry-dart#1513

'flutter-:os:-:channel:-:version:-:arch:-:hash:' -n '3.12.0' -a 'X64' stable
Unable to determine Flutter version for channel: stable version: 3.[12](https://github.com/getsentry/sentry-dart/actions/runs/5290529868/jobs/9574800183#step:4:14).0 architecture: x64
Error: Process completed with exit code 1.

_#skip-changelog_