### PR TITLE
deps: update `package_info_plus` constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Dependencies
 
+- Update package-info-plus constraint to include 5.0.1 ([#1749](https://github.com/getsentry/sentry-dart/pull/1749))
 - Bump Android SDK from v6.33.1 to v6.34.0 ([#1746](https://github.com/getsentry/sentry-dart/pull/1746))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#6340)
   - [diff](https://github.com/getsentry/sentry-java/compare/6.33.1...6.34.0)

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   sentry: 7.13.1
-  package_info_plus: '>=1.0.0 <5.0.0'
+  package_info_plus: '>=1.0.0 <=5.0.1'
   meta: ^1.3.0
   ffi: ^2.0.0
 


### PR DESCRIPTION
There's a new `5.0.1` version out which is not part of our constraint.

This also fixes the [package-analysis complaint](https://github.com/getsentry/sentry-dart/runs/18923673712) for flutter