### PR TITLE
Add app flavor to `flutter_context`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 - Breadcrumbs for database operations ([#1656](https://github.com/getsentry/sentry-dart/pull/1656))
 - APM for hive ([#1672](https://github.com/getsentry/sentry-dart/pull/1672))
 - Add `attachScreenshotOnlyWhenResumed` to options ([#1700](https://github.com/getsentry/sentry-dart/pull/1700))
+- Starting with Flutter 3.16, Sentry adds the [`appFlavor`](https://api.flutter.dev/flutter/services/appFlavor-constant.html) to the `flutter_context` ([#1700](https://github.com/getsentry/sentry-dart/pull/1700))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add `ConnectivityIntegration` for web ([#1765](https://github.com/getsentry/sentry-dart/pull/1765))
   - We only get the info if online/offline on web platform. The added breadcrumb is set to either `wifi` or `none`.
 - APM for isar ([#1726](https://github.com/getsentry/sentry-dart/pull/1726))
+- Starting with Flutter 3.16, Sentry adds the [`appFlavor`](https://api.flutter.dev/flutter/services/appFlavor-constant.html) to the `flutter_context` ([#1799](https://github.com/getsentry/sentry-dart/pull/1799))
 
 ## 7.14.0
 
@@ -68,7 +69,6 @@
 - Breadcrumbs for database operations ([#1656](https://github.com/getsentry/sentry-dart/pull/1656))
 - APM for hive ([#1672](https://github.com/getsentry/sentry-dart/pull/1672))
 - Add `attachScreenshotOnlyWhenResumed` to options ([#1700](https://github.com/getsentry/sentry-dart/pull/1700))
-- Starting with Flutter 3.16, Sentry adds the [`appFlavor`](https://api.flutter.dev/flutter/services/appFlavor-constant.html) to the `flutter_context` ([#1700](https://github.com/getsentry/sentry-dart/pull/1700))
 
 ### Dependencies
 

--- a/flutter/lib/src/event_processor/flutter_enricher_event_processor.dart
+++ b/flutter/lib/src/event_processor/flutter_enricher_event_processor.dart
@@ -153,6 +153,7 @@ class FlutterEnricherEventProcessor implements EventProcessor {
       // See https://github.com/flutter/flutter/issues/83919
       // 'window_is_visible': _window.viewConfiguration.visible,
       if (renderer != null) 'renderer': renderer,
+      if (_appFlavor != null) 'appFlavor': _appFlavor!,
     };
   }
 
@@ -266,3 +267,10 @@ class FlutterEnricherEventProcessor implements EventProcessor {
     return null;
   }
 }
+
+/// Copied from https://api.flutter.dev/flutter/services/appFlavor-constant.html
+/// As soon as Flutter 3.16 is the minimal supported version of Sentry, this
+/// can be replaced with the property from the link above.
+const String? _appFlavor = String.fromEnvironment('FLUTTER_APP_FLAVOR') != ''
+    ? String.fromEnvironment('FLUTTER_APP_FLAVOR')
+    : null;


### PR DESCRIPTION
## :scroll: Description
Starting with Flutter 3.16, you have access to the flavor. Therefore, this information can now be added.

## :bulb: Motivation and Context


## :green_heart: How did you test it?
Manually

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
