### PR TITLE
Add support for `readTransaction` in `sqflite`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add isar breadcrumbs ([#1800](https://github.com/getsentry/sentry-dart/pull/1800))
 - Starting with Flutter 3.16, Sentry adds the [`appFlavor`](https://api.flutter.dev/flutter/services/appFlavor-constant.html) to the `flutter_context` ([#1799](https://github.com/getsentry/sentry-dart/pull/1799))
 - Add beforeScreenshotCallback to SentryFlutterOptions ([#1805](https://github.com/getsentry/sentry-dart/pull/1805))
+- Add support for `readTransaction` in `sqflite` ([#1819](https://github.com/getsentry/sentry-dart/pull/1819))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@
 - Starting with Flutter 3.16, Sentry adds the [`appFlavor`](https://api.flutter.dev/flutter/services/appFlavor-constant.html) to the `flutter_context` ([#1799](https://github.com/getsentry/sentry-dart/pull/1799))
 - Add beforeScreenshotCallback to SentryFlutterOptions ([#1805](https://github.com/getsentry/sentry-dart/pull/1805))
 - Add support for `readTransaction` in `sqflite` ([#1819](https://github.com/getsentry/sentry-dart/pull/1819))
-  - This method was introduced in `sqflite > 2.5.0+2`. For older versions, this plugin will call `transaction`
   
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
 - Starting with Flutter 3.16, Sentry adds the [`appFlavor`](https://api.flutter.dev/flutter/services/appFlavor-constant.html) to the `flutter_context` ([#1799](https://github.com/getsentry/sentry-dart/pull/1799))
 - Add beforeScreenshotCallback to SentryFlutterOptions ([#1805](https://github.com/getsentry/sentry-dart/pull/1805))
 - Add support for `readTransaction` in `sqflite` ([#1819](https://github.com/getsentry/sentry-dart/pull/1819))
-
+  - This method was introduced in `sqflite > 2.5.0+2`. For older versions, this plugin will call `transaction`
+  
 ### Dependencies
 
 - Bump Android SDK from v7.0.0 to v7.1.0 ([#1788](https://github.com/getsentry/sentry-dart/pull/1788))

--- a/sqflite/lib/src/sentry_database.dart
+++ b/sqflite/lib/src/sentry_database.dart
@@ -201,6 +201,11 @@ class SentryDatabase extends SentryDatabaseExecutor implements Database {
   @override
   // ignore: override_on_non_overriding_member
   Future<T> readTransaction<T>(Future<T> Function(Transaction txn) action) {
-    return transaction(action);
+    try {
+      // ignore: return_of_invalid_type
+      return (_database as dynamic).readTransaction(action);
+    } on NoSuchMethodError catch (_) {
+      return transaction(action);
+    }
   }
 }

--- a/sqflite/lib/src/sentry_database.dart
+++ b/sqflite/lib/src/sentry_database.dart
@@ -36,7 +36,7 @@ class SentryDatabase extends SentryDatabaseExecutor implements Database {
 
   static const _dbSqlTransactionOp = 'db.sql.transaction';
 
-  static const _dbSqlReadTransactionOp = 'db.sql.readTransaction';
+  static const _dbSqlReadTransactionOp = 'db.sql.read_transaction';
 
   @internal
   // ignore: public_member_api_docs

--- a/sqflite/lib/src/sentry_database.dart
+++ b/sqflite/lib/src/sentry_database.dart
@@ -203,8 +203,7 @@ class SentryDatabase extends SentryDatabaseExecutor implements Database {
   }
 
   @override
-  // ignore: public_member_api_docs
-  // ignore: override_on_non_overriding_member
+  // ignore: override_on_non_overriding_member, public_member_api_docs
   Future<T> readTransaction<T>(Future<T> Function(Transaction txn) action) {
     return Future<T>(() async {
       final currentSpan = _hub.getSpan();

--- a/sqflite/lib/src/sentry_database.dart
+++ b/sqflite/lib/src/sentry_database.dart
@@ -230,14 +230,13 @@ class SentryDatabase extends SentryDatabaseExecutor implements Database {
           dbName: dbName,
         );
         final sentrySqfliteTransaction =
-        SentrySqfliteTransaction(executor, hub: _hub, dbName: dbName);
+            SentrySqfliteTransaction(executor, hub: _hub, dbName: dbName);
 
         return await action(sentrySqfliteTransaction);
       }
 
       try {
-        final result =
-        await _database.readTransaction(newAction);
+        final result = await _database.readTransaction(newAction);
 
         span?.status = SpanStatus.ok();
         breadcrumb.data?['status'] = 'ok';

--- a/sqflite/lib/src/sentry_database.dart
+++ b/sqflite/lib/src/sentry_database.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:meta/meta.dart';
 import 'package:sentry/sentry.dart';
 import 'package:sqflite/sqflite.dart';
@@ -32,7 +34,9 @@ class SentryDatabase extends SentryDatabaseExecutor implements Database {
   // ignore: public_member_api_docs
   static const dbSqlQueryOp = 'db.sql.query';
 
-  static const _dbSqlOp = 'db.sql.transaction';
+  static const _dbSqlTransactionOp = 'db.sql.transaction';
+
+  static const _dbSqlReadTransactionOp = 'db.sql.readTransaction';
 
   @internal
   // ignore: public_member_api_docs
@@ -144,7 +148,7 @@ class SentryDatabase extends SentryDatabaseExecutor implements Database {
       final currentSpan = _hub.getSpan();
       final description = 'Transaction DB: ${_database.path}';
       final span = currentSpan?.startChild(
-        _dbSqlOp,
+        _dbSqlTransactionOp,
         description: description,
       );
       // ignore: invalid_use_of_internal_member
@@ -153,7 +157,7 @@ class SentryDatabase extends SentryDatabaseExecutor implements Database {
 
       var breadcrumb = Breadcrumb(
         message: description,
-        category: _dbSqlOp,
+        category: _dbSqlTransactionOp,
         data: {},
         type: 'query',
       );
@@ -201,13 +205,82 @@ class SentryDatabase extends SentryDatabaseExecutor implements Database {
   @override
   // ignore: override_on_non_overriding_member
   Future<T> readTransaction<T>(Future<T> Function(Transaction txn) action) {
+    return Future<T>(() async {
+      final currentSpan = _hub.getSpan();
+      final description = 'Transaction DB: ${_database.path}';
+      final span = currentSpan?.startChild(
+        _dbSqlReadTransactionOp,
+        description: description,
+      );
+      // ignore: invalid_use_of_internal_member
+      span?.origin = SentryTraceOrigins.autoDbSqfliteDatabase;
+      setDatabaseAttributeData(span, dbName);
+
+      var breadcrumb = Breadcrumb(
+        message: description,
+        category: _dbSqlReadTransactionOp,
+        data: {},
+        type: 'query',
+      );
+      setDatabaseAttributeOnBreadcrumb(breadcrumb, dbName);
+
+      Future<T> newAction(Transaction txn) async {
+        final executor = SentryDatabaseExecutor(
+          txn,
+          parentSpan: span,
+          hub: _hub,
+          dbName: dbName,
+        );
+        final sentrySqfliteTransaction =
+            SentrySqfliteTransaction(executor, hub: _hub, dbName: dbName);
+
+        return await action(sentrySqfliteTransaction);
+      }
+
+      try {
+        final futureOrResult = _resolvedReadTransaction(newAction);
+        T result;
+
+        if (futureOrResult is Future<T>) {
+          result = await futureOrResult;
+        } else {
+          result = futureOrResult;
+        }
+
+        span?.status = SpanStatus.ok();
+        breadcrumb.data?['status'] = 'ok';
+
+        return result;
+      } catch (exception) {
+        span?.throwable = exception;
+        span?.status = SpanStatus.internalError();
+        breadcrumb.data?['status'] = 'internal_error';
+        breadcrumb = breadcrumb.copyWith(
+          level: SentryLevel.warning,
+        );
+
+        rethrow;
+      } finally {
+        await span?.finish();
+
+        // ignore: invalid_use_of_internal_member
+        await _hub.scope.addBreadcrumb(breadcrumb);
+      }
+    });
+  }
+
+  FutureOr<T> _resolvedReadTransaction<T>(
+    Future<T> Function(Transaction txn) action,
+  ) async {
     try {
       // ignore: return_of_invalid_type
-      return (_database as dynamic).readTransaction(action);
+      final result = await (_database as dynamic).readTransaction(action);
+      // Await and cast, as directly returning the future resulted in a runtime error.
+      return result as T;
     } on NoSuchMethodError catch (_) {
       // The `readTransaction` does not exists on sqflite version < 2.5.0+2.
       // Fallback to transaction instead.
-      return transaction(action);
+      return _database.transaction(action);
     }
   }
 }

--- a/sqflite/lib/src/sentry_database.dart
+++ b/sqflite/lib/src/sentry_database.dart
@@ -203,8 +203,8 @@ class SentryDatabase extends SentryDatabaseExecutor implements Database {
   }
 
   @override
-  // ignore: override_on_non_overriding_member
   // ignore: public_member_api_docs
+  // ignore: override_on_non_overriding_member
   Future<T> readTransaction<T>(Future<T> Function(Transaction txn) action) {
     return Future<T>(() async {
       final currentSpan = _hub.getSpan();

--- a/sqflite/lib/src/sentry_database.dart
+++ b/sqflite/lib/src/sentry_database.dart
@@ -204,6 +204,7 @@ class SentryDatabase extends SentryDatabaseExecutor implements Database {
 
   @override
   // ignore: override_on_non_overriding_member
+  // ignore: public_member_api_docs
   Future<T> readTransaction<T>(Future<T> Function(Transaction txn) action) {
     return Future<T>(() async {
       final currentSpan = _hub.getSpan();

--- a/sqflite/lib/src/sentry_database.dart
+++ b/sqflite/lib/src/sentry_database.dart
@@ -205,6 +205,8 @@ class SentryDatabase extends SentryDatabaseExecutor implements Database {
       // ignore: return_of_invalid_type
       return (_database as dynamic).readTransaction(action);
     } on NoSuchMethodError catch (_) {
+      // The `readTransaction` does not exists on sqflite version < 2.5.0+2.
+      // Fallback to transaction instead.
       return transaction(action);
     }
   }

--- a/sqflite/lib/src/sentry_database.dart
+++ b/sqflite/lib/src/sentry_database.dart
@@ -32,9 +32,7 @@ class SentryDatabase extends SentryDatabaseExecutor implements Database {
   // ignore: public_member_api_docs
   static const dbSqlQueryOp = 'db.sql.query';
 
-  static const _dbSqlTransactionOp = 'db.sql.transaction';
-
-  static const _dbSqlReadTransactionOp = 'db.sql.readTransaction';
+  static const _dbSqlOp = 'db.sql.transaction';
 
   @internal
   // ignore: public_member_api_docs
@@ -146,7 +144,7 @@ class SentryDatabase extends SentryDatabaseExecutor implements Database {
       final currentSpan = _hub.getSpan();
       final description = 'Transaction DB: ${_database.path}';
       final span = currentSpan?.startChild(
-        _dbSqlTransactionOp,
+        _dbSqlOp,
         description: description,
       );
       // ignore: invalid_use_of_internal_member
@@ -155,7 +153,7 @@ class SentryDatabase extends SentryDatabaseExecutor implements Database {
 
       var breadcrumb = Breadcrumb(
         message: description,
-        category: _dbSqlTransactionOp,
+        category: _dbSqlOp,
         data: {},
         type: 'query',
       );
@@ -203,60 +201,6 @@ class SentryDatabase extends SentryDatabaseExecutor implements Database {
   @override
   // ignore: override_on_non_overriding_member
   Future<T> readTransaction<T>(Future<T> Function(Transaction txn) action) {
-    return Future<T>(() async {
-      final currentSpan = _hub.getSpan();
-      final description = 'Transaction DB: ${_database.path}';
-      final span = currentSpan?.startChild(
-        _dbSqlReadTransactionOp,
-        description: description,
-      );
-      // ignore: invalid_use_of_internal_member
-      span?.origin = SentryTraceOrigins.autoDbSqfliteDatabase;
-      setDatabaseAttributeData(span, dbName);
-
-      var breadcrumb = Breadcrumb(
-        message: description,
-        category: _dbSqlReadTransactionOp,
-        data: {},
-        type: 'query',
-      );
-      setDatabaseAttributeOnBreadcrumb(breadcrumb, dbName);
-
-      Future<T> newAction(Transaction txn) async {
-        final executor = SentryDatabaseExecutor(
-          txn,
-          parentSpan: span,
-          hub: _hub,
-          dbName: dbName,
-        );
-        final sentrySqfliteTransaction =
-            SentrySqfliteTransaction(executor, hub: _hub, dbName: dbName);
-
-        return await action(sentrySqfliteTransaction);
-      }
-
-      try {
-        final result = await _database.readTransaction(newAction);
-
-        span?.status = SpanStatus.ok();
-        breadcrumb.data?['status'] = 'ok';
-
-        return result;
-      } catch (exception) {
-        span?.throwable = exception;
-        span?.status = SpanStatus.internalError();
-        breadcrumb.data?['status'] = 'internal_error';
-        breadcrumb = breadcrumb.copyWith(
-          level: SentryLevel.warning,
-        );
-
-        rethrow;
-      } finally {
-        await span?.finish();
-
-        // ignore: invalid_use_of_internal_member
-        await _hub.scope.addBreadcrumb(breadcrumb);
-      }
-    });
+    return transaction(action);
   }
 }

--- a/sqflite/test/sentry_database_test.dart
+++ b/sqflite/test/sentry_database_test.dart
@@ -114,7 +114,7 @@ void main() {
         expect(txn is SentrySqfliteTransaction, true);
       });
       final span = fixture.tracer.children.last;
-      expect(span.context.operation, 'db.sql.readTransaction');
+      expect(span.context.operation, 'db.sql.read_transaction');
       expect(span.context.description, 'Transaction DB: $inMemoryDatabasePath');
       expect(span.status, SpanStatus.ok());
       expect(span.data[SentryDatabase.dbSystemKey], SentryDatabase.dbSystem);
@@ -158,7 +158,7 @@ void main() {
 
       final breadcrumb = fixture.hub.scope.breadcrumbs.first;
       expect(breadcrumb.message, 'Transaction DB: $inMemoryDatabasePath');
-      expect(breadcrumb.category, 'db.sql.readTransaction');
+      expect(breadcrumb.category, 'db.sql.read_transaction');
       expect(breadcrumb.data?['status'], 'ok');
       expect(
         breadcrumb.data?[SentryDatabase.dbSystemKey],

--- a/sqflite/test/sentry_database_test.dart
+++ b/sqflite/test/sentry_database_test.dart
@@ -107,27 +107,6 @@ void main() {
       await db.close();
     });
 
-    test('creates readTransaction span', () async {
-      final db = await fixture.getSut();
-
-      await db.readTransaction((txn) async {
-        expect(txn is SentrySqfliteTransaction, true);
-      });
-      final span = fixture.tracer.children.last;
-      expect(span.context.operation, 'db.sql.readTransaction');
-      expect(span.context.description, 'Transaction DB: $inMemoryDatabasePath');
-      expect(span.status, SpanStatus.ok());
-      expect(span.data[SentryDatabase.dbSystemKey], SentryDatabase.dbSystem);
-      expect(span.data[SentryDatabase.dbNameKey], inMemoryDatabasePath);
-      expect(
-        span.origin,
-        // ignore: invalid_use_of_internal_member
-        SentryTraceOrigins.autoDbSqfliteDatabase,
-      );
-
-      await db.close();
-    });
-
     test('creates transaction breadcrumb', () async {
       final db = await fixture.getSut();
 
@@ -138,27 +117,6 @@ void main() {
       final breadcrumb = fixture.hub.scope.breadcrumbs.first;
       expect(breadcrumb.message, 'Transaction DB: $inMemoryDatabasePath');
       expect(breadcrumb.category, 'db.sql.transaction');
-      expect(breadcrumb.data?['status'], 'ok');
-      expect(
-        breadcrumb.data?[SentryDatabase.dbSystemKey],
-        SentryDatabase.dbSystem,
-      );
-      expect(breadcrumb.data?[SentryDatabase.dbNameKey], inMemoryDatabasePath);
-      expect(breadcrumb.type, 'query');
-
-      await db.close();
-    });
-
-    test('creates readTransaction breadcrumb', () async {
-      final db = await fixture.getSut();
-
-      await db.readTransaction((txn) async {
-        expect(txn is SentrySqfliteTransaction, true);
-      });
-
-      final breadcrumb = fixture.hub.scope.breadcrumbs.first;
-      expect(breadcrumb.message, 'Transaction DB: $inMemoryDatabasePath');
-      expect(breadcrumb.category, 'db.sql.readTransaction');
       expect(breadcrumb.data?['status'], 'ok');
       expect(
         breadcrumb.data?[SentryDatabase.dbSystemKey],


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

- Add support for `readTransaction` in `sqflite`

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes an issue where the most recent `sqflite` version is incompatible with the plugin, as it introduced a new method.

## :green_heart: How did you test it?

Unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes
