### PR TITLE
Fixes release of drift & hive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-### Fix
+### Fixes
 
 - Fixes release of drift & hive and adds missing integration & sdk version information in the hub options ([#1729](https://github.com/getsentry/sentry-dart/pull/1729))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fix
+
+- Fixes release of drift & hive and adds missing integration & sdk version information in the hub options ([#1729](https://github.com/getsentry/sentry-dart/pull/1729))
+
 ## 7.13.0
 
 ### Fixes 

--- a/drift/lib/src/sentry_query_executor.dart
+++ b/drift/lib/src/sentry_query_executor.dart
@@ -57,6 +57,7 @@ class SentryQueryExecutor extends QueryExecutor {
   })  : _hub = hub ?? HubAdapter(),
         _dbName = databaseName,
         _executor = queryExecutor ?? LazyDatabase(opener) {
+    // ignore: invalid_use_of_internal_member
     final options = _hub.options;
     options.sdk.addIntegration('SentryDriftTracing');
     options.sdk.addPackage(packageName, sdkVersion);

--- a/drift/lib/src/sentry_query_executor.dart
+++ b/drift/lib/src/sentry_query_executor.dart
@@ -4,6 +4,7 @@ import 'package:drift/backends.dart';
 import 'package:drift/drift.dart';
 import 'package:meta/meta.dart';
 import 'package:sentry/sentry.dart';
+import 'version.dart';
 import 'sentry_span_helper.dart';
 import 'sentry_transaction_executor.dart';
 
@@ -56,6 +57,9 @@ class SentryQueryExecutor extends QueryExecutor {
   })  : _hub = hub ?? HubAdapter(),
         _dbName = databaseName,
         _executor = queryExecutor ?? LazyDatabase(opener) {
+    final options = _hub.options;
+    options.sdk.addIntegration('SentryDriftTracing');
+    options.sdk.addPackage(packageName, sdkVersion);
     _spanHelper.setHub(_hub);
   }
 

--- a/drift/lib/src/version.dart
+++ b/drift/lib/src/version.dart
@@ -1,0 +1,5 @@
+/// The SDK version reported to Sentry.io in the submitted events.
+const String sdkVersion = '7.13.0';
+
+/// The package name reported to Sentry.io in the submitted events.
+const String packageName = 'pub:sentry_drift';

--- a/drift/test/sentry_database_test.dart
+++ b/drift/test/sentry_database_test.dart
@@ -628,8 +628,8 @@ void main() {
     test('adds package', () {
       expect(
         fixture.options.sdk.packages.any(
-              (element) =>
-          element.name == packageName && element.version == sdkVersion,
+          (element) =>
+              element.name == packageName && element.version == sdkVersion,
         ),
         true,
       );

--- a/drift/test/sentry_database_test.dart
+++ b/drift/test/sentry_database_test.dart
@@ -10,6 +10,7 @@ import 'package:sentry/sentry.dart';
 import 'package:sentry/src/sentry_tracer.dart';
 import 'package:sentry_drift/src/sentry_query_executor.dart';
 import 'package:sentry_drift/src/sentry_transaction_executor.dart';
+import 'package:sentry_drift/src/version.dart';
 import 'package:sqlite3/open.dart';
 
 import 'mocks/mocks.mocks.dart';
@@ -118,10 +119,11 @@ void main() {
 
     setUp(() async {
       fixture = Fixture();
-      await fixture.setUp();
 
       when(fixture.hub.options).thenReturn(fixture.options);
       when(fixture.hub.getSpan()).thenReturn(fixture.tracer);
+
+      await fixture.setUp();
     });
 
     tearDown(() async {
@@ -375,10 +377,11 @@ void main() {
 
     setUp(() async {
       fixture = Fixture();
-      await fixture.setUp();
 
       when(fixture.hub.options).thenReturn(fixture.options);
       when(fixture.hub.getSpan()).thenReturn(fixture.tracer);
+
+      await fixture.setUp();
     });
 
     tearDown(() async {
@@ -410,12 +413,13 @@ void main() {
 
     setUp(() async {
       fixture = Fixture();
-      await fixture.setUp(injectMock: true);
 
       when(fixture.hub.options).thenReturn(fixture.options);
       when(fixture.hub.getSpan()).thenReturn(fixture.tracer);
       when(fixture.mockLazyDatabase.ensureOpen(any))
           .thenAnswer((_) => Future.value(true));
+
+      await fixture.setUp(injectMock: true);
     });
 
     tearDown(() async {
@@ -594,6 +598,40 @@ void main() {
         expectedDeleteStatement,
         fixture.exception,
         fixture.getCreatedSpan(),
+      );
+    });
+  });
+
+  group('integrations', () {
+    late Fixture fixture;
+
+    setUp(() async {
+      fixture = Fixture();
+
+      when(fixture.hub.options).thenReturn(fixture.options);
+      when(fixture.hub.getSpan()).thenReturn(fixture.tracer);
+
+      await fixture.setUp();
+    });
+
+    tearDown(() async {
+      await fixture.tearDown();
+    });
+
+    test('adds integration', () {
+      expect(
+        fixture.options.sdk.integrations.contains('SentryDriftTracing'),
+        true,
+      );
+    });
+
+    test('adds package', () {
+      expect(
+        fixture.options.sdk.packages.any(
+              (element) =>
+          element.name == packageName && element.version == sdkVersion,
+        ),
+        true,
       );
     });
   });

--- a/hive/CHANGELOG.md
+++ b/hive/CHANGELOG.md
@@ -1,0 +1,1 @@
+../CHANGELOG.md

--- a/hive/CHANGELOG.md
+++ b/hive/CHANGELOG.md
@@ -1,1 +1,0 @@
-../CHANGELOG.md

--- a/hive/lib/src/sentry_hive_impl.dart
+++ b/hive/lib/src/sentry_hive_impl.dart
@@ -45,6 +45,7 @@ class SentryHiveImpl implements SentryHiveInterface {
 
   @override
   void setHub(Hub hub) {
+    // ignore: invalid_use_of_internal_member
     final options = hub.options;
     options.sdk.addIntegration('SentryHiveTracing');
     options.sdk.addPackage(packageName, sdkVersion);

--- a/hive/lib/src/sentry_hive_impl.dart
+++ b/hive/lib/src/sentry_hive_impl.dart
@@ -3,7 +3,7 @@ import 'dart:typed_data';
 import 'package:hive/hive.dart';
 import 'package:meta/meta.dart';
 import 'package:sentry/sentry.dart';
-import 'package:sentry_hive/src/version.dart';
+import 'version.dart';
 import 'sentry_box.dart';
 import 'sentry_lazy_box.dart';
 import 'sentry_hive_interface.dart';

--- a/hive/lib/src/sentry_hive_impl.dart
+++ b/hive/lib/src/sentry_hive_impl.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 import 'package:hive/hive.dart';
 import 'package:meta/meta.dart';
 import 'package:sentry/sentry.dart';
+import 'package:sentry_hive/src/version.dart';
 import 'sentry_box.dart';
 import 'sentry_lazy_box.dart';
 import 'sentry_hive_interface.dart';
@@ -44,6 +45,9 @@ class SentryHiveImpl implements SentryHiveInterface {
 
   @override
   void setHub(Hub hub) {
+    final options = hub.options;
+    options.sdk.addIntegration('SentryHiveTracing');
+    options.sdk.addPackage(packageName, sdkVersion);
     _hub = hub;
     _spanHelper.setHub(hub);
   }

--- a/hive/lib/src/version.dart
+++ b/hive/lib/src/version.dart
@@ -1,0 +1,5 @@
+/// The SDK version reported to Sentry.io in the submitted events.
+const String sdkVersion = '7.13.0';
+
+/// The package name reported to Sentry.io in the submitted events.
+const String packageName = 'pub:sentry_hive';

--- a/hive/test/sentry_hive_impl_test.dart
+++ b/hive/test/sentry_hive_impl_test.dart
@@ -9,6 +9,7 @@ import 'package:sentry/src/sentry_tracer.dart';
 import 'package:sentry_hive/src/sentry_box.dart';
 import 'package:sentry_hive/src/sentry_hive_impl.dart';
 import 'package:sentry_hive/src/sentry_lazy_box.dart';
+import 'package:sentry_hive/src/version.dart';
 import 'package:test/test.dart';
 
 import 'mocks/mocks.mocks.dart';
@@ -267,6 +268,41 @@ void main() {
         'openLazyBox',
         fixture.getCreatedSpan(),
         fixture.exception,
+      );
+    });
+  });
+
+  group('integrations', () {
+    late Fixture fixture;
+
+    setUp(() async {
+      fixture = Fixture();
+
+      when(fixture.hub.options).thenReturn(fixture.options);
+      when(fixture.hub.getSpan()).thenReturn(fixture.tracer);
+
+      await fixture.setUp();
+    });
+
+    tearDown(() async {
+      await fixture.tearDown();
+    });
+
+    test('adds integration', () {
+      print(fixture.options.sdk.integrations.length);
+      expect(
+        fixture.options.sdk.integrations.contains('SentryHiveTracing'),
+        true,
+      );
+    });
+
+    test('adds package', () {
+      expect(
+        fixture.options.sdk.packages.any(
+              (element) =>
+          element.name == packageName && element.version == sdkVersion,
+        ),
+        true,
       );
     });
   });

--- a/hive/test/sentry_hive_impl_test.dart
+++ b/hive/test/sentry_hive_impl_test.dart
@@ -289,7 +289,6 @@ void main() {
     });
 
     test('adds integration', () {
-      print(fixture.options.sdk.integrations.length);
       expect(
         fixture.options.sdk.integrations.contains('SentryHiveTracing'),
         true,
@@ -299,8 +298,8 @@ void main() {
     test('adds package', () {
       expect(
         fixture.options.sdk.packages.any(
-              (element) =>
-          element.name == packageName && element.version == sdkVersion,
+          (element) =>
+              element.name == packageName && element.version == sdkVersion,
         ),
         true,
       );

--- a/hive/test/sentry_hive_impl_test.dart
+++ b/hive/test/sentry_hive_impl_test.dart
@@ -46,10 +46,11 @@ void main() {
 
     setUp(() async {
       fixture = Fixture();
-      await fixture.setUp();
 
       when(fixture.hub.options).thenReturn(fixture.options);
       when(fixture.hub.getSpan()).thenReturn(fixture.tracer);
+
+      await fixture.setUp();
     });
 
     tearDown(() async {
@@ -114,11 +115,12 @@ void main() {
 
     setUp(() async {
       fixture = Fixture();
-      await fixture.setUp(injectMockHive: true);
 
       when(fixture.hub.options).thenReturn(fixture.options);
       when(fixture.hub.getSpan()).thenReturn(fixture.tracer);
       when(fixture.mockHive.close()).thenAnswer((_) async => {});
+
+      await fixture.setUp(injectMockHive: true);
     });
 
     test('throwing boxExists adds error span', () async {

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -10,7 +10,7 @@ NEW_VERSION="${2}"
 echo "Current version: ${OLD_VERSION}"
 echo "Bumping version: ${NEW_VERSION}"
 
-for pkg in {dart,flutter,logging,dio,file,sqflite}; do
+for pkg in {dart,flutter,logging,dio,file,sqflite,drift,hive}; do
   # Bump version in pubspec.yaml
   perl -pi -e "s/^version: .*/version: $NEW_VERSION/" $pkg/pubspec.yaml
   # Bump sentry dependency version in pubspec.yaml


### PR DESCRIPTION
## :scroll: Description
Fixes the release process of drift and hive and adds the missing integration information in the options


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?
Unit test
Release can be tested after

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
