### PR TITLE
Ensure Breadcrumbs and SentryEvents are always serialisable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Ensure Breadcrumbs and SentryEvents are always serialisable ([#1582](https://github.com/getsentry/sentry-dart/pull/1582))
+
 ## 7.9.0
 
 ### Features

--- a/logging/lib/src/extension.dart
+++ b/logging/lib/src/extension.dart
@@ -12,9 +12,9 @@ extension LogRecordX on LogRecord {
       level: level.toSentryLevel(),
       message: message,
       data: <String, Object>{
-        if (object != null) 'LogRecord.object': object!,
-        if (error != null) 'LogRecord.error': error!,
-        if (stackTrace != null) 'LogRecord.stackTrace': stackTrace!,
+        if (object != null) 'LogRecord.object': object!.toString(),
+        if (error != null) 'LogRecord.error': error!.toString(),
+        if (stackTrace != null) 'LogRecord.stackTrace': stackTrace!.toString(),
         'LogRecord.loggerName': loggerName,
         'LogRecord.sequenceNumber': sequenceNumber,
       },
@@ -30,7 +30,7 @@ extension LogRecordX on LogRecord {
       throwable: error,
       // ignore: deprecated_member_use
       extra: <String, Object>{
-        if (object != null) 'LogRecord.object': object!,
+        if (object != null) 'LogRecord.object': object!.toString(),
         'LogRecord.sequenceNumber': sequenceNumber,
       },
     );

--- a/logging/test/extension_test.dart
+++ b/logging/test/extension_test.dart
@@ -2,6 +2,10 @@ import 'package:logging/logging.dart';
 import 'package:sentry_logging/src/extension.dart';
 import 'package:test/test.dart';
 
+class _TestObject {}
+
+class _TestErrorObject {}
+
 void main() {
   test('breadcrumb time is always utc', () {
     final log = LogRecord(Level.CONFIG, 'foo bar', 'test logger');
@@ -13,5 +17,42 @@ void main() {
     final log = LogRecord(Level.CONFIG, 'foo bar', 'test logger');
 
     expect(log.toEvent().timestamp?.isUtc, true);
+  });
+
+  test('user defined objects are converted to string', () {
+    // Every value in the data and extra map must be convertible to by the
+    // StandardMessageCodec. We convert all user supplied types and the
+    // StackTrace to a string to make this property hold.
+
+    final object = _TestObject();
+    final error = _TestErrorObject();
+    final stackTrace = StackTrace.current;
+
+    final log = LogRecord(
+      Level.CONFIG,
+      'foo bar',
+      'test logger',
+      error,
+      stackTrace,
+      null,
+      object,
+    );
+
+    final breadcrumb = log.toBreadcrumb();
+    expect(
+      breadcrumb.data,
+      containsPair('LogRecord.object', object.toString()),
+    );
+    expect(
+      log.toBreadcrumb().data,
+      containsPair('LogRecord.stackTrace', stackTrace.toString()),
+    );
+
+    final event = log.toEvent();
+    expect(
+      // ignore: deprecated_member_use
+      event.extra,
+      containsPair('LogRecord.object', object.toString()),
+    );
   });
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Fixes unserialisable Breadcrumbs and SentryEvents created from log records containing an `object`, `stacktrace` or `error` of a type not supported by the [`StandardMessageCodec`](https://api.flutter.dev/flutter/services/StandardMessageCodec-class.html).

Fixes #1581 

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1581 

## :green_heart: How did you test it?

Run the dart tests in the repo.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps

I'm not sure if there is any utility in uploading a second copy of the object this way. It should always be identical to the existing `message` field of the breadcrumb, so it is just a duplicate. The only information it adds that the log call looked like `log.info(MyObject())`, rather than `log.info('${MyObject}')` which is irrelevant.