### PR TITLE
deps: update package_info_plus range to include 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Dependencies
 
+- Expand dependency range of `package_info_plus` to include major version 7 ([#1984](https://github.com/getsentry/sentry-dart/pull/1984))
 - Bump Android SDK from v7.6.0 to v7.8.0 ([#1977](https://github.com/getsentry/sentry-dart/pull/1977))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#780)
   - [diff](https://github.com/getsentry/sentry-java/compare/7.6.0...7.8.0)

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   sentry: 7.19.0
-  package_info_plus: '>=1.0.0 <7.0.0'
+  package_info_plus: '>=1.0.0 <8.0.0'
   meta: ^1.3.0
   ffi: ^2.0.0
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Updates the range and includes version 7 of package info plus

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
FIxes #1974 

Package info has come out with a new major version 7

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
