### PR TITLE
chore: reenable testing sentry-dart on windows

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -47,8 +47,8 @@ jobs:
       - name: Test (VM and browser)
         run: |
           dart pub get
-          dart test -p chrome --test-randomize-ordering-seed=random --chain-stack-traces
-#          dart test -p vm --coverage=coverage --test-randomize-ordering-seed=random --chain-stack-traces
+#          dart test -p chrome --test-randomize-ordering-seed=random --chain-stack-traces
+          dart test -p vm --coverage=coverage --test-randomize-ordering-seed=random --chain-stack-traces
 #          dart pub run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --packages=.dart_tool/package_config.json --report-on=lib
 
       - name: Install webdev

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -48,8 +48,8 @@ jobs:
         run: |
           dart pub get
           dart test -p chrome --test-randomize-ordering-seed=random --chain-stack-traces
-          dart test -p vm --coverage=coverage --test-randomize-ordering-seed=random --chain-stack-traces
-          dart pub run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --packages=.dart_tool/package_config.json --report-on=lib
+#          dart test -p vm --coverage=coverage --test-randomize-ordering-seed=random --chain-stack-traces
+#          dart pub run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --packages=.dart_tool/package_config.json --report-on=lib
 
       - name: Install webdev
         if: runner.os != 'Windows'

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -31,8 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO: exclude windows for now, because of failing tests in the new image runner
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         sdk: [stable, beta]
         exclude:
           - os: windows-latest

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -47,9 +47,9 @@ jobs:
       - name: Test (VM and browser)
         run: |
           dart pub get
-#          dart test -p chrome --test-randomize-ordering-seed=random --chain-stack-traces
+          dart test -p chrome --test-randomize-ordering-seed=random --chain-stack-traces
           dart test -p vm --coverage=coverage --test-randomize-ordering-seed=random --chain-stack-traces
-#          dart pub run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --packages=.dart_tool/package_config.json --report-on=lib
+          dart pub run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --packages=.dart_tool/package_config.json --report-on=lib
 
       - name: Install webdev
         if: runner.os != 'Windows'


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
This is fixed here https://github.com/dart-lang/test/pull/2177 and should successfully run the tests now.

#skip-changelog

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
