### PR TITLE
Fix memory leak issue in SentryFlutterPlugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fixing memory leak issue in SentryFlutterPlugin (Android Plugin) ([#1588](https://github.com/getsentry/sentry-dart/pull/1588))
+
+
 ## 7.9.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@
 ### Fixes
 
 - Fixing memory leak issue in SentryFlutterPlugin (Android Plugin) ([#1588](https://github.com/getsentry/sentry-dart/pull/1588))
-
-
 ## 7.9.0
 
 ### Features

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -11,11 +11,13 @@ import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 import io.sentry.Breadcrumb
+import io.sentry.DateUtils
+import io.sentry.Hint
 import io.sentry.HubAdapter
+import io.sentry.Sentry
 import io.sentry.SentryEvent
 import io.sentry.SentryLevel
-import io.sentry.Sentry
-import io.sentry.DateUtils
+import io.sentry.SentryOptions
 import io.sentry.android.core.ActivityFramesTracker
 import io.sentry.android.core.AppStartState
 import io.sentry.android.core.BuildConfig.VERSION_NAME
@@ -26,7 +28,6 @@ import io.sentry.protocol.DebugImage
 import io.sentry.protocol.SdkVersion
 import io.sentry.protocol.SentryId
 import io.sentry.protocol.User
-import io.sentry.protocol.Geo
 import java.io.File
 import java.lang.ref.WeakReference
 import java.util.Locale
@@ -39,10 +40,6 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
   private var activity: WeakReference<Activity>? = null
   private var framesTracker: ActivityFramesTracker? = null
   private var autoPerformanceTracingEnabled = false
-
-  private val flutterSdk = "sentry.dart.flutter"
-  private val androidSdk = "sentry.java.android.flutter"
-  private val nativeSdk = "sentry.native.android.flutter"
 
   override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
     context = flutterPluginBinding.applicationContext
@@ -183,12 +180,7 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
       options.sdkVersion = sdkVersion
       options.sentryClientName = "$androidSdk/$VERSION_NAME"
       options.nativeSdkName = nativeSdk
-
-      options.setBeforeSend { event, _ ->
-        setEventOriginTag(event)
-        addPackages(event, options.sdkVersion)
-        event
-      }
+      options.beforeSend = BeforeSendCallbackImpl(options.sdkVersion)
 
       args.getIfNotNull<Int>("connectionTimeoutMillis") { options.connectionTimeoutMillis = it }
       args.getIfNotNull<Int>("readTimeoutMillis") { options.readTimeoutMillis = it }
@@ -216,7 +208,7 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
       val appStartTimeMillis = DateUtils.nanosToMillis(appStartTime.nanoTimestamp().toDouble())
       val item = mapOf<String, Any?>(
         "appStartTime" to appStartTimeMillis,
-        "isColdStart" to isColdStart
+        "isColdStart" to isColdStart,
       )
       result.success(item)
     }
@@ -257,7 +249,7 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
       val frames = mapOf<String, Any?>(
         "totalFrames" to total,
         "slowFrames" to slow,
-        "frozenFrames" to frozen
+        "frozenFrames" to frozen,
       )
       result.success(frames)
     }
@@ -408,30 +400,44 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     result.success("")
   }
 
-  private fun setEventOriginTag(event: SentryEvent) {
-    event.sdk?.let {
-      when (it.name) {
-        flutterSdk -> setEventEnvironmentTag(event, "flutter", "dart")
-        androidSdk -> setEventEnvironmentTag(event, environment = "java")
-        nativeSdk -> setEventEnvironmentTag(event, environment = "native")
-        else -> return
-      }
+  private class BeforeSendCallbackImpl(private val sdkVersion: SdkVersion?) : SentryOptions.BeforeSendCallback {
+    override fun execute(event: SentryEvent, hint: Hint): SentryEvent {
+      setEventOriginTag(event)
+      addPackages(event, sdkVersion)
+      return event
     }
   }
 
-  private fun setEventEnvironmentTag(event: SentryEvent, origin: String = "android", environment: String) {
-    event.setTag("event.origin", origin)
-    event.setTag("event.environment", environment)
-  }
+  companion object {
 
-  private fun addPackages(event: SentryEvent, sdk: SdkVersion?) {
-    event.sdk?.let {
-      if (it.name == flutterSdk) {
-        sdk?.packageSet?.forEach { sentryPackage ->
-          it.addPackage(sentryPackage.name, sentryPackage.version)
+    private const val flutterSdk = "sentry.dart.flutter"
+    private const val androidSdk = "sentry.java.android.flutter"
+    private const val nativeSdk = "sentry.native.android.flutter"
+    private fun setEventOriginTag(event: SentryEvent) {
+      event.sdk?.let {
+        when (it.name) {
+          flutterSdk -> setEventEnvironmentTag(event, "flutter", "dart")
+          androidSdk -> setEventEnvironmentTag(event, environment = "java")
+          nativeSdk -> setEventEnvironmentTag(event, environment = "native")
+          else -> return
         }
-        sdk?.integrationSet?.forEach { integration ->
-          it.addIntegration(integration)
+      }
+    }
+
+    private fun setEventEnvironmentTag(event: SentryEvent, origin: String = "android", environment: String) {
+      event.setTag("event.origin", origin)
+      event.setTag("event.environment", environment)
+    }
+
+    private fun addPackages(event: SentryEvent, sdk: SdkVersion?) {
+      event.sdk?.let {
+        if (it.name == flutterSdk) {
+          sdk?.packageSet?.forEach { sentryPackage ->
+            it.addPackage(sentryPackage.name, sentryPackage.version)
+          }
+          sdk?.integrationSet?.forEach { integration ->
+            it.addIntegration(integration)
+          }
         }
       }
     }

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -124,9 +124,15 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
       args.getIfNotNull<String>("environment") { options.environment = it }
       args.getIfNotNull<String>("release") { options.release = it }
       args.getIfNotNull<String>("dist") { options.dist = it }
-      args.getIfNotNull<Boolean>("enableAutoSessionTracking") { options.isEnableAutoSessionTracking = it }
-      args.getIfNotNull<Long>("autoSessionTrackingIntervalMillis") { options.sessionTrackingIntervalMillis = it }
-      args.getIfNotNull<Long>("anrTimeoutIntervalMillis") { options.anrTimeoutIntervalMillis = it }
+      args.getIfNotNull<Boolean>("enableAutoSessionTracking") {
+        options.isEnableAutoSessionTracking = it
+      }
+      args.getIfNotNull<Long>("autoSessionTrackingIntervalMillis") {
+        options.sessionTrackingIntervalMillis = it
+      }
+      args.getIfNotNull<Long>("anrTimeoutIntervalMillis") {
+        options.anrTimeoutIntervalMillis = it
+      }
       args.getIfNotNull<Boolean>("attachThreads") { options.isAttachThreads = it }
       args.getIfNotNull<Boolean>("attachStacktrace") { options.isAttachStacktrace = it }
       args.getIfNotNull<Boolean>("enableAutoNativeBreadcrumbs") {
@@ -208,7 +214,7 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
       val appStartTimeMillis = DateUtils.nanosToMillis(appStartTime.nanoTimestamp().toDouble())
       val item = mapOf<String, Any?>(
         "appStartTime" to appStartTimeMillis,
-        "isColdStart" to isColdStart,
+        "isColdStart" to isColdStart
       )
       result.success(item)
     }
@@ -249,7 +255,7 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
       val frames = mapOf<String, Any?>(
         "totalFrames" to total,
         "slowFrames" to slow,
-        "frozenFrames" to frozen,
+        "frozenFrames" to frozen
       )
       result.success(frames)
     }
@@ -400,7 +406,9 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     result.success("")
   }
 
-  private class BeforeSendCallbackImpl(private val sdkVersion: SdkVersion?) : SentryOptions.BeforeSendCallback {
+  private class BeforeSendCallbackImpl(
+    private val sdkVersion: SdkVersion?
+  ) : SentryOptions.BeforeSendCallback {
     override fun execute(event: SentryEvent, hint: Hint): SentryEvent {
       setEventOriginTag(event)
       addPackages(event, sdkVersion)
@@ -424,7 +432,11 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
       }
     }
 
-    private fun setEventEnvironmentTag(event: SentryEvent, origin: String = "android", environment: String) {
+    private fun setEventEnvironmentTag(
+      event: SentryEvent,
+      origin: String = "android",
+      environment: String
+    ) {
       event.setTag("event.origin", origin)
       event.setTag("event.environment", environment)
     }


### PR DESCRIPTION
I fixed the memory leak issue in SentryFlutterPlugin by removing the anonymous inner class that was holding a reference to the external SentryFlutterPlugin object, which was causing a memory leak problem with the MethodChannel object.

## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

To reproduce the steps:

- Integrate sentry_flutter into your project.
- Open the application's MainActivity and press the back button to return to the Launcher. Repeat this process multiple times.
- Use Android Studio Profiler to dump the memory for analysis.


![WX20230808-095220](https://github.com/getsentry/sentry-dart/assets/5371228/d5e3d6ac-ab8f-4900-b822-e6d2c4197adf)



## :green_heart: How did you test it?

Since the SentryFlutterPlugin does not have unit test code, I repeated the steps mentioned above after making the modifications and confirmed that the issue has been fixed.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
