### PR TITLE
fix typo in docs

### DIFF
--- a/flutter/README.md
+++ b/flutter/README.md
@@ -99,7 +99,7 @@ runApp(
 );
 ```
 
-This adds performance tracing for all `AssetBundle` usages, where the `AssetBundle` is accessed with `DefaultAssetBunlde.of(context)`.
+This adds performance tracing for all `AssetBundle` usages, where the `AssetBundle` is accessed with `DefaultAssetBundle.of(context)`.
 This includes all of Flutters internal access of `AssetBundle`s, like `Image.asset` for example.
 
 ##### Tracking HTTP events


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

- Fixed typo in README.md for sentry_flutter package (`DefaultAssetBundle.of(context)` instead of `DefaultAssetBunlde.of(context)`)

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes small typo in docs

## :green_heart: How did you test it?

Checked that now typo is fixed

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
