### PR TITLE
Apple Privacy Manifest Info

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,10 @@ For detailed usage, check out the inner [dart](https://github.com/getsentry/sent
 * [![Discord Chat](https://img.shields.io/discord/621778831602221064?logo=discord&logoColor=ffffff&color=7389D8)](https://discord.gg/PXa5Apfe7K)  
 * [![Stack Overflow](https://img.shields.io/badge/stack%20overflow-sentry-green.svg)](https://stackoverflow.com/questions/tagged/sentry)
 * [![Twitter Follow](https://img.shields.io/twitter/follow/getsentry?label=getsentry&style=social)](https://twitter.com/intent/follow?screen_name=getsentry)
+
+#### Apple Privacy Manifest
+
+Starting with [May 1st 2024](https://developer.apple.com/news/?id=3d8a9yyh), iOS apps are required to declare approved reasons to access certain APIs. This also includes third-party SDKs.
+If you are using `sentry-flutter`, update to at least version `7.17.0` to get the updated `sentry-cocoa` native iOS/macOS SDK, supporting the privacy manifest.
+All other used dependencies with file declarations are supported by Sentry packages.
+Please run `flutter pub upgrade` to get the latest dependency versions.

--- a/README.md
+++ b/README.md
@@ -54,4 +54,4 @@ For detailed usage, check out the inner [dart](https://github.com/getsentry/sent
 Starting with [May 1st 2024](https://developer.apple.com/news/?id=3d8a9yyh), iOS apps are required to declare approved reasons to access certain APIs. This also includes third-party SDKs.
 If you are using `sentry-flutter`, update to at least version `7.17.0` to get the updated `sentry-cocoa` native iOS/macOS SDK, supporting the privacy manifest.
 All other used dependencies with file declarations are supported by Sentry packages.
-Please run `flutter pub upgrade` to get the latest dependency versions.
+Run [flutter pub upgrade](https://docs.flutter.dev/release/upgrade#upgrading-packages) to the latest compatible versions of all the dependencies.


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->

- Checked all dependencies if they include a `PrivacyInfo.xcprivacy` file and document the version if so.
- Added more info to `readme` file.

| Sentry Package  | Dependency | Has `PrivacyInfo` file | Dependency Version | Sentry Supports Version |
| --------------- | ---------- | ---------------------- | ------------------ | ----------------------- |
| dart | http | No | -- | -- |
| dart | meta | No | -- | -- |
| dart | stack_trace | No | -- | -- |
| dart | uuid | No | -- | -- |
| flutter | package_info_plus | Yes | 6.0.0 | Yes `>=1.0.0 <8.0.0` |
| flutter | ffi | No | -- | -- |
| dio | dio | No | -- | -- |
| drift | drift | No | -- | -- |
| file | file | No | -- | -- |
| hive | hive | No | -- | -- |
| isar | isar | No | -- | -- |
| isar | isar_flutter_libs | No | -- | -- |
| isar | path | No | -- | -- |
| logging | logging | No | -- | -- |
| sqflite | sqflite | Yes | 2.3.1 | Yes `^2.0.0` |
| logging | sqflite_common | No | -- | -- |


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #1946
