### PR TITLE
Add override `captureFailedRequests` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ## Features
 
 - Add override `captureFailedRequests` option ([#1931](https://github.com/getsentry/sentry-dart/pull/1931))
+  - The `dio` integration and `SentryHttpClient` now take an additional `captureFailedRequests` option.
+  - This is useful if you want to disable this option on native and only enable it on `dio` for example.
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Features
+
+- Add override `captureFailedRequests` option ([#1931](https://github.com/getsentry/sentry-dart/pull/1931))
+
 ### Dependencies
 
 - Bump Android SDK from v7.5.0 to v7.6.0 ([#1927](https://github.com/getsentry/sentry-dart/pull/1927))
@@ -29,7 +33,6 @@
     - `didPop` doesn't trigger a new transaction
     - Change transaction operation name to `ui.load` instead of `navigation`
 - Use `recordHttpBreadcrumbs` to set iOS `enableNetworkBreadcrumbs` ([#1884](https://github.com/getsentry/sentry-dart/pull/1884))
-- Add override `captureFailedRequests` option ([#1931](https://github.com/getsentry/sentry-dart/pull/1931))
 - Apply `beforeBreadcrumb` on native iOS crumbs ([#1914](https://github.com/getsentry/sentry-dart/pull/1914))
 - Add `maxQueueSize` to limit the number of unawaited events sent to Sentry ([#1868](https://github.com/getsentry/sentry-dart/pull/1868))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Use `recordHttpBreadcrumbs` to set iOS `enableNetworkBreadcrumbs` ([#1884](https://github.com/getsentry/sentry-dart/pull/1884))
+- Add override `captureFailedRequests` option ([#1931](https://github.com/getsentry/sentry-dart/pull/1931))
 
 ### Improvements
 

--- a/dart/lib/src/http_client/failed_request_client.dart
+++ b/dart/lib/src/http_client/failed_request_client.dart
@@ -77,11 +77,7 @@ class FailedRequestClient extends BaseClient {
   })  : _hub = hub ?? HubAdapter(),
         _client = client ?? Client(),
         _captureFailedRequests = captureFailedRequests {
-    if (captureFailedRequests == null) {
-      if (_hub.options.captureFailedRequests) {
-        _hub.options.sdk.addIntegration('HTTPClientError');
-      }
-    } else if (captureFailedRequests) {
+    if (captureFailedRequests ?? _hub.options.captureFailedRequests) {
       _hub.options.sdk.addIntegration('HTTPClientError');
     }
   }
@@ -136,11 +132,7 @@ class FailedRequestClient extends BaseClient {
       StackTrace? stackTrace,
       StreamedResponse? response,
       Duration duration) async {
-
-    if (_captureFailedRequests == false) {
-      return;
-    }
-    if (_captureFailedRequests != true && !_hub.options.captureFailedRequests) {
+    if (!(_captureFailedRequests ?? _hub.options.captureFailedRequests)) {
       return;
     }
 

--- a/dart/lib/src/http_client/sentry_http_client.dart
+++ b/dart/lib/src/http_client/sentry_http_client.dart
@@ -73,6 +73,9 @@ import 'failed_request_client.dart';
 /// Remarks:
 /// HTTP traffic can contain PII (personal identifiable information).
 /// Read more on data scrubbing [here](https://docs.sentry.io/product/data-management-settings/advanced-datascrubbing/).
+///
+/// The constructor parameter `captureFailedRequests` will override what you
+/// have configured in options.
 /// ```
 class SentryHttpClient extends BaseClient {
   static const defaultFailedRequestStatusCodes = [
@@ -86,6 +89,7 @@ class SentryHttpClient extends BaseClient {
     List<SentryStatusCode> failedRequestStatusCodes =
         defaultFailedRequestStatusCodes,
     List<String> failedRequestTargets = defaultFailedRequestTargets,
+    bool? captureFailedRequests,
   }) {
     _hub = hub ?? HubAdapter();
 
@@ -96,6 +100,7 @@ class SentryHttpClient extends BaseClient {
       failedRequestTargets: failedRequestTargets,
       hub: _hub,
       client: innerClient,
+      captureFailedRequests: captureFailedRequests,
     );
 
     if (_hub.options.isTracingEnabled()) {

--- a/dart/test/http_client/failed_request_client_test.dart
+++ b/dart/test/http_client/failed_request_client_test.dart
@@ -70,7 +70,9 @@ void main() {
       expect(eventCall.contexts.response, isNull);
     });
 
-    test('exception does not gets reported if client throws but override disables capture', () async {
+    test(
+        'exception does not gets reported if client throws but override disables capture',
+        () async {
       fixture._hub.options.captureFailedRequests = true;
       fixture._hub.options.sendDefaultPii = true;
 
@@ -80,7 +82,7 @@ void main() {
       );
 
       await expectLater(
-            () async => await sut.get(requestUri, headers: {'Cookie': 'foo=bar'}),
+        () async => await sut.get(requestUri, headers: {'Cookie': 'foo=bar'}),
         throwsException,
       );
 
@@ -111,7 +113,7 @@ void main() {
       );
 
       await expectLater(
-            () async => await sut.get(requestUri, headers: {'Cookie': 'foo=bar'}),
+        () async => await sut.get(requestUri, headers: {'Cookie': 'foo=bar'}),
         throwsException,
       );
 
@@ -375,12 +377,11 @@ class Fixture {
   }) {
     final mc = client ?? getClient();
     return FailedRequestClient(
-      client: mc,
-      hub: _hub,
-      failedRequestStatusCodes: failedRequestStatusCodes,
-      failedRequestTargets: failedRequestTargets,
-      captureFailedRequests: captureFailedRequests
-    );
+        client: mc,
+        hub: _hub,
+        failedRequestStatusCodes: failedRequestStatusCodes,
+        failedRequestTargets: failedRequestTargets,
+        captureFailedRequests: captureFailedRequests);
   }
 
   MockClient getClient(

--- a/dart/test/http_client/sentry_http_client_test.dart
+++ b/dart/test/http_client/sentry_http_client_test.dart
@@ -49,7 +49,7 @@ void main() {
 
       final sut = fixture.getSut(
         client: createThrowingClient(),
-          captureFailedRequests: true,
+        captureFailedRequests: true,
       );
 
       await expectLater(() async => await sut.get(requestUri), throwsException);
@@ -75,7 +75,9 @@ void main() {
       expect(fixture.hub.addBreadcrumbCalls.length, 1);
     });
 
-    test('no captured event with when enabling $FailedRequestClient with override', () async {
+    test(
+        'no captured event with when enabling $FailedRequestClient with override',
+        () async {
       fixture.hub.options.captureFailedRequests = true;
       final sut = fixture.getSut(
         client: createThrowingClient(),

--- a/dart/test/http_client/sentry_http_client_test.dart
+++ b/dart/test/http_client/sentry_http_client_test.dart
@@ -32,15 +32,29 @@ void main() {
     });
 
     test('no captured event with default config', () async {
+      fixture.hub.options.captureFailedRequests = false;
+
       final sut = fixture.getSut(
         client: createThrowingClient(),
-        captureFailedRequests: false,
       );
 
       await expectLater(() async => await sut.get(requestUri), throwsException);
 
       expect(fixture.hub.captureEventCalls.length, 0);
       expect(fixture.hub.addBreadcrumbCalls.length, 1);
+    });
+
+    test('captured event with override', () async {
+      fixture.hub.options.captureFailedRequests = false;
+
+      final sut = fixture.getSut(
+        client: createThrowingClient(),
+          captureFailedRequests: true,
+      );
+
+      await expectLater(() async => await sut.get(requestUri), throwsException);
+
+      expect(fixture.hub.captureEventCalls.length, 1);
     });
 
     test('one captured event with when enabling $FailedRequestClient',
@@ -59,6 +73,18 @@ void main() {
       // The breadcrumb for the request should still be added for every
       // following event.
       expect(fixture.hub.addBreadcrumbCalls.length, 1);
+    });
+
+    test('no captured event with when enabling $FailedRequestClient with override', () async {
+      fixture.hub.options.captureFailedRequests = true;
+      final sut = fixture.getSut(
+        client: createThrowingClient(),
+        captureFailedRequests: false,
+      );
+
+      await expectLater(() async => await sut.get(requestUri), throwsException);
+
+      expect(fixture.hub.captureEventCalls.length, 0);
     });
 
     test('close does get called for user defined client', () async {
@@ -116,14 +142,14 @@ class Fixture {
   SentryHttpClient getSut({
     MockClient? client,
     List<SentryStatusCode> badStatusCodes = const [],
-    bool captureFailedRequests = true,
+    bool? captureFailedRequests,
   }) {
     final mc = client ?? getClient();
-    hub.options.captureFailedRequests = captureFailedRequests;
     return SentryHttpClient(
       client: mc,
       hub: hub,
       failedRequestStatusCodes: badStatusCodes,
+      captureFailedRequests: captureFailedRequests,
     );
   }
 

--- a/dio/lib/src/failed_request_interceptor.dart
+++ b/dio/lib/src/failed_request_interceptor.dart
@@ -27,8 +27,8 @@ class FailedRequestInterceptor extends Interceptor {
     ErrorInterceptorHandler handler,
   ) async {
     // ignore: invalid_use_of_internal_member
-    final captureFailedRequests =
-        _captureFailedRequests ?? _hub.options.captureFailedRequests;
+    final cfr = _captureFailedRequests ?? _hub.options.captureFailedRequests;
+
     final containsStatusCode =
         _failedRequestStatusCodes.containsStatusCode(err.response?.statusCode);
     final containsRequestTarget = containsTargetOrMatchesRegExp(
@@ -36,7 +36,7 @@ class FailedRequestInterceptor extends Interceptor {
       err.requestOptions.path,
     );
 
-    if (captureFailedRequests && containsStatusCode && containsRequestTarget) {
+    if (cfr && containsStatusCode && containsRequestTarget) {
       final mechanism = Mechanism(type: 'SentryDioClientAdapter');
       final throwableMechanism = ThrowableMechanism(mechanism, err);
 

--- a/dio/lib/src/failed_request_interceptor.dart
+++ b/dio/lib/src/failed_request_interceptor.dart
@@ -27,7 +27,8 @@ class FailedRequestInterceptor extends Interceptor {
     ErrorInterceptorHandler handler,
   ) async {
     // ignore: invalid_use_of_internal_member
-    final captureFailedRequests = _captureFailedRequests ?? _hub.options.captureFailedRequests;
+    final captureFailedRequests =
+        _captureFailedRequests ?? _hub.options.captureFailedRequests;
     final containsStatusCode =
         _failedRequestStatusCodes.containsStatusCode(err.response?.statusCode);
     final containsRequestTarget = containsTargetOrMatchesRegExp(

--- a/dio/lib/src/failed_request_interceptor.dart
+++ b/dio/lib/src/failed_request_interceptor.dart
@@ -10,13 +10,16 @@ class FailedRequestInterceptor extends Interceptor {
         SentryHttpClient.defaultFailedRequestStatusCodes,
     List<String> failedRequestTargets =
         SentryHttpClient.defaultFailedRequestTargets,
+    bool? captureFailedRequests,
   })  : _hub = hub ?? HubAdapter(),
         _failedRequestStatusCodes = failedRequestStatusCodes,
-        _failedRequestTargets = failedRequestTargets;
+        _failedRequestTargets = failedRequestTargets,
+        _captureFailedRequests = captureFailedRequests;
 
   final Hub _hub;
   final List<SentryStatusCode> _failedRequestStatusCodes;
   final List<String> _failedRequestTargets;
+  final bool? _captureFailedRequests;
 
   @override
   Future<void> onError(
@@ -24,8 +27,7 @@ class FailedRequestInterceptor extends Interceptor {
     ErrorInterceptorHandler handler,
   ) async {
     // ignore: invalid_use_of_internal_member
-    final captureFailedRequests = _hub.options.captureFailedRequests;
-
+    final captureFailedRequests = _captureFailedRequests ?? _hub.options.captureFailedRequests;
     final containsStatusCode =
         _failedRequestStatusCodes.containsStatusCode(err.response?.statusCode);
     final containsRequestTarget = containsTargetOrMatchesRegExp(

--- a/dio/lib/src/sentry_dio_extension.dart
+++ b/dio/lib/src/sentry_dio_extension.dart
@@ -42,12 +42,15 @@ extension SentryDioExtension on Dio {
   ///   failedRequestTargets: ['my-api.com'],
   /// );
   /// ```
+  ///
+  /// The captureFailedRequests argument will take precedent over options.
   void addSentry({
     Hub? hub,
     List<SentryStatusCode> failedRequestStatusCodes =
         SentryHttpClient.defaultFailedRequestStatusCodes,
     List<String> failedRequestTargets =
         SentryHttpClient.defaultFailedRequestTargets,
+    bool? captureFailedRequests,
   }) {
     hub = hub ?? HubAdapter();
 
@@ -71,7 +74,7 @@ extension SentryDioExtension on Dio {
     }
     options.sdk.addPackage(packageName, sdkVersion);
 
-    if (options.captureFailedRequests) {
+    if (captureFailedRequests ?? options.captureFailedRequests) {
       // Add FailedRequestInterceptor at index 0, so it's the first interceptor.
       // This ensures that it is called and not skipped by any previous interceptor.
       interceptors.insert(

--- a/dio/test/sentry_dio_extension_test.dart
+++ b/dio/test/sentry_dio_extension_test.dart
@@ -49,7 +49,9 @@ void main() {
       );
     });
 
-    test('addSentry adds $FailedRequestInterceptor if captureFailedRequests true', () {
+    test(
+        'addSentry adds $FailedRequestInterceptor if captureFailedRequests true',
+        () {
       final dio = fixture.getSut();
 
       fixture.hub.options.captureFailedRequests = true;
@@ -57,14 +59,14 @@ void main() {
       dio.addSentry(hub: fixture.hub);
 
       expect(
-        dio.interceptors
-            .whereType<FailedRequestInterceptor>()
-            .length,
+        dio.interceptors.whereType<FailedRequestInterceptor>().length,
         1,
       );
     });
 
-    test('addSentry does not add $FailedRequestInterceptor if captureFailedRequests false', () {
+    test(
+        'addSentry does not add $FailedRequestInterceptor if captureFailedRequests false',
+        () {
       final dio = fixture.getSut();
 
       fixture.hub.options.captureFailedRequests = false;
@@ -72,9 +74,7 @@ void main() {
       dio.addSentry(hub: fixture.hub);
 
       expect(
-        dio.interceptors
-            .whereType<FailedRequestInterceptor>()
-            .length,
+        dio.interceptors.whereType<FailedRequestInterceptor>().length,
         0,
       );
     });
@@ -87,14 +87,13 @@ void main() {
       dio.addSentry(hub: fixture.hub, captureFailedRequests: true);
 
       expect(
-        dio.interceptors
-            .whereType<FailedRequestInterceptor>()
-            .length,
+        dio.interceptors.whereType<FailedRequestInterceptor>().length,
         1,
       );
     });
 
-    test('addSentry does not add $FailedRequestInterceptor if override false', () {
+    test('addSentry does not add $FailedRequestInterceptor if override false',
+        () {
       final dio = fixture.getSut();
 
       fixture.hub.options.captureFailedRequests = true;
@@ -102,9 +101,7 @@ void main() {
       dio.addSentry(hub: fixture.hub, captureFailedRequests: false);
 
       expect(
-        dio.interceptors
-            .whereType<FailedRequestInterceptor>()
-            .length,
+        dio.interceptors.whereType<FailedRequestInterceptor>().length,
         0,
       );
     });

--- a/dio/test/sentry_dio_extension_test.dart
+++ b/dio/test/sentry_dio_extension_test.dart
@@ -4,6 +4,7 @@ import 'package:dio/dio.dart';
 import 'package:sentry_dio/sentry_dio.dart';
 import 'package:sentry_dio/src/dio_error_extractor.dart';
 import 'package:sentry_dio/src/dio_stacktrace_extractor.dart';
+import 'package:sentry_dio/src/failed_request_interceptor.dart';
 import 'package:sentry_dio/src/sentry_dio_client_adapter.dart';
 import 'package:sentry_dio/src/sentry_dio_extension.dart';
 import 'package:sentry_dio/src/sentry_transformer.dart';
@@ -45,6 +46,66 @@ void main() {
             .whereType<DioEventProcessor>()
             .length,
         1,
+      );
+    });
+
+    test('addSentry adds $FailedRequestInterceptor if captureFailedRequests true', () {
+      final dio = fixture.getSut();
+
+      fixture.hub.options.captureFailedRequests = true;
+
+      dio.addSentry(hub: fixture.hub);
+
+      expect(
+        dio.interceptors
+            .whereType<FailedRequestInterceptor>()
+            .length,
+        1,
+      );
+    });
+
+    test('addSentry does not add $FailedRequestInterceptor if captureFailedRequests false', () {
+      final dio = fixture.getSut();
+
+      fixture.hub.options.captureFailedRequests = false;
+
+      dio.addSentry(hub: fixture.hub);
+
+      expect(
+        dio.interceptors
+            .whereType<FailedRequestInterceptor>()
+            .length,
+        0,
+      );
+    });
+
+    test('addSentry adds $FailedRequestInterceptor if override true', () {
+      final dio = fixture.getSut();
+
+      fixture.hub.options.captureFailedRequests = false;
+
+      dio.addSentry(hub: fixture.hub, captureFailedRequests: true);
+
+      expect(
+        dio.interceptors
+            .whereType<FailedRequestInterceptor>()
+            .length,
+        1,
+      );
+    });
+
+    test('addSentry does not add $FailedRequestInterceptor if override false', () {
+      final dio = fixture.getSut();
+
+      fixture.hub.options.captureFailedRequests = true;
+
+      dio.addSentry(hub: fixture.hub, captureFailedRequests: false);
+
+      expect(
+        dio.interceptors
+            .whereType<FailedRequestInterceptor>()
+            .length,
+        0,
       );
     });
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Adds `captureFailedRequests` argument to dio and sentry http client, which takes precedence over options.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #1877

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes
