### PR TITLE
feat: tracing without performance for dio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Tracing without performance for Dio integration ([#1837](https://github.com/getsentry/sentry-dart/pull/1837))
+
 ## 7.15.0
 
 ### Features

--- a/dio/lib/src/tracing_client_adapter.dart
+++ b/dio/lib/src/tracing_client_adapter.dart
@@ -51,12 +51,12 @@ class TracingClientAdapter implements HttpClientAdapter {
 
     ResponseBody? response;
     try {
-      if (span != null) {
-        if (containsTargetOrMatchesRegExp(
-          // ignore: invalid_use_of_internal_member
-          _hub.options.tracePropagationTargets,
-          options.uri.toString(),
-        )) {
+      if (containsTargetOrMatchesRegExp(
+        // ignore: invalid_use_of_internal_member
+        _hub.options.tracePropagationTargets,
+        options.uri.toString(),
+      )) {
+        if (span != null) {
           addSentryTraceHeaderFromSpan(span, options.headers);
           addBaggageHeaderFromSpan(
             span,
@@ -64,6 +64,25 @@ class TracingClientAdapter implements HttpClientAdapter {
             // ignore: invalid_use_of_internal_member
             logger: _hub.options.logger,
           );
+        } else {
+          // ignore: invalid_use_of_internal_member
+          final scope = _hub.scope;
+          // ignore: invalid_use_of_internal_member
+          final propagationContext = scope.propagationContext;
+
+          final traceHeader = propagationContext.toSentryTrace();
+          addSentryTraceHeader(traceHeader, options.headers);
+
+          final baggage = propagationContext.baggage;
+          if (baggage != null) {
+            final baggageHeader = SentryBaggageHeader.fromBaggage(baggage);
+            addBaggageHeader(
+              baggageHeader,
+              options.headers,
+              // ignore: invalid_use_of_internal_member
+              logger: _hub.options.logger,
+            );
+          }
         }
       }
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Tracing without performance was implemented for `HttpClient` in https://github.com/getsentry/sentry-dart/pull/1621 but it was never implemented for `sentry_dio` package.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
On my project, we updated sentry to the latest version in order to get tracing without performance, but it wasn't working. Turned out this is because we are using `Dio` with `sentry_dio`. This PR resolves that issue.

## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
