### PR TITLE
Add rate limit to metrics and update normalization rules

### DIFF
--- a/dart/lib/src/transport/data_category.dart
+++ b/dart/lib/src/transport/data_category.dart
@@ -7,6 +7,7 @@ enum DataCategory {
   transaction,
   attachment,
   security,
+  metricBucket,
   unknown
 }
 
@@ -27,6 +28,8 @@ extension DataCategoryExtension on DataCategory {
         return DataCategory.attachment;
       case 'security':
         return DataCategory.security;
+      case 'metric_bucket':
+        return DataCategory.metricBucket;
     }
     return DataCategory.unknown;
   }
@@ -47,6 +50,8 @@ extension DataCategoryExtension on DataCategory {
         return 'attachment';
       case DataCategory.security:
         return 'security';
+      case DataCategory.metricBucket:
+        return 'metric_bucket';
       case DataCategory.unknown:
         return 'unknown';
     }

--- a/dart/lib/src/transport/rate_limit.dart
+++ b/dart/lib/src/transport/rate_limit.dart
@@ -2,8 +2,10 @@ import 'data_category.dart';
 
 /// `RateLimit` containing limited `DataCategory` and duration in milliseconds.
 class RateLimit {
-  RateLimit(this.category, this.duration);
+  RateLimit(this.category, this.duration, {List<String>? namespaces})
+      : namespaces = (namespaces?..removeWhere((e) => e.isEmpty)) ?? [];
 
   final DataCategory category;
   final Duration duration;
+  final List<String> namespaces;
 }

--- a/dart/lib/src/transport/rate_limit_parser.dart
+++ b/dart/lib/src/transport/rate_limit_parser.dart
@@ -14,6 +14,7 @@ class RateLimitParser {
     if (rateLimitHeader == null) {
       return [];
     }
+    // example: 2700:metric_bucket:organization:quota_exceeded:custom,...
     final rateLimits = <RateLimit>[];
     final rateLimitValues = rateLimitHeader.toLowerCase().split(',');
     for (final rateLimitValue in rateLimitValues) {
@@ -30,7 +31,17 @@ class RateLimitParser {
         final categoryValues = allCategories.split(';');
         for (final categoryValue in categoryValues) {
           final category = DataCategoryExtension.fromStringValue(categoryValue);
-          if (category != DataCategory.unknown) {
+          // Metric buckets rate limit can have namespaces
+          if (category == DataCategory.metricBucket) {
+            final namespaces = durationAndCategories.length > 4
+                ? durationAndCategories[4]
+                : null;
+            rateLimits.add(RateLimit(
+              category,
+              duration,
+              namespaces: namespaces?.trim().split(','),
+            ));
+          } else if (category != DataCategory.unknown) {
             rateLimits.add(RateLimit(category, duration));
           }
         }

--- a/dart/lib/src/transport/rate_limiter.dart
+++ b/dart/lib/src/transport/rate_limiter.dart
@@ -64,6 +64,11 @@ class RateLimiter {
     }
 
     for (final rateLimit in rateLimits) {
+      if (rateLimit.category == DataCategory.metricBucket &&
+          rateLimit.namespaces.isNotEmpty &&
+          !rateLimit.namespaces.contains('custom')) {
+        continue;
+      }
       _applyRetryAfterOnlyIfLonger(
         rateLimit.category,
         DateTime.fromMillisecondsSinceEpoch(
@@ -111,6 +116,10 @@ class RateLimiter {
         return DataCategory.attachment;
       case 'transaction':
         return DataCategory.transaction;
+      // The envelope item type used for metrics is statsd,
+      // whereas the client report category is metric_bucket
+      case 'statsd':
+        return DataCategory.metricBucket;
       default:
         return DataCategory.unknown;
     }

--- a/dart/test/protocol/rate_limit_parser_test.dart
+++ b/dart/test/protocol/rate_limit_parser_test.dart
@@ -75,6 +75,45 @@ void main() {
       expect(sut[0].duration.inMilliseconds,
           RateLimitParser.httpRetryAfterDefaultDelay.inMilliseconds);
     });
+
+    test('do not parse namespaces if not metric_bucket', () {
+      final sut =
+          RateLimitParser('1:transaction:organization:quota_exceeded:custom')
+              .parseRateLimitHeader();
+
+      expect(sut.length, 1);
+      expect(sut[0].category, DataCategory.transaction);
+      expect(sut[0].namespaces, isEmpty);
+    });
+
+    test('parse namespaces on metric_bucket', () {
+      final sut =
+          RateLimitParser('1:metric_bucket:organization:quota_exceeded:custom')
+              .parseRateLimitHeader();
+
+      expect(sut.length, 1);
+      expect(sut[0].category, DataCategory.metricBucket);
+      expect(sut[0].namespaces, isNotEmpty);
+      expect(sut[0].namespaces.first, 'custom');
+    });
+
+    test('parse empty namespaces on metric_bucket', () {
+      final sut =
+          RateLimitParser('1:metric_bucket:organization:quota_exceeded:')
+              .parseRateLimitHeader();
+
+      expect(sut.length, 1);
+      expect(sut[0].category, DataCategory.metricBucket);
+      expect(sut[0].namespaces, isEmpty);
+    });
+
+    test('parse missing namespaces on metric_bucket', () {
+      final sut = RateLimitParser('1:metric_bucket').parseRateLimitHeader();
+
+      expect(sut.length, 1);
+      expect(sut[0].category, DataCategory.metricBucket);
+      expect(sut[0].namespaces, isEmpty);
+    });
   });
 
   group('parseRetryAfterHeader', () {


### PR DESCRIPTION
## :scroll: Description
added metric_bucket data category for rate limits
updated metric normalization rules

#skip-changelog


## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-dart/issues/1957 and https://github.com/getsentry/sentry-dart/issues/1965


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
