### PR TITLE
Fix iOS "Arithmetic Overflow"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Remove Flutter dependency from Drift integration ([#1867](https://github.com/getsentry/sentry-dart/pull/1867))
 - Remove dead code, cold start bool is now always present ([#1861](https://github.com/getsentry/sentry-dart/pull/1861))
+- Fix iOS "Arithmetic Overflow" ([#1874](https://github.com/getsentry/sentry-dart/pull/1874))
 
 ### Dependencies
 

--- a/flutter/ios/Classes/SentryFlutterPluginApple.swift
+++ b/flutter/ios/Classes/SentryFlutterPluginApple.swift
@@ -430,10 +430,9 @@ public class SentryFlutterPluginApple: NSObject, FlutterPlugin {
       }
 
       let currentFrames = PrivateSentrySDKOnly.currentScreenFrames
-
-      let total = currentFrames.total - totalFrames
-      let frozen = currentFrames.frozen - frozenFrames
-      let slow = currentFrames.slow - slowFrames
+      let total = max(Int(currentFrames.total) - Int(totalFrames), 0)
+      let frozen = max(Int(currentFrames.frozen) - Int(frozenFrames), 0)
+      let slow = max(Int(currentFrames.slow) - Int(slowFrames), 0)
 
       if total <= 0 && frozen <= 0 && slow <= 0 {
         result(nil)

--- a/flutter/lib/src/navigation/sentry_navigator_observer.dart
+++ b/flutter/lib/src/navigation/sentry_navigator_observer.dart
@@ -207,6 +207,7 @@ class SentryNavigatorObserver extends RouteObserver<PageRoute<dynamic>> {
       autoFinishAfter: _autoFinishAfter,
       trimEnd: true,
       onFinish: (transaction) async {
+        _transaction = null;
         final nativeFrames = await _native
             ?.endNativeFramesCollection(transaction.context.traceId);
         if (nativeFrames != null) {
@@ -241,8 +242,13 @@ class SentryNavigatorObserver extends RouteObserver<PageRoute<dynamic>> {
   }
 
   Future<void> _finishTransaction() async {
+    final transaction = _transaction;
+    if (transaction == null || transaction.finished) {
+      return;
+    }
     _transaction?.status ??= SpanStatus.ok();
     await _transaction?.finish();
+    _transaction = null;
   }
 }
 

--- a/flutter/lib/src/navigation/sentry_navigator_observer.dart
+++ b/flutter/lib/src/navigation/sentry_navigator_observer.dart
@@ -243,12 +243,12 @@ class SentryNavigatorObserver extends RouteObserver<PageRoute<dynamic>> {
 
   Future<void> _finishTransaction() async {
     final transaction = _transaction;
+    _transaction = null;
     if (transaction == null || transaction.finished) {
       return;
     }
-    _transaction?.status ??= SpanStatus.ok();
-    await _transaction?.finish();
-    _transaction = null;
+    transaction.status ??= SpanStatus.ok();
+    await transaction.finish();
   }
 }
 

--- a/flutter/test/sentry_navigator_observer_test.dart
+++ b/flutter/test/sentry_navigator_observer_test.dart
@@ -293,6 +293,24 @@ void main() {
       verify(span.finish());
     });
 
+    test('multiple didPop only finish transaction once', () {
+      final currentRoute = route(RouteSettings(name: 'Current Route'));
+
+      final hub = _MockHub();
+      final span = getMockSentryTracer(finished: false);
+      when(span.context).thenReturn(SentrySpanContext(operation: 'op'));
+      when(span.status).thenReturn(null);
+      _whenAnyStart(hub, span);
+
+      final sut = fixture.getSut(hub: hub);
+
+      sut.didPush(currentRoute, null);
+      sut.didPop(currentRoute, null);
+      sut.didPop(currentRoute, null);
+
+      verify(span.finish()).called(1);
+    });
+
     test('didPop re-starts previous', () {
       final previousRoute = route(RouteSettings(name: 'Previous Route'));
       final currentRoute = route(RouteSettings(name: 'Current Route'));

--- a/flutter/test/sentry_navigator_observer_test.dart
+++ b/flutter/test/sentry_navigator_observer_test.dart
@@ -261,7 +261,7 @@ void main() {
       final secondRoute = route(RouteSettings(name: 'Second Route'));
 
       final hub = _MockHub();
-      final span = getMockSentryTracer();
+      final span = getMockSentryTracer(finished: false);
       when(span.context).thenReturn(SentrySpanContext(operation: 'op'));
       when(span.status).thenReturn(null);
       _whenAnyStart(hub, span);
@@ -279,7 +279,7 @@ void main() {
       final currentRoute = route(RouteSettings(name: 'Current Route'));
 
       final hub = _MockHub();
-      final span = getMockSentryTracer();
+      final span = getMockSentryTracer(finished: false);
       when(span.context).thenReturn(SentrySpanContext(operation: 'op'));
       when(span.status).thenReturn(null);
       _whenAnyStart(hub, span);
@@ -833,9 +833,10 @@ class _MockHub extends MockHub {
   }
 }
 
-ISentrySpan getMockSentryTracer({String? name}) {
+ISentrySpan getMockSentryTracer({String? name, bool? finished}) {
   final tracer = MockSentryTracer();
   when(tracer.name).thenReturn(name ?? 'name');
+  when(tracer.finished).thenReturn(finished ?? true);
   return tracer;
 }
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

- Guard against "Arithmetic Overflow"
- Fix duplicate finish transaction in `SentryNavigatorObserver`

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #1872

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes
