### PR TITLE
Bump compileSdkVersion to 34 in Gradle buildscripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Build
+
+- Bump compileSdkVersion to 34 in Gradle buildscripts ([#1980](https://github.com/getsentry/sentry-dart/pull/1980))
+
 ## 7.19.0
 
 ### Features
@@ -65,7 +71,7 @@
 
 - Fix transaction end timestamp trimming ([#1916](https://github.com/getsentry/sentry-dart/pull/1916))
   - Transaction end timestamps are now correctly trimmed to the latest child span end timestamp
-- remove transitive dart:io reference for web ([#1898](https://github.com/getsentry/sentry-dart/pull/1898))  
+- remove transitive dart:io reference for web ([#1898](https://github.com/getsentry/sentry-dart/pull/1898))
 
 ### Features
 
@@ -114,7 +120,7 @@
     - Method `hint.addAll(Map<String, dynamic> keysAndValues)` now takes `Map<String, dynamic>` instead of `Map<String, Object>`
     - Method `set(String key, dynamic value)` now takes value of `dynamic` instead of `Object`
     - Method `hint.get(String key)` now returns `dynamic` instead of `Object?`
-   
+
 ### Dependencies
 
 - Bump Cocoa SDK from v8.18.0 to v8.19.0 ([#1803](https://github.com/getsentry/sentry-dart/pull/1844))
@@ -136,7 +142,7 @@
 - Starting with Flutter 3.16, Sentry adds the [`appFlavor`](https://api.flutter.dev/flutter/services/appFlavor-constant.html) to the `flutter_context` ([#1799](https://github.com/getsentry/sentry-dart/pull/1799))
 - Add beforeScreenshotCallback to SentryFlutterOptions ([#1805](https://github.com/getsentry/sentry-dart/pull/1805))
 - Add support for `readTransaction` in `sqflite` ([#1819](https://github.com/getsentry/sentry-dart/pull/1819))
-  
+
 ### Dependencies
 
 - Bump Android SDK from v7.0.0 to v7.2.0 ([#1788](https://github.com/getsentry/sentry-dart/pull/1788), [#1815](https://github.com/getsentry/sentry-dart/pull/1815))
@@ -153,7 +159,7 @@
 ### Fixes
 
 - Add debug_meta to all events ([#1756](https://github.com/getsentry/sentry-dart/pull/1756))
-  - Fixes obfuscated stacktraces when `captureMessage` or `captureEvent` is called with `attachStacktrace` option 
+  - Fixes obfuscated stacktraces when `captureMessage` or `captureEvent` is called with `attachStacktrace` option
 
 ### Features
 
@@ -173,7 +179,7 @@
 
 ### Fixes
 
--  Fix SIGSEV, SIGABRT and SIGBUS crashes happening after/around the August Google Play System update, see [#2955](https://github-redirect.dependabot.com/getsentry/sentry-java/issues/2955) for more details (fix provided by Native SDK bump)
+- Fix SIGSEV, SIGABRT and SIGBUS crashes happening after/around the August Google Play System update, see [#2955](https://github-redirect.dependabot.com/getsentry/sentry-java/issues/2955) for more details (fix provided by Native SDK bump)
 
 ### Dependencies
 
@@ -190,7 +196,7 @@
 
 ## 7.13.0
 
-### Fixes 
+### Fixes
 
 - Fixes setting the correct locale to contexts with navigatorKey ([#1724](https://github.com/getsentry/sentry-dart/pull/1724))
   - If you have a selected locale in e.g MaterialApp, this fix will retrieve the correct locale for the event context.
@@ -416,7 +422,7 @@
 
 ### Features
 
-- Add `SentryIOOverridesIntegration` that automatically wraps `File` into `SentryFile`  ([#1362](https://github.com/getsentry/sentry-dart/pull/1362))
+- Add `SentryIOOverridesIntegration` that automatically wraps `File` into `SentryFile` ([#1362](https://github.com/getsentry/sentry-dart/pull/1362))
 
 ```dart
 import 'package:sentry_file/sentry_file.dart';
@@ -1105,8 +1111,8 @@ options.beforeSend = (event, {hint}) {
 
 ### Fixes
 
-* Scope.clone incorrectly accesses tags ([#978](https://github.com/getsentry/sentry-dart/pull/978))
-* beforeBreadcrumb was not adding the mutated breadcrumb ([#982](https://github.com/getsentry/sentry-dart/pull/982))
+- Scope.clone incorrectly accesses tags ([#978](https://github.com/getsentry/sentry-dart/pull/978))
+- beforeBreadcrumb was not adding the mutated breadcrumb ([#982](https://github.com/getsentry/sentry-dart/pull/982))
 
 ### Features
 
@@ -1121,25 +1127,26 @@ options.beforeSend = (event, {hint}) {
 
 ### Features
 
-* Bump Flutter's min. supported version from 1.17.0 to 2.0.0 ([#966](https://github.com/getsentry/sentry-dart/pull/966))
+- Bump Flutter's min. supported version from 1.17.0 to 2.0.0 ([#966](https://github.com/getsentry/sentry-dart/pull/966))
 
 This should not break anything since the Dart's min. version is already 2.12.0 and Flutter 2.0.0 uses Dart 2.12.0
 
 ### Fixes
 
-* Back compatibility of Object.hash for Dart 2.12.0 ([#966](https://github.com/getsentry/sentry-dart/pull/966))
-* Fix back compatibility for OnErrorIntegration integration ([#965](https://github.com/getsentry/sentry-dart/pull/965))
+- Back compatibility of Object.hash for Dart 2.12.0 ([#966](https://github.com/getsentry/sentry-dart/pull/966))
+- Fix back compatibility for OnErrorIntegration integration ([#965](https://github.com/getsentry/sentry-dart/pull/965))
 
 ## 6.8.1
 
 ### Fixes
 
-* `Scope#setContexts` pasing a List value would't not work ([#932](https://github.com/getsentry/sentry-dart/pull/932))
+- `Scope#setContexts` pasing a List value would't not work ([#932](https://github.com/getsentry/sentry-dart/pull/932))
 
 ### Features
 
-* Add integration for `PlatformDispatcher.onError` ([#915](https://github.com/getsentry/sentry-dart/pull/915))
-- Bump Cocoa SDK to v7.22.0 ([#960](https://github.com/getsentry/sentry-dart/pull/960))
+- Add integration for `PlatformDispatcher.onError` ([#915](https://github.com/getsentry/sentry-dart/pull/915))
+
+* Bump Cocoa SDK to v7.22.0 ([#960](https://github.com/getsentry/sentry-dart/pull/960))
   - [changelog](https://github.com/getsentry/sentry-cocoa/blob/master/CHANGELOG.md#7220)
   - [diff](https://github.com/getsentry/sentry-cocoa/compare/7.21.0...7.22.0)
 
@@ -1147,23 +1154,23 @@ This should not break anything since the Dart's min. version is already 2.12.0 a
 
 ### Fixes
 
-* Missing OS context for iOS events ([#958](https://github.com/getsentry/sentry-dart/pull/958))
-* Fix: `Scope#clone` calls the Native bridges again via the `scopeObserver` ([#959](https://github.com/getsentry/sentry-dart/pull/959))
+- Missing OS context for iOS events ([#958](https://github.com/getsentry/sentry-dart/pull/958))
+- Fix: `Scope#clone` calls the Native bridges again via the `scopeObserver` ([#959](https://github.com/getsentry/sentry-dart/pull/959))
 
 ### Features
 
-* Dio Integration adds response data ([#934](https://github.com/getsentry/sentry-dart/pull/934))
+- Dio Integration adds response data ([#934](https://github.com/getsentry/sentry-dart/pull/934))
 
 ## 6.7.0
 
 ### Fixes
 
-* Maps with Key Object, Object would fail during serialization if not String, Object ([#935](https://github.com/getsentry/sentry-dart/pull/935))
-* Breadcrumbs "Concurrent Modification" ([#948](https://github.com/getsentry/sentry-dart/pull/948))
-* Duplicative Screen size changed breadcrumbs ([#888](https://github.com/getsentry/sentry-dart/pull/888))
-* Duplicated Android Breadcrumbs with no Mechanism ([#954](https://github.com/getsentry/sentry-dart/pull/954))
-* Fix windows native method need default result ([#943](https://github.com/getsentry/sentry-dart/pull/943))
-* Add request instead of response data to `SentryRequest` in `DioEventProcessor` [#933](https://github.com/getsentry/sentry-dart/pull/933)
+- Maps with Key Object, Object would fail during serialization if not String, Object ([#935](https://github.com/getsentry/sentry-dart/pull/935))
+- Breadcrumbs "Concurrent Modification" ([#948](https://github.com/getsentry/sentry-dart/pull/948))
+- Duplicative Screen size changed breadcrumbs ([#888](https://github.com/getsentry/sentry-dart/pull/888))
+- Duplicated Android Breadcrumbs with no Mechanism ([#954](https://github.com/getsentry/sentry-dart/pull/954))
+- Fix windows native method need default result ([#943](https://github.com/getsentry/sentry-dart/pull/943))
+- Add request instead of response data to `SentryRequest` in `DioEventProcessor` [#933](https://github.com/getsentry/sentry-dart/pull/933)
 
 ### Features
 
@@ -1178,7 +1185,7 @@ This should not break anything since the Dart's min. version is already 2.12.0 a
 
 ### Fixes
 
-* Context Escape with ScopeCallback ([#925](https://github.com/getsentry/sentry-dart/pull/925))
+- Context Escape with ScopeCallback ([#925](https://github.com/getsentry/sentry-dart/pull/925))
 
 ## 6.6.2
 
@@ -1193,419 +1200,419 @@ This should not break anything since the Dart's min. version is already 2.12.0 a
 
 ### Fixes
 
-* Send DidBecomeActiveNotification when OOM enabled (#905)
-* `dio.addSentry` hangs if `dsn` is empty and SDK NoOp ([#920](https://github.com/getsentry/sentry-dart/pull/920))
-* addBreadcrumb throws on Android API < 24 because of NewApi usage ([#923](https://github.com/getsentry/sentry-dart/pull/923))
-* [`sentry_dio`](https://pub.dev/packages/sentry_dio) is promoted to GA and not experimental anymore ([#914](https://github.com/getsentry/sentry-dart/pull/914))
+- Send DidBecomeActiveNotification when OOM enabled (#905)
+- `dio.addSentry` hangs if `dsn` is empty and SDK NoOp ([#920](https://github.com/getsentry/sentry-dart/pull/920))
+- addBreadcrumb throws on Android API < 24 because of NewApi usage ([#923](https://github.com/getsentry/sentry-dart/pull/923))
+- [`sentry_dio`](https://pub.dev/packages/sentry_dio) is promoted to GA and not experimental anymore ([#914](https://github.com/getsentry/sentry-dart/pull/914))
 
 ## 6.6.1
 
 ### Fixes
 
-* Filter out app starts with more than 60s (#895)
+- Filter out app starts with more than 60s (#895)
 
 ## 6.6.0
 
 ### Fixes
 
-* Bump: Sentry-Cocoa to 7.18.0 and Sentry-Android to 6.1.2 (#892)
-* Fix: Add missing iOS contexts (#761)
-* Fix serialization of threads (#844)
-* Fix: `SentryAssetBundle` on Flutter >= 3.1 (#877)
+- Bump: Sentry-Cocoa to 7.18.0 and Sentry-Android to 6.1.2 (#892)
+- Fix: Add missing iOS contexts (#761)
+- Fix serialization of threads (#844)
+- Fix: `SentryAssetBundle` on Flutter >= 3.1 (#877)
 
 ### Features
 
-* Feat: Client Reports (#829)
-* Feat: Allow manual init of the Native SDK (#765)
-* Feat: Attach Isolate name to thread context (#847)
-* Feat: Add Android thread to platform stacktraces (#853)
-* Feat: Sync Scope to Native (#858)
+- Feat: Client Reports (#829)
+- Feat: Allow manual init of the Native SDK (#765)
+- Feat: Attach Isolate name to thread context (#847)
+- Feat: Add Android thread to platform stacktraces (#853)
+- Feat: Sync Scope to Native (#858)
 
 ### Sentry Self-hosted Compatibility
 
-* Starting with version `6.6.0` of `sentry`, [Sentry's version >= v21.9.0](https://github.com/getsentry/self-hosted/releases) is required or you have to manually disable sending client reports via the `sendClientReports` option. This only applies to self-hosted Sentry. If you are using [sentry.io](https://sentry.io), no action is needed.
+- Starting with version `6.6.0` of `sentry`, [Sentry's version >= v21.9.0](https://github.com/getsentry/self-hosted/releases) is required or you have to manually disable sending client reports via the `sendClientReports` option. This only applies to self-hosted Sentry. If you are using [sentry.io](https://sentry.io), no action is needed.
 
 ## 6.6.0-beta.4
 
-* Bump: Sentry-Cocoa to 7.17.0 and Sentry-Android to 6.1.1 (#891)
+- Bump: Sentry-Cocoa to 7.17.0 and Sentry-Android to 6.1.1 (#891)
 
 ## 6.6.0-beta.3
 
-* Bump: Sentry-Cocoa to 7.16.1 (#886)
+- Bump: Sentry-Cocoa to 7.16.1 (#886)
 
 ## 6.6.0-beta.2
 
-* Fix: Add user setter back in the scope (#883)
-* Fix: clear method sets all properties synchronously (#882)
+- Fix: Add user setter back in the scope (#883)
+- Fix: clear method sets all properties synchronously (#882)
 
 ## 6.6.0-beta.1
 
-* Feat: Sync Scope to Native (#858)
+- Feat: Sync Scope to Native (#858)
 
 ## 6.6.0-alpha.3
 
-* Feat: Attach Isolate name to thread context (#847)
-* Fix: `SentryAssetBundle` on Flutter >= 3.1 (#877)
-* Feat: Add Android thread to platform stacktraces (#853)
-* Fix: Rename auto initialize property (#857)
-* Bump: Sentry-Android to 6.0.0 (#879)
+- Feat: Attach Isolate name to thread context (#847)
+- Fix: `SentryAssetBundle` on Flutter >= 3.1 (#877)
+- Feat: Add Android thread to platform stacktraces (#853)
+- Fix: Rename auto initialize property (#857)
+- Bump: Sentry-Android to 6.0.0 (#879)
 
 ## 6.6.0-alpha.2
 
-* Fix serialization of threads (#844)
-* Feat: Allow manual init of the Native SDK (#765)
+- Fix serialization of threads (#844)
+- Feat: Allow manual init of the Native SDK (#765)
 
 ## 6.6.0-alpha.1
 
-* Feat: Client Reports (#829)
-* Fix: Add missing iOS contexts (#761)
+- Feat: Client Reports (#829)
+- Fix: Add missing iOS contexts (#761)
 
 ### Sentry Self-hosted Compatibility
 
-* Starting with version `6.6.0` of `sentry`, [Sentry's version >= v21.9.0](https://github.com/getsentry/self-hosted/releases) is required or you have to manually disable sending client reports via the `sendClientReports` option. This only applies to self-hosted Sentry. If you are using [sentry.io](https://sentry.io), no action is needed.
+- Starting with version `6.6.0` of `sentry`, [Sentry's version >= v21.9.0](https://github.com/getsentry/self-hosted/releases) is required or you have to manually disable sending client reports via the `sendClientReports` option. This only applies to self-hosted Sentry. If you are using [sentry.io](https://sentry.io), no action is needed.
 
 ## 6.5.1
 
-* Update event contexts (#838)
+- Update event contexts (#838)
 
 ## 6.5.0
 
-* No documented changes.
+- No documented changes.
 
 ## 6.5.0-beta.2
 
-* Fix: Do not set the transaction to scope if no op (#828)
+- Fix: Do not set the transaction to scope if no op (#828)
 
 ## 6.5.0-beta.1
 
-* No documented changes.
+- No documented changes.
 
 ## 6.5.0-alpha.3
 
-* Feat: Support for platform stacktraces on Android (#788)
+- Feat: Support for platform stacktraces on Android (#788)
 
 ## 6.5.0-alpha.2
 
-* Bump: Sentry-Android to 5.7.0 and Sentry-Cocoa to 7.11.0 (#796)
-* Fix: Dio event processor safelly bails if no DioError in the exception list (#795)
+- Bump: Sentry-Android to 5.7.0 and Sentry-Cocoa to 7.11.0 (#796)
+- Fix: Dio event processor safelly bails if no DioError in the exception list (#795)
 
 ## 6.5.0-alpha.1
 
-* Feat: Mobile Vitals - Native App Start (#749)
-* Feat: Mobile Vitals - Native Frames (#772)
+- Feat: Mobile Vitals - Native App Start (#749)
+- Feat: Mobile Vitals - Native Frames (#772)
 
 ## 6.4.0
 
 ### Various fixes & improvements
 
-* Fix: Missing userId on iOS when userId is not set (#782) by @marandaneto
-* Allow to set startTimestamp & endTimestamp manually to SentrySpan (#676) by @fatihergin
+- Fix: Missing userId on iOS when userId is not set (#782) by @marandaneto
+- Allow to set startTimestamp & endTimestamp manually to SentrySpan (#676) by @fatihergin
 
 ## 6.4.0-beta.3
 
-* Feat: Allow to set startTimestamp & endTimestamp manually to SentrySpan (#676)
-* Bump: Sentry-Cocoa to 7.10.0 (#777)
-* Feat: Additional Dart/Flutter context information (#778)
-* Bump: Kotlin plugin to 1.5.31 (#763)
-* Fix: Missing userId on iOS when userId is not set (#782)
+- Feat: Allow to set startTimestamp & endTimestamp manually to SentrySpan (#676)
+- Bump: Sentry-Cocoa to 7.10.0 (#777)
+- Feat: Additional Dart/Flutter context information (#778)
+- Bump: Kotlin plugin to 1.5.31 (#763)
+- Fix: Missing userId on iOS when userId is not set (#782)
 
 ## 6.4.0-beta.2
 
-* No documented changes.
+- No documented changes.
 
 ## 6.4.0-beta.1
 
-* Fix: Disable log by default in debug mode (#753)
-* [Dio] Ref: Replace FailedRequestAdapter with FailedRequestInterceptor (#728)
-* Fix: Add missing return values - dart analyzer (#742)
-* Feat: Add `DioEventProcessor` which improves DioError crash reports (#718)
-* Fix: Do not report duplicated packages and integrations (#760)
-* Feat: Allow manual init of the Native SDK or no Native SDK at all (#765)
+- Fix: Disable log by default in debug mode (#753)
+- [Dio] Ref: Replace FailedRequestAdapter with FailedRequestInterceptor (#728)
+- Fix: Add missing return values - dart analyzer (#742)
+- Feat: Add `DioEventProcessor` which improves DioError crash reports (#718)
+- Fix: Do not report duplicated packages and integrations (#760)
+- Feat: Allow manual init of the Native SDK or no Native SDK at all (#765)
 
 ## 6.3.0
 
-* Feat: Support maxSpan for performance API and expose SentryOptions through Hub (#716)
-* Fix: await ZonedGuard integration to run (#732)
-* Fix: `sentry_logging` incorrectly setting SDK name (#725)
-* Bump: Sentry-Android to 5.6.1 and Sentry-Cocoa to 7.9.0 (#736)
-* Feat: Support Attachment.addToTransactions (#709)
-* Fix: captureTransaction should return emptyId when transaction is discarded (#713)
-* Add `SentryAssetBundle` for automatic spans for asset loading (#685)
-* Fix: `maxRequestBodySize` should be `never` by default when using the FailedRequestClientAdapter directly (#701)
-* Feat: Add support for [Dio](https://pub.dev/packages/dio) (#688)
-* Fix: Use correct data/extras type in tracer (#693)
-* Fix: Do not throw when Throwable type is not supported for associating errors to a transaction (#692)
-* Feat: Automatically create transactions when navigating between screens (#643)
+- Feat: Support maxSpan for performance API and expose SentryOptions through Hub (#716)
+- Fix: await ZonedGuard integration to run (#732)
+- Fix: `sentry_logging` incorrectly setting SDK name (#725)
+- Bump: Sentry-Android to 5.6.1 and Sentry-Cocoa to 7.9.0 (#736)
+- Feat: Support Attachment.addToTransactions (#709)
+- Fix: captureTransaction should return emptyId when transaction is discarded (#713)
+- Add `SentryAssetBundle` for automatic spans for asset loading (#685)
+- Fix: `maxRequestBodySize` should be `never` by default when using the FailedRequestClientAdapter directly (#701)
+- Feat: Add support for [Dio](https://pub.dev/packages/dio) (#688)
+- Fix: Use correct data/extras type in tracer (#693)
+- Fix: Do not throw when Throwable type is not supported for associating errors to a transaction (#692)
+- Feat: Automatically create transactions when navigating between screens (#643)
 
 ## 6.3.0-beta.4
 
-* Feat: Support Attachment.addToTransactions (#709)
-* Fix: captureTransaction should return emptyId when transaction is discarded (#713)
+- Feat: Support Attachment.addToTransactions (#709)
+- Fix: captureTransaction should return emptyId when transaction is discarded (#713)
 
 ## 6.3.0-beta.3
 
-* Feat: Auto transactions duration trimming (#702)
-* Add `SentryAssetBundle` for automatic spans for asset loading (#685)
-* Feat: Configure idle transaction duration (#705)
-* Fix: `maxRequestBodySize` should be `never` by default when using the FailedRequestClientAdapter directly (#701)
+- Feat: Auto transactions duration trimming (#702)
+- Add `SentryAssetBundle` for automatic spans for asset loading (#685)
+- Feat: Configure idle transaction duration (#705)
+- Fix: `maxRequestBodySize` should be `never` by default when using the FailedRequestClientAdapter directly (#701)
 
 ## 6.3.0-beta.2
 
-* Feat: Improve configuration options of `SentryNavigatorObserver` (#684)
-* Feat: Add support for [Dio](https://pub.dev/packages/dio) (#688)
-* Bump: Sentry-Android to 5.5.2 and Sentry-Cocoa to 7.8.0 (#696)
+- Feat: Improve configuration options of `SentryNavigatorObserver` (#684)
+- Feat: Add support for [Dio](https://pub.dev/packages/dio) (#688)
+- Bump: Sentry-Android to 5.5.2 and Sentry-Cocoa to 7.8.0 (#696)
 
 ## 6.3.0-beta.1
 
-* Enha: Replace flutter default root name '/' with 'root' (#678)
-* Fix: Use 'navigation' instead of 'ui.load' for auto transaction operation (#675)
-* Fix: Use correct data/extras type in tracer (#693)
-* Fix: Do not throw when Throwable type is not supported for associating errors to a transaction (#692)
+- Enha: Replace flutter default root name '/' with 'root' (#678)
+- Fix: Use 'navigation' instead of 'ui.load' for auto transaction operation (#675)
+- Fix: Use correct data/extras type in tracer (#693)
+- Fix: Do not throw when Throwable type is not supported for associating errors to a transaction (#692)
 
 ## 6.3.0-alpha.1
 
-* Feat: Automatically create transactions when navigating between screens (#643)
+- Feat: Automatically create transactions when navigating between screens (#643)
 
 ## 6.2.2
 
-* Fix: ConcurrentModificationError in when finishing span (#664)
-* Feat: Add enableNdkScopeSync Android support (#665)
+- Fix: ConcurrentModificationError in when finishing span (#664)
+- Feat: Add enableNdkScopeSync Android support (#665)
 
 ## 6.2.1
 
-* Fix: `sentry_logging` works now on web (#660)
-* Fix: `sentry_logging` timestamps are in UTC (#660)
-* Fix: `sentry_logging` Level.Off is never recorded (#660)
-* Fix: Rate limiting fallback to retryAfterHeader (#658)
+- Fix: `sentry_logging` works now on web (#660)
+- Fix: `sentry_logging` timestamps are in UTC (#660)
+- Fix: `sentry_logging` Level.Off is never recorded (#660)
+- Fix: Rate limiting fallback to retryAfterHeader (#658)
 
 ## 6.2.0
 
-* Feat: Integration for `logging` (#631)
-* Feat: Add logger name to `SentryLogger` and send errors in integrations to the registered logger (#641)
+- Feat: Integration for `logging` (#631)
+- Feat: Add logger name to `SentryLogger` and send errors in integrations to the registered logger (#641)
 
 ## 6.1.2
 
-* Fix: Remove is Enum check to support older Dart versions (#635)
+- Fix: Remove is Enum check to support older Dart versions (#635)
 
 ## 6.1.1
 
-* Fix: Transaction serialization if not encodable (#633)
+- Fix: Transaction serialization if not encodable (#633)
 
 ## 6.1.0
 
-* Bump: Sentry-Android to 5.3.0 and Sentry-Cocoa to 7.5.1 (#629)
-* Fix: event.origin tag for macOS and other Apple platforms (#622)
-* Feat: Add current route as transaction (#615)
-* Feat: Add Breadcrumbs for Flutters `debugPrint` (#618)
-* Feat: Enrich Dart context with isolate name (#600)
-* Feat: Sentry Performance for HTTP client (#603)
-* Performance API for Dart/Flutter (#530)
+- Bump: Sentry-Android to 5.3.0 and Sentry-Cocoa to 7.5.1 (#629)
+- Fix: event.origin tag for macOS and other Apple platforms (#622)
+- Feat: Add current route as transaction (#615)
+- Feat: Add Breadcrumbs for Flutters `debugPrint` (#618)
+- Feat: Enrich Dart context with isolate name (#600)
+- Feat: Sentry Performance for HTTP client (#603)
+- Performance API for Dart/Flutter (#530)
 
 ### Breaking Changes:
 
-* `SentryEvent` inherits from the `SentryEventLike` mixin
-* `Scope#transaction` sets and reads from the `Scope#span` object if bound to the Scope
+- `SentryEvent` inherits from the `SentryEventLike` mixin
+- `Scope#transaction` sets and reads from the `Scope#span` object if bound to the Scope
 
 ## 6.1.0-beta.1
 
-* Feat: Add current route as transaction (#615)
-* Feat: Add Breadcrumbs for Flutters `debugPrint` (#618)
+- Feat: Add current route as transaction (#615)
+- Feat: Add Breadcrumbs for Flutters `debugPrint` (#618)
 
 ## 6.1.0-alpha.2
 
-* Bump Sentry Android SDK to [5.2.0](https://github.com/getsentry/sentry-dart/pull/594) (#594)
+- Bump Sentry Android SDK to [5.2.0](https://github.com/getsentry/sentry-dart/pull/594) (#594)
   - [changelog](https://github.com/getsentry/sentry-java/blob/5.2.0/CHANGELOG.md)
   - [diff](https://github.com/getsentry/sentry-java/compare/5.1.2...5.2.0)
-* Feat: Enrich Dart context with isolate name (#600)
-* Feat: Sentry Performance for HTTP client (#603)
+- Feat: Enrich Dart context with isolate name (#600)
+- Feat: Sentry Performance for HTTP client (#603)
 
 ## 6.1.0-alpha.1
 
-* Performance API for Dart/Flutter (#530)
+- Performance API for Dart/Flutter (#530)
 
 ### Breaking Changes:
 
-* `SentryEvent` inherits from the `SentryEventLike` mixin
-* `Scope#transaction` sets and reads from the `Scope#span` object if bound to the Scope
+- `SentryEvent` inherits from the `SentryEventLike` mixin
+- `Scope#transaction` sets and reads from the `Scope#span` object if bound to the Scope
 
 ## 6.0.1
 
-* Fix: Set custom SentryHttpClientError when HTTP error is captured without an exception (#580)
-* Bump: Android AGP 4.1 (#586)
-* Bump: Sentry Cocoa to 7.3.0 (#589)
+- Fix: Set custom SentryHttpClientError when HTTP error is captured without an exception (#580)
+- Bump: Android AGP 4.1 (#586)
+- Bump: Sentry Cocoa to 7.3.0 (#589)
 
 ## 6.0.0
 
-* Fix: Update `SentryUser` according to docs (#561)
-* Feat: Enable or disable reporting of packages (#563)
-* Bump: Sentry-Cocoa to 7.2.7 (#578)
-* Bump: Sentry-Android to 5.1.2 (#578)
-* Fix: Read Sentry config from environment variables as fallback (#567)
+- Fix: Update `SentryUser` according to docs (#561)
+- Feat: Enable or disable reporting of packages (#563)
+- Bump: Sentry-Cocoa to 7.2.7 (#578)
+- Bump: Sentry-Android to 5.1.2 (#578)
+- Fix: Read Sentry config from environment variables as fallback (#567)
 
 ## 6.0.0-beta.4
 
 ### Breaking Changes:
 
-* Feat: Lists of exceptions and threads (#524)
-* Feat: Collect more information for exceptions collected via `FlutterError.onError` (#538)
-* Feat: Add maxAttachmentSize option (#553)
-* Feat: HTTP breadcrumbs have the request & response size if available (#552)
+- Feat: Lists of exceptions and threads (#524)
+- Feat: Collect more information for exceptions collected via `FlutterError.onError` (#538)
+- Feat: Add maxAttachmentSize option (#553)
+- Feat: HTTP breadcrumbs have the request & response size if available (#552)
 
 ## 6.0.0-beta.3
 
-* Fix: Re-initialization of Flutter SDK (#526)
-* Enhancement: Call `toString()` on all non-serializable fields (#528)
-* Fix: Always call `Flutter.onError` in order to not swallow messages (#533)
-* Bump: Android SDK to 5.1.0-beta.6 (#535)
+- Fix: Re-initialization of Flutter SDK (#526)
+- Enhancement: Call `toString()` on all non-serializable fields (#528)
+- Fix: Always call `Flutter.onError` in order to not swallow messages (#533)
+- Bump: Android SDK to 5.1.0-beta.6 (#535)
 
 ## 6.0.0-beta.2
 
-* Fix: Serialization of Flutter Context (#520)
-* Feat: Add support for attachments (#505)
-* Feat: Add support for User Feedback (#506)
+- Fix: Serialization of Flutter Context (#520)
+- Feat: Add support for attachments (#505)
+- Feat: Add support for User Feedback (#506)
 
 ## 6.0.0-beta.1
 
-* Feat: Browser detection (#502)
-* Feat: Enrich events with more context (#452)
-* Feat: Add Culture Context (#491)
-* Feat: Add DeduplicationEventProcessor (#498)
-* Feat: Capture failed requests as event (#473)
-* Feat: `beforeSend` callback accepts async code (#494)
+- Feat: Browser detection (#502)
+- Feat: Enrich events with more context (#452)
+- Feat: Add Culture Context (#491)
+- Feat: Add DeduplicationEventProcessor (#498)
+- Feat: Capture failed requests as event (#473)
+- Feat: `beforeSend` callback accepts async code (#494)
 
 ### Breaking Changes:
 
-* Ref: EventProcessor changed to an interface (#489)
-* Feat: Support envelope based transport for events (#391)
-  * The method signature of `Transport` changed from `Future<SentryId> send(SentryEvent event)` to `Future<SentryId> send(SentryEnvelope envelope)`
-* Remove `Sentry.currentHub` (#490)
-* Ref: Rename `cacheDirSize` to `maxCacheItems` and add `maxCacheItems` for iOS (#495)
-* Ref: Add error and stacktrace parameter to logger (#503)
-* Feat: Change timespans to Durations in SentryOptions (#504)
-* Feat: `beforeSend` callback accepts async code (#494)
+- Ref: EventProcessor changed to an interface (#489)
+- Feat: Support envelope based transport for events (#391)
+  - The method signature of `Transport` changed from `Future<SentryId> send(SentryEvent event)` to `Future<SentryId> send(SentryEnvelope envelope)`
+- Remove `Sentry.currentHub` (#490)
+- Ref: Rename `cacheDirSize` to `maxCacheItems` and add `maxCacheItems` for iOS (#495)
+- Ref: Add error and stacktrace parameter to logger (#503)
+- Feat: Change timespans to Durations in SentryOptions (#504)
+- Feat: `beforeSend` callback accepts async code (#494)
 
 ### Sentry Self Hosted Compatibility
 
-* Since version `6.0.0` of the `sentry`, [Sentry's version >= v20.6.0](https://github.com/getsentry/self-hosted/releases) is required. This only applies to on-premise Sentry, if you are using sentry.io no action is needed.
+- Since version `6.0.0` of the `sentry`, [Sentry's version >= v20.6.0](https://github.com/getsentry/self-hosted/releases) is required. This only applies to on-premise Sentry, if you are using sentry.io no action is needed.
 
 ## 5.1.0
 
-* Fix: Merge user from event and scope (#467)
-* Feature: Allow setting of default values for in-app-frames via `SentryOptions.considerInAppFramesByDefault` (#482)
-* Bump: sentry-android to v5.0.1 (#486)
-* Bump: Sentry-Cocoa to 7.1.3 for iOS and macOS (#488)
+- Fix: Merge user from event and scope (#467)
+- Feature: Allow setting of default values for in-app-frames via `SentryOptions.considerInAppFramesByDefault` (#482)
+- Bump: sentry-android to v5.0.1 (#486)
+- Bump: Sentry-Cocoa to 7.1.3 for iOS and macOS (#488)
 
 ## 5.1.0-beta.1
 
-* Fix: `Sentry.close()` closes native SDK integrations (#388)
-* Feat: Support for macOS (#389)
-* Feat: Support for Linux (#402)
-* Feat: Support for Windows (#407)
-* Fix: Mark `Sentry.currentHub` as deprecated (#406)
-* Fix: Set console logger as default logger in debug mode (#413)
-* Fix: Use name from pubspec.yaml for release if package id is not available (#411)
-* Feat: `SentryHttpClient` tracks the duration which a request takes and logs failed requests (#414)
-* Bump: sentry-cocoa to v7.0.0 (#424)
-* Feat: Support for Out-of-Memory-Tracking on macOS/iOS (#424)
-* Fix: Trim `\u0000` from Windows package info (#420)
-* Feature: Log calls to `print()` as Breadcrumbs (#439)
-* Fix: `dist` was read from `SENTRY_DSN`, now it's read from `SENTRY_DIST` (#442)
-* Bump: sentry-cocoa to v7.0.3 (#445)
-* Fix: Fix adding integrations on web (#450)
-* Fix: Use `log()` instead of `print()` for SDK logging (#453)
-* Bump: sentry-android to v5.0.0-beta.2 (#457)
-* Feature: Add `withScope` callback to capture methods (#463)
-* Fix: Add missing properties `language`, `screenHeightPixels` and `screenWidthPixels` to `SentryDevice` (#465)
+- Fix: `Sentry.close()` closes native SDK integrations (#388)
+- Feat: Support for macOS (#389)
+- Feat: Support for Linux (#402)
+- Feat: Support for Windows (#407)
+- Fix: Mark `Sentry.currentHub` as deprecated (#406)
+- Fix: Set console logger as default logger in debug mode (#413)
+- Fix: Use name from pubspec.yaml for release if package id is not available (#411)
+- Feat: `SentryHttpClient` tracks the duration which a request takes and logs failed requests (#414)
+- Bump: sentry-cocoa to v7.0.0 (#424)
+- Feat: Support for Out-of-Memory-Tracking on macOS/iOS (#424)
+- Fix: Trim `\u0000` from Windows package info (#420)
+- Feature: Log calls to `print()` as Breadcrumbs (#439)
+- Fix: `dist` was read from `SENTRY_DSN`, now it's read from `SENTRY_DIST` (#442)
+- Bump: sentry-cocoa to v7.0.3 (#445)
+- Fix: Fix adding integrations on web (#450)
+- Fix: Use `log()` instead of `print()` for SDK logging (#453)
+- Bump: sentry-android to v5.0.0-beta.2 (#457)
+- Feature: Add `withScope` callback to capture methods (#463)
+- Fix: Add missing properties `language`, `screenHeightPixels` and `screenWidthPixels` to `SentryDevice` (#465)
 
 ### Sentry Self Hosted Compatibility
 
-* This version of the `sentry` Dart package requires [Sentry server >= v20.6.0](https://github.com/getsentry/self-hosted/releases). This only applies to on-premise Sentry, if you are using sentry.io no action is needed.
+- This version of the `sentry` Dart package requires [Sentry server >= v20.6.0](https://github.com/getsentry/self-hosted/releases). This only applies to on-premise Sentry, if you are using sentry.io no action is needed.
 
 ## 5.0.0
 
-* Sound null safety
-* Fix: event.origin and event.environment tags have wrong value for iOS (#365) and (#369)
-* Fix: Fix deprecated `registrar.messenger` call in `SentryFlutterWeb` (#364)
-* Fix: Enable breadcrumb recording mechanism based on platform (#366)
-* Feat: Send default PII options (#360)
-* Bump: sentry-cocoa to v6.2.1 (#360)
-* Feat: Migration from `package_info` to `package_info_plus` plugin (#370)
-* Fix: Set `SentryOptions.debug` in `sentry` (#376)
-* Fix: Read all environment variables in `sentry` (#375)
+- Sound null safety
+- Fix: event.origin and event.environment tags have wrong value for iOS (#365) and (#369)
+- Fix: Fix deprecated `registrar.messenger` call in `SentryFlutterWeb` (#364)
+- Fix: Enable breadcrumb recording mechanism based on platform (#366)
+- Feat: Send default PII options (#360)
+- Bump: sentry-cocoa to v6.2.1 (#360)
+- Feat: Migration from `package_info` to `package_info_plus` plugin (#370)
+- Fix: Set `SentryOptions.debug` in `sentry` (#376)
+- Fix: Read all environment variables in `sentry` (#375)
 
 ### Breaking Changes:
 
-* Return type of `Sentry.close()` changed from `void` to `Future<void>` and `Integration.close()` changed from `void` to `FutureOr<void>` (#395)
-* Remove deprecated member `enableLifecycleBreadcrumbs`. Use `enableAppLifecycleBreadcrumbs` instead. (#366)
+- Return type of `Sentry.close()` changed from `void` to `Future<void>` and `Integration.close()` changed from `void` to `FutureOr<void>` (#395)
+- Remove deprecated member `enableLifecycleBreadcrumbs`. Use `enableAppLifecycleBreadcrumbs` instead. (#366)
 
 ## 4.1.0-nullsafety.1
 
-* Bump: sentry-android to v4.3.0 (#343)
-* Fix: Multiple FlutterError.onError calls in FlutterErrorIntegration (#345)
-* Fix: Pass hint to EventProcessors (#356)
-* Fix: EventProcessors were not dropping events when returning null (#353)
+- Bump: sentry-android to v4.3.0 (#343)
+- Fix: Multiple FlutterError.onError calls in FlutterErrorIntegration (#345)
+- Fix: Pass hint to EventProcessors (#356)
+- Fix: EventProcessors were not dropping events when returning null (#353)
 
 ### Breaking Changes:
 
-* Fix: Plugin Registrant class moved to barrel file (#358)
-  * This changed the import from `import 'package:sentry_flutter/src/sentry_flutter_web.dart';`
+- Fix: Plugin Registrant class moved to barrel file (#358)
+  - This changed the import from `import 'package:sentry_flutter/src/sentry_flutter_web.dart';`
     to `import 'package:sentry_flutter/sentry_flutter_web.dart';`
-  * This could lead to breaking changes. Typically it shouldn't because the referencing file is auto-generated.
-* Fix: Prefix classes with Sentry (#357)
-  * A couple of classes were often conflicting with user's code.
+  - This could lead to breaking changes. Typically it shouldn't because the referencing file is auto-generated.
+- Fix: Prefix classes with Sentry (#357)
+  - A couple of classes were often conflicting with user's code.
     Thus this change renames the following classes:
-    * `App` -> `SentryApp`
-    * `Browser` -> `SentryBrowser`
-    * `Device` -> `SentryDevice`
-    * `Gpu` -> `SentryGpu`
-    * `Integration` -> `SentryIntegration`
-    * `Message` -> `SentryMessage`
-    * `OperatingSystem` -> `SentryOperatingSystem`
-    * `Request` -> `SentryRequest`
-    * `User` -> `SentryUser`
-    * `Orientation` -> `SentryOrientation`
+    - `App` -> `SentryApp`
+    - `Browser` -> `SentryBrowser`
+    - `Device` -> `SentryDevice`
+    - `Gpu` -> `SentryGpu`
+    - `Integration` -> `SentryIntegration`
+    - `Message` -> `SentryMessage`
+    - `OperatingSystem` -> `SentryOperatingSystem`
+    - `Request` -> `SentryRequest`
+    - `User` -> `SentryUser`
+    - `Orientation` -> `SentryOrientation`
 
 ## 4.1.0-nullsafety.0
 
-* Fix: Do not append stack trace to the exception if there are no frames
-* Fix: Empty DSN disables the SDK and runs the App
-* Feat: sentry and sentry_flutter null-safety thanks to @ueman and @fzyzcjy
+- Fix: Do not append stack trace to the exception if there are no frames
+- Fix: Empty DSN disables the SDK and runs the App
+- Feat: sentry and sentry_flutter null-safety thanks to @ueman and @fzyzcjy
 
 ## 4.0.6
 
-* Fix: captureMessage defaults SentryLevel to info
-* Fix: SentryEvent.throwable returns the unwrapped throwable instead of the throwableMechanism
-* Feat: Support enableNativeCrashHandling on iOS
+- Fix: captureMessage defaults SentryLevel to info
+- Fix: SentryEvent.throwable returns the unwrapped throwable instead of the throwableMechanism
+- Feat: Support enableNativeCrashHandling on iOS
 
 ## 4.0.5
 
-* Bump: sentry-android to v4.0.0
-* Fix: Pana Flutter upper bound deprecation
-* Fix: sentry_flutter static analysis (pana) using stable version
+- Bump: sentry-android to v4.0.0
+- Fix: Pana Flutter upper bound deprecation
+- Fix: sentry_flutter static analysis (pana) using stable version
 
 ## 4.0.4
 
-* Fix: Call WidgetsFlutterBinding.ensureInitialized() within runZoneGuarded
+- Fix: Call WidgetsFlutterBinding.ensureInitialized() within runZoneGuarded
 
 ## 4.0.3
 
-* Fix: Auto session tracking start on iOS #274
-* Bump: Sentry-cocoa to 6.1.4
+- Fix: Auto session tracking start on iOS #274
+- Bump: Sentry-cocoa to 6.1.4
 
 ## 4.0.2
 
-* Fix: Mark session as `errored` in iOS #270
-* Fix: Pass auto session tracking interval to iOS
-* Fix: Deprecated binaryMessenger (MethodChannel member) for Flutter Web
-* Ref: Make `WidgetsFlutterBinding.ensureInitialized();` the first thing the Sentry SDK calls.
-* Bump: Sentry-cocoa to 6.0.12
-* Feat: Respect FlutterError silent flag #248
-* Bump: Android SDK to v3.2.1 #273
+- Fix: Mark session as `errored` in iOS #270
+- Fix: Pass auto session tracking interval to iOS
+- Fix: Deprecated binaryMessenger (MethodChannel member) for Flutter Web
+- Ref: Make `WidgetsFlutterBinding.ensureInitialized();` the first thing the Sentry SDK calls.
+- Bump: Sentry-cocoa to 6.0.12
+- Feat: Respect FlutterError silent flag #248
+- Bump: Android SDK to v3.2.1 #273
 
 ## 4.0.1
 
-* Ref: Changed category of Flutter lifecycle tracking [#240](https://github.com/getsentry/sentry-dart/issues/240)
-* Fix: Envelope length should be based on the UTF8 array instead of String length
+- Ref: Changed category of Flutter lifecycle tracking [#240](https://github.com/getsentry/sentry-dart/issues/240)
+- Fix: Envelope length should be based on the UTF8 array instead of String length
 
 ## 4.0.0
 
@@ -1615,100 +1622,100 @@ New features not offered by <= v4.0.0:
 
 ### Dart SDK
 
-* Sentry's [Unified API](https://develop.sentry.dev/sdk/unified-api/).
-* Complete Sentry's [Protocol](https://develop.sentry.dev/sdk/event-payloads/) available.
-* [Dart SDK](https://docs.sentry.io/platforms/dart/) docs.
-* Automatic [HTTP Breadcrumbs](https://docs.sentry.io/platforms/dart/usage/advanced-usage/#automatic-breadcrumbs) for [http.Client](https://pub.dev/documentation/http/latest/http/Client-class.html)
-* No boilerplate for `runZonedGuarded` and `Isolate.current.addErrorListener`
-* All events are enriched with [Scope's Contexts](https://develop.sentry.dev/sdk/event-payloads/#scope-interfaces), this includes Breadcrumbs, tags, User, etc...
+- Sentry's [Unified API](https://develop.sentry.dev/sdk/unified-api/).
+- Complete Sentry's [Protocol](https://develop.sentry.dev/sdk/event-payloads/) available.
+- [Dart SDK](https://docs.sentry.io/platforms/dart/) docs.
+- Automatic [HTTP Breadcrumbs](https://docs.sentry.io/platforms/dart/usage/advanced-usage/#automatic-breadcrumbs) for [http.Client](https://pub.dev/documentation/http/latest/http/Client-class.html)
+- No boilerplate for `runZonedGuarded` and `Isolate.current.addErrorListener`
+- All events are enriched with [Scope's Contexts](https://develop.sentry.dev/sdk/event-payloads/#scope-interfaces), this includes Breadcrumbs, tags, User, etc...
 
 ### Flutter SDK
 
-* The Flutter SDK is built on top of the Dart SDK, so it includes all the available features, plus
-* [Flutter SDK](https://docs.sentry.io/platforms/flutter/) docs.
-* Automatic [NavigatorObserver Breadcrumbs](https://docs.sentry.io/platforms/flutter/usage/advanced-usage/#automatic-breadcrumbs)
-* Automatic [Device's Breadcrumbs](https://docs.sentry.io/platforms/flutter/usage/advanced-usage/#automatic-breadcrumbs) through the Android and iOS SDKs or via Sentry's `WidgetsBindingObserver` wrapper
-* No boilerplate for `FlutterError.onError`
-* All events are enriched with [Contexts's data](https://develop.sentry.dev/sdk/event-payloads/contexts/), this includes Device's, OS, App info, etc...
-* Offline caching
-* [Release health](https://docs.sentry.io/product/releases/health/)
-* Captures not only Dart and Flutter errors, but also errors caused on the native platforms, Like Kotlin, Java, C and C++ for Android and Swift, ObjC, C, C++ for iOS
-* Supports Fatal crashes, Event is going to be sent on App's restart
-* Supports `split-debug-info` for Android only
-* Flutter Android, iOS and limited support for Flutter Web
+- The Flutter SDK is built on top of the Dart SDK, so it includes all the available features, plus
+- [Flutter SDK](https://docs.sentry.io/platforms/flutter/) docs.
+- Automatic [NavigatorObserver Breadcrumbs](https://docs.sentry.io/platforms/flutter/usage/advanced-usage/#automatic-breadcrumbs)
+- Automatic [Device's Breadcrumbs](https://docs.sentry.io/platforms/flutter/usage/advanced-usage/#automatic-breadcrumbs) through the Android and iOS SDKs or via Sentry's `WidgetsBindingObserver` wrapper
+- No boilerplate for `FlutterError.onError`
+- All events are enriched with [Contexts's data](https://develop.sentry.dev/sdk/event-payloads/contexts/), this includes Device's, OS, App info, etc...
+- Offline caching
+- [Release health](https://docs.sentry.io/product/releases/health/)
+- Captures not only Dart and Flutter errors, but also errors caused on the native platforms, Like Kotlin, Java, C and C++ for Android and Swift, ObjC, C, C++ for iOS
+- Supports Fatal crashes, Event is going to be sent on App's restart
+- Supports `split-debug-info` for Android only
+- Flutter Android, iOS and limited support for Flutter Web
 
 Improvements:
 
-* Feat: Added a copyWith method to all the protocol classes
+- Feat: Added a copyWith method to all the protocol classes
 
 Packages were released on [sentry pubdev](https://pub.dev/packages/sentry) and [sentry_flutter pubdev](https://pub.dev/packages/sentry_flutter)
 
 ### Sentry Self Hosted Compatibility
 
-* Since version `4.0.0` of the `sentry_flutter`, [Sentry's version >= v20.6.0](https://github.com/getsentry/self-hosted/releases) is required. This only applies to on-premise Sentry, if you are using sentry.io no action is needed.
+- Since version `4.0.0` of the `sentry_flutter`, [Sentry's version >= v20.6.0](https://github.com/getsentry/self-hosted/releases) is required. This only applies to on-premise Sentry, if you are using sentry.io no action is needed.
 
 ## 4.0.0-beta.2
 
-* Ref: Remove duplicated attachStackTrace field
-* Fix: Flutter Configurations should be able to mutate the SentryFlutterOptions
-* Enhancement: Add SentryWidgetsBindingObserver, an Integration that captures certain window and device events.
-* Enhancement: Set `options.environment` on SDK init based on the flags (kReleaseMode, kDebugMode, kProfileMode or SENTRY_ENVIRONMENT).
-* Feature: SentryHttpClient to capture HTTP requests as breadcrumbs
-* Ref: Only assign non-null option values in Android native integration in order preserve default values
-* Enhancement: Add 'attachThreads' in options. When enabled, threads are attached to all logged events for Android
-* Ref: Rename typedef `Logger` to `SentryLogger` to prevent name clashes with logging packages
-* Fix: Scope Event processors should be awaited
-* Fix: Package usage as git dependency
+- Ref: Remove duplicated attachStackTrace field
+- Fix: Flutter Configurations should be able to mutate the SentryFlutterOptions
+- Enhancement: Add SentryWidgetsBindingObserver, an Integration that captures certain window and device events.
+- Enhancement: Set `options.environment` on SDK init based on the flags (kReleaseMode, kDebugMode, kProfileMode or SENTRY_ENVIRONMENT).
+- Feature: SentryHttpClient to capture HTTP requests as breadcrumbs
+- Ref: Only assign non-null option values in Android native integration in order preserve default values
+- Enhancement: Add 'attachThreads' in options. When enabled, threads are attached to all logged events for Android
+- Ref: Rename typedef `Logger` to `SentryLogger` to prevent name clashes with logging packages
+- Fix: Scope Event processors should be awaited
+- Fix: Package usage as git dependency
 
 ### Breaking changes
 
-* `Logger` typedef is renamed to `SentryLogger`
-* `attachStackTrace` is renamed to `attachStacktrace`
+- `Logger` typedef is renamed to `SentryLogger`
+- `attachStackTrace` is renamed to `attachStacktrace`
 
 ## 4.0.0-beta.1
 
-* Fix: StackTrace frames with 'package' uri.scheme are inApp by default #185
-* Fix: Missing App's StackTrace frames for Flutter errors
-* Enhancement: Add isolateErrorIntegration and runZonedGuardedIntegration to default integrations in sentry-dart
-* Fix: Breadcrumb list is a plain list instead of a values list #201
-* Ref: Remove deprecated classes (Flutter Plugin for Android) and cleaning up #186
-* Fix: Handle immutable event lists and maps
-* Fix: NDK integration was being disabled by a typo
-* Fix: Missing toList for debug meta #192
-* Enhancement: NavigationObserver to record Breadcrumbs for navigation events #197
-* Fix: Integrations should be closeable
-* Feat: Support split-debug-info for Android #191
-* Fix: the event payload must never serialize null or empty fields
-* Ref: Make hints optional
+- Fix: StackTrace frames with 'package' uri.scheme are inApp by default #185
+- Fix: Missing App's StackTrace frames for Flutter errors
+- Enhancement: Add isolateErrorIntegration and runZonedGuardedIntegration to default integrations in sentry-dart
+- Fix: Breadcrumb list is a plain list instead of a values list #201
+- Ref: Remove deprecated classes (Flutter Plugin for Android) and cleaning up #186
+- Fix: Handle immutable event lists and maps
+- Fix: NDK integration was being disabled by a typo
+- Fix: Missing toList for debug meta #192
+- Enhancement: NavigationObserver to record Breadcrumbs for navigation events #197
+- Fix: Integrations should be closeable
+- Feat: Support split-debug-info for Android #191
+- Fix: the event payload must never serialize null or empty fields
+- Ref: Make hints optional
 
 ### Breaking changes
 
-* `Sentry.init` and `SentryFlutter.init` have an optional callback argument which runs the host App after Sentry initialization.
-* `Integration` is an `Interface` instead of a pure Function
-* `Hints` are optional arguments
-* Sentry Dart SDK adds an `IsolateError` handler by default
+- `Sentry.init` and `SentryFlutter.init` have an optional callback argument which runs the host App after Sentry initialization.
+- `Integration` is an `Interface` instead of a pure Function
+- `Hints` are optional arguments
+- Sentry Dart SDK adds an `IsolateError` handler by default
 
 ## 4.0.0-alpha.2
 
-* Enhancement: `Contexts` were added to the `Scope` #154
-* Fix: App. would hang if `debug` mode was enabled and refactoring ##157
-* Enhancement: Sentry Protocol v7
-* Enhancement: Added missing Protocol fields, `Request`, `SentryStackTrace`...) #155
-* Feat: Added `attachStackTrace` options to attach stack traces on `captureMessage` calls
-* Feat: Flutter SDK has the Native SDKs embedded (Android and Apple) #158
+- Enhancement: `Contexts` were added to the `Scope` #154
+- Fix: App. would hang if `debug` mode was enabled and refactoring ##157
+- Enhancement: Sentry Protocol v7
+- Enhancement: Added missing Protocol fields, `Request`, `SentryStackTrace`...) #155
+- Feat: Added `attachStackTrace` options to attach stack traces on `captureMessage` calls
+- Feat: Flutter SDK has the Native SDKs embedded (Android and Apple) #158
 
 ### Breaking changes
 
-* `Sentry.init` returns a `Future`.
-* Dart min. SDK is `2.8.0`
-* Flutter min. SDK is `1.17.0`
-* Timestamp has millis precision.
-* For better groupping, add your own package to the `addInAppInclude` list, e.g.  `options.addInAppInclude('sentry_flutter_example');`
-* A few classes of the `Protocol` were renamed.
+- `Sentry.init` returns a `Future`.
+- Dart min. SDK is `2.8.0`
+- Flutter min. SDK is `1.17.0`
+- Timestamp has millis precision.
+- For better groupping, add your own package to the `addInAppInclude` list, e.g. `options.addInAppInclude('sentry_flutter_example');`
+- A few classes of the `Protocol` were renamed.
 
 ### Sentry Self Hosted Compatibility
 
-* Since version `4.0.0` of the `sentry_flutter`, `Sentry` version >= `v20.6.0` is required. This only applies to on-premise Sentry, if you are using sentry.io no action is needed.
+- Since version `4.0.0` of the `sentry_flutter`, `Sentry` version >= `v20.6.0` is required. This only applies to on-premise Sentry, if you are using sentry.io no action is needed.
 
 ## 4.0.0-alpha.1
 
@@ -1716,10 +1723,10 @@ First Release of Sentry's new SDK for Dart/Flutter.
 
 New features not offered by <= v4.0.0:
 
-* Sentry's [Unified API](https://develop.sentry.dev/sdk/unified-api/).
-* Complete Sentry [Protocol](https://develop.sentry.dev/sdk/event-payloads/) available.
-* Docs and Migration is under review on this [PR](https://github.com/getsentry/sentry-docs/pull/2599)
-* For all the breaking changes follow this [PR](https://github.com/getsentry/sentry-dart/pull/117), they'll be soon available on the Migration page.
+- Sentry's [Unified API](https://develop.sentry.dev/sdk/unified-api/).
+- Complete Sentry [Protocol](https://develop.sentry.dev/sdk/event-payloads/) available.
+- Docs and Migration is under review on this [PR](https://github.com/getsentry/sentry-docs/pull/2599)
+- For all the breaking changes follow this [PR](https://github.com/getsentry/sentry-dart/pull/117), they'll be soon available on the Migration page.
 
 Packages were released on [pubdev](https://pub.dev/packages/sentry)
 
@@ -1728,85 +1735,85 @@ Until then, the stable SDK offered by Sentry is at version [3.0.1](https://githu
 
 ## 3.0.1
 
-* Add support for Contexts in Sentry events
+- Add support for Contexts in Sentry events
 
 ## 3.0.0+1
 
-* `pubspec.yaml` and example code clean-up.
+- `pubspec.yaml` and example code clean-up.
 
 ## 3.0.0
 
-* Support Web
-  * `SentryClient` from `package:sentry/sentry.dart` with conditional import
-  * `SentryBrowserClient` for web from `package:sentry/browser_client.dart`
-  * `SentryIOClient` for VM and Flutter from `package:sentry/io_client.dart`
+- Support Web
+  - `SentryClient` from `package:sentry/sentry.dart` with conditional import
+  - `SentryBrowserClient` for web from `package:sentry/browser_client.dart`
+  - `SentryIOClient` for VM and Flutter from `package:sentry/io_client.dart`
 
 ## 2.3.1
 
-* Support non-standard port numbers and paths in DSN URL.
+- Support non-standard port numbers and paths in DSN URL.
 
 ## 2.3.0
 
-* Add [breadcrumb](https://docs.sentry.io/development/sdk-dev/event-payloads/breadcrumbs/) support.
+- Add [breadcrumb](https://docs.sentry.io/development/sdk-dev/event-payloads/breadcrumbs/) support.
 
 ## 2.2.0
 
-* Add a `stackFrameFilter` argument to `SentryClient`'s `capture` method (96be842).
-* Clean-up code using pre-Dart 2 API (91c7706, b01ebf8).
+- Add a `stackFrameFilter` argument to `SentryClient`'s `capture` method (96be842).
+- Clean-up code using pre-Dart 2 API (91c7706, b01ebf8).
 
 ## 2.1.1
 
-* Defensively copy internal maps event attributes to
+- Defensively copy internal maps event attributes to
   avoid shared mutable state (https://github.com/flutter/sentry/commit/044e4c1f43c2d199ed206e5529e2a630c90e4434)
 
 ## 2.1.0
 
-* Support DNS format without secret key.
-* Remove dependency on `package:quiver`.
-* The `clock` argument to `SentryClient` constructor _should_ now be
+- Support DNS format without secret key.
+- Remove dependency on `package:quiver`.
+- The `clock` argument to `SentryClient` constructor _should_ now be
   `ClockProvider` (but still accepts `Clock` for backwards compatibility).
 
 ## 2.0.2
 
-* Add support for user context in Sentry events.
+- Add support for user context in Sentry events.
 
 ## 2.0.1
 
-* Invert stack frames to be compatible with Sentry's default culprit detection.
+- Invert stack frames to be compatible with Sentry's default culprit detection.
 
 ## 2.0.0
 
-* Fixed deprecation warnings for Dart 2
-* Refactored tests to work with Dart 2
+- Fixed deprecation warnings for Dart 2
+- Refactored tests to work with Dart 2
 
 ## 1.0.0
 
-* first and last Dart 1-compatible release (we may fix bugs on a separate branch if there's demand)
-* fix code for Dart 2
+- first and last Dart 1-compatible release (we may fix bugs on a separate branch if there's demand)
+- fix code for Dart 2
 
 ## 0.0.6
 
-* use UTC in the `timestamp` field
+- use UTC in the `timestamp` field
 
 ## 0.0.5
 
-* remove sub-seconds from the timestamp
+- remove sub-seconds from the timestamp
 
 ## 0.0.4
 
-* parse and report async gaps in stack traces
+- parse and report async gaps in stack traces
 
 ## 0.0.3
 
-* environment attributes
-* auto-generate event_id and timestamp for events
+- environment attributes
+- auto-generate event_id and timestamp for events
 
 ## 0.0.2
 
-* parse and report stack traces
-* use x-sentry-error HTTP response header
-* gzip outgoing payloads by default
+- parse and report stack traces
+- use x-sentry-error HTTP response header
+- gzip outgoing payloads by default
 
 ## 0.0.1
 
-* basic ability to send exception reports to Sentry.io
+- basic ability to send exception reports to Sentry.io

--- a/flutter/android/build.gradle
+++ b/flutter/android/build.gradle
@@ -22,7 +22,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     // Conditional for compatibility with AGP <4.2.
     if (project.android.hasProperty("namespace")) {

--- a/flutter/example/android/app/build.gradle
+++ b/flutter/example/android/app/build.gradle
@@ -40,7 +40,7 @@ android {
         languageVersion = "1.4"
     }
 
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -49,7 +49,7 @@ android {
     defaultConfig {
         applicationId "io.sentry.samples.flutter"
         minSdkVersion flutter.minSdkVersion
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
 


### PR DESCRIPTION
## :scroll: Description

This PR only bumps `compileSdkVersion` from 33 to 34 (both of the Android plugin, and the Android example app).


## :bulb: Motivation and Context

See https://github.com/flutter/flutter/issues/63533#issuecomment-2027851231 to learn more why this change is beneficial for downstream users.


## :green_heart: How did you test it?

I run the example app locally – it works.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps

Release this :)