### PR TITLE
Add debug_meta to all events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Fixes
 
 - Add debug_meta to all events ([#1756](https://github.com/getsentry/sentry-dart/pull/1756))
+  - Fixes obfuscated stacktraces when `captureMessage` or `captureEvent` is called with `attachStacktrace` option 
+
 ### Features
 
 - Add option to opt out of fatal level for automatically collected errors ([#1738](https://github.com/getsentry/sentry-dart/pull/1738))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Add debug_meta to all events ([#1756](https://github.com/getsentry/sentry-dart/pull/1756))
+
 ## 7.13.2
 
 ### Fixes

--- a/flutter/lib/src/integrations/load_image_list_integration.dart
+++ b/flutter/lib/src/integrations/load_image_list_integration.dart
@@ -38,7 +38,10 @@ extension _NeedsSymbolication on SentryEvent {
     }
     if (threads?.isNotEmpty == true) {
       var stacktraces = threads?.map((e) => e.stacktrace);
-      return stacktraces?.where((element) => element != null).expand((element) => element!.frames).toList();
+      return stacktraces
+          ?.where((element) => element != null)
+          .expand((element) => element!.frames)
+          .toList();
     }
     return null;
   }

--- a/flutter/lib/src/integrations/load_image_list_integration.dart
+++ b/flutter/lib/src/integrations/load_image_list_integration.dart
@@ -25,14 +25,22 @@ extension _NeedsSymbolication on SentryEvent {
     if (this is SentryTransaction) {
       return false;
     }
-    if (exceptions?.isNotEmpty == false) {
-      return false;
-    }
-    final frames = exceptions?.first.stackTrace?.frames;
+    final frames = _getStacktraceFrames();
     if (frames == null) {
       return false;
     }
-    return frames.any((frame) => 'native' == frame.platform);
+    return frames.any((frame) => 'native' == frame?.platform);
+  }
+
+  List<SentryStackFrame?>? _getStacktraceFrames() {
+    if (exceptions?.isNotEmpty == true) {
+      return exceptions?.first.stackTrace?.frames;
+    }
+    if (threads?.isNotEmpty == true) {
+      var stacktraces = threads?.map((e) => e.stacktrace);
+      return stacktraces?.where((element) => element != null).expand((element) => element!.frames).toList();
+    }
+    return null;
   }
 }
 

--- a/flutter/test/integrations/load_image_list_test.dart
+++ b/flutter/test/integrations/load_image_list_test.dart
@@ -187,12 +187,7 @@ void main() {
 SentryEvent _getEvent() {
   final frame = SentryStackFrame(platform: 'native');
   final st = SentryStackTrace(frames: [frame]);
-  final ex = SentryException(
-    type: 'type',
-    value: 'value',
-    stackTrace: st,
-  );
-  return SentryEvent(exceptions: [ex]);
+  return SentryEvent(threads: [SentryThread(stacktrace: st)]);
 }
 
 class Fixture {


### PR DESCRIPTION

## :scroll: Description
`load_image_list_integration` now appends `debug_meta info to all non-transaction events with a stacktrace, instead of checking for Exception existence


## :bulb: Motivation and Context
Events generated through `captureMessage` or `captureEvent` had obfuscated stacktraces attached to them, when using the `attachStacktrace` option, due to the lack of `debug_meta` info.
Fixes https://github.com/getsentry/sentry-dart/issues/1744 and https://github.com/getsentry/sentry-dart/issues/1663


## :green_heart: How did you test it?
The tests now use event without exception

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
