### PR TITLE
fix: transaction timestamp trimming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fixes
+
+- Fix transaction end timestamp trimming ([#1916](https://github.com/getsentry/sentry-dart/pull/1916))
+  - Transaction end timestamps are now correctly trimmed to the latest child span end timestamp
+
 ### Features
 
 - Use `recordHttpBreadcrumbs` to set iOS `enableNetworkBreadcrumbs` ([#1884](https://github.com/getsentry/sentry-dart/pull/1884))

--- a/dart/lib/src/sentry_tracer.dart
+++ b/dart/lib/src/sentry_tracer.dart
@@ -114,7 +114,7 @@ class SentryTracer extends ISentrySpan {
       if (_trimEnd && children.isNotEmpty) {
         DateTime? latestEndTime;
 
-        for (var child in children) {
+        for (final child in children) {
           final childEndTimestamp = child.endTimestamp;
           if (childEndTimestamp != null) {
             if (latestEndTime == null ||

--- a/dart/lib/src/sentry_tracer.dart
+++ b/dart/lib/src/sentry_tracer.dart
@@ -49,9 +49,9 @@ class SentryTracer extends ISentrySpan {
   /// highest timestamp of child spans, trimming the duration of the
   /// transaction. This is useful to discard extra time in the transaction that
   /// is not accounted for in child spans, like what happens in the
-  /// [SentryNavigatorObserver] idle transactions, where we finish the
-  /// transaction after a given "idle time" and we don't want this "idle time"
-  /// to be part of the transaction.
+  /// [SentryNavigatorObserver](https://pub.dev/documentation/sentry_flutter/latest/sentry_flutter/SentryNavigatorObserver-class.html)
+  /// idle transactions, where we finish the transaction after a given
+  /// "idle time" and we don't want this "idle time" to be part of the transaction.
   SentryTracer(
     SentryTransactionContext transactionContext,
     this._hub, {

--- a/dart/lib/src/sentry_tracer.dart
+++ b/dart/lib/src/sentry_tracer.dart
@@ -368,8 +368,7 @@ class SentryTracer extends ISentrySpan {
       Dsn.parse(_hub.options.dsn!).publicKey,
       release: _hub.options.release,
       environment: _hub.options.environment,
-      userId: null,
-      // because of PII not sending it for now
+      userId: null, // because of PII not sending it for now
       userSegment: user?.segment,
       transaction:
           _isHighQualityTransactionName(transactionNameSource) ? name : null,

--- a/dart/test/sentry_tracer_test.dart
+++ b/dart/test/sentry_tracer_test.dart
@@ -397,9 +397,9 @@ void main() {
       final childB = sut.startChild('operation-b', description: 'description');
       final childC = sut.startChild('operation-c', description: 'description');
 
-      await childA.finish(endTimestamp: childEnd1);
-      await childB.finish(endTimestamp: childEnd2);
-      await childC.finish(endTimestamp: childEnd3);
+      await childA.finish(endTimestamp: childAEnd);
+      await childB.finish(endTimestamp: childBEnd);
+      await childC.finish(endTimestamp: childCEnd);
 
       await sut.finish(endTimestamp: rootEndInitial);
 

--- a/dart/test/sentry_tracer_test.dart
+++ b/dart/test/sentry_tracer_test.dart
@@ -386,6 +386,28 @@ void main() {
       expect(sut.endTimestamp, endTimestamp);
     });
 
+    test('end trimmed to latest child end timestamp', () async {
+      final sut = fixture.getSut(trimEnd: true);
+      final rootEndInitial = getUtcDateTime();
+      final childEnd1 = rootEndInitial;
+      final childEnd2 = rootEndInitial.add(Duration(seconds: 1));
+      final childEnd3 = rootEndInitial;
+
+      final childA = sut.startChild('operation-a', description: 'description');
+      final childB = sut.startChild('operation-b', description: 'description');
+      final childC = sut.startChild('operation-c', description: 'description');
+
+      await childA.finish(endTimestamp: childEnd1);
+      await childB.finish(endTimestamp: childEnd2);
+      await childC.finish(endTimestamp: childEnd3);
+
+      await sut.finish(endTimestamp: rootEndInitial);
+
+      expect(sut.endTimestamp, equals(childB.endTimestamp),
+          reason:
+          'The root end timestamp should be updated to match the latest child end timestamp.');
+    });
+
     test('does not add more spans than configured in options', () async {
       fixture.hub.options.maxSpans = 2;
       final sut = fixture.getSut();

--- a/dart/test/sentry_tracer_test.dart
+++ b/dart/test/sentry_tracer_test.dart
@@ -405,7 +405,7 @@ void main() {
 
       expect(sut.endTimestamp, equals(childB.endTimestamp),
           reason:
-          'The root end timestamp should be updated to match the latest child end timestamp.');
+              'The root end timestamp should be updated to match the latest child end timestamp.');
     });
 
     test('does not add more spans than configured in options', () async {

--- a/dart/test/sentry_tracer_test.dart
+++ b/dart/test/sentry_tracer_test.dart
@@ -389,9 +389,9 @@ void main() {
     test('end trimmed to latest child end timestamp', () async {
       final sut = fixture.getSut(trimEnd: true);
       final rootEndInitial = getUtcDateTime();
-      final childEnd1 = rootEndInitial;
-      final childEnd2 = rootEndInitial.add(Duration(seconds: 1));
-      final childEnd3 = rootEndInitial;
+      final childAEnd = rootEndInitial;
+      final childBEnd = rootEndInitial.add(Duration(seconds: 1));
+      final childCEnd = rootEndInitial;
 
       final childA = sut.startChild('operation-a', description: 'description');
       final childB = sut.startChild('operation-b', description: 'description');


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Correctly trims the transaction end to the end of the longest running child span

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This bug has been discovered during TTFD development

## :green_heart: How did you test it?
Unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
