### PR TITLE
Move lifecycle to paused before moving to detached

### DIFF
--- a/flutter/test/widgets_binding_observer_test.dart
+++ b/flutter/test/widgets_binding_observer_test.dart
@@ -136,6 +136,7 @@ void main() {
       expect(breadcrumb.level, SentryLevel.info);
 
       // detached lifecycle event
+      await sendLifecycle('paused');
       await sendLifecycle('detached');
 
       breadcrumb =


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->

Fixes an invalid lifecycle transition that we have in a test.

## :green_heart: How did you test it?

Run tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes

