### PR TITLE
ci: use personal auth token for e2e

### DIFF
--- a/.github/workflows/e2e_dart.yml
+++ b/.github/workflows/e2e_dart.yml
@@ -13,7 +13,7 @@ on:
       - "e2e_test/**"
 
 env:
-  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+  SENTRY_AUTH_TOKEN_E2E: ${{ secrets.SENTRY_AUTH_TOKEN_E2E }}
   SENTRY_DIST: 1
 
 jobs:

--- a/e2e_test/bin/e2e_test.dart
+++ b/e2e_test/bin/e2e_test.dart
@@ -10,7 +10,7 @@ const _exampleDsn =
 const _org = 'sentry-sdks';
 const _projectSlug = 'sentry-flutter';
 
-final _token = Platform.environment['SENTRY_AUTH_TOKEN'] ?? '';
+final _token = Platform.environment['SENTRY_AUTH_TOKEN_E2E'] ?? '';
 
 void main(List<String> arguments) async {
   print('Starting');


### PR DESCRIPTION
It makes for us easier to differentiate

let's use personal auth token `SENTRY_AUTH_TOKEN_E2E` for e2e test which needs to access the events

everything else:  will use the org token `SENTRY_AUTH_TOKEN` for uploading sourcemaps, debug symbols etc

#skip-changelog