### PR TITLE
chore(android): Remove dead code, cold start bool is now always present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Remove dead code, cold start bool is now always present ([#1861](https://github.com/getsentry/sentry-dart/pull/1861))
+
 ## 7.16.0
 
 ### Features

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -147,9 +147,6 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     if (appStartTime == null) {
       Log.w("Sentry", "App start won't be sent due to missing appStartTime")
       result.success(null)
-    } else if (isColdStart == null) {
-      Log.w("Sentry", "App start won't be sent due to missing isColdStart")
-      result.success(null)
     } else {
       val appStartTimeMillis = DateUtils.nanosToMillis(appStartTime.nanoTimestamp().toDouble())
       val item = mapOf<String, Any?>(


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
This PR removed the dead code that was introduced during the upgrade to `sentry-android` v7. The `isColdStart` bool is now always present and cant ever be null.

## :green_heart: How did you test it?
ci

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
