### PR TITLE
Apply `beforeBreadcrumb` on native iOS crumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Use `recordHttpBreadcrumbs` to set iOS `enableNetworkBreadcrumbs` ([#1884](https://github.com/getsentry/sentry-dart/pull/1884))
+- Apply `beforeBreadcrumb` on native iOS crumbs ([#1914](https://github.com/getsentry/sentry-dart/pull/1914))
 
 ### Improvements
 

--- a/flutter/lib/src/integrations/load_contexts_integration.dart
+++ b/flutter/lib/src/integrations/load_contexts_integration.dart
@@ -155,13 +155,23 @@ class _LoadContextsIntegrationEventProcessor implements EventProcessor {
         final breadcrumbsJson =
             List<Map<dynamic, dynamic>>.from(breadcrumbsList);
         final breadcrumbs = <Breadcrumb>[];
+        final beforeBreadcrumb = _options.beforeBreadcrumb;
 
         for (final breadcrumbJson in breadcrumbsJson) {
           final breadcrumb = Breadcrumb.fromJson(
             Map<String, dynamic>.from(breadcrumbJson),
           );
-          breadcrumbs.add(breadcrumb);
+
+          if (beforeBreadcrumb != null) {
+            final processedBreadcrumb = beforeBreadcrumb(breadcrumb);
+            if (processedBreadcrumb != null) {
+              breadcrumbs.add(processedBreadcrumb);
+            }
+          } else {
+            breadcrumbs.add(breadcrumb);
+          }
         }
+
         event = event.copyWith(breadcrumbs: breadcrumbs);
       }
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Call Sentry Flutters `beforeBreadcrumb` on native iOS breadcrumbs.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Relates to #1903

## :green_heart: How did you test it?

Unit tests. Tested with example app.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps

Since we sync contexts only on iOS, this would only work for iOS native breadcrumbs. Functionality on Android would stay as before.
