### PR TITLE
Improve `FileSystemTransport` by using `compute()`

### DIFF
--- a/dart/lib/src/sentry_envelope.dart
+++ b/dart/lib/src/sentry_envelope.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 import 'client_reports/client_report.dart';
 import 'protocol.dart';
 import 'sentry_item_type.dart';
-import 'sentry_options.dart';
 import 'sentry_trace_context_header.dart';
 import 'utils.dart';
 import 'sentry_attachment/sentry_attachment.dart';

--- a/dart/lib/src/sentry_envelope.dart
+++ b/dart/lib/src/sentry_envelope.dart
@@ -83,7 +83,7 @@ class SentryEnvelope {
   }
 
   /// Stream binary data representation of `Envelope` file encoded.
-  Stream<List<int>> envelopeStream(SentryOptions options) async* {
+  Stream<List<int>> envelopeStream(int maxAttachmentSize) async* {
     yield utf8JsonEncoder.convert(header.toJson());
 
     final newLineData = utf8.encode('\n');
@@ -97,7 +97,7 @@ class SentryEnvelope {
       // Only attachments should be filtered according to
       // SentryOptions.maxAttachmentSize
       if (item.header.type == SentryItemType.attachment) {
-        if (await item.header.length() > options.maxAttachmentSize) {
+        if (await item.header.length() > maxAttachmentSize) {
           continue;
         }
       }

--- a/dart/lib/src/sentry_envelope.dart
+++ b/dart/lib/src/sentry_envelope.dart
@@ -93,8 +93,7 @@ class SentryEnvelope {
       if (length < 0) {
         continue;
       }
-      // Only attachments should be filtered according to
-      // SentryOptions.maxAttachmentSize
+      // Filter out attachments larger than maxAttachmentSize
       if (item.header.type == SentryItemType.attachment) {
         if (await item.header.length() > maxAttachmentSize) {
           continue;

--- a/dart/lib/src/transport/http_transport_request_handler.dart
+++ b/dart/lib/src/transport/http_transport_request_handler.dart
@@ -34,12 +34,12 @@ class HttpTransportRequestHandler {
     if (_options.compressPayload) {
       final compressionSink = compressInSink(streamedRequest.sink, _headers);
       envelope
-          .envelopeStream(_options)
+          .envelopeStream(_options.maxAttachmentSize)
           .listen(compressionSink.add)
           .onDone(compressionSink.close);
     } else {
       envelope
-          .envelopeStream(_options)
+          .envelopeStream(_options.maxAttachmentSize)
           .listen(streamedRequest.sink.add)
           .onDone(streamedRequest.sink.close);
     }

--- a/dart/test/mocks/mock_envelope.dart
+++ b/dart/test/mocks/mock_envelope.dart
@@ -11,7 +11,7 @@ class MockEnvelope implements SentryEnvelope {
   }
 
   @override
-  Stream<List<int>> envelopeStream(SentryOptions options) async* {
+  Stream<List<int>> envelopeStream(int maxAttachmentSize) async* {
     yield [0];
   }
 

--- a/dart/test/sentry_envelope_test.dart
+++ b/dart/test/sentry_envelope_test.dart
@@ -51,7 +51,7 @@ void main() {
           '$expectedHeaderJsonSerialized\n$expectedItemSerialized\n$expectedItemSerialized');
 
       final envelopeData = <int>[];
-      await sut.envelopeStream(SentryOptions()).forEach(envelopeData.addAll);
+      await sut.envelopeStream(20 * 1024 * 1024).forEach(envelopeData.addAll);
       expect(envelopeData, expected);
     });
 
@@ -155,13 +155,11 @@ void main() {
       );
 
       final sutEnvelopeData = <int>[];
-      await sut
-          .envelopeStream(SentryOptions()..maxAttachmentSize = 1)
-          .forEach(sutEnvelopeData.addAll);
+      await sut.envelopeStream(1).forEach(sutEnvelopeData.addAll);
 
       final envelopeData = <int>[];
       await expectedEnvelopeItem
-          .envelopeStream(SentryOptions())
+          .envelopeStream(20 * 1024 * 1024)
           .forEach(envelopeData.addAll);
 
       expect(sutEnvelopeData, envelopeData);
@@ -181,7 +179,7 @@ void main() {
         dsn: fakeDsn,
       );
 
-      final _ = sut.envelopeStream(SentryOptions()).map((e) => e);
+      final _ = sut.envelopeStream(20 * 1024 * 1024).map((e) => e);
     });
   });
 }

--- a/dart/test/sentry_envelope_vm_test.dart
+++ b/dart/test/sentry_envelope_vm_test.dart
@@ -35,7 +35,7 @@ void main() {
 
       final envelopeData = <int>[];
       await envelope
-          .envelopeStream(SentryOptions())
+          .envelopeStream(20 * 1024 * 1024)
           .forEach(envelopeData.addAll);
 
       final expectedEnvelopeFile =
@@ -60,7 +60,7 @@ void main() {
         attachments: [attachment],
       );
 
-      final data = (await envelope.envelopeStream(SentryOptions()).toList())
+      final data = (await envelope.envelopeStream(20 * 1024 * 1024).toList())
           .reduce((a, b) => a + b);
 
       final file = File('test_resources/envelope-no-attachment.envelope');

--- a/dart/test/transport/http_transport_test.dart
+++ b/dart/test/transport/http_transport_test.dart
@@ -76,7 +76,7 @@ void main() {
 
       final envelopeData = <int>[];
       await filteredEnvelope
-          .envelopeStream(fixture.options)
+          .envelopeStream(20 * 1024 * 1024)
           .forEach(envelopeData.addAll);
 
       expect(body, envelopeData);

--- a/dart/test/transport/spotlight_http_transport_test.dart
+++ b/dart/test/transport/spotlight_http_transport_test.dart
@@ -43,7 +43,7 @@ void main() {
 
       final envelopeData = <int>[];
       await envelope
-          .envelopeStream(fixture.options)
+          .envelopeStream(20 * 1024 * 1024)
           .forEach(envelopeData.addAll);
 
       expect(body, envelopeData);

--- a/flutter/example/integration_test/integration_test.dart
+++ b/flutter/example/integration_test/integration_test.dart
@@ -56,6 +56,21 @@ void main() {
     expect(sentryId != const SentryId.empty(), true);
   });
 
+  testWidgets('setup sentry and capture event with attachment', (tester) async {
+    await setupSentryAndApp(tester);
+
+    final event = SentryEvent();
+    final attachment = SentryAttachment.fromIntList(
+      utf8.encode('Lorem Ipsum dolar sit amet'),
+      'foobar.txt',
+      contentType: 'text/plain',
+    );
+    final hint = Hint.withAttachment(attachment);
+    final sentryId = await Sentry.captureEvent(event, hint: hint);
+
+    expect(sentryId != const SentryId.empty(), true);
+  });
+
   testWidgets('setup sentry and capture exception', (tester) async {
     await setupSentryAndApp(tester);
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

- Use `compute` to convert the `SentryEnvelope` to binary data.
- Changed the method signature of `envelopeStream` to just take `int` `maxAttachmentSize` instead of `SentryOptions` object.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes  #536

## :green_heart: How did you test it?

- Run example app, as there are no tests AFAIK that guarantee correct envelope data transfer to the mobile plugins.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps

- [x] ~~We should think about profiling if this has a positive impact.~~ Cant really measure, as the runtime would be the same, it would just be on a background isolate.
- [x] We are using closures to delay envelope item to binary conversion. Can we guarantee we won't close over objects that are not supported to be sent to another Isolate? -> NO

```
SentryTransaction
- SentrySpan
 - SentrySpanContext
   - Hub
     - SentryTracesSampler
       - SentryOptions
     - SentryOptions
```

Through the closures we have a reference to `SentryOptions`, and therefore potentially always to objects which we cannot send. See examples below, tested on the example app.

Capturing a sentry transaction.

```
[sentry] [error] Error while capturing transaction with id: b25abc26513d4d6c95e9ca2bd853395f
         Invalid argument(s): Illegal argument in isolate message: (object is a Pointer)
 <- __objc_msgSend_1058Ptr in Instance of 'Sentr...
         #0      Isolate._spawnFunction (dart:isolate-patch/isolate_patch.dart:398:25)
         #1      Isolate.spawn (dart:isolate-patch/isolate_patch.dart:378:7)
         #2      Isolate.run (dart:isolate:285:15)
         #3      compute (package:flutter/src/foundation/_isolates_io.dart:18:18)
         #4      compute (package:flutter/src/foundation/isolates.dart:76:19)
         #5      FileSystemTransport.send (package:sentry_flutter/src/file_system_transport.dart:17:32)
         #6      SentryClient._attachClientReportsAndSend (package:sentry/src/sentry_client.dart:517:31)
         #7      SentryClient.captureEnvelope (package:sentry/src/sentry_client.dart:364:12)
         #8      SentryClient.captureTransaction (package:sentry/src/sentry_client.dart:357:22)
         <asynchronous suspension>
         #9      Hub.captureTransaction (package:sentry/src/hub.dart:539:22)
         <asynchronous suspension>
         #10     SentryTracer.finish (package:sentry/src/sentry_tracer.dart:153:7)
         <asynchronous suspension>
         #11     makeWebRequest (package:sentry_flutter_example/main.dart:909:3)
         <asynchronous suspension>
 ```

Passing `SentryOptions` to the `compute` function. For example, the `IsolateErrorIntegration` has a reference to `RawReceivePort`.

```
         Invalid argument(s): Illegal argument in isolate message: (object is a ReceivePort)
 <- _receivePort in Instance of 'IsolateErro...
         #0      Isolate._spawnFunction (dart:isolate-patch/isolate_patch.dart:398:25)
         #1      Isolate.spawn (dart:isolate-patch/isolate_patch.dart:378:7)
         #2      Isolate.run (dart:isolate:285:15)
         #3      compute (package:flutter/src/foundation/_isolates_io.dart:18:18)
         #4      compute (package:flutter/src/foundation/isolates.dart:76:19)
         #5      FileSystemTransport.send (package:sentry_flutter/src/file_system_transport.dart:17:32)
         #6      SentryClient._attachClientReportsAndSend (package:sentry/src/sentry_client.dart:517:31)
         #7      SentryClient.captureEnvelope (package:sentry/src/sentry_client.dart:364:12)
         #8      SentryClient.captureEvent (package:sentry/src/sentry_client.dart:151:22)
         <asynchronous suspension>
         #9      Hub.captureException (package:sentry/src/hub.dart:161:20)
         <asynchronous suspension>
         #10     tryCatch (package:sentry_flutter_example/main.dart:738:5)
         <asynchronous suspension>
```

When commenting it out, we still fail as we have captured a `Pointer` somewhere.

```
         Invalid argument(s): Illegal argument in isolate message: (object is a Pointer)
 <- __objc_msgSend_1058Ptr in Instance of 'Sentr...
         #0      Isolate._spawnFunction (dart:isolate-patch/isolate_patch.dart:398:25)
         #1      Isolate.spawn (dart:isolate-patch/isolate_patch.dart:378:7)
         #2      Isolate.run (dart:isolate:285:15)
         #3      compute (package:flutter/src/foundation/_isolates_io.dart:18:18)
         #4      compute (package:flutter/src/foundation/isolates.dart:76:19)
         #5      FileSystemTransport.send (package:sentry_flutter/src/file_system_transport.dart:17:32)
         #6      SentryClient._attachClientReportsAndSend (package:sentry/src/sentry_client.dart:517:31)
         #7      SentryClient.captureEnvelope (package:sentry/src/sentry_client.dart:364:12)
         #8      SentryClient.captureEvent (package:sentry/src/sentry_client.dart:151:22)
         <asynchronous suspension>
         #9      Hub.captureException (package:sentry/src/hub.dart:161:20)
         <asynchronous suspension>
         #10     tryCatch (package:sentry_flutter_example/main.dart:738:5)
         <asynchronous suspension>
 ```
