### PR TITLE
Add option to opt out of fatal level for automatically collected errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add option to opt out of fatal level for automatically collected errors ([#1738](https://github.com/getsentry/sentry-dart/pull/1738))
+
 ## 7.13.1
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Add option to opt out of fatal level for automatically collected errors ([#1738](https://github.com/getsentry/sentry-dart/pull/1738))
+
 ## 7.13.2
 
 ### Fixes

--- a/dart/lib/src/run_zoned_guarded_integration.dart
+++ b/dart/lib/src/run_zoned_guarded_integration.dart
@@ -50,7 +50,9 @@ class RunZonedGuardedIntegration extends Integration<SentryOptions> {
 
     final event = SentryEvent(
       throwable: throwableMechanism,
-      level: SentryLevel.fatal,
+      level: options.markAutomaticallyCollectedErrorsAsFatal
+          ? SentryLevel.fatal
+          : SentryLevel.error,
       timestamp: hub.options.clock(),
     );
 

--- a/dart/lib/src/sentry_isolate.dart
+++ b/dart/lib/src/sentry_isolate.dart
@@ -74,7 +74,9 @@ class SentryIsolate {
       final throwableMechanism = ThrowableMechanism(mechanism, throwable);
       final event = SentryEvent(
         throwable: throwableMechanism,
-        level: SentryLevel.fatal,
+        level: hub.options.markAutomaticallyCollectedErrorsAsFatal
+            ? SentryLevel.fatal
+            : SentryLevel.error,
         timestamp: hub.options.clock(),
       );
 

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -369,6 +369,11 @@ class SentryOptions {
   @internal
   bool automatedTestMode = false;
 
+  /// Errors that the SDK automatically collects, for example in
+  /// [SentryIsolate], have `level` [SentryLevel.fatal] set per default.
+  /// Settings this to `false` will set the `level` to [SentryLevel.error].
+  bool markAutomaticallyCollectedErrorsAsFatal = true;
+
   SentryOptions({this.dsn, PlatformChecker? checker}) {
     if (checker != null) {
       platformChecker = checker;

--- a/dart/test/run_zoned_guarded_integration_test.dart
+++ b/dart/test/run_zoned_guarded_integration_test.dart
@@ -54,6 +54,23 @@ void main() {
 
       expect(onErrorCalled, true);
     });
+
+    test('sets level to error instead of fatal', () async {
+      final exception = StateError('error');
+      final stackTrace = StackTrace.current;
+
+      final hub = Hub(fixture.options);
+      final client = MockSentryClient();
+      hub.bindClient(client);
+
+      final sut = fixture.getSut(runner: () async {});
+
+      fixture.options.markAutomaticallyCollectedErrorsAsFatal = false;
+      await sut.captureError(hub, fixture.options, exception, stackTrace);
+
+      final capturedEvent = client.captureEventCalls.last.event;
+      expect(capturedEvent.level, SentryLevel.error);
+    });
   });
 }
 

--- a/flutter/lib/src/integrations/flutter_error_integration.dart
+++ b/flutter/lib/src/integrations/flutter_error_integration.dart
@@ -63,7 +63,9 @@ class FlutterErrorIntegration implements Integration<SentryFlutterOptions> {
 
         var event = SentryEvent(
           throwable: throwableMechanism,
-          level: SentryLevel.fatal,
+          level: options.markAutomaticallyCollectedErrorsAsFatal
+              ? SentryLevel.fatal
+              : SentryLevel.error,
           contexts: flutterErrorDetails.isNotEmpty
               ? (Contexts()..['flutter_error_details'] = flutterErrorDetails)
               : null,

--- a/flutter/lib/src/native/cocoa/binding.dart
+++ b/flutter/lib/src/native/cocoa/binding.dart
@@ -37603,7 +37603,8 @@ class ObjCBlock_bool_ObjCObject_ffiUnsignedLong_bool extends _ObjCBlockBase {
   ObjCBlock_bool_ObjCObject_ffiUnsignedLong_bool.fromFunctionPointer(
       SentryCocoa lib,
       ffi.Pointer<
-              ffi.NativeFunction<
+              ffi
+              .NativeFunction<
                   ffi.Bool Function(ffi.Pointer<ObjCObject> arg0,
                       ffi.UnsignedLong arg1, ffi.Pointer<ffi.Bool> arg2)>>
           ptr)
@@ -42031,15 +42032,17 @@ class ObjCBlock_bool_ObjCObject_bool extends _ObjCBlockBase {
                       ffi.Pointer<ffi.Bool> arg1)>>
           ptr)
       : this._(
-            lib._newBlock1(
-                _cFuncTrampoline ??= ffi.Pointer.fromFunction<
-                            ffi.Bool Function(
-                                ffi.Pointer<_ObjCBlock> block,
-                                ffi.Pointer<ObjCObject> arg0,
-                                ffi.Pointer<ffi.Bool> arg1)>(
-                        _ObjCBlock_bool_ObjCObject_bool_fnPtrTrampoline, false)
-                    .cast(),
-                ptr.cast()),
+            lib
+                ._newBlock1(
+                    _cFuncTrampoline ??= ffi.Pointer.fromFunction<
+                                ffi.Bool Function(
+                                    ffi.Pointer<_ObjCBlock> block,
+                                    ffi.Pointer<ObjCObject> arg0,
+                                    ffi.Pointer<ffi.Bool> arg1)>(
+                            _ObjCBlock_bool_ObjCObject_bool_fnPtrTrampoline,
+                            false)
+                        .cast(),
+                    ptr.cast()),
             lib);
   static ffi.Pointer<ffi.Void>? _cFuncTrampoline;
 

--- a/flutter/test/integrations/flutter_error_integration_test.dart
+++ b/flutter/test/integrations/flutter_error_integration_test.dart
@@ -246,6 +246,20 @@ void main() {
 
       await span?.finish();
     });
+
+    test('captures error with level error', () async {
+      final exception = StateError('error');
+
+      fixture.options.markAutomaticallyCollectedErrorsAsFatal = false;
+
+      _reportError(exception: exception);
+
+      final event = verify(
+        await fixture.hub.captureEvent(captureAny, hint: anyNamed('hint')),
+      ).captured.first as SentryEvent;
+
+      expect(event.level, SentryLevel.error);
+    });
   });
 }
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Add `markAutomaticallyCollectedErrorsAsFatal` option to `SentryOptions`. When disabled the level for automatically tracked `unhandled` errors will be set to `error` instead of `fatal`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Relates to #1624
Closes #1720

## :green_heart: How did you test it?

Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes
