### PR TITLE
fix(sentry-dart): remove transitive dart:io reference for web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Bump Android SDK from v7.3.0 to v7.5.0 ([#1907](https://github.com/getsentry/sentry-dart/pull/1907))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#750)
   - [diff](https://github.com/getsentry/sentry-java/compare/7.3.0...7.5.0)
+- remove transitive dart:io reference for web ([#1898](https://github.com/getsentry/sentry-dart/pull/1898))
 
 ## 7.16.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fix transaction end timestamp trimming ([#1916](https://github.com/getsentry/sentry-dart/pull/1916))
   - Transaction end timestamps are now correctly trimmed to the latest child span end timestamp
+- remove transitive dart:io reference for web ([#1898](https://github.com/getsentry/sentry-dart/pull/1898))  
 
 ### Features
 
@@ -24,7 +25,6 @@
 - Bump Android SDK from v7.3.0 to v7.5.0 ([#1907](https://github.com/getsentry/sentry-dart/pull/1907))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#750)
   - [diff](https://github.com/getsentry/sentry-java/compare/7.3.0...7.5.0)
-- remove transitive dart:io reference for web ([#1898](https://github.com/getsentry/sentry-dart/pull/1898))
 
 ## 7.16.1
 

--- a/dart/lib/src/utils/transport_utils.dart
+++ b/dart/lib/src/utils/transport_utils.dart
@@ -1,7 +1,9 @@
 import 'package:http/http.dart';
 
-import '../../sentry_io.dart';
 import '../client_reports/discard_reason.dart';
+import '../protocol.dart';
+import '../sentry_envelope.dart';
+import '../sentry_options.dart';
 import '../transport/data_category.dart';
 
 class TransportUtils {

--- a/dart/test/example_web_compile_test.dart
+++ b/dart/test/example_web_compile_test.dart
@@ -1,0 +1,74 @@
+@TestOn('vm')
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+// Tests for the following issue
+// https://github.com/getsentry/sentry-dart/issues/1893
+void main() {
+  group('Compile example_web', () {
+    test('dart pub get should run successfully', () async {
+      final result = await _runProcess('dart pub get',
+          workingDirectory: _exampleWebWorkingDir);
+      expect(result.exitCode, 0,
+          reason: 'Could run `dart pub get` for example_web. '
+              'Likely caused by outdated dependencies');
+    });
+    test('dart run build_runner build should run successfully', () async {
+      // running this test locally require clean working directory
+      final cleanResult = await _runProcess('dart run build_runner clean',
+          workingDirectory: _exampleWebWorkingDir);
+      expect(cleanResult.exitCode, 0);
+      final result = await _runProcess(
+          'dart run build_runner build -r web -o build --delete-conflicting-outputs',
+          workingDirectory: _exampleWebWorkingDir);
+      expect(result.exitCode, 0,
+          reason: 'Could not compile example_web project');
+      expect(
+          result.stdout,
+          isNot(contains(
+              'Skipping compiling sentry_dart_web_example|web/main.dart')),
+          reason:
+              'Could not compile main.dart, likely because of dart:io import.');
+      expect(result.stdout,
+          contains('build_web_compilers:entrypoint on web/main.dart:Compiled'));
+    });
+  });
+}
+
+/// Runs [command] with command's stdout and stderr being forwrarded to
+/// test runner's respective streams. It buffers stdout and returns it.
+///
+/// Returns [_CommandResult] with exitCode and stdout as a single sting
+Future<_CommandResult> _runProcess(String command,
+    {String workingDirectory = '.'}) async {
+  final parts = command.split(' ');
+  assert(parts.isNotEmpty);
+  final cmd = parts[0];
+  final args = parts.skip(1).toList();
+  final process =
+      await Process.start(cmd, args, workingDirectory: workingDirectory);
+  // forward standard streams
+  unawaited(stderr.addStream(process.stderr));
+  final buffer = <int>[];
+  await for (final units in process.stdout) {
+    buffer.addAll(units);
+    stdout.add(units);
+  }
+  final processOut = utf8.decode(buffer);
+  int exitCode = await process.exitCode;
+  return _CommandResult(exitCode: exitCode, stdout: processOut);
+}
+
+String get _exampleWebWorkingDir {
+  return Directory.current.uri.resolve('./example_web').normalizePath().path;
+}
+
+class _CommandResult {
+  final int exitCode;
+  final String stdout;
+
+  const _CommandResult({required this.exitCode, required this.stdout});
+}

--- a/dart/test/example_web_compile_test.dart
+++ b/dart/test/example_web_compile_test.dart
@@ -38,7 +38,7 @@ void main() {
                 'build_web_compilers:entrypoint on web/main.dart:Compiled'));
       },
       timeout: Timeout(const Duration(minutes: 1)), // double of detault timeout
-    ); 
+    );
   });
 }
 


### PR DESCRIPTION
TransportUtils imported sentry_io.dart which prevented web projects such as example_web from building when build_runner was used.

Resolves getsentry/sentry-dart#1893

## :scroll: Description

Removed `sentry_io.dart` dependency in a file that is used by web projects too.

## :bulb: Motivation and Context

Running `dart run build_runner build` or `serve` in `example_web` folder failed because of `sentry_io.dart` was imported in `transport_utils.dart`.

More broadly, `sentry_io.dart` in `transport_utils.dart` file prevents any dart web project from compiling that uses `build_web_compilers` (webdev).

## :green_heart: How did you test it?

Locally built `example_web` with the following command:

```sh
dart run build_runner build
```

Observed failure before changeset and success after.

## :pencil: Checklist

- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
