### PR TITLE
Introduce `BeforeInitNativeSDKCallback`

### DIFF
--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -90,6 +90,12 @@ Future<void> setupSentry(
         options.environment = 'integration';
         options.beforeSend = beforeSendCallback;
       }
+
+      options.beforeInitNativeSdk = (arguments) {
+        arguments['recordHttpBreadcrumbs'] = false;
+        return arguments;
+      };
+
     },
     // Init your App.
     appRunner: appRunner,

--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -92,7 +92,7 @@ Future<void> setupSentry(
       }
 
       options.beforeInitNativeSdk = (arguments) {
-        arguments['recordHttpBreadcrumbs'] = false;
+        arguments['captureFailedRequests'] = false;
         return arguments;
       };
 

--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -91,6 +91,7 @@ Future<void> setupSentry(
         options.beforeSend = beforeSendCallback;
       }
 
+      options.captureFailedRequests = true;
       options.beforeInitNativeSdk = (arguments) {
         arguments['captureFailedRequests'] = false;
         return arguments;

--- a/flutter/lib/src/integrations/native_sdk_integration.dart
+++ b/flutter/lib/src/integrations/native_sdk_integration.dart
@@ -17,45 +17,52 @@ class NativeSdkIntegration implements Integration<SentryFlutterOptions> {
     if (!options.autoInitializeNativeSdk) {
       return;
     }
-    try {
-      await _channel.invokeMethod('initNativeSdk', <String, dynamic>{
-        'dsn': options.dsn,
-        'debug': options.debug,
-        'environment': options.environment,
-        'release': options.release,
-        'enableAutoSessionTracking': options.enableAutoSessionTracking,
-        'enableNativeCrashHandling': options.enableNativeCrashHandling,
-        'attachStacktrace': options.attachStacktrace,
-        'attachThreads': options.attachThreads,
-        'autoSessionTrackingIntervalMillis':
-            options.autoSessionTrackingInterval.inMilliseconds,
-        'dist': options.dist,
-        'integrations': options.sdk.integrations,
-        'packages':
-            options.sdk.packages.map((e) => e.toJson()).toList(growable: false),
-        'diagnosticLevel': options.diagnosticLevel.name,
-        'maxBreadcrumbs': options.maxBreadcrumbs,
-        'anrEnabled': options.anrEnabled,
-        'anrTimeoutIntervalMillis': options.anrTimeoutInterval.inMilliseconds,
-        'enableAutoNativeBreadcrumbs': options.enableAutoNativeBreadcrumbs,
-        'maxCacheItems': options.maxCacheItems,
-        'sendDefaultPii': options.sendDefaultPii,
-        'enableWatchdogTerminationTracking':
-            options.enableWatchdogTerminationTracking,
-        'enableNdkScopeSync': options.enableNdkScopeSync,
-        'enableAutoPerformanceTracing': options.enableAutoPerformanceTracing,
-        'sendClientReports': options.sendClientReports,
-        'proguardUuid': options.proguardUuid,
-        'maxAttachmentSize': options.maxAttachmentSize,
-        'recordHttpBreadcrumbs': options.recordHttpBreadcrumbs,
-        'captureFailedRequests': options.captureFailedRequests,
-        'enableAppHangTracking': options.enableAppHangTracking,
-        'connectionTimeoutMillis': options.connectionTimeout.inMilliseconds,
-        'readTimeoutMillis': options.readTimeout.inMilliseconds,
-        'appHangTimeoutIntervalMillis':
-            options.appHangTimeoutInterval.inMilliseconds,
-      });
 
+    var arguments = <String, dynamic>{
+      'dsn': options.dsn,
+      'debug': options.debug,
+      'environment': options.environment,
+      'release': options.release,
+      'enableAutoSessionTracking': options.enableAutoSessionTracking,
+      'enableNativeCrashHandling': options.enableNativeCrashHandling,
+      'attachStacktrace': options.attachStacktrace,
+      'attachThreads': options.attachThreads,
+      'autoSessionTrackingIntervalMillis':
+      options.autoSessionTrackingInterval.inMilliseconds,
+      'dist': options.dist,
+      'integrations': options.sdk.integrations,
+      'packages':
+      options.sdk.packages.map((e) => e.toJson()).toList(growable: false),
+      'diagnosticLevel': options.diagnosticLevel.name,
+      'maxBreadcrumbs': options.maxBreadcrumbs,
+      'anrEnabled': options.anrEnabled,
+      'anrTimeoutIntervalMillis': options.anrTimeoutInterval.inMilliseconds,
+      'enableAutoNativeBreadcrumbs': options.enableAutoNativeBreadcrumbs,
+      'maxCacheItems': options.maxCacheItems,
+      'sendDefaultPii': options.sendDefaultPii,
+      'enableWatchdogTerminationTracking':
+      options.enableWatchdogTerminationTracking,
+      'enableNdkScopeSync': options.enableNdkScopeSync,
+      'enableAutoPerformanceTracing': options.enableAutoPerformanceTracing,
+      'sendClientReports': options.sendClientReports,
+      'proguardUuid': options.proguardUuid,
+      'maxAttachmentSize': options.maxAttachmentSize,
+      'recordHttpBreadcrumbs': options.recordHttpBreadcrumbs,
+      'captureFailedRequests': options.captureFailedRequests,
+      'enableAppHangTracking': options.enableAppHangTracking,
+      'connectionTimeoutMillis': options.connectionTimeout.inMilliseconds,
+      'readTimeoutMillis': options.readTimeout.inMilliseconds,
+      'appHangTimeoutIntervalMillis':
+      options.appHangTimeoutInterval.inMilliseconds,
+    };
+
+    try {
+      final beforeInitNativeSdk = options.beforeInitNativeSdk;
+      if (beforeInitNativeSdk != null) {
+        arguments = await beforeInitNativeSdk(arguments);
+      }
+
+      await _channel.invokeMethod('initNativeSdk', arguments);
       options.sdk.addIntegration('nativeSdkIntegration');
     } catch (exception, stackTrace) {
       options.logger(

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -28,6 +28,11 @@ class SentryFlutterOptions extends SentryOptions {
   /// Defaults to `true`.
   bool autoInitializeNativeSdk = true;
 
+  /// Set so you can mutate arguments being passed to sentry native SDKs.
+  ///
+  /// NOTE: Be careful and only use this if you know what you are doing.
+  BeforeInitNativeSDKCallback? beforeInitNativeSdk;
+
   /// Enable or disable reporting of used packages.
   bool reportPackages = true;
 
@@ -307,3 +312,9 @@ typedef BeforeScreenshotCallback = FutureOr<bool> Function(
   SentryEvent event, {
   Hint? hint,
 });
+
+/// Callback being executed in [NativeSdkIntegration] before passing arguments
+/// to sentry native.
+typedef BeforeInitNativeSDKCallback = FutureOr<Map<String, dynamic>> Function(
+  Map<String, dynamic> arguments,
+);


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Provide uses with a callback to mutate arguments passed to native SDKs. This is just an idea to resolve #1877 and we should discuss if this is a viable solution. 

We could introduce `SentryNativeOptions` and pass it instead of the map, so we'd have type safety and maybe also only expose a subset of options.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Relates to #1877

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
