### PR TITLE
Set `sentry_flutter.podspec` version from `pubspec.yaml`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+- Set `sentry_flutter.podspec` version from `pubspec.yaml` ([#1941](https://github.com/getsentry/sentry-dart/pull/1941))
+
 ## 7.18.0
 
 ### Features

--- a/flutter/ios/sentry_flutter.podspec
+++ b/flutter/ios/sentry_flutter.podspec
@@ -1,6 +1,10 @@
+require 'yaml'
+pubspec = YAML.load_file('./../pubspec.yaml')
+version = pubspec['version'].to_s
+
 Pod::Spec.new do |s|
   s.name             = 'sentry_flutter'
-  s.version          = '0.0.1'
+  s.version          = version
   s.summary          = 'Sentry SDK for Flutter.'
   s.description      = <<-DESC
 Sentry SDK for Flutter with support to native through sentry-cocoa.

--- a/flutter/ios/test.rb
+++ b/flutter/ios/test.rb
@@ -1,6 +1,0 @@
-require 'yaml'
-
-pubspec = YAML.load_file('./../pubspec.yaml')
-version = pubspec['version']
-
-puts version

--- a/flutter/ios/test.rb
+++ b/flutter/ios/test.rb
@@ -1,0 +1,6 @@
+require 'yaml'
+
+pubspec = YAML.load_file('./../pubspec.yaml')
+version = pubspec['version']
+
+puts version


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Set `sentry_flutter.podspec` version from `pubspec.yaml`

### Before

Podfile.lock
```
- sentry_flutter (0.0.1):
  - Flutter
  - FlutterMacOS
  - Sentry/HybridSDK (= 8.21.0)
```

<img width="449" alt="Bildschirmfoto 2024-03-19 um 14 42 54" src="https://github.com/getsentry/sentry-dart/assets/3984453/acf2a2c1-1259-4dc8-a34e-e13014a5da0c">

### After

Podfile.lock
```
- sentry_flutter (7.18.0):
  - Flutter
  - FlutterMacOS
  - Sentry/HybridSDK (= 8.21.0)
```

<img width="446" alt="Bildschirmfoto 2024-03-19 um 14 43 11" src="https://github.com/getsentry/sentry-dart/assets/3984453/76264d3c-eab6-4658-bf3c-fc5bbcf1766d">

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #1928

## :green_heart: How did you test it?

In example app:
- Delete `Pods` folder and `Podfile.lock`
- Execute `pod install` 

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes
