### PR TITLE
Add `maxQueueSize` to limit the number of unawaited events sent to Sentry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Use `recordHttpBreadcrumbs` to set iOS `enableNetworkBreadcrumbs` ([#1884](https://github.com/getsentry/sentry-dart/pull/1884))
+- Add `maxQueueSize` to limit the number of unawaited events sent to Sentry ([#1868]((https://github.com/getsentry/sentry-dart/pull/1868))
 
 ## 7.16.1
 

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -81,6 +81,15 @@ class SentryOptions {
     _maxSpans = maxSpans;
   }
 
+  int _maxQueueSize = 30;
+
+  int get maxQueueSize => _maxQueueSize;
+
+  set maxQueueSize(int count) {
+    assert(count > 0);
+    _maxQueueSize = count;
+  }
+
   /// Configures up to which size request bodies should be included in events.
   /// This does not change whether an event is captured.
   MaxRequestBodySize maxRequestBodySize = MaxRequestBodySize.never;

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -83,8 +83,13 @@ class SentryOptions {
 
   int _maxQueueSize = 30;
 
+  /// Returns the max number of events Sentry will send when calling capture
+  /// methods in a tight loop. Default is 30.
   int get maxQueueSize => _maxQueueSize;
 
+  /// Sets how many unawaited events can be sent by Sentry. (e.g. capturing
+  /// events in a tight loop) at once. If you need to send more, please use the
+  /// await keyword.
   set maxQueueSize(int count) {
     assert(count > 0);
     _maxQueueSize = count;

--- a/dart/lib/src/transport/task_queue.dart
+++ b/dart/lib/src/transport/task_queue.dart
@@ -19,9 +19,11 @@ class TaskQueue<T> {
       return fallbackResult;
     } else {
       _queueCount++;
-      final result = await task();
-      _queueCount--;
-      return result;
+      try {
+        return await task();
+      } finally {
+        _queueCount--;
+      }
     }
   }
 }

--- a/dart/lib/src/transport/task_queue.dart
+++ b/dart/lib/src/transport/task_queue.dart
@@ -1,0 +1,27 @@
+import 'dart:async';
+
+import '../../sentry.dart';
+
+typedef Task<T> = Future<T> Function();
+
+class TaskQueue<T> {
+  TaskQueue(this._maxQueueSize, this._logger);
+
+  final int _maxQueueSize;
+  final SentryLogger _logger;
+
+  int _queueCount = 0;
+
+  Future<T> enqueue(Task<T> task, T fallbackResult) async {
+    if (_queueCount >= _maxQueueSize) {
+      _logger(SentryLevel.warning,
+          'Task dropped due to backpressure. Avoid capturing in a tight loop.');
+      return fallbackResult;
+    } else {
+      _queueCount++;
+      final result = await task();
+      _queueCount--;
+      return result;
+    }
+  }
+}

--- a/dart/test/transport/tesk_queue_test.dart
+++ b/dart/test/transport/tesk_queue_test.dart
@@ -1,0 +1,100 @@
+import 'dart:async';
+
+import 'package:sentry/sentry.dart';
+import 'package:sentry/src/transport/task_queue.dart';
+import 'package:test/test.dart';
+
+import '../mocks.dart';
+
+void main() {
+  group("called sync", () {
+    late Fixture fixture;
+
+    setUp(() {
+      fixture = Fixture();
+    });
+
+    test("enqueue only executed `maxQueueSize` times when not awaiting",
+        () async {
+      final sut = fixture.getSut(5);
+
+      var completedTasks = 0;
+
+      for (int i = 0; i < 10; i++) {
+        sut.enqueue(() async {
+          print('Task $i');
+          await Future.delayed(Duration(milliseconds: 1));
+          completedTasks += 1;
+          return 1 + 1;
+        }, -1);
+      }
+
+      // This will always await the other futures, even if they are running longer, as it was scheduled after them.
+      print('Started waiting for first 5 tasks');
+      await Future.delayed(Duration(milliseconds: 1));
+      print('Stopped waiting for first 5 tasks');
+
+      expect(completedTasks, 5);
+    });
+
+    test("enqueue picks up tasks again after await in-between", () async {
+      final sut = fixture.getSut(5);
+
+      var completedTasks = 0;
+
+      for (int i = 1; i <= 10; i++) {
+        sut.enqueue(() async {
+          print('Started task $i');
+          await Future.delayed(Duration(milliseconds: 1));
+          print('Completed task $i');
+          completedTasks += 1;
+          return 1 + 1;
+        }, -1);
+      }
+
+      print('Started waiting for first 5 tasks');
+      await Future.delayed(Duration(milliseconds: 1));
+      print('Stopped waiting for first 5 tasks');
+
+      for (int i = 6; i <= 15; i++) {
+        sut.enqueue(() async {
+          print('Started task $i');
+          await Future.delayed(Duration(milliseconds: 1));
+          print('Completed task $i');
+          completedTasks += 1;
+          return 1 + 1;
+        }, -1);
+      }
+
+      print('Started waiting for second 5 tasks');
+      await Future.delayed(Duration(milliseconds: 5));
+      print('Stopped waiting for second 5 tasks');
+
+      expect(completedTasks, 10); // 10 were dropped
+    });
+
+    test("enqueue executes all tasks when awaiting", () async {
+      final sut = fixture.getSut(5);
+
+      var completedTasks = 0;
+
+      for (int i = 0; i < 10; i++) {
+        await sut.enqueue(() async {
+          print('Task $i');
+          await Future.delayed(Duration(milliseconds: 1));
+          completedTasks += 1;
+          return 1 + 1;
+        }, -1);
+      }
+      expect(completedTasks, 10);
+    });
+  });
+}
+
+class Fixture {
+  final options = SentryOptions(dsn: fakeDsn);
+
+  TaskQueue<int> getSut(int maxQueueSize) {
+    return TaskQueue(maxQueueSize, options.logger);
+  }
+}


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Limit the max number of unawaited tasks that can be executed by Sentry in a tight loop.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


The goal of this PR is to evaluate if this approach can be used to solve #408.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps

- [ ] Evaluate if this approach is feasible.
- [ ] Move to transport implementations?
- [ ] Record discard reason?
- [x] Error handling
