### PR TITLE
Add `markUnhandledAsFatal` to `SentryOptions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 8.0.0
 
+### Features
+
+- Add `markUnhandledAsFatal` to `SentryOptions` ([#1720](https://github.com/getsentry/sentry-dart/pull/1720))
+
 ### Breaking Changes
 
 - Mark exceptions not handled by the user as `handled: false` ([#1535](https://github.com/getsentry/sentry-dart/pull/1535))

--- a/dart/lib/src/run_zoned_guarded_integration.dart
+++ b/dart/lib/src/run_zoned_guarded_integration.dart
@@ -50,7 +50,8 @@ class RunZonedGuardedIntegration extends Integration<SentryOptions> {
 
     final event = SentryEvent(
       throwable: throwableMechanism,
-      level: SentryLevel.fatal,
+      level:
+          options.markUnhandledAsFatal ? SentryLevel.fatal : SentryLevel.error,
       timestamp: hub.options.clock(),
     );
 

--- a/dart/lib/src/sentry_isolate.dart
+++ b/dart/lib/src/sentry_isolate.dart
@@ -72,10 +72,11 @@ class SentryIsolate {
       //  Isolate errors don't crash the app, but is not handled by the user.
       final mechanism = Mechanism(type: 'isolateError', handled: false);
       final throwableMechanism = ThrowableMechanism(mechanism, throwable);
-
       final event = SentryEvent(
         throwable: throwableMechanism,
-        level: SentryLevel.fatal,
+        level: hub.options.markUnhandledAsFatal
+            ? SentryLevel.fatal
+            : SentryLevel.error,
         timestamp: hub.options.clock(),
       );
 

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -4,7 +4,7 @@ import 'dart:developer';
 import 'package:meta/meta.dart';
 import 'package:http/http.dart';
 
-import '../sentry.dart';
+import '../sentry_io.dart';
 import 'client_reports/client_report_recorder.dart';
 import 'client_reports/noop_client_report_recorder.dart';
 import 'sentry_exception_factory.dart';
@@ -357,6 +357,11 @@ class SentryOptions {
   /// - Rethrow exceptions that occur in user provided closures
   @internal
   bool devMode = false;
+
+  /// Unhandled exceptions that the SDK automatically reports, for example in
+  /// [SentryIsolate], have `level` [SentryLevel.fatal] set per default.
+  /// Settings this to `false` will set the `level` to [SentryLevel.error].
+  bool markUnhandledAsFatal = true;
 
   SentryOptions({this.dsn, PlatformChecker? checker}) {
     if (checker != null) {

--- a/dart/test/run_zoned_guarded_integration_test.dart
+++ b/dart/test/run_zoned_guarded_integration_test.dart
@@ -54,6 +54,23 @@ void main() {
 
       expect(onErrorCalled, true);
     });
+
+    test('sets level to error instead of fatal', () async {
+      final exception = StateError('error');
+      final stackTrace = StackTrace.current;
+
+      final hub = Hub(fixture.options);
+      final client = MockSentryClient();
+      hub.bindClient(client);
+
+      final sut = fixture.getSut(runner: () async {});
+
+      fixture.options.markUnhandledAsFatal = false;
+      await sut.captureError(hub, fixture.options, exception, stackTrace);
+
+      final capturedEvent = client.captureEventCalls.last.event;
+      expect(capturedEvent.level, SentryLevel.error);
+    });
   });
 }
 

--- a/dart/test/sentry_client_test.dart
+++ b/dart/test/sentry_client_test.dart
@@ -847,8 +847,7 @@ void main() {
       expect(capturedEvent.user?.ipAddress, '{{auto}}');
     });
 
-    test('event has a user with IP address',
-        () async {
+    test('event has a user with IP address', () async {
       final client = fixture.getSut(sendDefaultPii: true);
 
       await client.captureEvent(fakeEvent);
@@ -864,8 +863,7 @@ void main() {
       expect(capturedEvent.user?.email, fakeEvent.user!.email);
     });
 
-    test('event has a user without IP address',
-        () async {
+    test('event has a user without IP address', () async {
       final client = fixture.getSut(sendDefaultPii: true);
 
       final event = fakeEvent.copyWith(user: fakeUser);

--- a/dart/test/sentry_isolate_test.dart
+++ b/dart/test/sentry_isolate_test.dart
@@ -1,9 +1,7 @@
 @TestOn('vm')
 
-import 'package:sentry/src/hub.dart';
-import 'package:sentry/src/protocol/span_status.dart';
+import 'package:sentry/sentry.dart';
 import 'package:sentry/src/sentry_isolate.dart';
-import 'package:sentry/src/sentry_options.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';
@@ -47,6 +45,23 @@ void main() {
       expect(span?.status, const SpanStatus.internalError());
 
       await span?.finish();
+    });
+
+    test('sets level to error instead of fatal', () async {
+      final exception = StateError('error');
+      final stackTrace = StackTrace.current.toString();
+
+      final hub = Hub(fixture.options);
+      final client = MockSentryClient();
+      hub.bindClient(client);
+
+      fixture.options.markUnhandledAsFatal = false;
+
+      await SentryIsolate.handleIsolateError(
+          hub, [exception.toString(), stackTrace]);
+
+      final capturedEvent = client.captureEventCalls.last.event;
+      expect(capturedEvent.level, SentryLevel.error);
     });
   });
 }

--- a/flutter/lib/src/integrations/flutter_error_integration.dart
+++ b/flutter/lib/src/integrations/flutter_error_integration.dart
@@ -60,7 +60,9 @@ class FlutterErrorIntegration implements Integration<SentryFlutterOptions> {
 
         var event = SentryEvent(
           throwable: throwableMechanism,
-          level: SentryLevel.fatal,
+          level: options.markUnhandledAsFatal
+              ? SentryLevel.fatal
+              : SentryLevel.error,
           contexts: flutterErrorDetails.isNotEmpty
               ? (Contexts()..['flutter_error_details'] = flutterErrorDetails)
               : null,

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -1,6 +1,7 @@
 import 'package:meta/meta.dart';
 import 'package:sentry/sentry.dart';
 import 'package:flutter/widgets.dart';
+import 'package:sentry/sentry_io.dart';
 
 import 'binding_wrapper.dart';
 import 'renderer/renderer.dart';

--- a/flutter/test/integrations/flutter_error_integration_test.dart
+++ b/flutter/test/integrations/flutter_error_integration_test.dart
@@ -246,6 +246,20 @@ void main() {
 
       await span?.finish();
     });
+
+    test('captures error with level error', () async {
+      final exception = StateError('error');
+
+      fixture.options.markUnhandledAsFatal = false;
+
+      _reportError(exception: exception);
+
+      final event = verify(
+        await fixture.hub.captureEvent(captureAny, hint: anyNamed('hint')),
+      ).captured.first as SentryEvent;
+
+      expect(event.level, SentryLevel.error);
+    });
   });
 }
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Add `markUnhandledAsFatal` option to `SentryOptions`. When disabled the level for automatically tracked `unhandled` evetns will be set to `error` instead of `fatal`/

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Relates to #1624

## :green_heart: How did you test it?

Unit tets

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes
