### PR TITLE
Fix Android & iOS CI issues

### DIFF
--- a/.github/workflows/flutter_test.yml
+++ b/.github/workflows/flutter_test.yml
@@ -134,7 +134,7 @@ jobs:
       - name: launch ios simulator
         id: sim
         run: |
-          simulator_id=$(xcrun simctl create sentryPhone com.apple.CoreSimulator.SimDeviceType.iPhone-14 com.apple.CoreSimulator.SimRuntime.iOS-16-2)
+          simulator_id=$(xcrun simctl create sentryPhone com.apple.CoreSimulator.SimDeviceType.iPhone-14 com.apple.CoreSimulator.SimRuntime.iOS-16-4)
           echo "SIMULATOR_ID=${simulator_id}" >> "$GITHUB_OUTPUT"
           xcrun simctl boot ${simulator_id}
 # Disable flutter integration tests because of flaky execution

--- a/.github/workflows/flutter_test.yml
+++ b/.github/workflows/flutter_test.yml
@@ -82,7 +82,7 @@ jobs:
       - name: launch android emulator & run android native test
         uses: reactivecircus/android-emulator-runner@d94c3fbe4fe6a29e4a5ba47c12fb47677c73656b #pin@v2.28.0
         with:
-          working-directory: ./flutter/example
+          working-directory: ./flutter/example/android
           api-level: 31
           profile: Nexus 6
           arch: x86_64

--- a/.github/workflows/flutter_test.yml
+++ b/.github/workflows/flutter_test.yml
@@ -66,12 +66,13 @@ jobs:
         uses: reactivecircus/android-emulator-runner@d94c3fbe4fe6a29e4a5ba47c12fb47677c73656b #pin@v2.28.0
         with:
           working-directory: ./flutter/example
-          api-level: 21
-          force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: false
-          arch: x86_64
+          api-level: 31
           profile: Nexus 6
+          arch: arm64-v8a
+          force-avd-creation: false
+          avd-name: macOS-avd-arm64-v8a-31
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
           script: echo 'Generated AVD snapshot for caching.'
 
       - name: build apk
@@ -81,25 +82,27 @@ jobs:
       - name: launch android emulator & run android native test
         uses: reactivecircus/android-emulator-runner@d94c3fbe4fe6a29e4a5ba47c12fb47677c73656b #pin@v2.28.0
         with:
-          working-directory: ./flutter/example/android
-          api-level: 21
+          working-directory: ./flutter/example
+          api-level: 31
+          profile: Nexus 6
+          arch: arm64-v8a
           force-avd-creation: false
+          avd-name: macOS-avd-arm64-v8a-31
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          arch: x86_64
-          profile: Nexus 6
           script: ./gradlew testDebugUnitTest
 
       - name: launch android emulator & run android integration test
         uses: reactivecircus/android-emulator-runner@d94c3fbe4fe6a29e4a5ba47c12fb47677c73656b #pin@v2.28.0
         with:
           working-directory: ./flutter/example
-          api-level: 21
+          api-level: 31
+          profile: Nexus 6
+          arch: arm64-v8a
           force-avd-creation: false
+          avd-name: macOS-avd-arm64-v8a-31
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          arch: x86_64
-          profile: Nexus 6
           script: flutter test integration_test/integration_test.dart --verbose
 
   test-ios:

--- a/.github/workflows/flutter_test.yml
+++ b/.github/workflows/flutter_test.yml
@@ -68,9 +68,9 @@ jobs:
           working-directory: ./flutter/example
           api-level: 31
           profile: Nexus 6
-          arch: arm64-v8a
+          arch: x86_64
           force-avd-creation: false
-          avd-name: macOS-avd-arm64-v8a-31
+          avd-name: macOS-avd-x86_64-31
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: echo 'Generated AVD snapshot for caching.'
@@ -85,9 +85,9 @@ jobs:
           working-directory: ./flutter/example
           api-level: 31
           profile: Nexus 6
-          arch: arm64-v8a
+          arch: x86_64
           force-avd-creation: false
-          avd-name: macOS-avd-arm64-v8a-31
+          avd-name: macOS-avd-x86_64-31
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: ./gradlew testDebugUnitTest
@@ -98,9 +98,9 @@ jobs:
           working-directory: ./flutter/example
           api-level: 31
           profile: Nexus 6
-          arch: arm64-v8a
+          arch: x86_64
           force-avd-creation: false
-          avd-name: macOS-avd-arm64-v8a-31
+          avd-name: macOS-avd-x86_64-31
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: flutter test integration_test/integration_test.dart --verbose

--- a/.github/workflows/flutter_test.yml
+++ b/.github/workflows/flutter_test.yml
@@ -59,7 +59,7 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-21
+          key: avd-31
 
       - name: create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->

- Use iOS 16.4 simulator to run native tests
- Update parameters of android emulator to [avoid flakiness](https://github.com/ReactiveCircus/android-emulator-runner/issues/324)

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- Apparently the `macos-13` runner was updated and the iOS 16.2 sim was not valid anymore.
- The booting of Android emulator with `android-emulator-runner` seems to be unreliable 

## :green_heart: How did you test it?

Run CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes
