### PR TITLE
refactor: fetch app start in integration instead of event processor

### DIFF
--- a/.github/workflows/flutter_test.yml
+++ b/.github/workflows/flutter_test.yml
@@ -111,7 +111,7 @@ jobs:
 
   cocoa:
     name: "${{ matrix.target }} | ${{ matrix.sdk }}"
-    runs-on: macos-13
+    runs-on: macos-latest-xlarge
     timeout-minutes: 30
     defaults:
       run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+- App start is now fetched within integration instead of event processor ([#1905](https://github.com/getsentry/sentry-dart/pull/1905))
+
 ## 7.16.1
 
 ### Fixes

--- a/flutter/example/integration_test/integration_test.dart
+++ b/flutter/example/integration_test/integration_test.dart
@@ -1,4 +1,5 @@
 // ignore_for_file: avoid_print
+// ignore_for_file: invalid_use_of_internal_member
 
 import 'dart:async';
 import 'dart:convert';
@@ -8,6 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:sentry_flutter_example/main.dart';
 import 'package:http/http.dart';
+import 'package:sentry_flutter/src/integrations/native_app_start_integration.dart';
 
 void main() {
   // const org = 'sentry-sdks';
@@ -24,6 +26,8 @@ void main() {
   // Using fake DSN for testing purposes.
   Future<void> setupSentryAndApp(WidgetTester tester,
       {String? dsn, BeforeSendCallback? beforeSendCallback}) async {
+    NativeAppStartIntegration.isIntegrationTest = true;
+
     await setupSentry(
       () async {
         await tester.pumpWidget(SentryScreenshotWidget(

--- a/flutter/lib/src/event_processor/native_app_start_event_processor.dart
+++ b/flutter/lib/src/event_processor/native_app_start_event_processor.dart
@@ -23,7 +23,7 @@ class NativeAppStartEventProcessor implements EventProcessor {
 
     if (measurement != null) {
       event.measurements[measurement.name] = measurement;
-      _native.setDidAddAppStartMeasurement(true);
+      _native.didAddAppStartMeasurement = true;
     }
     return event;
   }

--- a/flutter/lib/src/event_processor/native_app_start_event_processor.dart
+++ b/flutter/lib/src/event_processor/native_app_start_event_processor.dart
@@ -2,57 +2,29 @@ import 'dart:async';
 
 import 'package:sentry/sentry.dart';
 
-import '../native/sentry_native.dart';
+import '../integrations/integrations.dart';
 
 /// EventProcessor that enriches [SentryTransaction] objects with app start
 /// measurement.
 class NativeAppStartEventProcessor implements EventProcessor {
-  /// We filter out App starts more than 60s
-  static const _maxAppStartMillis = 60000;
+  NativeAppStartEventProcessor();
 
-  NativeAppStartEventProcessor(
-    this._native,
-  );
-
-  final SentryNative _native;
+  // We want the app start measurement to only be added once to the first transaction
+  bool _didAddAppStartMeasurement = false;
 
   @override
   Future<SentryEvent?> apply(SentryEvent event, {Hint? hint}) async {
-    final appStartEnd = _native.appStartEnd;
+    if (_didAddAppStartMeasurement || event is! SentryTransaction) {
+      return event;
+    }
 
-    if (appStartEnd != null &&
-        event is SentryTransaction &&
-        !_native.didFetchAppStart) {
-      final nativeAppStart = await _native.fetchNativeAppStart();
-      if (nativeAppStart == null) {
-        return event;
-      }
-      final measurement = nativeAppStart.toMeasurement(appStartEnd);
-      // We filter out app start more than 60s.
-      // This could be due to many different reasons.
-      // If you do the manual init and init the SDK too late and it does not
-      // compute the app start end in the very first Screen.
-      // If the process starts but the App isn't in the foreground.
-      // If the system forked the process earlier to accelerate the app start.
-      // And some unknown reasons that could not be reproduced.
-      // We've seen app starts with hours, days and even months.
-      if (measurement.value >= _maxAppStartMillis) {
-        return event;
-      }
+    final appStartInfo = await NativeAppStartIntegration.getAppStartInfo();
+    final measurement = appStartInfo?.toMeasurement();
+
+    if (measurement != null) {
       event.measurements[measurement.name] = measurement;
+      _didAddAppStartMeasurement = true;
     }
     return event;
-  }
-}
-
-extension NativeAppStartMeasurement on NativeAppStart {
-  SentryMeasurement toMeasurement(DateTime appStartEnd) {
-    final appStartDateTime =
-        DateTime.fromMillisecondsSinceEpoch(appStartTime.toInt());
-    final duration = appStartEnd.difference(appStartDateTime);
-
-    return isColdStart
-        ? SentryMeasurement.coldAppStart(duration)
-        : SentryMeasurement.warmAppStart(duration);
   }
 }

--- a/flutter/lib/src/event_processor/native_app_start_event_processor.dart
+++ b/flutter/lib/src/event_processor/native_app_start_event_processor.dart
@@ -3,18 +3,18 @@ import 'dart:async';
 import 'package:sentry/sentry.dart';
 
 import '../integrations/integrations.dart';
+import '../native/sentry_native.dart';
 
 /// EventProcessor that enriches [SentryTransaction] objects with app start
 /// measurement.
 class NativeAppStartEventProcessor implements EventProcessor {
-  NativeAppStartEventProcessor();
+  final SentryNative _native;
 
-  // We want the app start measurement to only be added once to the first transaction
-  bool _didAddAppStartMeasurement = false;
+  NativeAppStartEventProcessor(this._native);
 
   @override
   Future<SentryEvent?> apply(SentryEvent event, {Hint? hint}) async {
-    if (_didAddAppStartMeasurement || event is! SentryTransaction) {
+    if (_native.didAddAppStartMeasurement || event is! SentryTransaction) {
       return event;
     }
 
@@ -23,7 +23,7 @@ class NativeAppStartEventProcessor implements EventProcessor {
 
     if (measurement != null) {
       event.measurements[measurement.name] = measurement;
-      _didAddAppStartMeasurement = true;
+      _native.setDidAddAppStartMeasurement(true);
     }
     return event;
   }

--- a/flutter/lib/src/frame_callback_handler.dart
+++ b/flutter/lib/src/frame_callback_handler.dart
@@ -7,6 +7,9 @@ abstract class FrameCallbackHandler {
 class DefaultFrameCallbackHandler implements FrameCallbackHandler {
   @override
   void addPostFrameCallback(FrameCallback callback) {
-    SchedulerBinding.instance.addPostFrameCallback(callback);
+    try {
+      /// Flutter >= 2.12 throws if SchedulerBinding.instance isn't initialized.
+      SchedulerBinding.instance.addPostFrameCallback(callback);
+    } catch (_) {}
   }
 }

--- a/flutter/lib/src/frame_callback_handler.dart
+++ b/flutter/lib/src/frame_callback_handler.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/scheduler.dart';
+
+abstract class FrameCallbackHandler {
+  void addPostFrameCallback(FrameCallback callback);
+}
+
+class DefaultFrameCallbackHandler implements FrameCallbackHandler {
+  @override
+  void addPostFrameCallback(FrameCallback callback) {
+    SchedulerBinding.instance.addPostFrameCallback(callback);
+  }
+}

--- a/flutter/lib/src/integrations/native_app_start_integration.dart
+++ b/flutter/lib/src/integrations/native_app_start_integration.dart
@@ -25,6 +25,9 @@ class NativeAppStartIntegration extends Integration<SentryFlutterOptions> {
   @internal
   static void setAppStartInfo(AppStartInfo? appStartInfo) {
     _appStartInfo = appStartInfo;
+    if (_appStartCompleter.isCompleted) {
+      _appStartCompleter = Completer<AppStartInfo?>();
+    }
     _appStartCompleter.complete(appStartInfo);
   }
 

--- a/flutter/lib/src/integrations/native_app_start_integration.dart
+++ b/flutter/lib/src/integrations/native_app_start_integration.dart
@@ -23,6 +23,9 @@ class NativeAppStartIntegration extends Integration<SentryFlutterOptions> {
   static AppStartInfo? _appStartInfo;
 
   @internal
+  static bool isIntegrationTest = false;
+
+  @internal
   static void setAppStartInfo(AppStartInfo? appStartInfo) {
     _appStartInfo = appStartInfo;
     if (_appStartCompleter.isCompleted) {
@@ -47,10 +50,17 @@ class NativeAppStartIntegration extends Integration<SentryFlutterOptions> {
 
   @override
   void call(Hub hub, SentryFlutterOptions options) {
+    if (isIntegrationTest) {
+      final appStartInfo = AppStartInfo(AppStartType.cold,
+          start: DateTime.now(),
+          end: DateTime.now().add(const Duration(milliseconds: 100)));
+      setAppStartInfo(appStartInfo);
+      return;
+    }
+
     if (options.autoAppStart) {
       _frameCallbackHandler.addPostFrameCallback((timeStamp) async {
         if (_native.didFetchAppStart) {
-          setAppStartInfo(null);
           return;
         }
 

--- a/flutter/lib/src/integrations/native_app_start_integration.dart
+++ b/flutter/lib/src/integrations/native_app_start_integration.dart
@@ -66,7 +66,6 @@ class NativeAppStartIntegration extends Integration<SentryFlutterOptions> {
           final nativeAppStart = await _native.fetchNativeAppStart();
 
           if (nativeAppStart == null || appStartEnd == null) {
-            setAppStartInfo(null);
             return;
           }
 

--- a/flutter/lib/src/integrations/native_app_start_integration.dart
+++ b/flutter/lib/src/integrations/native_app_start_integration.dart
@@ -59,8 +59,8 @@ class NativeAppStartIntegration extends Integration<SentryFlutterOptions> {
             return;
           }
 
-          // ignore: invalid_use_of_internal_member
           // We only assign the current time if it's not already set - this is useful in tests
+          // ignore: invalid_use_of_internal_member
           _native.appStartEnd ??= options.clock();
           final appStartEnd = _native.appStartEnd;
           final nativeAppStart = await _native.fetchNativeAppStart();
@@ -99,7 +99,7 @@ class NativeAppStartIntegration extends Integration<SentryFlutterOptions> {
       }
     }
 
-    options.addEventProcessor(NativeAppStartEventProcessor());
+    options.addEventProcessor(NativeAppStartEventProcessor(_native));
 
     options.sdk.addIntegration('nativeAppStartIntegration');
   }

--- a/flutter/lib/src/integrations/native_app_start_integration.dart
+++ b/flutter/lib/src/integrations/native_app_start_integration.dart
@@ -1,9 +1,28 @@
-import 'package:flutter/scheduler.dart';
-import 'package:sentry/sentry.dart';
+import 'dart:async';
 
-import '../sentry_flutter_options.dart';
+import 'package:meta/meta.dart';
+
+import '../../sentry_flutter.dart';
+import '../frame_callback_handler.dart';
 import '../native/sentry_native.dart';
 import '../event_processor/native_app_start_event_processor.dart';
+
+enum AppStartType { cold, warm }
+
+class AppStartInfo {
+  AppStartInfo(this.type, {required this.start, required this.end});
+
+  final AppStartType type;
+  final DateTime start;
+  final DateTime end;
+
+  SentryMeasurement toMeasurement() {
+    final duration = end.difference(start);
+    return type == AppStartType.cold
+        ? SentryMeasurement.coldAppStart(duration)
+        : SentryMeasurement.warmAppStart(duration);
+  }
+}
 
 /// Integration which handles communication with native frameworks in order to
 /// enrich [SentryTransaction] objects with app start data for mobile vitals.
@@ -13,6 +32,35 @@ class NativeAppStartIntegration extends Integration<SentryFlutterOptions> {
   final SentryNative _native;
   final SchedulerBindingProvider _schedulerBindingProvider;
 
+  /// We filter out App starts more than 60s
+  static const _maxAppStartMillis = 60000;
+
+  static Completer<AppStartInfo?> _appStartCompleter =
+      Completer<AppStartInfo?>();
+  static AppStartInfo? _appStartInfo;
+
+  @internal
+  static void setAppStartInfo(AppStartInfo? appStartInfo) {
+    _appStartInfo = appStartInfo;
+    _appStartCompleter.complete(appStartInfo);
+  }
+
+  @internal
+  static Future<AppStartInfo?> getAppStartInfo() {
+    if (_appStartInfo != null) {
+      return Future.value(_appStartInfo);
+    }
+    return _appStartCompleter.future;
+  }
+
+  @internal
+  static void clearAppStartInfo() {
+    _appStartInfo = null;
+    if (_appStartCompleter.isCompleted) {
+      _appStartCompleter = Completer<AppStartInfo?>();
+    }
+  }
+
   @override
   void call(Hub hub, SentryFlutterOptions options) {
     if (options.autoAppStart) {
@@ -21,18 +69,60 @@ class NativeAppStartIntegration extends Integration<SentryFlutterOptions> {
         options.logger(SentryLevel.debug,
             'Scheduler binding is null. Can\'t auto detect app start time.');
       } else {
-        schedulerBinding.addPostFrameCallback((timeStamp) {
+        schedulerBinding.addPostFrameCallback((timeStamp) async {
           // ignore: invalid_use_of_internal_member
-          _native.appStartEnd = options.clock();
+          // We only assign the current time if it's not already set
+          // this is useful in tests
+          _native.appStartEnd ??= options.clock();
+          final appStartEnd = _native.appStartEnd;
+
+          if (_native.didFetchAppStart || appStartEnd == null) {
+            setAppStartInfo(null);
+            return;
+          }
+
+          final nativeAppStart = await _native.fetchNativeAppStart();
+
+          if (nativeAppStart == null) {
+            setAppStartInfo(null);
+            return;
+          }
+
+          final appStartDateTime = DateTime.fromMillisecondsSinceEpoch(
+              nativeAppStart.appStartTime.toInt());
+          final duration = appStartEnd.difference(appStartDateTime);
+
+          // We filter out app start more than 60s.
+          // This could be due to many different reasons.
+          // If you do the manual init and init the SDK too late and it does not
+          // compute the app start end in the very first Screen.
+          // If the process starts but the App isn't in the foreground.
+          // If the system forked the process earlier to accelerate the app start.
+          // And some unknown reasons that could not be reproduced.
+          // We've seen app starts with hours, days and even months.
+          if (duration.inMilliseconds > _maxAppStartMillis) {
+            setAppStartInfo(null);
+            return;
+          }
+
+          final appStartInfo = AppStartInfo(
+              nativeAppStart.isColdStart
+                  ? AppStartType.cold
+                  : AppStartType.warm,
+              start: DateTime.fromMillisecondsSinceEpoch(
+                  nativeAppStart.appStartTime.toInt()),
+              end: appStartEnd);
+          setAppStartInfo(appStartInfo);
         });
       }
     }
 
-    options.addEventProcessor(NativeAppStartEventProcessor(_native));
+    options.addEventProcessor(NativeAppStartEventProcessor());
 
     options.sdk.addIntegration('nativeAppStartIntegration');
   }
 }
 
 /// Used to provide scheduler binding at call time.
-typedef SchedulerBindingProvider = SchedulerBinding? Function();
+typedef SchedulerBindingProvider = FrameCallbackHandler? Function();
+

--- a/flutter/lib/src/integrations/native_app_start_integration.dart
+++ b/flutter/lib/src/integrations/native_app_start_integration.dart
@@ -36,12 +36,10 @@ class NativeAppStartIntegration extends Integration<SentryFlutterOptions> {
     return _appStartCompleter.future;
   }
 
-  @internal
+  @visibleForTesting
   static void clearAppStartInfo() {
     _appStartInfo = null;
-    if (_appStartCompleter.isCompleted) {
-      _appStartCompleter = Completer<AppStartInfo?>();
-    }
+    _appStartCompleter = Completer<AppStartInfo?>();
   }
 
   @override

--- a/flutter/lib/src/integrations/native_app_start_integration.dart
+++ b/flutter/lib/src/integrations/native_app_start_integration.dart
@@ -53,20 +53,18 @@ class NativeAppStartIntegration extends Integration<SentryFlutterOptions> {
             'Scheduler binding is null. Can\'t auto detect app start time.');
       } else {
         schedulerBinding.addPostFrameCallback((timeStamp) async {
-          // ignore: invalid_use_of_internal_member
-          // We only assign the current time if it's not already set
-          // this is useful in tests
-          _native.appStartEnd ??= options.clock();
-          final appStartEnd = _native.appStartEnd;
-
-          if (_native.didFetchAppStart || appStartEnd == null) {
+          if (_native.didFetchAppStart) {
             setAppStartInfo(null);
             return;
           }
 
+          // ignore: invalid_use_of_internal_member
+          // We only assign the current time if it's not already set - this is useful in tests
+          _native.appStartEnd ??= options.clock();
+          final appStartEnd = _native.appStartEnd;
           final nativeAppStart = await _native.fetchNativeAppStart();
 
-          if (nativeAppStart == null) {
+          if (nativeAppStart == null || appStartEnd == null) {
             setAppStartInfo(null);
             return;
           }

--- a/flutter/lib/src/integrations/native_app_start_integration.dart
+++ b/flutter/lib/src/integrations/native_app_start_integration.dart
@@ -10,10 +10,10 @@ import '../event_processor/native_app_start_event_processor.dart';
 /// Integration which handles communication with native frameworks in order to
 /// enrich [SentryTransaction] objects with app start data for mobile vitals.
 class NativeAppStartIntegration extends Integration<SentryFlutterOptions> {
-  NativeAppStartIntegration(this._native, this._schedulerBindingProvider);
+  NativeAppStartIntegration(this._native, this._frameCallbackHandler);
 
   final SentryNative _native;
-  final SchedulerBindingProvider _schedulerBindingProvider;
+  final FrameCallbackHandler _frameCallbackHandler;
 
   /// We filter out App starts more than 60s
   static const _maxAppStartMillis = 60000;
@@ -48,54 +48,46 @@ class NativeAppStartIntegration extends Integration<SentryFlutterOptions> {
   @override
   void call(Hub hub, SentryFlutterOptions options) {
     if (options.autoAppStart) {
-      final schedulerBinding = _schedulerBindingProvider();
-      if (schedulerBinding == null) {
-        options.logger(SentryLevel.debug,
-            'Scheduler binding is null. Can\'t auto detect app start time.');
-      } else {
-        schedulerBinding.addPostFrameCallback((timeStamp) async {
-          if (_native.didFetchAppStart) {
-            setAppStartInfo(null);
-            return;
-          }
+      _frameCallbackHandler.addPostFrameCallback((timeStamp) async {
+        if (_native.didFetchAppStart) {
+          setAppStartInfo(null);
+          return;
+        }
 
-          // We only assign the current time if it's not already set - this is useful in tests
-          // ignore: invalid_use_of_internal_member
-          _native.appStartEnd ??= options.clock();
-          final appStartEnd = _native.appStartEnd;
-          final nativeAppStart = await _native.fetchNativeAppStart();
+        // We only assign the current time if it's not already set - this is useful in tests
+        // ignore: invalid_use_of_internal_member
+        _native.appStartEnd ??= options.clock();
+        final appStartEnd = _native.appStartEnd;
+        final nativeAppStart = await _native.fetchNativeAppStart();
 
-          if (nativeAppStart == null || appStartEnd == null) {
-            return;
-          }
+        if (nativeAppStart == null || appStartEnd == null) {
+          return;
+        }
 
-          final appStartDateTime = DateTime.fromMillisecondsSinceEpoch(
-              nativeAppStart.appStartTime.toInt());
-          final duration = appStartEnd.difference(appStartDateTime);
+        final appStartDateTime = DateTime.fromMillisecondsSinceEpoch(
+            nativeAppStart.appStartTime.toInt());
+        final duration = appStartEnd.difference(appStartDateTime);
 
-          // We filter out app start more than 60s.
-          // This could be due to many different reasons.
-          // If you do the manual init and init the SDK too late and it does not
-          // compute the app start end in the very first Screen.
-          // If the process starts but the App isn't in the foreground.
-          // If the system forked the process earlier to accelerate the app start.
-          // And some unknown reasons that could not be reproduced.
-          // We've seen app starts with hours, days and even months.
-          if (duration.inMilliseconds > _maxAppStartMillis) {
-            setAppStartInfo(null);
-            return;
-          }
+        // We filter out app start more than 60s.
+        // This could be due to many different reasons.
+        // If you do the manual init and init the SDK too late and it does not
+        // compute the app start end in the very first Screen.
+        // If the process starts but the App isn't in the foreground.
+        // If the system forked the process earlier to accelerate the app start.
+        // And some unknown reasons that could not be reproduced.
+        // We've seen app starts with hours, days and even months.
+        if (duration.inMilliseconds > _maxAppStartMillis) {
+          setAppStartInfo(null);
+          return;
+        }
 
-          final appStartInfo = AppStartInfo(
-              nativeAppStart.isColdStart
-                  ? AppStartType.cold
-                  : AppStartType.warm,
-              start: DateTime.fromMillisecondsSinceEpoch(
-                  nativeAppStart.appStartTime.toInt()),
-              end: appStartEnd);
-          setAppStartInfo(appStartInfo);
-        });
-      }
+        final appStartInfo = AppStartInfo(
+            nativeAppStart.isColdStart ? AppStartType.cold : AppStartType.warm,
+            start: DateTime.fromMillisecondsSinceEpoch(
+                nativeAppStart.appStartTime.toInt()),
+            end: appStartEnd);
+        setAppStartInfo(appStartInfo);
+      });
     }
 
     options.addEventProcessor(NativeAppStartEventProcessor(_native));
@@ -103,9 +95,6 @@ class NativeAppStartIntegration extends Integration<SentryFlutterOptions> {
     options.sdk.addIntegration('nativeAppStartIntegration');
   }
 }
-
-/// Used to provide scheduler binding at call time.
-typedef SchedulerBindingProvider = FrameCallbackHandler? Function();
 
 enum AppStartType { cold, warm }
 

--- a/flutter/lib/src/integrations/native_app_start_integration.dart
+++ b/flutter/lib/src/integrations/native_app_start_integration.dart
@@ -7,23 +7,6 @@ import '../frame_callback_handler.dart';
 import '../native/sentry_native.dart';
 import '../event_processor/native_app_start_event_processor.dart';
 
-enum AppStartType { cold, warm }
-
-class AppStartInfo {
-  AppStartInfo(this.type, {required this.start, required this.end});
-
-  final AppStartType type;
-  final DateTime start;
-  final DateTime end;
-
-  SentryMeasurement toMeasurement() {
-    final duration = end.difference(start);
-    return type == AppStartType.cold
-        ? SentryMeasurement.coldAppStart(duration)
-        : SentryMeasurement.warmAppStart(duration);
-  }
-}
-
 /// Integration which handles communication with native frameworks in order to
 /// enrich [SentryTransaction] objects with app start data for mobile vitals.
 class NativeAppStartIntegration extends Integration<SentryFlutterOptions> {
@@ -126,3 +109,19 @@ class NativeAppStartIntegration extends Integration<SentryFlutterOptions> {
 /// Used to provide scheduler binding at call time.
 typedef SchedulerBindingProvider = FrameCallbackHandler? Function();
 
+enum AppStartType { cold, warm }
+
+class AppStartInfo {
+  AppStartInfo(this.type, {required this.start, required this.end});
+
+  final AppStartType type;
+  final DateTime start;
+  final DateTime end;
+
+  SentryMeasurement toMeasurement() {
+    final duration = end.difference(start);
+    return type == AppStartType.cold
+        ? SentryMeasurement.coldAppStart(duration)
+        : SentryMeasurement.warmAppStart(duration);
+  }
+}

--- a/flutter/lib/src/native/sentry_native.dart
+++ b/flutter/lib/src/native/sentry_native.dart
@@ -27,14 +27,8 @@ class SentryNative {
   /// Flag indicating if app start was already fetched.
   bool get didFetchAppStart => _didFetchAppStart;
 
-  bool _didAddAppStartMeasurement = false;
-
   /// Flag indicating if app start measurement was added to the first transaction.
-  bool get didAddAppStartMeasurement => _didAddAppStartMeasurement;
-
-  void setDidAddAppStartMeasurement(bool value) {
-    _didAddAppStartMeasurement = value;
-  }
+  bool didAddAppStartMeasurement = false;
 
   /// Fetch [NativeAppStart] from native channels. Can only be called once.
   Future<NativeAppStart?> fetchNativeAppStart() async {

--- a/flutter/lib/src/native/sentry_native.dart
+++ b/flutter/lib/src/native/sentry_native.dart
@@ -27,6 +27,15 @@ class SentryNative {
   /// Flag indicating if app start was already fetched.
   bool get didFetchAppStart => _didFetchAppStart;
 
+  bool _didAddAppStartMeasurement = false;
+
+  /// Flag indicating if app start measurement was added to the first transaction.
+  bool get didAddAppStartMeasurement => _didAddAppStartMeasurement;
+
+  void setDidAddAppStartMeasurement(bool value) {
+    _didAddAppStartMeasurement = value;
+  }
+
   /// Fetch [NativeAppStart] from native channels. Can only be called once.
   Future<NativeAppStart?> fetchNativeAppStart() async {
     _didFetchAppStart = true;

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -189,13 +189,7 @@ mixin SentryFlutter {
     if (_native != null) {
       integrations.add(NativeAppStartIntegration(
         _native!,
-        () {
-          try {
-            /// Flutter >= 2.12 throws if SchedulerBinding.instance isn't initialized.
-            return DefaultFrameCallbackHandler();
-          } catch (_) {}
-          return null;
-        },
+        DefaultFrameCallbackHandler(),
       ));
     }
     return integrations;
@@ -231,6 +225,7 @@ mixin SentryFlutter {
 
   @internal
   static SentryNative? get native => _native;
+
   @internal
   static set native(SentryNative? value) => _native = value;
   static SentryNative? _native;

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:ui';
 
-import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
@@ -9,6 +8,7 @@ import '../sentry_flutter.dart';
 import 'event_processor/android_platform_exception_event_processor.dart';
 import 'event_processor/flutter_exception_event_processor.dart';
 import 'event_processor/platform_exception_event_processor.dart';
+import 'frame_callback_handler.dart';
 import 'integrations/connectivity/connectivity_integration.dart';
 import 'integrations/screenshot_integration.dart';
 import 'native/factory.dart';
@@ -192,7 +192,7 @@ mixin SentryFlutter {
         () {
           try {
             /// Flutter >= 2.12 throws if SchedulerBinding.instance isn't initialized.
-            return SchedulerBinding.instance;
+            return DefaultFrameCallbackHandler();
           } catch (_) {}
           return null;
         },

--- a/flutter/test/fake_frame_callback_handler.dart
+++ b/flutter/test/fake_frame_callback_handler.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/scheduler.dart';
+import 'package:sentry_flutter/src/frame_callback_handler.dart';
+
+class FakeFrameCallbackHandler implements FrameCallbackHandler {
+  FrameCallback? storedCallback;
+
+  final Duration _finishAfterDuration;
+
+  FakeFrameCallbackHandler(
+      {Duration finishAfterDuration = const Duration(milliseconds: 500)})
+      : _finishAfterDuration = finishAfterDuration;
+
+  @override
+  void addPostFrameCallback(FrameCallback callback) async {
+    await Future.delayed(_finishAfterDuration);
+    callback(Duration.zero);
+  }
+}

--- a/flutter/test/fake_frame_callback_handler.dart
+++ b/flutter/test/fake_frame_callback_handler.dart
@@ -12,6 +12,7 @@ class FakeFrameCallbackHandler implements FrameCallbackHandler {
 
   @override
   void addPostFrameCallback(FrameCallback callback) async {
+    // ignore: inference_failure_on_instance_creation
     await Future.delayed(_finishAfterDuration);
     callback(Duration.zero);
   }

--- a/flutter/test/integrations/native_app_start_integration_test.dart
+++ b/flutter/test/integrations/native_app_start_integration_test.dart
@@ -91,8 +91,8 @@ void main() {
       expect(enriched.measurements.isEmpty, true);
     });
 
-
-    test('native app start integration is called and sets app start info', () async {
+    test('native app start integration is called and sets app start info',
+        () async {
       fixture.native.appStartEnd = DateTime.fromMillisecondsSinceEpoch(10);
       fixture.binding.nativeAppStart = NativeAppStart(0, true);
 
@@ -119,10 +119,7 @@ class Fixture {
   NativeAppStartIntegration getNativeAppStartIntegration() {
     return NativeAppStartIntegration(
       native,
-      () {
-        TestWidgetsFlutterBinding.ensureInitialized();
-        return FakeFrameCallbackHandler();
-      },
+      FakeFrameCallbackHandler(),
     );
   }
 

--- a/flutter/test/integrations/native_app_start_integration_test.dart
+++ b/flutter/test/integrations/native_app_start_integration_test.dart
@@ -90,6 +90,18 @@ void main() {
 
       expect(enriched.measurements.isEmpty, true);
     });
+
+
+    test('native app start integration is called and sets app start info', () async {
+      fixture.native.appStartEnd = DateTime.fromMillisecondsSinceEpoch(10);
+      fixture.binding.nativeAppStart = NativeAppStart(0, true);
+
+      fixture.getNativeAppStartIntegration().call(fixture.hub, fixture.options);
+
+      final appStartInfo = await NativeAppStartIntegration.getAppStartInfo();
+      expect(appStartInfo?.start, DateTime.fromMillisecondsSinceEpoch(0));
+      expect(appStartInfo?.end, DateTime.fromMillisecondsSinceEpoch(10));
+    });
   });
 }
 

--- a/flutter/test/integrations/native_app_start_integration_test.dart
+++ b/flutter/test/integrations/native_app_start_integration_test.dart
@@ -1,5 +1,4 @@
 @TestOn('vm')
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
@@ -7,6 +6,7 @@ import 'package:sentry_flutter/src/integrations/native_app_start_integration.dar
 import 'package:sentry_flutter/src/native/sentry_native.dart';
 import 'package:sentry/src/sentry_tracer.dart';
 
+import '../fake_frame_callback_handler.dart';
 import '../mocks.dart';
 import '../mocks.mocks.dart';
 
@@ -18,10 +18,10 @@ void main() {
       TestWidgetsFlutterBinding.ensureInitialized();
 
       fixture = Fixture();
+      NativeAppStartIntegration.clearAppStartInfo();
     });
 
     test('native app start measurement added to first transaction', () async {
-      fixture.options.autoAppStart = false;
       fixture.native.appStartEnd = DateTime.fromMillisecondsSinceEpoch(10);
       fixture.binding.nativeAppStart = NativeAppStart(0, true);
 
@@ -40,7 +40,6 @@ void main() {
 
     test('native app start measurement not added to following transactions',
         () async {
-      fixture.options.autoAppStart = false;
       fixture.native.appStartEnd = DateTime.fromMillisecondsSinceEpoch(10);
       fixture.binding.nativeAppStart = NativeAppStart(0, true);
 
@@ -58,7 +57,6 @@ void main() {
     });
 
     test('measurements appended', () async {
-      fixture.options.autoAppStart = false;
       fixture.native.appStartEnd = DateTime.fromMillisecondsSinceEpoch(10);
       fixture.binding.nativeAppStart = NativeAppStart(0, true);
       final measurement = SentryMeasurement.warmAppStart(Duration(seconds: 1));
@@ -79,7 +77,6 @@ void main() {
     });
 
     test('native app start measurement not added if more than 60s', () async {
-      fixture.options.autoAppStart = false;
       fixture.native.appStartEnd = DateTime.fromMillisecondsSinceEpoch(60001);
       fixture.binding.nativeAppStart = NativeAppStart(0, true);
 
@@ -111,7 +108,8 @@ class Fixture {
     return NativeAppStartIntegration(
       native,
       () {
-        return TestWidgetsFlutterBinding.ensureInitialized();
+        TestWidgetsFlutterBinding.ensureInitialized();
+        return FakeFrameCallbackHandler();
       },
     );
   }

--- a/flutter/test/mocks.dart
+++ b/flutter/test/mocks.dart
@@ -171,10 +171,8 @@ class TestMockSentryNative implements SentryNative {
   @override
   bool get didFetchAppStart => _didFetchAppStart;
 
-  bool _didAddAppStartMeasurement = false;
-
   @override
-  bool get didAddAppStartMeasurement => _didAddAppStartMeasurement;
+  bool didAddAppStartMeasurement = false;
 
   Breadcrumb? breadcrumb;
   var numberOfAddBreadcrumbCalls = 0;
@@ -294,11 +292,6 @@ class TestMockSentryNative implements SentryNative {
   Future<void> discardProfiler(SentryId traceId) {
     numberOfDiscardProfilerCalls++;
     return Future.value(null);
-  }
-
-  @override
-  void setDidAddAppStartMeasurement(bool value) {
-    _didAddAppStartMeasurement = value;
   }
 }
 

--- a/flutter/test/mocks.dart
+++ b/flutter/test/mocks.dart
@@ -171,6 +171,11 @@ class TestMockSentryNative implements SentryNative {
   @override
   bool get didFetchAppStart => _didFetchAppStart;
 
+  bool _didAddAppStartMeasurement = false;
+
+  @override
+  bool get didAddAppStartMeasurement => _didAddAppStartMeasurement;
+
   Breadcrumb? breadcrumb;
   var numberOfAddBreadcrumbCalls = 0;
   var numberOfBeginNativeFramesCollectionCalls = 0;
@@ -289,6 +294,11 @@ class TestMockSentryNative implements SentryNative {
   Future<void> discardProfiler(SentryId traceId) {
     numberOfDiscardProfilerCalls++;
     return Future.value(null);
+  }
+
+  @override
+  void setDidAddAppStartMeasurement(bool value) {
+    _didAddAppStartMeasurement = value;
   }
 }
 


### PR DESCRIPTION
## :scroll: Description
Refactor the app start to be fetched in integration and not in event processor. The event processor is only used for attaching the measurement in this case.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is a prerequisite for TTID/TTFD implementation since TTID requires app start as well

This is also a split pr of #1882 

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
