### PR TITLE
fix: remove Flutter dep from Drift integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes 
+
+- Remove Flutter dependency from Drift integration ([#1867](https://github.com/getsentry/sentry-dart/pull/1867))
+
 ### Dependencies
 
 - Bump Cocoa SDK from v8.19.0 to v8.20.0 ([#1856](https://github.com/getsentry/sentry-dart/pull/1856))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-### Fixes 
+### Fixes
 
 - Remove Flutter dependency from Drift integration ([#1867](https://github.com/getsentry/sentry-dart/pull/1867))
 - Remove dead code, cold start bool is now always present ([#1861](https://github.com/getsentry/sentry-dart/pull/1861))

--- a/drift/example/example.dart
+++ b/drift/example/example.dart
@@ -30,7 +30,7 @@ Future<void> runApp() async {
 
   await db.into(db.todoItems).insert(
         TodoItemsCompanion.insert(
-          title: 'This is a test item',
+          title: 'This is a test thing',
           content: 'test',
         ),
       );

--- a/drift/example/example.dart
+++ b/drift/example/example.dart
@@ -30,7 +30,7 @@ Future<void> runApp() async {
 
   await db.into(db.todoItems).insert(
         TodoItemsCompanion.insert(
-          title: 'This is a test thing',
+          title: 'This is a test item',
           content: 'test',
         ),
       );

--- a/drift/pubspec.yaml
+++ b/drift/pubspec.yaml
@@ -7,7 +7,6 @@ issue_tracker: https://github.com/getsentry/sentry-dart/issues
 
 environment:
   sdk: '>=2.17.0 <4.0.0'
-  flutter: '>=3.3.0'
 
 dependencies:
   sentry: 7.16.0


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Flutter dependency is not needed for the Drift integration

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1865 

## :green_heart: How did you test it?
ci

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
