### PR TITLE
Allows `package_info_plus` v8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Bump Cocoa SDK from v8.21.0 to v8.24.0 ([#1986](https://github.com/getsentry/sentry-dart/pull/1986))
   - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8240)
   - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.21.0...8.24.0)
-- Expand dependency range of `package_info_plus` to include major version 8 ([#2010](https://github.com/getsentry/sentry-dart/pull/2010))
+- Expand dependency range of `package_info_plus` to allow an open range starting from version 1 ([#2010](https://github.com/getsentry/sentry-dart/pull/2010))
 
 ## 8.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Bump Cocoa SDK from v8.21.0 to v8.24.0 ([#1986](https://github.com/getsentry/sentry-dart/pull/1986))
   - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8240)
   - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.21.0...8.24.0)
-- Expand dependency range of `package_info_plus` to include major version 9 ([#2010](https://github.com/getsentry/sentry-dart/pull/2010))
+- Expand dependency range of `package_info_plus` to include major version 8 ([#2010](https://github.com/getsentry/sentry-dart/pull/2010))
 
 ## 8.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Bump Cocoa SDK from v8.21.0 to v8.24.0 ([#1986](https://github.com/getsentry/sentry-dart/pull/1986))
   - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8240)
   - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.21.0...8.24.0)
+- Expand dependency range of `package_info_plus` to include major version 9 ([#2010](https://github.com/getsentry/sentry-dart/pull/2010))
 
 ## 8.0.0
 

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   sentry: 8.0.0
-  package_info_plus: '>=1.0.0 <9.0.0'
+  package_info_plus: '>=1.0.0'
   meta: ^1.3.0
   ffi: ^2.0.0
 

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   sentry: 8.0.0
-  package_info_plus: '>=1.0.0 <8.0.0'
+  package_info_plus: '>=1.0.0 <9.0.0'
   meta: ^1.3.0
   ffi: ^2.0.0
 


### PR DESCRIPTION
## :scroll: Description

Update the version constraint of `package_info_plus` dependency from `>=1.0.0 <8.0.0` to `>=1.0.0`.

## :bulb: Motivation and Context

A major version was released with the corresponding package, and `sentry_flutter` doesn't allow it to be resolved.

## :green_heart: How did you test it?

N/A

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes
