### PR TITLE
Use `recordHttpBreadcrumbs` to set iOS `enableNetworkBreadcrumbs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Use `recordHttpBreadcrumbs` to set iOS `enableNetworkBreadcrumbs` ([#1884](https://github.com/getsentry/sentry-dart/pull/1884))
+
 ## 7.16.1
 
 ### Fixes

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -248,11 +248,13 @@ class SentryOptions {
   /// - In an browser environment this can be requests which fail because of CORS.
   /// - In an mobile or desktop application this can be requests which failed
   ///   because the connection was interrupted.
-  /// Use with [SentryHttpClient] or `sentry_dio` integration for this to work
+  /// Use with [SentryHttpClient] or `sentry_dio` integration for this to work,
+  /// or iOS native where it sets the value to `enableCaptureFailedRequests`.
   bool captureFailedRequests = true;
 
   /// Whether to records requests as breadcrumbs. This is on by default.
-  /// It only has an effect when the SentryHttpClient or dio integration is in use
+  /// It only has an effect when the SentryHttpClient or dio integration is in
+  /// use, or iOS native where it sets the value to `enableNetworkBreadcrumbs`.
   bool recordHttpBreadcrumbs = true;
 
   /// Whether [SentryEvent] deduplication is enabled.

--- a/flutter/example/ios/RunnerTests/SentryFlutterTests.swift
+++ b/flutter/example/ios/RunnerTests/SentryFlutterTests.swift
@@ -41,6 +41,7 @@ final class SentryFlutterTests: XCTestCase {
                 "enableWatchdogTerminationTracking": false,
                 "sendClientReports": false,
                 "maxAttachmentSize": NSNumber(value: 9004),
+                "recordHttpBreadcrumbs": false,
                 "captureFailedRequests": false,
                 "enableAppHangTracking": false,
                 "appHangTimeoutIntervalMillis": NSNumber(value: 10000)
@@ -65,6 +66,7 @@ final class SentryFlutterTests: XCTestCase {
         XCTAssertEqual(false, fixture.options.enableWatchdogTerminationTracking)
         XCTAssertEqual(false, fixture.options.sendClientReports)
         XCTAssertEqual(9004, fixture.options.maxAttachmentSize)
+        XCTAssertEqual(false, fixture.options.enableNetworkBreadcrumbs)
         XCTAssertEqual(false, fixture.options.enableCaptureFailedRequests)
         XCTAssertEqual(false, fixture.options.enableAppHangTracking)
         XCTAssertEqual(10, fixture.options.appHangTimeoutInterval)

--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -79,6 +79,10 @@ Future<void> setupSentry(AppRunner appRunner, String dsn,
     options.maxRequestBodySize = MaxRequestBodySize.always;
     options.maxResponseBodySize = MaxResponseBodySize.always;
 
+    options.enableAutoNativeBreadcrumbs = false;
+    options.recordHttpBreadcrumbs = false;
+    options.captureFailedRequests = false;
+
     _isIntegrationTest = isIntegrationTest;
     if (_isIntegrationTest) {
       options.dist = '1';

--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -79,10 +79,6 @@ Future<void> setupSentry(AppRunner appRunner, String dsn,
     options.maxRequestBodySize = MaxRequestBodySize.always;
     options.maxResponseBodySize = MaxResponseBodySize.always;
 
-    options.enableAutoNativeBreadcrumbs = false;
-    options.recordHttpBreadcrumbs = false;
-    options.captureFailedRequests = false;
-
     _isIntegrationTest = isIntegrationTest;
     if (_isIntegrationTest) {
       options.dist = '1';

--- a/flutter/ios/Classes/SentryFlutter.swift
+++ b/flutter/ios/Classes/SentryFlutter.swift
@@ -58,6 +58,9 @@ public final class SentryFlutter {
         if let maxAttachmentSize = data["maxAttachmentSize"] as? NSNumber {
             options.maxAttachmentSize = maxAttachmentSize.uintValue
         }
+        if let recordHttpBreadcrumbs = data["recordHttpBreadcrumbs"] as? Bool {
+            options.enableNetworkBreadcrumbs = recordHttpBreadcrumbs
+        }
         if let captureFailedRequests = data["captureFailedRequests"] as? Bool {
             options.enableCaptureFailedRequests = captureFailedRequests
         }

--- a/flutter/lib/src/integrations/native_sdk_integration.dart
+++ b/flutter/lib/src/integrations/native_sdk_integration.dart
@@ -47,6 +47,7 @@ class NativeSdkIntegration implements Integration<SentryFlutterOptions> {
         'sendClientReports': options.sendClientReports,
         'proguardUuid': options.proguardUuid,
         'maxAttachmentSize': options.maxAttachmentSize,
+        'recordHttpBreadcrumbs': options.recordHttpBreadcrumbs,
         'captureFailedRequests': options.captureFailedRequests,
         'enableAppHangTracking': options.enableAppHangTracking,
         'connectionTimeoutMillis': options.connectionTimeout.inMilliseconds,

--- a/flutter/test/integrations/init_native_sdk_integration_test.dart
+++ b/flutter/test/integrations/init_native_sdk_integration_test.dart
@@ -58,6 +58,7 @@ void main() {
         'sendClientReports': true,
         'proguardUuid': null,
         'maxAttachmentSize': 20 * 1024 * 1024,
+        'recordHttpBreadcrumbs': true,
         'captureFailedRequests': true,
         'enableAppHangTracking': true,
         'connectionTimeoutMillis': 5000,
@@ -98,6 +99,7 @@ void main() {
         ..enableNdkScopeSync = true
         ..proguardUuid = fakeProguardUuid
         ..maxAttachmentSize = 10
+        ..recordHttpBreadcrumbs = false
         ..captureFailedRequests = false
         ..enableAppHangTracking = false
         ..connectionTimeout = Duration(milliseconds: 9001)
@@ -141,6 +143,7 @@ void main() {
         'sendClientReports': false,
         'proguardUuid': fakeProguardUuid,
         'maxAttachmentSize': 10,
+        'recordHttpBreadcrumbs': false,
         'captureFailedRequests': false,
         'enableAppHangTracking': false,
         'connectionTimeoutMillis': 9001,


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

We could not disable http breadcrumbs when running on iOS. This PR uses the `recordHttpBreadcrumbs` option to set `enableNetworkBreadcrumbs` option on the iOS side. This is the same mechanism as the `captureFailedRequests ` to `enableCaptureFailedRequests` option pair.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #1873

## :green_heart: How did you test it?

Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes