### PR TITLE
Log SDK errors to the console if the log level is `fatal` even if `debug` is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add http.request.method attribute to http spans data ([#1633](https://github.com/getsentry/sentry-dart/pull/1633))
 - Add db.system and db.name attributes to db spans data ([#1629](https://github.com/getsentry/sentry-dart/pull/1629))
+- Log SDK errors to the console if the log level is `fatal` even if `debug` is disabled ([#1635](https://github.com/getsentry/sentry-dart/pull/1635))
 
 ### Features
 

--- a/dart/lib/src/diagnostic_logger.dart
+++ b/dart/lib/src/diagnostic_logger.dart
@@ -26,6 +26,8 @@ class DiagnosticLogger {
   }
 
   bool _isEnabled(SentryLevel level) {
-    return _options.debug && level.ordinal >= _options.diagnosticLevel.ordinal;
+    return _options.debug &&
+            level.ordinal >= _options.diagnosticLevel.ordinal ||
+        level == SentryLevel.fatal;
   }
 }

--- a/dart/test/diagnostic_logger_test.dart
+++ b/dart/test/diagnostic_logger_test.dart
@@ -1,0 +1,64 @@
+import 'package:sentry/sentry.dart';
+import 'package:sentry/src/diagnostic_logger.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late Fixture fixture;
+
+  setUp(() {
+    fixture = Fixture();
+  });
+
+  test('$DiagnosticLogger do not log if debug is disabled', () {
+    fixture.options.debug = false;
+
+    fixture.getSut().log(SentryLevel.error, 'foobar');
+
+    expect(fixture.loggedMessage, isNull);
+  });
+
+  test('$DiagnosticLogger log if debug is enabled', () {
+    fixture.options.debug = true;
+
+    fixture.getSut().log(SentryLevel.error, 'foobar');
+
+    expect(fixture.loggedMessage, 'foobar');
+  });
+
+  test('$DiagnosticLogger do not log if level is too low', () {
+    fixture.options.debug = true;
+    fixture.options.diagnosticLevel = SentryLevel.error;
+
+    fixture.getSut().log(SentryLevel.warning, 'foobar');
+
+    expect(fixture.loggedMessage, isNull);
+  });
+
+  test('$DiagnosticLogger always log fatal', () {
+    fixture.options.debug = false;
+
+    fixture.getSut().log(SentryLevel.fatal, 'foobar');
+
+    expect(fixture.loggedMessage, 'foobar');
+  });
+}
+
+class Fixture {
+  var options = SentryOptions();
+
+  Object? loggedMessage;
+
+  DiagnosticLogger getSut() {
+    return DiagnosticLogger(mockLogger, options);
+  }
+
+  void mockLogger(
+    SentryLevel level,
+    String message, {
+    String? logger,
+    Object? exception,
+    StackTrace? stackTrace,
+  }) {
+    loggedMessage = message;
+  }
+}


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

- Log SDK errors to the console if the log level is `fatal` even if `debug` is disabled

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #1496 

## :green_heart: How did you test it?

Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes
