### PR TITLE
ci: generate code coverage in flutter integration test

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -109,6 +109,7 @@ jobs:
         with:
           name: sentry_flutter
           file: ./flutter/coverage/lcov.info
+          functionalities: "search" # remove after https://github.com/codecov/codecov-action/issues/600
 
       - uses: VeryGoodOpenSource/very_good_coverage@e5c91bc7ce9843e87c800b3bcafdfb86fbe28491 # pin@v2.1.0
         if: runner.os == 'Linux' && matrix.sdk == 'stable' && matrix.target == 'linux'

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -109,7 +109,6 @@ jobs:
         with:
           name: sentry_flutter
           file: ./flutter/coverage/lcov.info
-          functionalities: "search" # remove after https://github.com/codecov/codecov-action/issues/600
 
       - uses: VeryGoodOpenSource/very_good_coverage@e5c91bc7ce9843e87c800b3bcafdfb86fbe28491 # pin@v2.1.0
         if: runner.os == 'Linux' && matrix.sdk == 'stable' && matrix.target == 'linux'

--- a/.github/workflows/flutter_test.yml
+++ b/.github/workflows/flutter_test.yml
@@ -110,7 +110,7 @@ jobs:
         if: matrix.sdk == 'stable'
         with:
           name: sentry_flutter_integration_android
-          file: ./flutter/coverage/lcov.info
+          file: ./flutter/example/coverage/lcov.info
 
   cocoa:
     name: "${{ matrix.target }} | ${{ matrix.sdk }}"
@@ -160,18 +160,18 @@ jobs:
 
       - name: run integration test
         # Disable flutter integration tests for iOS for now (https://github.com/getsentry/sentry-dart/issues/1605#issuecomment-1695809346)
-        if: ${{ matrix.target != 'ios' }}
+        if: ${{ matrix.target == 'macos' }}
         run: flutter test --coverage -d "${{ steps.device.outputs.name }}" integration_test --verbose
 
       - name: run native test
         # We only have the native unit test package in the iOS xcodeproj at the moment.
         # Should be OK because it will likely be removed after switching to FFI (see https://github.com/getsentry/sentry-dart/issues/1444).
-        if: ${{ matrix.target != 'macos' }}
+        if: ${{ matrix.target == 'ios' }}
         working-directory: ./flutter/example/${{ matrix.target }}
         run: xcodebuild test -workspace Runner.xcworkspace -scheme Runner -configuration Debug -destination "platform=${{ steps.device.outputs.platform }}" -allowProvisioningUpdates CODE_SIGNING_ALLOWED=NO
 
       - uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # pin@v3
-        if: matrix.sdk == 'stable'
+        if: ${{ matrix.sdk == 'stable' && matrix.target == 'macos' }}
         with:
           name: sentry_flutter_integration_cocoa
-          file: ./flutter/coverage/lcov.info
+          file: ./flutter/example/coverage/lcov.info

--- a/.github/workflows/flutter_test.yml
+++ b/.github/workflows/flutter_test.yml
@@ -104,7 +104,13 @@ jobs:
           avd-name: macOS-avd-x86_64-31
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: flutter test integration_test --verbose
+          script: flutter test --coverage integration_test --verbose
+
+      - uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # pin@v3
+        if: matrix.sdk == 'stable'
+        with:
+          name: sentry_flutter_integration_android
+          file: ./flutter/coverage/lcov.info
 
   cocoa:
     name: "${{ matrix.target }} | ${{ matrix.sdk }}"
@@ -155,7 +161,7 @@ jobs:
       - name: run integration test
         # Disable flutter integration tests for iOS for now (https://github.com/getsentry/sentry-dart/issues/1605#issuecomment-1695809346)
         if: ${{ matrix.target != 'ios' }}
-        run: flutter test -d "${{ steps.device.outputs.name }}" integration_test --verbose
+        run: flutter test --coverage -d "${{ steps.device.outputs.name }}" integration_test --verbose
 
       - name: run native test
         # We only have the native unit test package in the iOS xcodeproj at the moment.
@@ -163,3 +169,9 @@ jobs:
         if: ${{ matrix.target != 'macos' }}
         working-directory: ./flutter/example/${{ matrix.target }}
         run: xcodebuild test -workspace Runner.xcworkspace -scheme Runner -configuration Debug -destination "platform=${{ steps.device.outputs.platform }}" -allowProvisioningUpdates CODE_SIGNING_ALLOWED=NO
+
+      - uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # pin@v3
+        if: matrix.sdk == 'stable'
+        with:
+          name: sentry_flutter_integration_cocoa
+          file: ./flutter/coverage/lcov.info

--- a/.github/workflows/flutter_test.yml
+++ b/.github/workflows/flutter_test.yml
@@ -111,6 +111,7 @@ jobs:
         with:
           name: sentry_flutter_integration_android
           file: ./flutter/example/coverage/lcov.info
+          functionalities: "search" # remove after https://github.com/codecov/codecov-action/issues/600
 
   cocoa:
     name: "${{ matrix.target }} | ${{ matrix.sdk }}"
@@ -175,3 +176,4 @@ jobs:
         with:
           name: sentry_flutter_integration_cocoa
           file: ./flutter/example/coverage/lcov.info
+          functionalities: "search" # remove after https://github.com/codecov/codecov-action/issues/600

--- a/.github/workflows/sqflite.yml
+++ b/.github/workflows/sqflite.yml
@@ -22,7 +22,7 @@ jobs:
           access_token: ${{ github.token }}
 
   build:
-    name: ${{ matrix.target }} | ${{ matrix.os }} | ${{ matrix.sdk }}
+    name: "${{ matrix.target }} | ${{ matrix.os }} | ${{ matrix.sdk }}"
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     defaults:
@@ -98,7 +98,6 @@ jobs:
         with:
           name: sentry_sqflite
           file: ./sqflite/coverage/lcov.info
-          functionalities: "search" # remove after https://github.com/codecov/codecov-action/issues/600
 
       - uses: VeryGoodOpenSource/very_good_coverage@e5c91bc7ce9843e87c800b3bcafdfb86fbe28491 # pin@v2.1.0
         if: runner.os == 'Linux' && matrix.sdk == 'stable' && matrix.target == 'linux'

--- a/.github/workflows/sqflite.yml
+++ b/.github/workflows/sqflite.yml
@@ -98,6 +98,7 @@ jobs:
         with:
           name: sentry_sqflite
           file: ./sqflite/coverage/lcov.info
+          functionalities: "search" # remove after https://github.com/codecov/codecov-action/issues/600
 
       - uses: VeryGoodOpenSource/very_good_coverage@e5c91bc7ce9843e87c800b3bcafdfb86fbe28491 # pin@v2.1.0
         if: runner.os == 'Linux' && matrix.sdk == 'stable' && matrix.target == 'linux'

--- a/.gitignore
+++ b/.gitignore
@@ -14,14 +14,8 @@ build/
 .cxx/
 .vscode/
 
-
 .test_coverage.dart
-dart/coverage/*
-logging/coverage/*
-dio/coverage/*
-file/coverage/*
-flutter/coverage/*
-sqflite/coverage/*
+**/coverage/*
 
 pubspec.lock
 Podfile.lock


### PR DESCRIPTION
This adds code coverage reporting to integration tests, with hopes of getting reports on coverage of cocoa FFI briding code in 	#1611

Not sure if this actually works - can someone who understands codecov UI check if the change looks as expected?
