### PR TITLE
Fix flaky iOS integration test

### DIFF
--- a/.github/workflows/flutter_integration_test.yml
+++ b/.github/workflows/flutter_integration_test.yml
@@ -57,7 +57,7 @@ jobs:
 
   # Enable after fixing https://github.com/getsentry/sentry-dart/issues/1448
   test-ios:
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 30
     defaults:
       run:
@@ -83,7 +83,7 @@ jobs:
 
       - name: launch ios simulator
         run: |
-          simulator_id=$(xcrun simctl create sentryPhone com.apple.CoreSimulator.SimDeviceType.iPhone-14 com.apple.CoreSimulator.SimRuntime.iOS-16-2)
+          simulator_id=$(xcrun simctl create sentryPhone com.apple.CoreSimulator.SimDeviceType.iPhone-14 com.apple.CoreSimulator.SimRuntime.iOS-16-4)
           xcrun simctl boot ${simulator_id}
         
       - name: run ios integration test

--- a/.github/workflows/flutter_integration_test.yml
+++ b/.github/workflows/flutter_integration_test.yml
@@ -17,45 +17,44 @@ jobs:
         with:
           access_token: ${{ github.token }}
           
-  # test-android:
-  #   runs-on: macos-latest
-  #   timeout-minutes: 30
-  #   defaults:
-  #     run:
-  #       working-directory: ./flutter/example
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       sdk: ['stable', 'beta']
-  #   steps:
-  #     - name: checkout
-  #       uses: actions/checkout@v3
+  test-android:
+    runs-on: macos-latest
+    timeout-minutes: 30
+    defaults:
+     run:
+       working-directory: ./flutter/example
+    strategy:
+     fail-fast: false
+     matrix:
+       sdk: ['stable', 'beta']
+    steps:
+     - name: checkout
+       uses: actions/checkout@v3
 
-  #     - uses: actions/setup-java@v3
-  #       with:
-  #         distribution: 'adopt'
-  #         java-version: '11'
+     - uses: actions/setup-java@v3
+       with:
+         distribution: 'adopt'
+         java-version: '11'
 
-  #     - uses: subosito/flutter-action@48cafc24713cca54bbe03cdc3a423187d413aafa # pin@v2.10.0
-  #       with:
-  #         channel: ${{ matrix.sdk }}
+     - uses: subosito/flutter-action@48cafc24713cca54bbe03cdc3a423187d413aafa # pin@v2.10.0
+       with:
+         channel: ${{ matrix.sdk }}
 
-  #     - name: flutter upgrade
-  #       run: flutter upgrade
+     - name: flutter upgrade
+       run: flutter upgrade
 
-  #     - name: flutter pub get
-  #       run: flutter pub get
+     - name: flutter pub get
+       run: flutter pub get
 
-  #     - name: launch android emulator & run android integration test
-  #       uses: reactivecircus/android-emulator-runner@50986b1464923454c95e261820bc626f38490ec0 #pin@v2.27.0
-  #       with:
-  #         working-directory: ./flutter/example
-  #         api-level: 21
-  #         arch: x86_64
-  #         profile: Nexus 6
-  #         script: flutter test integration_test/integration_test.dart --verbose
+     - name: launch android emulator & run android integration test
+       uses: reactivecircus/android-emulator-runner@50986b1464923454c95e261820bc626f38490ec0 #pin@v2.27.0
+       with:
+         working-directory: ./flutter/example
+         api-level: 21
+         arch: x86_64
+         profile: Nexus 6
+         script: flutter test integration_test/integration_test.dart --verbose
 
-  # Enable after fixing https://github.com/getsentry/sentry-dart/issues/1448
   test-ios:
     runs-on: macos-13
     timeout-minutes: 30
@@ -85,6 +84,6 @@ jobs:
         run: |
           simulator_id=$(xcrun simctl create sentryPhone com.apple.CoreSimulator.SimDeviceType.iPhone-14 com.apple.CoreSimulator.SimRuntime.iOS-16-2)
           xcrun simctl boot ${simulator_id}
-        
+
       - name: run ios integration test
         run: flutter test integration_test/integration_test.dart --verbose

--- a/.github/workflows/flutter_integration_test.yml
+++ b/.github/workflows/flutter_integration_test.yml
@@ -17,46 +17,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
           
