### PR TITLE
fix: add missing FFI depdendency

### DIFF
--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   sentry: 7.9.0
   package_info_plus: '>=1.0.0 <5.0.0'
   meta: ^1.3.0
+  ffi: ^2.0.0
 
 dev_dependencies:
   build_runner: ^2.4.2


### PR DESCRIPTION
This failed while publishing. 

Note: we can't test publishing beforehand at the moment because `dart pub publish --dry-run` exits with a non-zero exit code due to a warning with too-tight version constraints on sentry package. 
related: https://github.com/dart-lang/pub/issues/3807

#skip-changelog
