### PR TITLE
fix: macos compilation due to cocoa SDK changes

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -160,7 +160,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       # https://github.com/CocoaPods/CocoaPods/issues/5275#issuecomment-315461879
-      - run: pod lib lint ios/sentry_flutter.podspec --configuration=Debug --skip-import-validation --allow-warnings
+      - run: pod lib lint ios/sentry_flutter.podspec --configuration=Debug --skip-import-validation --allow-warnings --verbose
 
   swift-lint:
     runs-on: ubuntu-latest

--- a/flutter/example/ios/Podfile
+++ b/flutter/example/ios/Podfile
@@ -1,7 +1,5 @@
-wanted_project_target = '11.0'
-
 # Uncomment this line to define a global platform for your project
-platform :ios, wanted_project_target
+platform :ios, '11.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
@@ -37,15 +35,6 @@ target 'Runner' do
 end
 
 post_install do |installer|
-  # remove after https://github.com/flutter/flutter/issues/124340 getting into all channels
-  installer.generated_projects.each do |project|
-    project.targets.each do |target|
-        target.build_configurations.each do |config|
-            config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = wanted_project_target
-        end
-    end
-  end
-
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
   end

--- a/flutter/ios/Classes/SentryFlutterPluginApple.swift
+++ b/flutter/ios/Classes/SentryFlutterPluginApple.swift
@@ -466,6 +466,7 @@ public class SentryFlutterPluginApple: NSObject, FlutterPlugin {
     }
 
     private func fetchNativeAppStart(result: @escaping FlutterResult) {
+        #if os(iOS) || os(tvOS)
         guard let appStartMeasurement = PrivateSentrySDKOnly.appStartMeasurement else {
             print("warning: appStartMeasurement is null")
             result(nil)
@@ -481,6 +482,10 @@ public class SentryFlutterPluginApple: NSObject, FlutterPlugin {
         ]
 
         result(item)
+        #else
+            print("note: appStartMeasurement not available on this platform")
+            result(nil)
+        #endif
     }
 
     private var totalFrames: UInt = 0

--- a/flutter/ios/sentry_flutter.podspec
+++ b/flutter/ios/sentry_flutter.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
 Sentry SDK for Flutter with support to native through sentry-cocoa.
                        DESC
   s.homepage         = 'https://sentry.io'
-  s.license          = { :file => '../LICENSE' }
+  s.license          = { :type => 'MIT', :file => '../LICENSE' }
   s.authors          = "Sentry"
   s.source           = { :git => "https://github.com/getsentry/sentry-dart.git",
                          :tag => s.version.to_s }


### PR DESCRIPTION
Broken by https://github.com/getsentry/sentry-cocoa/pull/3157 (v8.9.2) because the `SentryAppStartMeasurement` is not exported anymore.

closes #1596

Note: integration test failures are unrelated: #1605 

#skip-changelog
