### PR TITLE
[starfish] add http.request.method attribute to http spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+- Add http.request.method attribute to http spans data ([#1633](https://github.com/getsentry/sentry-dart/pull/1633))
 - Add db.system and db.name attributes to db spans data ([#1629](https://github.com/getsentry/sentry-dart/pull/1629))
 
 ### Features

--- a/dart/lib/src/http_client/tracing_client.dart
+++ b/dart/lib/src/http_client/tracing_client.dart
@@ -41,7 +41,7 @@ class TracingClient extends BaseClient {
       span = null;
     }
 
-    span?.setData('http.method', request.method);
+    span?.setData('http.request.method', request.method);
     urlDetails?.applyToSpan(span);
 
     StreamedResponse? response;

--- a/dart/test/http_client/tracing_client_test.dart
+++ b/dart/test/http_client/tracing_client_test.dart
@@ -38,7 +38,7 @@ void main() {
       expect(span.status, SpanStatus.ok());
       expect(span.context.operation, 'http.client');
       expect(span.context.description, 'GET https://example.com');
-      expect(span.data['http.method'], 'GET');
+      expect(span.data['http.request.method'], 'GET');
       expect(span.data['url'], 'https://example.com');
       expect(span.data['http.query'], 'foo=bar');
       expect(span.data['http.fragment'], 'baz');

--- a/dio/lib/src/sentry_transformer.dart
+++ b/dio/lib/src/sentry_transformer.dart
@@ -27,7 +27,7 @@ class SentryTransformer implements Transformer {
           description: description,
         );
 
-    span?.setData('http.method', options.method);
+    span?.setData('http.request.method', options.method);
     // ignore: invalid_use_of_internal_member
     span?.origin = SentryTraceOrigins.autoHttpDioTransformer;
 
@@ -65,7 +65,7 @@ class SentryTransformer implements Transformer {
           description: description,
         );
 
-    span?.setData('http.method', options.method);
+    span?.setData('http.request.method', options.method);
     // ignore: invalid_use_of_internal_member
     span?.origin = SentryTraceOrigins.autoHttpDioTransformer;
 

--- a/dio/lib/src/tracing_client_adapter.dart
+++ b/dio/lib/src/tracing_client_adapter.dart
@@ -46,7 +46,7 @@ class TracingClientAdapter implements HttpClientAdapter {
       span = null;
     }
 
-    span?.setData('http.method', options.method);
+    span?.setData('http.request.method', options.method);
     urlDetails?.applyToSpan(span);
 
     ResponseBody? response;

--- a/dio/test/sentry_transformer_test.dart
+++ b/dio/test/sentry_transformer_test.dart
@@ -39,7 +39,7 @@ void main() {
       expect(span.status, SpanStatus.ok());
       expect(span.context.operation, 'serialize.http.client');
       expect(span.context.description, 'GET https://example.com');
-      expect(span.data['http.method'], 'GET');
+      expect(span.data['http.request.method'], 'GET');
       expect(span.data['url'], 'https://example.com');
       expect(span.data['http.query'], 'foo=bar');
       expect(span.data['http.fragment'], 'baz');
@@ -67,7 +67,7 @@ void main() {
       expect(span.status, SpanStatus.internalError());
       expect(span.context.operation, 'serialize.http.client');
       expect(span.context.description, 'GET https://example.com');
-      expect(span.data['http.method'], 'GET');
+      expect(span.data['http.request.method'], 'GET');
       expect(span.data['url'], 'https://example.com');
       expect(span.data['http.query'], 'foo=bar');
       expect(span.data['http.fragment'], 'baz');
@@ -96,7 +96,7 @@ void main() {
       expect(span.status, SpanStatus.ok());
       expect(span.context.operation, 'serialize.http.client');
       expect(span.context.description, 'GET https://example.com');
-      expect(span.data['http.method'], 'GET');
+      expect(span.data['http.request.method'], 'GET');
       expect(span.data['url'], 'https://example.com');
       expect(span.data['http.query'], 'foo=bar');
       expect(span.data['http.fragment'], 'baz');
@@ -126,7 +126,7 @@ void main() {
       expect(span.status, SpanStatus.internalError());
       expect(span.context.operation, 'serialize.http.client');
       expect(span.context.description, 'GET https://example.com');
-      expect(span.data['http.method'], 'GET');
+      expect(span.data['http.request.method'], 'GET');
       expect(span.data['url'], 'https://example.com');
       expect(span.data['http.query'], 'foo=bar');
       expect(span.data['http.fragment'], 'baz');

--- a/dio/test/tracing_client_adapter_test.dart
+++ b/dio/test/tracing_client_adapter_test.dart
@@ -43,7 +43,7 @@ void main() {
       expect(span.status, SpanStatus.ok());
       expect(span.context.operation, 'http.client');
       expect(span.context.description, 'GET https://example.com');
-      expect(span.data['http.method'], 'GET');
+      expect(span.data['http.request.method'], 'GET');
       expect(span.data['url'], 'https://example.com');
       expect(span.data['http.query'], 'foo=bar');
       expect(span.data['http.fragment'], 'baz');


### PR DESCRIPTION
## :scroll: Description
Add `http.request.method` attribute to http spans


## :bulb: Motivation and Context
Closes #1609 


## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
