### PR TITLE
Refrain from overwriting the span status for unfinished spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - This will affect your release health data, and is therefore considered a breaking change.
 - Refrain from overwriting the span status for unfinished spans ([#1577](https://github.com/getsentry/sentry-dart/pull/1577))
   - Older self-hosted sentry instances will drop transactions containing unfinished spans.
+    - This change was introduced in [relay/#1690](https://github.com/getsentry/relay/pull/1690) and released with [22.12.0](https://github.com/getsentry/relay/releases/tag/22.12.0)
   
 ## 7.9.0
   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 - Mark exceptions not handled by the user as `handled: false` ([#1535](https://github.com/getsentry/sentry-dart/pull/1535))
   - This will affect your release health data, and is therefore considered a breaking change.
-
+- Refrain from overwriting the span status for unfinished spans ([#1577](https://github.com/getsentry/sentry-dart/pull/1577))
+  - Older self-hosted sentry instances will drop transactions containing unfinished spans.
+  
 ## 7.9.0
   
 ### Features

--- a/dart/lib/src/sentry_tracer.dart
+++ b/dart/lib/src/sentry_tracer.dart
@@ -85,15 +85,6 @@ class SentryTracer extends ISentrySpan {
       _children.removeWhere(
           (span) => !_hasSpanSuitableTimestamps(span, commonEndTimestamp));
 
-      // finish unfinished spans otherwise transaction gets dropped
-      final spansToBeFinished = _children.where((span) => !span.finished);
-      for (final span in spansToBeFinished) {
-        await span.finish(
-          status: SpanStatus.deadlineExceeded(),
-          endTimestamp: commonEndTimestamp,
-        );
-      }
-
       var _rootEndTimestamp = commonEndTimestamp;
       if (_trimEnd && children.isNotEmpty) {
         final childEndTimestamps = children

--- a/dart/test/sentry_tracer_test.dart
+++ b/dart/test/sentry_tracer_test.dart
@@ -68,24 +68,7 @@ void main() {
       expect(sut.endTimestamp, endTimestamp);
     });
 
-    test(
-        'tracer finish sets given end timestamp to all children while finishing them',
-        () async {
-      final sut = fixture.getSut();
-
-      final childA = sut.startChild('operation-a', description: 'description');
-      final childB = sut.startChild('operation-b', description: 'description');
-      final endTimestamp = getUtcDateTime();
-
-      await sut.finish(endTimestamp: endTimestamp);
-      await childA.finish();
-      await childB.finish();
-
-      expect(childA.endTimestamp, endTimestamp);
-      expect(childB.endTimestamp, endTimestamp);
-    });
-
-    test('tracer finishes unfinished spans', () async {
+    test('tracer does not finish unfinished spans', () async {
       final sut = fixture.getSut();
       sut.startChild('child');
 
@@ -94,7 +77,8 @@ void main() {
       final tr = fixture.hub.captureTransactionCalls.first;
       final child = tr.transaction.spans.first;
 
-      expect(child.status.toString(), 'deadline_exceeded');
+      expect(child.status, isNull);
+      expect(child.endTimestamp, isNull);
     });
 
     test('tracer sets data to extra', () async {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Don't finish unfinished spans on the client.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #1481

## :green_heart: How did you test it?

Checked if relay ingested the transaction.

<img width="1118" alt="Bildschirmfoto 2023-08-01 um 14 55 29" src="https://github.com/getsentry/sentry-dart/assets/3984453/743c7685-03b8-449f-9d98-21f5df571553">

<img width="1817" alt="Bildschirmfoto 2023-08-01 um 14 58 26" src="https://github.com/getsentry/sentry-dart/assets/3984453/a2ad07fc-13a0-4c22-b566-8c56dc8e303c">

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [ ] No breaking changes