-  test-android:
-    runs-on: macos-latest
-    timeout-minutes: 30
-    defaults:
-      run:
-        working-directory: ./flutter/example
-    strategy:
-      fail-fast: false
-      matrix:
-        sdk: ['stable', 'beta']
-    steps:
-      - name: checkout
-        uses: actions/checkout@v3
-
-      - uses: actions/setup-java@v3
-        with:
-          distribution: 'adopt'
-          java-version: '11'
-
-      - uses: subosito/flutter-action@48cafc24713cca54bbe03cdc3a423187d413aafa # pin@v2.10.0
-        with:
-          channel: ${{ matrix.sdk }}
-
-      - name: flutter upgrade
-        run: flutter upgrade
-
-      - name: flutter pub get
-        run: flutter pub get
-
-      - name: launch android emulator & run android integration test
-        uses: reactivecircus/android-emulator-runner@50986b1464923454c95e261820bc626f38490ec0 #pin@v2.27.0
-        with:
-          working-directory: ./flutter/example
-          api-level: 21
-          arch: x86_64
-          profile: Nexus 6
-          script: flutter test integration_test/integration_test.dart --verbose
-
-  # Enable after fixing https://github.com/getsentry/sentry-dart/issues/1448
-  # test-ios:
+  # test-android:
   #   runs-on: macos-latest
   #   timeout-minutes: 30
   #   defaults:
@@ -65,11 +26,15 @@ jobs:
   #   strategy:
   #     fail-fast: false
   #     matrix:
-  #       # 'beta' is flaky because of https://github.com/flutter/flutter/issues/124340
-  #       sdk: ['stable']
+  #       sdk: ['stable', 'beta']
   #   steps:
   #     - name: checkout
   #       uses: actions/checkout@v3
+
+  #     - uses: actions/setup-java@v3
+  #       with:
+  #         distribution: 'adopt'
+  #         java-version: '11'
 
   #     - uses: subosito/flutter-action@48cafc24713cca54bbe03cdc3a423187d413aafa # pin@v2.10.0
   #       with:
@@ -81,11 +46,45 @@ jobs:
   #     - name: flutter pub get
   #       run: flutter pub get
 
-  #     - name: launch ios emulator
-  #       uses: futureware-tech/simulator-action@ee05c113b79f056b47f354d7b313555f5491e158 #pin@v2
+  #     - name: launch android emulator & run android integration test
+  #       uses: reactivecircus/android-emulator-runner@50986b1464923454c95e261820bc626f38490ec0 #pin@v2.27.0
   #       with:
-  #         model: 'iPhone 14'
-  #         os_version: '16.2'
+  #         working-directory: ./flutter/example
+  #         api-level: 21
+  #         arch: x86_64
+  #         profile: Nexus 6
+  #         script: flutter test integration_test/integration_test.dart --verbose
 
-  #     - name: run ios integration test
-  #       run: flutter test integration_test/integration_test.dart --verbose
+  # Enable after fixing https://github.com/getsentry/sentry-dart/issues/1448
+  test-ios:
+    runs-on: macos-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: ./flutter/example
+    strategy:
+      fail-fast: false
+      matrix:
+        # 'beta' is flaky because of https://github.com/flutter/flutter/issues/124340
+        sdk: ['stable']
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - uses: subosito/flutter-action@48cafc24713cca54bbe03cdc3a423187d413aafa # pin@v2.10.0
+        with:
+          channel: ${{ matrix.sdk }}
+
+      - name: flutter upgrade
+        run: flutter upgrade
+
+      - name: flutter pub get
+        run: flutter pub get
+
+      - name: launch ios simulator
+        run: |
+          simulator_id=$(xcrun simctl create sentryPhone com.apple.CoreSimulator.SimDeviceType.iPhone-14 com.apple.CoreSimulator.SimRuntime.iOS-16-2)
+          xcrun simctl boot ${simulator_id}
+        
+      - name: run ios integration test
+        run: flutter test integration_test/integration_test.dart --verbose

--- a/.github/workflows/flutter_integration_test.yml
+++ b/.github/workflows/flutter_integration_test.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: launch ios simulator
         run: |
-          simulator_id=$(xcrun simctl create sentryPhone com.apple.CoreSimulator.SimDeviceType.iPhone-14 com.apple.CoreSimulator.SimRuntime.iOS-16-4)
+          simulator_id=$(xcrun simctl create sentryPhone com.apple.CoreSimulator.SimDeviceType.iPhone-14 com.apple.CoreSimulator.SimRuntime.iOS-16-2)
           xcrun simctl boot ${simulator_id}
         
       - name: run ios integration test

--- a/flutter/example/integration_test/integration_test.dart
+++ b/flutter/example/integration_test/integration_test.dart
@@ -6,7 +6,7 @@ import 'package:sentry_flutter_example/main.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  setUp(() async {
+  tearDown(() async {
     await Sentry.close();
   });
 
@@ -18,7 +18,6 @@ void main() {
         bundle: SentryAssetBundle(enableStructuredDataTracing: true),
         child: const MyApp(),
       )));
-      await tester.pumpAndSettle();
     }, 'https://abc@def.ingest.sentry.io/1234567');
   }
 


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->

Use latest macos to run integration tests.

Relates to #1448

## :green_heart: How did you test it?

Run on CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps

We should probably run it a couple of times to verify it always works.
