### PR TITLE
feat: Add sentry widget that includes other sentry widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Features
 
 - Add `SentryWidget` ([#1846](https://github.com/getsentry/sentry-dart/pull/1846))
-  - Deprecates `SentryScreenshotWidget` and `SentryUserInteractionWidget`
 - APM for isar ([#1726](https://github.com/getsentry/sentry-dart/pull/1726))
 - Performance monitoring support for isar ([#1726](https://github.com/getsentry/sentry-dart/pull/1726))
 - Tracing without performance for Dio integration ([#1837](https://github.com/getsentry/sentry-dart/pull/1837))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features
 
+- Add `SentryWidget` ([#1846](https://github.com/getsentry/sentry-dart/pull/1846))
+  - Deprecates `SentryScreenshotWidget` and `SentryUserInteractionWidget`
 - APM for isar ([#1726](https://github.com/getsentry/sentry-dart/pull/1726))
 - Tracing without performance for Dio integration ([#1837](https://github.com/getsentry/sentry-dart/pull/1837))
 - Accept `Map<String, dynamic>` in `Hint` class ([#1807](https://github.com/getsentry/sentry-dart/pull/1807))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Add `SentryWidget` ([#1846](https://github.com/getsentry/sentry-dart/pull/1846))
+  - Prefer to use `SentryWidget` now instead of `SentryScreenshotWidget` and `SentryUserInteractionWidget` directly
 - APM for isar ([#1726](https://github.com/getsentry/sentry-dart/pull/1726))
 - Performance monitoring support for isar ([#1726](https://github.com/getsentry/sentry-dart/pull/1726))
 - Tracing without performance for Dio integration ([#1837](https://github.com/getsentry/sentry-dart/pull/1837))

--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -43,12 +43,10 @@ final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 Future<void> main() async {
   await setupSentry(
       () => runApp(
-            SentryScreenshotWidget(
-              child: SentryUserInteractionWidget(
-                child: DefaultAssetBundle(
-                  bundle: SentryAssetBundle(),
-                  child: const MyApp(),
-                ),
+            SentryWidget(
+              child: DefaultAssetBundle(
+                bundle: SentryAssetBundle(),
+                child: const MyApp(),
               ),
             ),
           ),

--- a/flutter/lib/sentry_flutter.dart
+++ b/flutter/lib/sentry_flutter.dart
@@ -15,3 +15,4 @@ export 'src/screenshot/sentry_screenshot_widget.dart';
 export 'src/screenshot/sentry_screenshot_quality.dart';
 export 'src/user_interaction/sentry_user_interaction_widget.dart';
 export 'src/binding_wrapper.dart';
+export 'src/sentry_widget.dart';

--- a/flutter/lib/src/screenshot/sentry_screenshot_widget.dart
+++ b/flutter/lib/src/screenshot/sentry_screenshot_widget.dart
@@ -23,7 +23,6 @@ final sentryScreenshotWidgetGlobalKey =
 ///   information see https://flutter.dev/docs/development/tools/web-renderers
 /// - You can only have one [SentryScreenshotWidget] widget in your widget tree at all
 ///   times.
-@Deprecated('Use [SentryWidget] instead')
 class SentryScreenshotWidget extends StatefulWidget {
   final Widget child;
   late final Hub _hub;
@@ -50,6 +49,7 @@ class _SentryScreenshotWidgetState extends State<SentryScreenshotWidget> {
 
   @override
   Widget build(BuildContext context) {
+    print('got it ${_options?.attachScreenshot}');
     if (_options?.attachScreenshot ?? false) {
       return RepaintBoundary(
         key: sentryScreenshotWidgetGlobalKey,

--- a/flutter/lib/src/screenshot/sentry_screenshot_widget.dart
+++ b/flutter/lib/src/screenshot/sentry_screenshot_widget.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
 
+import '../../sentry_flutter.dart';
+
 /// Key which is used to identify the [RepaintBoundary]
 @internal
 final sentryScreenshotWidgetGlobalKey =
@@ -23,20 +25,37 @@ final sentryScreenshotWidgetGlobalKey =
 ///   times.
 @Deprecated('Use [SentryWidget] instead')
 class SentryScreenshotWidget extends StatefulWidget {
-  const SentryScreenshotWidget({super.key, required this.child});
-
   final Widget child;
+  late final Hub _hub;
+
+  SentryFlutterOptions? get _options =>
+      // ignore: invalid_use_of_internal_member
+      _hub.options is SentryFlutterOptions
+          // ignore: invalid_use_of_internal_member
+          ? _hub.options as SentryFlutterOptions
+          : null;
+
+  SentryScreenshotWidget({
+    super.key,
+    required this.child,
+    @internal Hub? hub,
+  }) : _hub = hub ?? HubAdapter();
 
   @override
   _SentryScreenshotWidgetState createState() => _SentryScreenshotWidgetState();
 }
 
 class _SentryScreenshotWidgetState extends State<SentryScreenshotWidget> {
+  SentryFlutterOptions? get _options => widget._options;
+
   @override
   Widget build(BuildContext context) {
-    return RepaintBoundary(
-      key: sentryScreenshotWidgetGlobalKey,
-      child: widget.child,
-    );
+    if (_options?.attachScreenshot ?? false) {
+      return RepaintBoundary(
+        key: sentryScreenshotWidgetGlobalKey,
+        child: widget.child,
+      );
+    }
+    return widget.child;
   }
 }

--- a/flutter/lib/src/screenshot/sentry_screenshot_widget.dart
+++ b/flutter/lib/src/screenshot/sentry_screenshot_widget.dart
@@ -49,7 +49,6 @@ class _SentryScreenshotWidgetState extends State<SentryScreenshotWidget> {
 
   @override
   Widget build(BuildContext context) {
-    print('got it ${_options?.attachScreenshot}');
     if (_options?.attachScreenshot ?? false) {
       return RepaintBoundary(
         key: sentryScreenshotWidgetGlobalKey,

--- a/flutter/lib/src/screenshot/sentry_screenshot_widget.dart
+++ b/flutter/lib/src/screenshot/sentry_screenshot_widget.dart
@@ -21,6 +21,7 @@ final sentryScreenshotWidgetGlobalKey =
 ///   information see https://flutter.dev/docs/development/tools/web-renderers
 /// - You can only have one [SentryScreenshotWidget] widget in your widget tree at all
 ///   times.
+@Deprecated('Use [SentryWidget] instead')
 class SentryScreenshotWidget extends StatefulWidget {
   const SentryScreenshotWidget({super.key, required this.child});
 

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -33,6 +33,9 @@ typedef FlutterOptionsConfiguration = FutureOr<void> Function(
 mixin SentryFlutter {
   static const _channel = MethodChannel('sentry_flutter');
 
+  @internal
+  static SentryFlutterOptions flutterOptions = SentryFlutterOptions();
+
   static Future<void> init(
     FlutterOptionsConfiguration optionsConfiguration, {
     AppRunner? appRunner,
@@ -96,6 +99,8 @@ mixin SentryFlutter {
       // ignore: invalid_use_of_internal_member
       SentryNativeProfilerFactory.attachTo(Sentry.currentHub, _native!);
     }
+
+    SentryFlutter.flutterOptions = flutterOptions;
   }
 
   static Future<void> _initDefaultValues(

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -33,11 +33,6 @@ typedef FlutterOptionsConfiguration = FutureOr<void> Function(
 mixin SentryFlutter {
   static const _channel = MethodChannel('sentry_flutter');
 
-  static SentryFlutterOptions _flutterOptions = SentryFlutterOptions();
-
-  @internal
-  static SentryFlutterOptions get flutterOptions => _flutterOptions;
-
   static Future<void> init(
     FlutterOptionsConfiguration optionsConfiguration, {
     AppRunner? appRunner,
@@ -101,8 +96,6 @@ mixin SentryFlutter {
       // ignore: invalid_use_of_internal_member
       SentryNativeProfilerFactory.attachTo(Sentry.currentHub, _native!);
     }
-
-    SentryFlutter._flutterOptions = flutterOptions;
   }
 
   static Future<void> _initDefaultValues(

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -33,8 +33,10 @@ typedef FlutterOptionsConfiguration = FutureOr<void> Function(
 mixin SentryFlutter {
   static const _channel = MethodChannel('sentry_flutter');
 
+  static SentryFlutterOptions _flutterOptions = SentryFlutterOptions();
+
   @internal
-  static SentryFlutterOptions flutterOptions = SentryFlutterOptions();
+  static SentryFlutterOptions get flutterOptions => _flutterOptions;
 
   static Future<void> init(
     FlutterOptionsConfiguration optionsConfiguration, {
@@ -100,7 +102,7 @@ mixin SentryFlutter {
       SentryNativeProfilerFactory.attachTo(Sentry.currentHub, _native!);
     }
 
-    SentryFlutter.flutterOptions = flutterOptions;
+    SentryFlutter._flutterOptions = flutterOptions;
   }
 
   static Future<void> _initDefaultValues(

--- a/flutter/lib/src/sentry_widget.dart
+++ b/flutter/lib/src/sentry_widget.dart
@@ -1,11 +1,14 @@
 import 'package:flutter/cupertino.dart';
+import 'package:meta/meta.dart';
 import '../sentry_flutter.dart';
 
 /// A central widget that contains the Sentry widgets.
 class SentryWidget extends StatefulWidget {
-  const SentryWidget({super.key, required this.child});
-
+  late final Hub _hub;
   final Widget child;
+
+  SentryWidget({super.key, required this.child, @internal Hub? hub})
+      : _hub = hub ?? HubAdapter();
 
   @override
   _SentryWidgetState createState() => _SentryWidgetState();
@@ -32,7 +35,7 @@ class _SentryWidgetState extends State<SentryWidget> {
   Widget _maybeWrapUserInteractionWidget(Widget child) {
     if (_options.enableUserInteractionTracing ||
         _options.enableUserInteractionBreadcrumbs) {
-      return SentryUserInteractionWidget(child: child);
+      return SentryUserInteractionWidget(hub: widget._hub, child: child);
     }
     return child;
   }

--- a/flutter/lib/src/sentry_widget.dart
+++ b/flutter/lib/src/sentry_widget.dart
@@ -1,43 +1,23 @@
 import 'package:flutter/cupertino.dart';
-import 'package:meta/meta.dart';
 import '../sentry_flutter.dart';
 
-/// This widget serves as a wrapper to conditionally include Sentry widgets such
+/// This widget serves as a wrapper to include Sentry widgets such
 /// as [SentryScreenshotWidget] and [SentryUserInteractionWidget].
 class SentryWidget extends StatefulWidget {
-  late final Hub _hub;
   final Widget child;
 
-  SentryWidget({super.key, required this.child, @internal Hub? hub})
-      : _hub = hub ?? HubAdapter();
+  const SentryWidget({super.key, required this.child});
 
   @override
   _SentryWidgetState createState() => _SentryWidgetState();
 }
 
 class _SentryWidgetState extends State<SentryWidget> {
-  final _options = SentryFlutter.flutterOptions;
-
   @override
   Widget build(BuildContext context) {
     Widget content = widget.child;
-    content = _wrapWithScreenshotIfNeeded(content);
-    content = _wrapWithUserInteractionIfNeeded(content);
+    content = SentryScreenshotWidget(child: content);
+    content = SentryUserInteractionWidget(child: content);
     return content;
-  }
-
-  Widget _wrapWithScreenshotIfNeeded(Widget child) {
-    if (_options.attachScreenshot) {
-      return SentryScreenshotWidget(child: child);
-    }
-    return child;
-  }
-
-  Widget _wrapWithUserInteractionIfNeeded(Widget child) {
-    if (_options.enableUserInteractionTracing ||
-        _options.enableUserInteractionBreadcrumbs) {
-      return SentryUserInteractionWidget(hub: widget._hub, child: child);
-    }
-    return child;
   }
 }

--- a/flutter/lib/src/sentry_widget.dart
+++ b/flutter/lib/src/sentry_widget.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/cupertino.dart';
+import '../sentry_flutter.dart';
+
+/// A central widget that contains the Sentry widgets.
+class SentryWidget extends StatefulWidget {
+  const SentryWidget({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  _SentryWidgetState createState() => _SentryWidgetState();
+}
+
+class _SentryWidgetState extends State<SentryWidget> {
+  final _options = SentryFlutter.flutterOptions;
+
+  @override
+  Widget build(BuildContext context) {
+    Widget content = widget.child;
+    content = _maybeWrapScreenshotWidget(content);
+    content = _maybeWrapUserInteractionWidget(content);
+    return content;
+  }
+
+  Widget _maybeWrapScreenshotWidget(Widget child) {
+    if (_options.attachScreenshot) {
+      return SentryScreenshotWidget(child: child);
+    }
+    return child;
+  }
+
+  Widget _maybeWrapUserInteractionWidget(Widget child) {
+    if (_options.enableUserInteractionTracing ||
+        _options.enableUserInteractionBreadcrumbs) {
+      return SentryUserInteractionWidget(child: child);
+    }
+    return child;
+  }
+}

--- a/flutter/lib/src/sentry_widget.dart
+++ b/flutter/lib/src/sentry_widget.dart
@@ -2,7 +2,8 @@ import 'package:flutter/cupertino.dart';
 import 'package:meta/meta.dart';
 import '../sentry_flutter.dart';
 
-/// A central widget that contains the Sentry widgets.
+/// This widget serves as a wrapper to conditionally include Sentry widgets such
+/// as [SentryScreenshotWidget] and [SentryUserInteractionWidget].
 class SentryWidget extends StatefulWidget {
   late final Hub _hub;
   final Widget child;
@@ -20,19 +21,19 @@ class _SentryWidgetState extends State<SentryWidget> {
   @override
   Widget build(BuildContext context) {
     Widget content = widget.child;
-    content = _maybeWrapScreenshotWidget(content);
-    content = _maybeWrapUserInteractionWidget(content);
+    content = _wrapWithScreenshotIfNeeded(content);
+    content = _wrapWithUserInteractionIfNeeded(content);
     return content;
   }
 
-  Widget _maybeWrapScreenshotWidget(Widget child) {
+  Widget _wrapWithScreenshotIfNeeded(Widget child) {
     if (_options.attachScreenshot) {
       return SentryScreenshotWidget(child: child);
     }
     return child;
   }
 
-  Widget _maybeWrapUserInteractionWidget(Widget child) {
+  Widget _wrapWithUserInteractionIfNeeded(Widget child) {
     if (_options.enableUserInteractionTracing ||
         _options.enableUserInteractionBreadcrumbs) {
       return SentryUserInteractionWidget(hub: widget._hub, child: child);

--- a/flutter/lib/src/user_interaction/sentry_user_interaction_widget.dart
+++ b/flutter/lib/src/user_interaction/sentry_user_interaction_widget.dart
@@ -232,7 +232,6 @@ Element? _clickTrackerElement;
 ///
 /// If you are using the [SentryScreenshotWidget] as well, make sure to add
 /// [SentryUserInteractionWidget] as a child of [SentryScreenshotWidget].
-@Deprecated('Use [SentryWidget] instead')
 class SentryUserInteractionWidget extends StatefulWidget {
   SentryUserInteractionWidget({
     super.key,

--- a/flutter/lib/src/user_interaction/sentry_user_interaction_widget.dart
+++ b/flutter/lib/src/user_interaction/sentry_user_interaction_widget.dart
@@ -282,12 +282,16 @@ class _SentryUserInteractionWidgetState
 
   @override
   Widget build(BuildContext context) {
-    return Listener(
-      behavior: HitTestBehavior.translucent,
-      onPointerDown: _onPointerDown,
-      onPointerUp: _onPointerUp,
-      child: widget.child,
-    );
+    if ((_options?.enableUserInteractionTracing ?? true) ||
+        (_options?.enableUserInteractionBreadcrumbs ?? true)) {
+      return Listener(
+        behavior: HitTestBehavior.translucent,
+        onPointerDown: _onPointerDown,
+        onPointerUp: _onPointerUp,
+        child: widget.child,
+      );
+    }
+    return widget.child;
   }
 
   void _onPointerDown(PointerDownEvent event) {

--- a/flutter/lib/src/user_interaction/sentry_user_interaction_widget.dart
+++ b/flutter/lib/src/user_interaction/sentry_user_interaction_widget.dart
@@ -232,6 +232,7 @@ Element? _clickTrackerElement;
 ///
 /// If you are using the [SentryScreenshotWidget] as well, make sure to add
 /// [SentryUserInteractionWidget] as a child of [SentryScreenshotWidget].
+@Deprecated('Use [SentryWidget] instead')
 class SentryUserInteractionWidget extends StatefulWidget {
   SentryUserInteractionWidget({
     super.key,

--- a/flutter/test/event_processor/screenshot_event_processor_test.dart
+++ b/flutter/test/event_processor/screenshot_event_processor_test.dart
@@ -33,6 +33,7 @@ void main() {
       final sut = fixture.getSut(renderer, isWeb);
 
       await tester.pumpWidget(SentryScreenshotWidget(
+          hub: fixture.hub,
           child: Text('Catching Pokémon is a snap!',
               textDirection: TextDirection.ltr)));
 
@@ -178,7 +179,13 @@ void main() {
 }
 
 class Fixture {
+  late Hub hub;
   SentryFlutterOptions options = SentryFlutterOptions(dsn: fakeDsn);
+
+  Fixture() {
+    options.attachScreenshot = true;
+    hub = Hub(options);
+  }
 
   ScreenshotEventProcessor getSut(
       FlutterRenderer? flutterRenderer, bool isWeb) {

--- a/flutter/test/screenshot/sentry_screenshot_widget_test.dart
+++ b/flutter/test/screenshot/sentry_screenshot_widget_test.dart
@@ -1,0 +1,77 @@
+@TestOn('vm')
+// ignore_for_file: invalid_use_of_internal_member
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+import '../mocks.dart';
+
+void main() {
+  late Fixture fixture;
+  setUp(() {
+    fixture = Fixture();
+    TestWidgetsFlutterBinding.ensureInitialized();
+  });
+
+  testWidgets(
+    '$SentryScreenshotWidget does not apply when attachScreenshot is false',
+    (tester) async {
+      await tester.pumpWidget(
+        fixture.getSut(
+          attachScreenshot: false,
+        ),
+      );
+
+      final widget = find.byType(MyApp);
+      final repaintBoundaryFinder = find.descendant(
+        of: widget,
+        matching: find.byType(RepaintBoundary),
+      );
+      expect(repaintBoundaryFinder, findsNothing);
+    },
+  );
+
+  testWidgets(
+    '$SentryScreenshotWidget applies when attachScreenshot is true',
+    (tester) async {
+      await tester.pumpWidget(
+        fixture.getSut(
+          attachScreenshot: true,
+        ),
+      );
+
+      final widget = find.byType(MyApp);
+      final repaintBoundaryFinder = find.ancestor(
+        of: widget,
+        matching: find.byKey(sentryScreenshotWidgetGlobalKey),
+      );
+      expect(repaintBoundaryFinder, findsOneWidget);
+    },
+  );
+}
+
+class Fixture {
+  final _options = SentryFlutterOptions(dsn: fakeDsn);
+  late Hub hub;
+
+  SentryScreenshotWidget getSut({
+    bool attachScreenshot = false,
+  }) {
+    _options.attachScreenshot = attachScreenshot;
+
+    hub = Hub(_options);
+
+    return SentryScreenshotWidget(
+      hub: hub,
+      child: MaterialApp(home: MyApp()),
+    );
+  }
+}
+
+class MyApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return const Text('test');
+  }
+}

--- a/flutter/test/screenshot/sentry_screenshot_widget_test.dart
+++ b/flutter/test/screenshot/sentry_screenshot_widget_test.dart
@@ -70,6 +70,8 @@ class Fixture {
 }
 
 class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
   @override
   Widget build(BuildContext context) {
     return const Text('test');

--- a/flutter/test/sentry_widget_test.dart
+++ b/flutter/test/sentry_widget_test.dart
@@ -1,0 +1,123 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+import 'mocks.dart';
+import 'mocks.mocks.dart';
+import 'user_interaction/sentry_user_interaction_widget_test.dart';
+
+void main() {
+  group('SentryWidget', () {
+    late Fixture fixture;
+
+    setUp(() async {
+      fixture = Fixture();
+      TestWidgetsFlutterBinding.ensureInitialized();
+    });
+
+    testWidgets('attaches screenshot widget when enabled', (tester) async {
+      await tester.runAsync(() async {
+        await tester.pumpWidget(fixture.getSut());
+
+        expect(find.byType(SentryScreenshotWidget), findsOneWidget);
+      });
+    });
+
+    testWidgets('does not attach screenshot widget when disabled',
+        (tester) async {
+      await tester.runAsync(() async {
+        await tester.pumpWidget(fixture.getSut(attachScreenshot: false));
+
+        expect(find.byType(SentryScreenshotWidget), findsNothing);
+      });
+    });
+
+    testWidgets(
+        'attaches user interaction widget when enableUserInteractionTracing is enabled',
+        (tester) async {
+      await tester.runAsync(() async {
+        await tester.pumpWidget(fixture.getSut(
+            enableUserInteractionTracing: true,
+            enableUserInteractionBreadcrumbs: false));
+
+        expect(find.byType(SentryUserInteractionWidget), findsOneWidget);
+      });
+    });
+
+    testWidgets(
+        'attaches user interaction widget when enableUserInteractionBreadcrumbs is enabled',
+        (tester) async {
+      await tester.runAsync(() async {
+        await tester.pumpWidget(fixture.getSut(
+            enableUserInteractionTracing: false,
+            enableUserInteractionBreadcrumbs: true));
+
+        expect(find.byType(SentryUserInteractionWidget), findsOneWidget);
+      });
+    });
+
+    testWidgets('does not attach user interaction widget when disabled',
+        (tester) async {
+      await tester.runAsync(() async {
+        await tester.pumpWidget(fixture.getSut(
+            enableUserInteractionTracing: false,
+            enableUserInteractionBreadcrumbs: false));
+
+        expect(find.byType(SentryUserInteractionWidget), findsNothing);
+      });
+    });
+  });
+
+  group('SentryWidget', () {
+    test('test options are true in SentryFlutter.init', () async {
+      await SentryFlutter.init((p0) => {
+            p0.dsn = fakeDsn,
+            p0.attachScreenshot = true,
+            p0.enableUserInteractionTracing = true,
+            p0.enableUserInteractionBreadcrumbs = true,
+          });
+
+      expect(SentryFlutter.flutterOptions.attachScreenshot, true);
+      expect(SentryFlutter.flutterOptions.enableUserInteractionTracing, true);
+      expect(SentryFlutter.flutterOptions.enableUserInteractionBreadcrumbs, true);
+    });
+
+    test('test options are false in SentryFlutter.init', () async {
+      await SentryFlutter.init((p0) => {
+        p0.dsn = fakeDsn,
+        p0.attachScreenshot = false,
+        p0.enableUserInteractionTracing = false,
+        p0.enableUserInteractionBreadcrumbs = false,
+      });
+
+      expect(SentryFlutter.flutterOptions.attachScreenshot, false);
+      expect(SentryFlutter.flutterOptions.enableUserInteractionTracing, false);
+      expect(SentryFlutter.flutterOptions.enableUserInteractionBreadcrumbs, false);
+    });
+  });
+}
+
+class Fixture {
+  // SentryWidget uses an internal static flutterOptions reference to get the options
+  final _options = SentryFlutter.flutterOptions;
+  final _transport = MockTransport();
+  late Hub hub;
+
+  SentryWidget getSut({
+    bool enableUserInteractionTracing = true,
+    bool enableUserInteractionBreadcrumbs = true,
+    bool attachScreenshot = true,
+  }) {
+    _options.dsn = fakeDsn;
+    _options.transport = _transport;
+    _options.attachScreenshot = attachScreenshot;
+    _options.enableUserInteractionTracing = enableUserInteractionTracing;
+    _options.enableUserInteractionBreadcrumbs =
+        enableUserInteractionBreadcrumbs;
+
+    hub = Hub(_options);
+
+    return SentryWidget(
+      child: MyApp(),
+    );
+  }
+}

--- a/flutter/test/sentry_widget_test.dart
+++ b/flutter/test/sentry_widget_test.dart
@@ -1,122 +1,37 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
-import 'mocks.dart';
-import 'user_interaction/sentry_user_interaction_widget_test.dart';
-
 void main() {
   group('SentryWidget', () {
-    late Fixture fixture;
+    const testChild = Text('Test Child');
 
     setUp(() async {
-      fixture = Fixture();
       TestWidgetsFlutterBinding.ensureInitialized();
     });
 
-    testWidgets('attaches screenshot widget when enabled', (tester) async {
-      await tester.runAsync(() async {
-        await tester.pumpWidget(fixture.getSut());
+    testWidgets('SentryWidget wraps child with SentryUserInteractionWidget',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SentryWidget(child: testChild),
+        ),
+      );
 
-        expect(find.byType(SentryScreenshotWidget), findsOneWidget);
-      });
+      expect(find.byType(SentryUserInteractionWidget), findsOneWidget);
+      expect(find.byWidget(testChild), findsOneWidget);
     });
 
-    testWidgets('does not attach screenshot widget when disabled',
-        (tester) async {
-      await tester.runAsync(() async {
-        await tester.pumpWidget(fixture.getSut(attachScreenshot: false));
+    testWidgets('SentryWidget wraps child with SentryScreenshotWidget',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SentryWidget(child: testChild),
+        ),
+      );
 
-        expect(find.byType(SentryScreenshotWidget), findsNothing);
-      });
-    });
-
-    testWidgets(
-        'attaches user interaction widget when enableUserInteractionTracing is enabled',
-        (tester) async {
-      await tester.runAsync(() async {
-        await tester.pumpWidget(fixture.getSut(
-            enableUserInteractionTracing: true,
-            enableUserInteractionBreadcrumbs: false));
-
-        expect(find.byType(SentryUserInteractionWidget), findsOneWidget);
-      });
-    });
-
-    testWidgets(
-        'attaches user interaction widget when enableUserInteractionBreadcrumbs is enabled',
-        (tester) async {
-      await tester.runAsync(() async {
-        await tester.pumpWidget(fixture.getSut(
-            enableUserInteractionTracing: false,
-            enableUserInteractionBreadcrumbs: true));
-
-        expect(find.byType(SentryUserInteractionWidget), findsOneWidget);
-      });
-    });
-
-    testWidgets('does not attach user interaction widget when disabled',
-        (tester) async {
-      await tester.runAsync(() async {
-        await tester.pumpWidget(fixture.getSut(
-            enableUserInteractionTracing: false,
-            enableUserInteractionBreadcrumbs: false));
-
-        expect(find.byType(SentryUserInteractionWidget), findsNothing);
-      });
+      expect(find.byType(SentryScreenshotWidget), findsOneWidget);
+      expect(find.byWidget(testChild), findsOneWidget);
     });
   });
-
-  group('SentryWidget', () {
-    test('test options are true in SentryFlutter.init', () async {
-      await SentryFlutter.init((options) => {
-            options.dsn = fakeDsn,
-            options.attachScreenshot = true,
-            options.enableUserInteractionTracing = true,
-            options.enableUserInteractionBreadcrumbs = true,
-          });
-
-      expect(SentryFlutter.flutterOptions.attachScreenshot, true);
-      expect(SentryFlutter.flutterOptions.enableUserInteractionTracing, true);
-      expect(
-          SentryFlutter.flutterOptions.enableUserInteractionBreadcrumbs, true);
-    });
-
-    test('test options are false in SentryFlutter.init', () async {
-      await SentryFlutter.init((options) => {
-            options.dsn = fakeDsn,
-            options.attachScreenshot = false,
-            options.enableUserInteractionTracing = false,
-            options.enableUserInteractionBreadcrumbs = false,
-          });
-
-      expect(SentryFlutter.flutterOptions.attachScreenshot, false);
-      expect(SentryFlutter.flutterOptions.enableUserInteractionTracing, false);
-      expect(
-          SentryFlutter.flutterOptions.enableUserInteractionBreadcrumbs, false);
-    });
-  });
-}
-
-class Fixture {
-  // SentryWidget uses an internal static flutterOptions reference to get the options
-  final _options = SentryFlutter.flutterOptions;
-  late Hub hub;
-
-  SentryWidget getSut({
-    bool enableUserInteractionTracing = true,
-    bool enableUserInteractionBreadcrumbs = true,
-    bool attachScreenshot = true,
-  }) {
-    _options.dsn = fakeDsn;
-    _options.attachScreenshot = attachScreenshot;
-    _options.enableUserInteractionTracing = enableUserInteractionTracing;
-    _options.enableUserInteractionBreadcrumbs =
-        enableUserInteractionBreadcrumbs;
-
-    hub = Hub(_options);
-
-    return SentryWidget(
-      child: MyApp(),
-    );
-  }
 }

--- a/flutter/test/sentry_widget_test.dart
+++ b/flutter/test/sentry_widget_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
 import 'mocks.dart';
-import 'mocks.mocks.dart';
 import 'user_interaction/sentry_user_interaction_widget_test.dart';
 
 void main() {
@@ -78,20 +77,22 @@ void main() {
 
       expect(SentryFlutter.flutterOptions.attachScreenshot, true);
       expect(SentryFlutter.flutterOptions.enableUserInteractionTracing, true);
-      expect(SentryFlutter.flutterOptions.enableUserInteractionBreadcrumbs, true);
+      expect(
+          SentryFlutter.flutterOptions.enableUserInteractionBreadcrumbs, true);
     });
 
     test('test options are false in SentryFlutter.init', () async {
       await SentryFlutter.init((options) => {
-        options.dsn = fakeDsn,
-        options.attachScreenshot = false,
-        options.enableUserInteractionTracing = false,
-        options.enableUserInteractionBreadcrumbs = false,
-      });
+            options.dsn = fakeDsn,
+            options.attachScreenshot = false,
+            options.enableUserInteractionTracing = false,
+            options.enableUserInteractionBreadcrumbs = false,
+          });
 
       expect(SentryFlutter.flutterOptions.attachScreenshot, false);
       expect(SentryFlutter.flutterOptions.enableUserInteractionTracing, false);
-      expect(SentryFlutter.flutterOptions.enableUserInteractionBreadcrumbs, false);
+      expect(
+          SentryFlutter.flutterOptions.enableUserInteractionBreadcrumbs, false);
     });
   });
 }

--- a/flutter/test/sentry_widget_test.dart
+++ b/flutter/test/sentry_widget_test.dart
@@ -99,7 +99,6 @@ void main() {
 class Fixture {
   // SentryWidget uses an internal static flutterOptions reference to get the options
   final _options = SentryFlutter.flutterOptions;
-  final _transport = MockTransport();
   late Hub hub;
 
   SentryWidget getSut({
@@ -108,7 +107,6 @@ class Fixture {
     bool attachScreenshot = true,
   }) {
     _options.dsn = fakeDsn;
-    _options.transport = _transport;
     _options.attachScreenshot = attachScreenshot;
     _options.enableUserInteractionTracing = enableUserInteractionTracing;
     _options.enableUserInteractionBreadcrumbs =

--- a/flutter/test/sentry_widget_test.dart
+++ b/flutter/test/sentry_widget_test.dart
@@ -69,11 +69,11 @@ void main() {
 
   group('SentryWidget', () {
     test('test options are true in SentryFlutter.init', () async {
-      await SentryFlutter.init((p0) => {
-            p0.dsn = fakeDsn,
-            p0.attachScreenshot = true,
-            p0.enableUserInteractionTracing = true,
-            p0.enableUserInteractionBreadcrumbs = true,
+      await SentryFlutter.init((options) => {
+            options.dsn = fakeDsn,
+            options.attachScreenshot = true,
+            options.enableUserInteractionTracing = true,
+            options.enableUserInteractionBreadcrumbs = true,
           });
 
       expect(SentryFlutter.flutterOptions.attachScreenshot, true);
@@ -82,11 +82,11 @@ void main() {
     });
 
     test('test options are false in SentryFlutter.init', () async {
-      await SentryFlutter.init((p0) => {
-        p0.dsn = fakeDsn,
-        p0.attachScreenshot = false,
-        p0.enableUserInteractionTracing = false,
-        p0.enableUserInteractionBreadcrumbs = false,
+      await SentryFlutter.init((options) => {
+        options.dsn = fakeDsn,
+        options.attachScreenshot = false,
+        options.enableUserInteractionTracing = false,
+        options.enableUserInteractionBreadcrumbs = false,
       });
 
       expect(SentryFlutter.flutterOptions.attachScreenshot, false);

--- a/flutter/test/user_interaction/sentry_user_interaction_widget_test.dart
+++ b/flutter/test/user_interaction/sentry_user_interaction_widget_test.dart
@@ -32,6 +32,75 @@ void main() {
     },
   );
 
+  testWidgets(
+    '$SentryUserInteractionWidget does not apply when enableUserInteractionTracing and enableUserInteractionBreadcrumbs is false',
+    (tester) async {
+      await tester.runAsync(() async {
+        await tester.pumpWidget(
+          fixture.getSut(
+            enableUserInteractionTracing: false,
+            enableUserInteractionBreadcrumbs: false,
+          ),
+        );
+        final specificChildFinder = find.byType(MyApp);
+
+        expect(
+          find.ancestor(
+            of: specificChildFinder,
+            matching: find.byType(Listener),
+          ),
+          findsNothing,
+        );
+      });
+    },
+  );
+
+  testWidgets(
+    '$SentryUserInteractionWidget does apply when enableUserInteractionTracing is true',
+    (tester) async {
+      await tester.runAsync(() async {
+        await tester.pumpWidget(
+          fixture.getSut(
+            enableUserInteractionTracing: true,
+            enableUserInteractionBreadcrumbs: false,
+          ),
+        );
+        final specificChildFinder = find.byType(MyApp);
+
+        expect(
+          find.ancestor(
+            of: specificChildFinder,
+            matching: find.byType(Listener),
+          ),
+          findsOne,
+        );
+      });
+    },
+  );
+
+  testWidgets(
+    '$SentryUserInteractionWidget does apply when enableUserInteractionBreadcrumbs is true',
+    (tester) async {
+      await tester.runAsync(() async {
+        await tester.pumpWidget(
+          fixture.getSut(
+            enableUserInteractionTracing: false,
+            enableUserInteractionBreadcrumbs: true,
+          ),
+        );
+        final specificChildFinder = find.byType(MyApp);
+
+        expect(
+          find.ancestor(
+            of: specificChildFinder,
+            matching: find.byType(Listener),
+          ),
+          findsOne,
+        );
+      });
+    },
+  );
+
   group('$SentryUserInteractionWidget crumbs', () {
     testWidgets('Add crumb for MaterialButton', (tester) async {
       await tester.runAsync(() async {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
`SentryWidget` serves as a container widget that reduces the amount of widget nesting for the user and makes adding functionalities that depend on widgets much easier

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1839 

## :green_heart: How did you test it?
Manual
Unit Test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
