### PR TITLE
Set ip_address to {{auto}} by default, even if sendDefaultPII is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@
   - This will affect your callbacks, making this a breaking change.
 - Load Device Contexts from Sentry Java ([#1616](https://github.com/getsentry/sentry-dart/pull/1616))
   - Now the device context from Android is available in `BeforeSendCallback`
-
+- Set ip_address to {{auto}} by default, even if sendDefaultPII is disabled ([#1665](https://github.com/getsentry/sentry-dart/pull/1665))
+  - Instead use the "Prevent Storing of IP Addresses" option in the "Security & Privacy" project settings on sentry.io
+  
 ## Unreleased
   
 ### Fixes

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -23,8 +23,7 @@ import 'client_reports/discard_reason.dart';
 import 'transport/data_category.dart';
 
 /// Default value for [User.ipAddress]. It gets set when an event does not have
-/// a user and IP address. Only applies if [SentryOptions.sendDefaultPii] is set
-/// to true.
+/// a user and IP address.
 const _defaultIpAddress = '{{auto}}';
 
 /// Logs crash reports and events to the Sentry.io service.
@@ -142,7 +141,7 @@ class SentryClient {
       platform: event.platform ?? sdkPlatform(_options.platformChecker.isWeb),
     );
 
-    event = _applyDefaultPii(event);
+    event = _createUserOrSetDefaultIpAddress(event);
 
     if (event is SentryTransaction) {
       return event;
@@ -222,20 +221,13 @@ class SentryClient {
     return event;
   }
 
-  /// This modifies the users IP address according
-  /// to [SentryOptions.sendDefaultPii].
-  SentryEvent _applyDefaultPii(SentryEvent event) {
-    if (!_options.sendDefaultPii) {
-      return event;
-    }
+  SentryEvent _createUserOrSetDefaultIpAddress(SentryEvent event) {
     var user = event.user;
     if (user == null) {
-      user = SentryUser(ipAddress: _defaultIpAddress);
-      return event.copyWith(user: user);
+      return event.copyWith(user: SentryUser(ipAddress: _defaultIpAddress));
     } else if (event.user?.ipAddress == null) {
       return event.copyWith(user: user.copyWith(ipAddress: _defaultIpAddress));
     }
-
     return event;
   }
 

--- a/dart/test/sentry_client_test.dart
+++ b/dart/test/sentry_client_test.dart
@@ -826,25 +826,14 @@ void main() {
     });
   });
 
-  group('SentryClient: apply default pii', () {
+  group('SentryClient: sets user & user ip', () {
     late Fixture fixture;
 
     setUp(() {
       fixture = Fixture();
     });
 
-    test('sendDefaultPii is disabled', () async {
-      final client = fixture.getSut(sendDefaultPii: false);
-
-      await client.captureEvent(fakeEvent);
-
-      final capturedEnvelope = fixture.transport.envelopes.first;
-      final capturedEvent = await eventFromEnvelope(capturedEnvelope);
-
-      expect(capturedEvent.user?.toJson(), fakeEvent.user?.toJson());
-    });
-
-    test('sendDefaultPii is enabled and event has no user', () async {
+    test('event has no user', () async {
       final client = fixture.getSut(sendDefaultPii: true);
       var fakeEvent = SentryEvent();
 
@@ -858,7 +847,7 @@ void main() {
       expect(capturedEvent.user?.ipAddress, '{{auto}}');
     });
 
-    test('sendDefaultPii is enabled and event has a user with IP address',
+    test('event has a user with IP address',
         () async {
       final client = fixture.getSut(sendDefaultPii: true);
 
@@ -875,7 +864,7 @@ void main() {
       expect(capturedEvent.user?.email, fakeEvent.user!.email);
     });
 
-    test('sendDefaultPii is enabled and event has a user without IP address',
+    test('event has a user without IP address',
         () async {
       final client = fixture.getSut(sendDefaultPii: true);
 


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #1562

## :green_heart: How did you test it?

Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes