### PR TITLE
Disable canvasKit renderer tests for `beta` channel

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -101,7 +101,7 @@ jobs:
 
       # TODO: Revert when canvasKit is available again in `beta` channel
       - name: Test chrome (canvasKit)
-        if: runner.os == 'Linux' && matrix.sdk == 'beta'
+        if: runner.os == 'Linux' && matrix.sdk != 'beta'
         run: |
           cd flutter
           flutter test --platform chrome --test-randomize-ordering-seed=random --tags canvasKit --web-renderer canvaskit

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -93,11 +93,17 @@ jobs:
           cd flutter
           flutter pub get
 
-      - name: Test chrome
+      - name: Test chrome (exclude canvasKit)
         if: runner.os == 'Linux'
         run: |
           cd flutter
           flutter test --platform chrome --test-randomize-ordering-seed=random --exclude-tags canvasKit
+
+      # TODO: Revert when canvasKit is available again in `beta` channel
+      - name: Test chrome (canvasKit)
+        if: runner.os == 'Linux' && matrix.sdk == 'beta'
+        run: |
+          cd flutter
           flutter test --platform chrome --test-randomize-ordering-seed=random --tags canvasKit --web-renderer canvaskit
 
       - name: Test VM with coverage

--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -478,12 +478,8 @@ class MainScaffold extends StatelessWidget {
             TooltipButton(
               onPressed: () async {
                 final id = await Sentry.captureMessage('UserFeedback');
-                // ignore: use_build_context_synchronously
-                if (!context.isMounted) {
-                  return;
-                }
 
-                // ignore: use_build_context_synchronously
+                if (!context.mounted) return;
                 await showDialog(
                   context: context,
                   builder: (context) {
@@ -906,12 +902,7 @@ Future<void> makeWebRequest(BuildContext context) async {
 
   await transaction.finish(status: const SpanStatus.ok());
 
-  // ignore: use_build_context_synchronously
-  if (!context.isMounted) {
-    return;
-  }
-
-  // ignore: use_build_context_synchronously
+  if (!context.mounted) return;
   await showDialog<void>(
     context: context,
     builder: (context) {
@@ -957,12 +948,7 @@ Future<void> makeWebRequestWithDio(BuildContext context) async {
     await span.finish();
   }
 
-  // ignore: use_build_context_synchronously
-  if (!context.isMounted) {
-    return;
-  }
-
-  // ignore: use_build_context_synchronously
+  if (!context.mounted) return;
   await showDialog<void>(
     context: context,
     builder: (context) {
@@ -992,12 +978,7 @@ Future<void> showDialogWithTextAndImage(BuildContext context) async {
   final text =
       await DefaultAssetBundle.of(context).loadString('assets/lorem-ipsum.txt');
 
-  // ignore: use_build_context_synchronously
-  if (!context.isMounted) {
-    return;
-  }
-
-  // ignore: use_build_context_synchronously
+  if (!context.mounted) return;
   await showDialog<void>(
     context: context,
     // gets tracked if using SentryNavigatorObserver


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->

Disables canvasKit tests on Linux for `beta` channel.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Apparently tests cannot be run with `canvasKit` renderer on Linux web anymore on the most recent Flutter `beta` channel. 

## :green_heart: How did you test it?

Run CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

- [ ] Create an issue to re-enable those tests.
