### PR TITLE
Add `appHangTimeoutInterval` to `SentryFlutterOptions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 [Trace origin](https://develop.sentry.dev/sdk/performance/trace-origin/) indicates what created a trace or a span. Not all transactions and spans contain enough information to tell whether the user or what precisely in the SDK created it. Origin solves this problem. The SDK now sends origin for transactions and spans.
 
+- Add `appHangTimeoutInterval` to `SentryFlutterOptions` ([#1568](https://github.com/getsentry/sentry-dart/pull/1568))
+
 ### Dependencies
 
 - Bump Cocoa SDK from v8.8.0 to v8.9.1 ([#1553](https://github.com/getsentry/sentry-dart/pull/1553))

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -300,6 +300,12 @@ class SentryOptions {
 
   List<ScopeObserver> get scopeObservers => _scopeObservers;
 
+  /// The minimum amount of time an app should be unresponsive to be classified
+  /// as an App Hanging. The actual amount may be a little longer. Avoid using
+  /// values lower than 100ms, which may cause a lot of app hangs events being
+  /// transmitted.
+  Duration appHangTimeoutInterval = Duration(seconds: 2);
+
   void addScopeObserver(ScopeObserver scopeObserver) {
     _scopeObservers.add(scopeObserver);
   }

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -300,12 +300,6 @@ class SentryOptions {
 
   List<ScopeObserver> get scopeObservers => _scopeObservers;
 
-  /// The minimum amount of time an app should be unresponsive to be classified
-  /// as an App Hanging. The actual amount may be a little longer. Avoid using
-  /// values lower than 100ms, which may cause a lot of app hangs events being
-  /// transmitted.
-  Duration appHangTimeoutInterval = Duration(seconds: 2);
-
   void addScopeObserver(ScopeObserver scopeObserver) {
     _scopeObservers.add(scopeObserver);
   }

--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -2,7 +2,6 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io' show Platform;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';

--- a/flutter/ios/Classes/SentryFlutterPluginApple.swift
+++ b/flutter/ios/Classes/SentryFlutterPluginApple.swift
@@ -384,6 +384,10 @@ public class SentryFlutterPluginApple: NSObject, FlutterPlugin {
         if let enableAppHangTracking = arguments["enableAppHangTracking"] as? Bool {
             options.enableAppHangTracking = enableAppHangTracking
         }
+
+        if let appHangTimeoutIntervalMillis = arguments["appHangTimeoutIntervalMillis"] as? UInt {
+            options.appHangTimeoutInterval = TimeInterval(appHangTimeoutIntervalMillis) / 1000
+        }
     }
 
     private func logLevelFrom(diagnosticLevel: String) -> SentryLevel {

--- a/flutter/lib/src/integrations/native_sdk_integration.dart
+++ b/flutter/lib/src/integrations/native_sdk_integration.dart
@@ -51,7 +51,8 @@ class NativeSdkIntegration implements Integration<SentryFlutterOptions> {
         'enableAppHangTracking': options.enableAppHangTracking,
         'connectionTimeoutMillis': options.connectionTimeout.inMilliseconds,
         'readTimeoutMillis': options.readTimeout.inMilliseconds,
-        'appHangTimeoutIntervalMillis': options.appHangTimeoutInterval.inMilliseconds
+        'appHangTimeoutIntervalMillis':
+            options.appHangTimeoutInterval.inMilliseconds,
       });
 
       options.sdk.addIntegration('nativeSdkIntegration');

--- a/flutter/lib/src/integrations/native_sdk_integration.dart
+++ b/flutter/lib/src/integrations/native_sdk_integration.dart
@@ -51,6 +51,7 @@ class NativeSdkIntegration implements Integration<SentryFlutterOptions> {
         'enableAppHangTracking': options.enableAppHangTracking,
         'connectionTimeoutMillis': options.connectionTimeout.inMilliseconds,
         'readTimeoutMillis': options.readTimeout.inMilliseconds,
+        'appHangTimeoutIntervalMillis': options.appHangTimeoutInterval.inMilliseconds
       });
 
       options.sdk.addIntegration('nativeSdkIntegration');

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -195,7 +195,7 @@ class SentryFlutterOptions extends SentryOptions {
   bool attachViewHierarchy = false;
 
   /// When enabled, the SDK tracks when the application stops responding for a
-  /// specific amount of time.
+  /// specific amount of time, See [appHangTimeoutInterval].
   /// Only available on iOS and macOS.
   bool enableAppHangTracking = true;
 
@@ -203,6 +203,7 @@ class SentryFlutterOptions extends SentryOptions {
   /// as an App Hanging. The actual amount may be a little longer. Avoid using
   /// values lower than 100ms, which may cause a lot of app hangs events being
   /// transmitted.
+  /// Default to 2s.
   /// Only available on iOS and macOS.
   Duration appHangTimeoutInterval = Duration(seconds: 2);
 

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -195,9 +195,16 @@ class SentryFlutterOptions extends SentryOptions {
   bool attachViewHierarchy = false;
 
   /// When enabled, the SDK tracks when the application stops responding for a
-  /// specific amount of time (default 2s).
+  /// specific amount of time.
   /// Only available on iOS and macOS.
   bool enableAppHangTracking = true;
+
+  /// The minimum amount of time an app should be unresponsive to be classified
+  /// as an App Hanging. The actual amount may be a little longer. Avoid using
+  /// values lower than 100ms, which may cause a lot of app hangs events being
+  /// transmitted.
+  /// Only available on iOS and macOS.
+  Duration appHangTimeoutInterval = Duration(seconds: 2);
 
   /// Connection timeout. This will only be synced to the Android native SDK.
   Duration connectionTimeout = Duration(seconds: 5);

--- a/flutter/test/integrations/init_native_sdk_integration_test.dart
+++ b/flutter/test/integrations/init_native_sdk_integration_test.dart
@@ -62,6 +62,7 @@ void main() {
         'enableAppHangTracking': true,
         'connectionTimeoutMillis': 5000,
         'readTimeoutMillis': 5000,
+        'appHangTimeoutIntervalMillis': 2000,
       });
     });
 
@@ -100,7 +101,8 @@ void main() {
         ..captureFailedRequests = false
         ..enableAppHangTracking = false
         ..connectionTimeout = Duration(milliseconds: 9001)
-        ..readTimeout = Duration(milliseconds: 9002);
+        ..readTimeout = Duration(milliseconds: 9002)
+        ..appHangTimeoutInterval = Duration(milliseconds: 9003);
 
       options.sdk.addIntegration('foo');
       options.sdk.addPackage('bar', '1');
@@ -143,6 +145,7 @@ void main() {
         'enableAppHangTracking': false,
         'connectionTimeoutMillis': 9001,
         'readTimeoutMillis': 9002,
+        'appHangTimeoutIntervalMillis': 9003,
       });
     });
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

- Add `appHangTimeoutInterval ` to `SentryFlutterOptions`

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #1550

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes