### PR TITLE
Disable scope sync for cloned scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Normalize data properties of `SentryUser` and `Breadcrumb` before sending over method channel ([#1591](https://github.com/getsentry/sentry-dart/pull/1591))
 - Fixing memory leak issue in SentryFlutterPlugin (Android Plugin) ([#1588](https://github.com/getsentry/sentry-dart/pull/1588))
+- Disable scope sync for cloned scopes ([#1628](https://github.com/getsentry/sentry-dart/pull/1628))
 
 ### Dependencies
 

--- a/dart/lib/src/scope.dart
+++ b/dart/lib/src/scope.dart
@@ -136,6 +136,7 @@ class Scope {
       List.unmodifiable(_eventProcessors);
 
   final SentryOptions _options;
+  bool _enableScopeSync = true;
 
   final List<SentryAttachment> _attachments = [];
 
@@ -412,7 +413,8 @@ class Scope {
       ..level = level
       ..fingerprint = List.from(fingerprint)
       .._transaction = _transaction
-      ..span = span;
+      ..span = span
+      .._enableScopeSync = false;
 
     clone._setUserSync(user);
 
@@ -450,7 +452,7 @@ class Scope {
   }
 
   Future<void> _callScopeObservers(_OnScopeObserver action) async {
-    if (_options.enableScopeSync) {
+    if (_options.enableScopeSync && _enableScopeSync) {
       for (final scopeObserver in _options.scopeObservers) {
         await action(scopeObserver);
       }

--- a/dart/test/scope_test.dart
+++ b/dart/test/scope_test.dart
@@ -375,6 +375,14 @@ void main() {
     expect(1, fixture.mockScopeObserver.numberOfRemoveTagCalls);
   });
 
+  test('clone has disabled scope sync', () async {
+    final sut = fixture.getSut(scopeObserver: fixture.mockScopeObserver);
+    final clone = sut.clone();
+
+    await clone.setContexts("fixture-contexts-key", "fixture-contexts-value");
+    expect(0, fixture.mockScopeObserver.numberOfSetContextsCalls);
+  });
+
   group('Scope apply', () {
     final scopeUser = SentryUser(
       id: '800',

--- a/dio/test/dio_event_processor_test.dart
+++ b/dio/test/dio_event_processor_test.dart
@@ -67,7 +67,7 @@ void main() {
         throwable: throwable,
         exceptions: [
           fixture.sentryError(throwable),
-          fixture.sentryError(dioError)
+          fixture.sentryError(dioError),
         ],
       );
       final processedEvent = sut.apply(event) as SentryEvent;
@@ -96,7 +96,7 @@ void main() {
         throwable: throwable,
         exceptions: [
           fixture.sentryError(throwable),
-          fixture.sentryError(dioError)
+          fixture.sentryError(dioError),
         ],
       );
       final processedEvent = sut.apply(event) as SentryEvent;
@@ -125,7 +125,7 @@ void main() {
         throwable: throwable,
         exceptions: [
           fixture.sentryError(throwable),
-          fixture.sentryError(dioError)
+          fixture.sentryError(dioError),
         ],
       );
       final processedEvent = sut.apply(event) as SentryEvent;
@@ -177,7 +177,7 @@ void main() {
           throwable: throwable,
           exceptions: [
             fixture.sentryError(throwable),
-            fixture.sentryError(dioError)
+            fixture.sentryError(dioError),
           ],
         );
         final processedEvent = sut.apply(event) as SentryEvent;
@@ -207,7 +207,7 @@ void main() {
           data: 'foobar',
           headers: Headers.fromMap(<String, List<String>>{
             'foo': ['bar'],
-            'set-cookie': ['foo=bar']
+            'set-cookie': ['foo=bar'],
           }),
           requestOptions: request,
           isRedirect: true,
@@ -219,7 +219,7 @@ void main() {
         throwable: throwable,
         exceptions: [
           fixture.sentryError(throwable),
-          fixture.sentryError(dioError)
+          fixture.sentryError(dioError),
         ],
       );
       final processedEvent = sut.apply(event) as SentryEvent;
@@ -248,7 +248,7 @@ void main() {
         response: Response<dynamic>(
           data: 'foobar',
           headers: Headers.fromMap(<String, List<String>>{
-            'foo': ['bar']
+            'foo': ['bar'],
           }),
           requestOptions: request,
           isRedirect: true,
@@ -260,7 +260,7 @@ void main() {
         throwable: throwable,
         exceptions: [
           fixture.sentryError(throwable),
-          fixture.sentryError(dioError)
+          fixture.sentryError(dioError),
         ],
       );
       final processedEvent = sut.apply(event) as SentryEvent;
@@ -320,7 +320,7 @@ void main() {
           throwable: throwable,
           exceptions: [
             fixture.sentryError(throwable),
-            fixture.sentryError(dioError)
+            fixture.sentryError(dioError),
           ],
         );
         final processedEvent = sut.apply(event) as SentryEvent;
@@ -338,7 +338,7 @@ void main() {
       final dataByType = {
         ResponseType.plain: ['plain'],
         ResponseType.bytes: [
-          [1337]
+          [1337],
         ],
         ResponseType.json: [
           9001,
@@ -347,7 +347,7 @@ void main() {
           true,
           ['list'],
           {'map-key': 'map-value'},
-        ]
+        ],
       };
 
       for (final entry in dataByType.entries) {
@@ -375,7 +375,7 @@ void main() {
             throwable: throwable,
             exceptions: [
               fixture.sentryError(throwable),
-              fixture.sentryError(dioError)
+              fixture.sentryError(dioError),
             ],
           );
           final processedEvent = sut.apply(event) as SentryEvent;

--- a/dio/test/failed_request_interceptor_test.dart
+++ b/dio/test/failed_request_interceptor_test.dart
@@ -113,7 +113,7 @@ class Fixture {
 
   FailedRequestInterceptor getSut({
     List<SentryStatusCode> failedRequestStatusCodes = const [
-      SentryStatusCode.defaultRange()
+      SentryStatusCode.defaultRange(),
     ],
     List<String> failedRequestTargets = const ['.*'],
   }) {

--- a/dio/test/mocks.dart
+++ b/dio/test/mocks.dart
@@ -42,7 +42,7 @@ final fakeEvent = SentryEvent(
       type: 'navigation',
       data: <String, dynamic>{'screen': 'MainActivity', 'state': 'created'},
       level: SentryLevel.info,
-    )
+    ),
   ],
   contexts: Contexts(
     operatingSystem: const SentryOperatingSystem(

--- a/sqflite/test/mocks/mocks.dart
+++ b/sqflite/test/mocks/mocks.dart
@@ -33,7 +33,8 @@ ISentrySpan startTransactionShim(
     DatabaseExecutor,
   ],
   customMocks: [
-    MockSpec<Hub>(fallbackGenerators: {#startTransaction: startTransactionShim})
+    MockSpec<Hub>(
+        fallbackGenerators: {#startTransaction: startTransactionShim}),
   ],
 )
 void main() {}


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

- Disable scope sync for cloned scopes

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #1597

## :green_heart: How did you test it?

- Added tests
- Tested on sentry.io with example app

| error 1 |  error 2 | error 3 
:--------:|:--------:|:--------
<img width="726" alt="Bildschirmfoto 2023-09-05 um 14 48 08" src="https://github.com/getsentry/sentry-dart/assets/3984453/997bd799-d15d-4a8a-8dd7-ea1fd891fa04"> | <img width="1223" alt="Bildschirmfoto 2023-09-05 um 14 48 23" src="https://github.com/getsentry/sentry-dart/assets/3984453/92778ec1-7d8a-4a65-a59f-04c1e969a026"> | <img width="1216" alt="Bildschirmfoto 2023-09-05 um 14 48 35" src="https://github.com/getsentry/sentry-dart/assets/3984453/f8a2a771-e702-4d6d-8592-596bba045aa3">


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

The whole hub can be cloned, which in turn will peeking through all stack items, cloning all scopes. Scope sync for those is therefore also disabled. What is the use-case of cloning the hub?
