### PR TITLE
v7: update cocoa to 8.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Bump Cocoa SDK from v8.21.0 to v8.25.0 ([#2018](https://github.com/getsentry/sentry-dart/pull/2018))
+  - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8250)
+  - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.21.0...8.25.0)
+
 ## 7.20.0
 
 ### Build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+### Dependencies
+
 - Bump Cocoa SDK from v8.21.0 to v8.25.0 ([#2018](https://github.com/getsentry/sentry-dart/pull/2018))
   - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8250)
   - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.21.0...8.25.0)

--- a/flutter/ffi-cocoa.yaml
+++ b/flutter/ffi-cocoa.yaml
@@ -5,7 +5,7 @@ output: lib/src/native/cocoa/binding.dart
 headers:
   entry-points:
     - ./cocoa_bindings_temp/Sentry.framework/Versions/A/PrivateHeaders/PrivateSentrySDKOnly.h
-    - ./cocoa_bindings_temp/Sentry.framework/Versions/A/Headers/SentryId.h
+    - ./cocoa_bindings_temp/Sentry.framework/Versions/A/Headers/Sentry-Swift.h
 compiler-opts:
   - -DSENTRY_TARGET_PROFILING_SUPPORTED=1
   - -DCOCOAPODS=1
@@ -16,3 +16,5 @@ objc-interfaces:
   include:
     - PrivateSentrySDKOnly
     - SentryId
+module:
+  'SentryId': 'Sentry'

--- a/flutter/ios/sentry_flutter.podspec
+++ b/flutter/ios/sentry_flutter.podspec
@@ -16,7 +16,7 @@ Sentry SDK for Flutter with support to native through sentry-cocoa.
                          :tag => s.version.to_s }
   s.source_files     = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
-  s.dependency 'Sentry/HybridSDK', '8.21.0'
+  s.dependency 'Sentry/HybridSDK', '8.25.0'
   s.ios.dependency 'Flutter'
   s.osx.dependency 'FlutterMacOS'
   s.ios.deployment_target = '11.0'

--- a/flutter/lib/src/native/cocoa/binding.dart
+++ b/flutter/lib/src/native/cocoa/binding.dart
@@ -1012,6 +1012,10 @@ class SentryCocoa {
   late final _sel_URLWithString_1 = _registerName1("URLWithString:");
   late final _sel_URLWithString_relativeToURL_1 =
       _registerName1("URLWithString:relativeToURL:");
+  late final _sel_initWithString_encodingInvalidCharacters_1 =
+      _registerName1("initWithString:encodingInvalidCharacters:");
+  late final _sel_URLWithString_encodingInvalidCharacters_1 =
+      _registerName1("URLWithString:encodingInvalidCharacters:");
   late final _sel_initWithDataRepresentation_relativeToURL_1 =
       _registerName1("initWithDataRepresentation:relativeToURL:");
   instancetype _objc_msgSend_37(
@@ -4666,9 +4670,11 @@ class SentryCocoa {
   late final _sel_languageCode1 = _registerName1("languageCode");
   late final _sel_localizedStringForLanguageCode_1 =
       _registerName1("localizedStringForLanguageCode:");
+  late final _sel_languageIdentifier1 = _registerName1("languageIdentifier");
   late final _sel_countryCode1 = _registerName1("countryCode");
   late final _sel_localizedStringForCountryCode_1 =
       _registerName1("localizedStringForCountryCode:");
+  late final _sel_regionCode1 = _registerName1("regionCode");
   late final _sel_scriptCode1 = _registerName1("scriptCode");
   late final _sel_localizedStringForScriptCode_1 =
       _registerName1("localizedStringForScriptCode:");
@@ -6032,41 +6038,19 @@ class SentryCocoa {
       _registerName1("fileSystemRepresentation");
   late final _sel_isFileURL1 = _registerName1("isFileURL");
   late final _sel_standardizedURL1 = _registerName1("standardizedURL");
-  late final _sel_checkResourceIsReachableAndReturnError_1 =
-      _registerName1("checkResourceIsReachableAndReturnError:");
-  bool _objc_msgSend_225(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ffi.Pointer<ObjCObject>> error,
-  ) {
-    return __objc_msgSend_225(
-      obj,
-      sel,
-      error,
-    );
-  }
-
-  late final __objc_msgSend_225Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_225 = __objc_msgSend_225Ptr.asFunction<
-      bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ffi.Pointer<ObjCObject>>)>();
-
   late final _sel_isFileReferenceURL1 = _registerName1("isFileReferenceURL");
   late final _sel_fileReferenceURL1 = _registerName1("fileReferenceURL");
   late final _sel_filePathURL1 = _registerName1("filePathURL");
   late final _sel_getResourceValue_forKey_error_1 =
       _registerName1("getResourceValue:forKey:error:");
-  bool _objc_msgSend_226(
+  bool _objc_msgSend_225(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ffi.Pointer<ObjCObject>> value,
     ffi.Pointer<ObjCObject> key,
     ffi.Pointer<ffi.Pointer<ObjCObject>> error,
   ) {
-    return __objc_msgSend_226(
+    return __objc_msgSend_225(
       obj,
       sel,
       value,
@@ -6075,7 +6059,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_226Ptr = _lookup<
+  late final __objc_msgSend_225Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Bool Function(
               ffi.Pointer<ObjCObject>,
@@ -6083,7 +6067,7 @@ class SentryCocoa {
               ffi.Pointer<ffi.Pointer<ObjCObject>>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_226 = __objc_msgSend_226Ptr.asFunction<
+  late final __objc_msgSend_225 = __objc_msgSend_225Ptr.asFunction<
       bool Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -6093,13 +6077,13 @@ class SentryCocoa {
 
   late final _sel_resourceValuesForKeys_error_1 =
       _registerName1("resourceValuesForKeys:error:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_227(
+  ffi.Pointer<ObjCObject> _objc_msgSend_226(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> keys,
     ffi.Pointer<ffi.Pointer<ObjCObject>> error,
   ) {
-    return __objc_msgSend_227(
+    return __objc_msgSend_226(
       obj,
       sel,
       keys,
@@ -6107,14 +6091,14 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_227Ptr = _lookup<
+  late final __objc_msgSend_226Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_227 = __objc_msgSend_227Ptr.asFunction<
+  late final __objc_msgSend_226 = __objc_msgSend_226Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -6123,18 +6107,50 @@ class SentryCocoa {
 
   late final _sel_setResourceValue_forKey_error_1 =
       _registerName1("setResourceValue:forKey:error:");
-  bool _objc_msgSend_228(
+  bool _objc_msgSend_227(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> value,
     ffi.Pointer<ObjCObject> key,
     ffi.Pointer<ffi.Pointer<ObjCObject>> error,
   ) {
-    return __objc_msgSend_228(
+    return __objc_msgSend_227(
       obj,
       sel,
       value,
       key,
+      error,
+    );
+  }
+
+  late final __objc_msgSend_227Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Bool Function(
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
+  late final __objc_msgSend_227 = __objc_msgSend_227Ptr.asFunction<
+      bool Function(
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ffi.Pointer<ObjCObject>>)>();
+
+  late final _sel_setResourceValues_error_1 =
+      _registerName1("setResourceValues:error:");
+  bool _objc_msgSend_228(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> keyedValues,
+    ffi.Pointer<ffi.Pointer<ObjCObject>> error,
+  ) {
+    return __objc_msgSend_228(
+      obj,
+      sel,
+      keyedValues,
       error,
     );
   }
@@ -6145,40 +6161,8 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCObject>,
               ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
   late final __objc_msgSend_228 = __objc_msgSend_228Ptr.asFunction<
-      bool Function(
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ffi.Pointer<ObjCObject>>)>();
-
-  late final _sel_setResourceValues_error_1 =
-      _registerName1("setResourceValues:error:");
-  bool _objc_msgSend_229(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> keyedValues,
-    ffi.Pointer<ffi.Pointer<ObjCObject>> error,
-  ) {
-    return __objc_msgSend_229(
-      obj,
-      sel,
-      keyedValues,
-      error,
-    );
-  }
-
-  late final __objc_msgSend_229Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Bool Function(
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_229 = __objc_msgSend_229Ptr.asFunction<
       bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>, ffi.Pointer<ffi.Pointer<ObjCObject>>)>();
 
@@ -6191,7 +6175,7 @@ class SentryCocoa {
   late final _sel_bookmarkDataWithOptions_includingResourceValuesForKeys_relativeToURL_error_1 =
       _registerName1(
           "bookmarkDataWithOptions:includingResourceValuesForKeys:relativeToURL:error:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_230(
+  ffi.Pointer<ObjCObject> _objc_msgSend_229(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int options,
@@ -6199,7 +6183,7 @@ class SentryCocoa {
     ffi.Pointer<ObjCObject> relativeURL,
     ffi.Pointer<ffi.Pointer<ObjCObject>> error,
   ) {
-    return __objc_msgSend_230(
+    return __objc_msgSend_229(
       obj,
       sel,
       options,
@@ -6209,7 +6193,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_230Ptr = _lookup<
+  late final __objc_msgSend_229Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
@@ -6218,7 +6202,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_230 = __objc_msgSend_230Ptr.asFunction<
+  late final __objc_msgSend_229 = __objc_msgSend_229Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -6230,7 +6214,7 @@ class SentryCocoa {
   late final _sel_initByResolvingBookmarkData_options_relativeToURL_bookmarkDataIsStale_error_1 =
       _registerName1(
           "initByResolvingBookmarkData:options:relativeToURL:bookmarkDataIsStale:error:");
-  instancetype _objc_msgSend_231(
+  instancetype _objc_msgSend_230(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> bookmarkData,
@@ -6239,7 +6223,7 @@ class SentryCocoa {
     ffi.Pointer<ffi.Bool> isStale,
     ffi.Pointer<ffi.Pointer<ObjCObject>> error,
   ) {
-    return __objc_msgSend_231(
+    return __objc_msgSend_230(
       obj,
       sel,
       bookmarkData,
@@ -6250,7 +6234,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_231Ptr = _lookup<
+  late final __objc_msgSend_230Ptr = _lookup<
       ffi.NativeFunction<
           instancetype Function(
               ffi.Pointer<ObjCObject>,
@@ -6260,7 +6244,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ffi.Bool>,
               ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_231 = __objc_msgSend_231Ptr.asFunction<
+  late final __objc_msgSend_230 = __objc_msgSend_230Ptr.asFunction<
       instancetype Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -6275,13 +6259,13 @@ class SentryCocoa {
           "URLByResolvingBookmarkData:options:relativeToURL:bookmarkDataIsStale:error:");
   late final _sel_resourceValuesForKeys_fromBookmarkData_1 =
       _registerName1("resourceValuesForKeys:fromBookmarkData:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_232(
+  ffi.Pointer<ObjCObject> _objc_msgSend_231(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> keys,
     ffi.Pointer<ObjCObject> bookmarkData,
   ) {
-    return __objc_msgSend_232(
+    return __objc_msgSend_231(
       obj,
       sel,
       keys,
@@ -6289,14 +6273,14 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_232Ptr = _lookup<
+  late final __objc_msgSend_231Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_232 = __objc_msgSend_232Ptr.asFunction<
+  late final __objc_msgSend_231 = __objc_msgSend_231Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -6305,7 +6289,7 @@ class SentryCocoa {
 
   late final _sel_writeBookmarkData_toURL_options_error_1 =
       _registerName1("writeBookmarkData:toURL:options:error:");
-  bool _objc_msgSend_233(
+  bool _objc_msgSend_232(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> bookmarkData,
@@ -6313,7 +6297,7 @@ class SentryCocoa {
     int options,
     ffi.Pointer<ffi.Pointer<ObjCObject>> error,
   ) {
-    return __objc_msgSend_233(
+    return __objc_msgSend_232(
       obj,
       sel,
       bookmarkData,
@@ -6323,7 +6307,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_233Ptr = _lookup<
+  late final __objc_msgSend_232Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Bool Function(
               ffi.Pointer<ObjCObject>,
@@ -6332,7 +6316,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.UnsignedLong,
               ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_233 = __objc_msgSend_233Ptr.asFunction<
+  late final __objc_msgSend_232 = __objc_msgSend_232Ptr.asFunction<
       bool Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -6343,13 +6327,13 @@ class SentryCocoa {
 
   late final _sel_bookmarkDataWithContentsOfURL_error_1 =
       _registerName1("bookmarkDataWithContentsOfURL:error:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_234(
+  ffi.Pointer<ObjCObject> _objc_msgSend_233(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> bookmarkFileURL,
     ffi.Pointer<ffi.Pointer<ObjCObject>> error,
   ) {
-    return __objc_msgSend_234(
+    return __objc_msgSend_233(
       obj,
       sel,
       bookmarkFileURL,
@@ -6357,14 +6341,14 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_234Ptr = _lookup<
+  late final __objc_msgSend_233Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_234 = __objc_msgSend_234Ptr.asFunction<
+  late final __objc_msgSend_233 = __objc_msgSend_233Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -6373,14 +6357,14 @@ class SentryCocoa {
 
   late final _sel_URLByResolvingAliasFileAtURL_options_error_1 =
       _registerName1("URLByResolvingAliasFileAtURL:options:error:");
-  instancetype _objc_msgSend_235(
+  instancetype _objc_msgSend_234(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> url,
     int options,
     ffi.Pointer<ffi.Pointer<ObjCObject>> error,
   ) {
-    return __objc_msgSend_235(
+    return __objc_msgSend_234(
       obj,
       sel,
       url,
@@ -6389,7 +6373,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_235Ptr = _lookup<
+  late final __objc_msgSend_234Ptr = _lookup<
       ffi.NativeFunction<
           instancetype Function(
               ffi.Pointer<ObjCObject>,
@@ -6397,7 +6381,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Int32,
               ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_235 = __objc_msgSend_235Ptr.asFunction<
+  late final __objc_msgSend_234 = __objc_msgSend_234Ptr.asFunction<
       instancetype Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -6413,13 +6397,13 @@ class SentryCocoa {
       _registerName1("getPromisedItemResourceValue:forKey:error:");
   late final _sel_promisedItemResourceValuesForKeys_error_1 =
       _registerName1("promisedItemResourceValuesForKeys:error:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_236(
+  ffi.Pointer<ObjCObject> _objc_msgSend_235(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> keys,
     ffi.Pointer<ffi.Pointer<ObjCObject>> error,
   ) {
-    return __objc_msgSend_236(
+    return __objc_msgSend_235(
       obj,
       sel,
       keys,
@@ -6427,14 +6411,14 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_236Ptr = _lookup<
+  late final __objc_msgSend_235Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_236 = __objc_msgSend_236Ptr.asFunction<
+  late final __objc_msgSend_235 = __objc_msgSend_235Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -6443,6 +6427,26 @@ class SentryCocoa {
 
   late final _sel_checkPromisedItemIsReachableAndReturnError_1 =
       _registerName1("checkPromisedItemIsReachableAndReturnError:");
+  bool _objc_msgSend_236(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ffi.Pointer<ObjCObject>> error,
+  ) {
+    return __objc_msgSend_236(
+      obj,
+      sel,
+      error,
+    );
+  }
+
+  late final __objc_msgSend_236Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
+  late final __objc_msgSend_236 = __objc_msgSend_236Ptr.asFunction<
+      bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ffi.Pointer<ObjCObject>>)>();
+
   late final _sel_fileURLWithPathComponents_1 =
       _registerName1("fileURLWithPathComponents:");
   ffi.Pointer<ObjCObject> _objc_msgSend_237(
@@ -6478,6 +6482,8 @@ class SentryCocoa {
       _registerName1("URLByAppendingPathExtension:");
   late final _sel_URLByDeletingPathExtension1 =
       _registerName1("URLByDeletingPathExtension");
+  late final _sel_checkResourceIsReachableAndReturnError_1 =
+      _registerName1("checkResourceIsReachableAndReturnError:");
   late final _sel_URLByStandardizingPath1 =
       _registerName1("URLByStandardizingPath");
   late final _sel_URLByResolvingSymlinksInPath1 =
@@ -19070,36 +19076,173 @@ class SentryCocoa {
       instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>, int)>();
 
-  late final _sel_attributedStringByInflectingString1 =
-      _registerName1("attributedStringByInflectingString");
-  ffi.Pointer<ObjCObject> _objc_msgSend_675(
+  late final _sel_initWithFormat_options_locale_context_1 =
+      _registerName1("initWithFormat:options:locale:context:");
+  instancetype _objc_msgSend_675(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> format,
+    int options,
+    ffi.Pointer<ObjCObject> locale,
+    ffi.Pointer<ObjCObject> context,
   ) {
     return __objc_msgSend_675(
       obj,
       sel,
+      format,
+      options,
+      locale,
+      context,
     );
   }
 
   late final __objc_msgSend_675Ptr = _lookup<
       ffi.NativeFunction<
+          instancetype Function(
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Int32,
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
+  late final __objc_msgSend_675 = __objc_msgSend_675Ptr.asFunction<
+      instancetype Function(
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>,
+          int,
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCObject>)>();
+
+  late final _sel_initWithFormat_options_locale_context_arguments_1 =
+      _registerName1("initWithFormat:options:locale:context:arguments:");
+  instancetype _objc_msgSend_676(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> format,
+    int options,
+    ffi.Pointer<ObjCObject> locale,
+    ffi.Pointer<ObjCObject> context,
+    ffi.Pointer<__va_list_tag> arguments,
+  ) {
+    return __objc_msgSend_676(
+      obj,
+      sel,
+      format,
+      options,
+      locale,
+      context,
+      arguments,
+    );
+  }
+
+  late final __objc_msgSend_676Ptr = _lookup<
+      ffi.NativeFunction<
+          instancetype Function(
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Int32,
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<__va_list_tag>)>>('objc_msgSend');
+  late final __objc_msgSend_676 = __objc_msgSend_676Ptr.asFunction<
+      instancetype Function(
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>,
+          int,
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<__va_list_tag>)>();
+
+  late final _sel_localizedAttributedStringWithFormat_context_1 =
+      _registerName1("localizedAttributedStringWithFormat:context:");
+  instancetype _objc_msgSend_677(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> format,
+    ffi.Pointer<ObjCObject> context,
+  ) {
+    return __objc_msgSend_677(
+      obj,
+      sel,
+      format,
+      context,
+    );
+  }
+
+  late final __objc_msgSend_677Ptr = _lookup<
+      ffi.NativeFunction<
+          instancetype Function(
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
+  late final __objc_msgSend_677 = __objc_msgSend_677Ptr.asFunction<
+      instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCObject>)>();
+
+  late final _sel_localizedAttributedStringWithFormat_options_context_1 =
+      _registerName1("localizedAttributedStringWithFormat:options:context:");
+  instancetype _objc_msgSend_678(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> format,
+    int options,
+    ffi.Pointer<ObjCObject> context,
+  ) {
+    return __objc_msgSend_678(
+      obj,
+      sel,
+      format,
+      options,
+      context,
+    );
+  }
+
+  late final __objc_msgSend_678Ptr = _lookup<
+      ffi.NativeFunction<
+          instancetype Function(
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Int32,
+              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
+  late final __objc_msgSend_678 = __objc_msgSend_678Ptr.asFunction<
+      instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>, int, ffi.Pointer<ObjCObject>)>();
+
+  late final _sel_attributedStringByInflectingString1 =
+      _registerName1("attributedStringByInflectingString");
+  ffi.Pointer<ObjCObject> _objc_msgSend_679(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+  ) {
+    return __objc_msgSend_679(
+      obj,
+      sel,
+    );
+  }
+
+  late final __objc_msgSend_679Ptr = _lookup<
+      ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_675 = __objc_msgSend_675Ptr.asFunction<
+  late final __objc_msgSend_679 = __objc_msgSend_679Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
   late final _sel_localizedAttributedStringForKey_value_table_1 =
       _registerName1("localizedAttributedStringForKey:value:table:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_676(
+  ffi.Pointer<ObjCObject> _objc_msgSend_680(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> key,
     ffi.Pointer<ObjCObject> value,
     ffi.Pointer<ObjCObject> tableName,
   ) {
-    return __objc_msgSend_676(
+    return __objc_msgSend_680(
       obj,
       sel,
       key,
@@ -19108,7 +19251,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_676Ptr = _lookup<
+  late final __objc_msgSend_680Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
@@ -19116,7 +19259,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_676 = __objc_msgSend_676Ptr.asFunction<
+  late final __objc_msgSend_680 = __objc_msgSend_680Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -19141,13 +19284,13 @@ class SentryCocoa {
       _registerName1("preferredLocalizationsFromArray:");
   late final _sel_preferredLocalizationsFromArray_forPreferences_1 =
       _registerName1("preferredLocalizationsFromArray:forPreferences:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_677(
+  ffi.Pointer<ObjCObject> _objc_msgSend_681(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> localizationsArray,
     ffi.Pointer<ObjCObject> preferencesArray,
   ) {
-    return __objc_msgSend_677(
+    return __objc_msgSend_681(
       obj,
       sel,
       localizationsArray,
@@ -19155,14 +19298,14 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_677Ptr = _lookup<
+  late final __objc_msgSend_681Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_677 = __objc_msgSend_677Ptr.asFunction<
+  late final __objc_msgSend_681 = __objc_msgSend_681Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -19173,13 +19316,13 @@ class SentryCocoa {
       _registerName1("executableArchitectures");
   late final _sel_setPreservationPriority_forTags_1 =
       _registerName1("setPreservationPriority:forTags:");
-  void _objc_msgSend_678(
+  void _objc_msgSend_682(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     double priority,
     ffi.Pointer<ObjCObject> tags,
   ) {
-    return __objc_msgSend_678(
+    return __objc_msgSend_682(
       obj,
       sel,
       priority,
@@ -19187,11 +19330,11 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_678Ptr = _lookup<
+  late final __objc_msgSend_682Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Double, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_678 = __objc_msgSend_678Ptr.asFunction<
+  late final __objc_msgSend_682 = __objc_msgSend_682Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, double,
           ffi.Pointer<ObjCObject>)>();
 
@@ -19201,13 +19344,13 @@ class SentryCocoa {
       _getClass1("NSMutableAttributedString");
   late final _sel_setAttributes_range_1 =
       _registerName1("setAttributes:range:");
-  void _objc_msgSend_679(
+  void _objc_msgSend_683(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> attrs,
     _NSRange range,
   ) {
-    return __objc_msgSend_679(
+    return __objc_msgSend_683(
       obj,
       sel,
       attrs,
@@ -19215,43 +19358,43 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_679Ptr = _lookup<
+  late final __objc_msgSend_683Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>, _NSRange)>>('objc_msgSend');
-  late final __objc_msgSend_679 = __objc_msgSend_679Ptr.asFunction<
+  late final __objc_msgSend_683 = __objc_msgSend_683Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>, _NSRange)>();
 
   late final _sel_mutableString1 = _registerName1("mutableString");
-  ffi.Pointer<ObjCObject> _objc_msgSend_680(
+  ffi.Pointer<ObjCObject> _objc_msgSend_684(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_680(
+    return __objc_msgSend_684(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_680Ptr = _lookup<
+  late final __objc_msgSend_684Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_680 = __objc_msgSend_680Ptr.asFunction<
+  late final __objc_msgSend_684 = __objc_msgSend_684Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
   late final _sel_addAttribute_value_range_1 =
       _registerName1("addAttribute:value:range:");
-  void _objc_msgSend_681(
+  void _objc_msgSend_685(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> name,
     ffi.Pointer<ObjCObject> value,
     _NSRange range,
   ) {
-    return __objc_msgSend_681(
+    return __objc_msgSend_685(
       obj,
       sel,
       name,
@@ -19260,7 +19403,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_681Ptr = _lookup<
+  late final __objc_msgSend_685Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(
               ffi.Pointer<ObjCObject>,
@@ -19268,7 +19411,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>,
               _NSRange)>>('objc_msgSend');
-  late final __objc_msgSend_681 = __objc_msgSend_681Ptr.asFunction<
+  late final __objc_msgSend_685 = __objc_msgSend_685Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCObject>, _NSRange)>();
 
@@ -19276,13 +19419,13 @@ class SentryCocoa {
       _registerName1("addAttributes:range:");
   late final _sel_removeAttribute_range_1 =
       _registerName1("removeAttribute:range:");
-  void _objc_msgSend_682(
+  void _objc_msgSend_686(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> name,
     _NSRange range,
   ) {
-    return __objc_msgSend_682(
+    return __objc_msgSend_686(
       obj,
       sel,
       name,
@@ -19290,23 +19433,23 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_682Ptr = _lookup<
+  late final __objc_msgSend_686Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>, _NSRange)>>('objc_msgSend');
-  late final __objc_msgSend_682 = __objc_msgSend_682Ptr.asFunction<
+  late final __objc_msgSend_686 = __objc_msgSend_686Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>, _NSRange)>();
 
   late final _sel_replaceCharactersInRange_withAttributedString_1 =
       _registerName1("replaceCharactersInRange:withAttributedString:");
-  void _objc_msgSend_683(
+  void _objc_msgSend_687(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     _NSRange range,
     ffi.Pointer<ObjCObject> attrString,
   ) {
-    return __objc_msgSend_683(
+    return __objc_msgSend_687(
       obj,
       sel,
       range,
@@ -19314,23 +19457,23 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_683Ptr = _lookup<
+  late final __objc_msgSend_687Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               _NSRange, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_683 = __objc_msgSend_683Ptr.asFunction<
+  late final __objc_msgSend_687 = __objc_msgSend_687Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, _NSRange,
           ffi.Pointer<ObjCObject>)>();
 
   late final _sel_insertAttributedString_atIndex_1 =
       _registerName1("insertAttributedString:atIndex:");
-  void _objc_msgSend_684(
+  void _objc_msgSend_688(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> attrString,
     int loc,
   ) {
-    return __objc_msgSend_684(
+    return __objc_msgSend_688(
       obj,
       sel,
       attrString,
@@ -19338,33 +19481,33 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_684Ptr = _lookup<
+  late final __objc_msgSend_688Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>, ffi.UnsignedLong)>>('objc_msgSend');
-  late final __objc_msgSend_684 = __objc_msgSend_684Ptr.asFunction<
+  late final __objc_msgSend_688 = __objc_msgSend_688Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>, int)>();
 
   late final _sel_appendAttributedString_1 =
       _registerName1("appendAttributedString:");
-  void _objc_msgSend_685(
+  void _objc_msgSend_689(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> attrString,
   ) {
-    return __objc_msgSend_685(
+    return __objc_msgSend_689(
       obj,
       sel,
       attrString,
     );
   }
 
-  late final __objc_msgSend_685Ptr = _lookup<
+  late final __objc_msgSend_689Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_685 = __objc_msgSend_685Ptr.asFunction<
+  late final __objc_msgSend_689 = __objc_msgSend_689Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>)>();
 
@@ -19380,13 +19523,13 @@ class SentryCocoa {
       _registerName1("stringForObjectValue:");
   late final _sel_attributedStringForObjectValue_withDefaultAttributes_1 =
       _registerName1("attributedStringForObjectValue:withDefaultAttributes:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_686(
+  ffi.Pointer<ObjCObject> _objc_msgSend_690(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> obj1,
     ffi.Pointer<ObjCObject> attrs,
   ) {
-    return __objc_msgSend_686(
+    return __objc_msgSend_690(
       obj,
       sel,
       obj1,
@@ -19394,14 +19537,14 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_686Ptr = _lookup<
+  late final __objc_msgSend_690Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_686 = __objc_msgSend_686Ptr.asFunction<
+  late final __objc_msgSend_690 = __objc_msgSend_690Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -19412,14 +19555,14 @@ class SentryCocoa {
       _registerName1("editingStringForObjectValue:");
   late final _sel_getObjectValue_forString_errorDescription_1 =
       _registerName1("getObjectValue:forString:errorDescription:");
-  bool _objc_msgSend_687(
+  bool _objc_msgSend_691(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ffi.Pointer<ObjCObject>> obj1,
     ffi.Pointer<ObjCObject> string,
     ffi.Pointer<ffi.Pointer<ObjCObject>> error,
   ) {
-    return __objc_msgSend_687(
+    return __objc_msgSend_691(
       obj,
       sel,
       obj1,
@@ -19428,7 +19571,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_687Ptr = _lookup<
+  late final __objc_msgSend_691Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Bool Function(
               ffi.Pointer<ObjCObject>,
@@ -19436,7 +19579,7 @@ class SentryCocoa {
               ffi.Pointer<ffi.Pointer<ObjCObject>>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_687 = __objc_msgSend_687Ptr.asFunction<
+  late final __objc_msgSend_691 = __objc_msgSend_691Ptr.asFunction<
       bool Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -19446,14 +19589,14 @@ class SentryCocoa {
 
   late final _sel_isPartialStringValid_newEditingString_errorDescription_1 =
       _registerName1("isPartialStringValid:newEditingString:errorDescription:");
-  bool _objc_msgSend_688(
+  bool _objc_msgSend_692(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> partialString,
     ffi.Pointer<ffi.Pointer<ObjCObject>> newString,
     ffi.Pointer<ffi.Pointer<ObjCObject>> error,
   ) {
-    return __objc_msgSend_688(
+    return __objc_msgSend_692(
       obj,
       sel,
       partialString,
@@ -19462,7 +19605,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_688Ptr = _lookup<
+  late final __objc_msgSend_692Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Bool Function(
               ffi.Pointer<ObjCObject>,
@@ -19470,7 +19613,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ffi.Pointer<ObjCObject>>,
               ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_688 = __objc_msgSend_688Ptr.asFunction<
+  late final __objc_msgSend_692 = __objc_msgSend_692Ptr.asFunction<
       bool Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -19481,7 +19624,7 @@ class SentryCocoa {
   late final _sel_isPartialStringValid_proposedSelectedRange_originalString_originalSelectedRange_errorDescription_1 =
       _registerName1(
           "isPartialStringValid:proposedSelectedRange:originalString:originalSelectedRange:errorDescription:");
-  bool _objc_msgSend_689(
+  bool _objc_msgSend_693(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ffi.Pointer<ObjCObject>> partialStringPtr,
@@ -19490,7 +19633,7 @@ class SentryCocoa {
     _NSRange origSelRange,
     ffi.Pointer<ffi.Pointer<ObjCObject>> error,
   ) {
-    return __objc_msgSend_689(
+    return __objc_msgSend_693(
       obj,
       sel,
       partialStringPtr,
@@ -19501,7 +19644,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_689Ptr = _lookup<
+  late final __objc_msgSend_693Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Bool Function(
               ffi.Pointer<ObjCObject>,
@@ -19511,7 +19654,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               _NSRange,
               ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_689 = __objc_msgSend_689Ptr.asFunction<
+  late final __objc_msgSend_693 = __objc_msgSend_693Ptr.asFunction<
       bool Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -19522,47 +19665,47 @@ class SentryCocoa {
           ffi.Pointer<ffi.Pointer<ObjCObject>>)>();
 
   late final _sel_formattingContext1 = _registerName1("formattingContext");
-  int _objc_msgSend_690(
+  int _objc_msgSend_694(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_690(
+    return __objc_msgSend_694(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_690Ptr = _lookup<
+  late final __objc_msgSend_694Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Int32 Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_690 = __objc_msgSend_690Ptr.asFunction<
+  late final __objc_msgSend_694 = __objc_msgSend_694Ptr.asFunction<
       int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
   late final _sel_setFormattingContext_1 =
       _registerName1("setFormattingContext:");
-  void _objc_msgSend_691(
+  void _objc_msgSend_695(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int value,
   ) {
-    return __objc_msgSend_691(
+    return __objc_msgSend_695(
       obj,
       sel,
       value,
     );
   }
 
-  late final __objc_msgSend_691Ptr = _lookup<
+  late final __objc_msgSend_695Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_691 = __objc_msgSend_691Ptr.asFunction<
+  late final __objc_msgSend_695 = __objc_msgSend_695Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
 
   late final _sel_getObjectValue_forString_range_error_1 =
       _registerName1("getObjectValue:forString:range:error:");
-  bool _objc_msgSend_692(
+  bool _objc_msgSend_696(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ffi.Pointer<ObjCObject>> obj1,
@@ -19570,7 +19713,7 @@ class SentryCocoa {
     ffi.Pointer<_NSRange> rangep,
     ffi.Pointer<ffi.Pointer<ObjCObject>> error,
   ) {
-    return __objc_msgSend_692(
+    return __objc_msgSend_696(
       obj,
       sel,
       obj1,
@@ -19580,7 +19723,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_692Ptr = _lookup<
+  late final __objc_msgSend_696Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Bool Function(
               ffi.Pointer<ObjCObject>,
@@ -19589,7 +19732,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<_NSRange>,
               ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_692 = __objc_msgSend_692Ptr.asFunction<
+  late final __objc_msgSend_696 = __objc_msgSend_696Ptr.asFunction<
       bool Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -19602,14 +19745,14 @@ class SentryCocoa {
   late final _sel_dateFromString_1 = _registerName1("dateFromString:");
   late final _sel_localizedStringFromDate_dateStyle_timeStyle_1 =
       _registerName1("localizedStringFromDate:dateStyle:timeStyle:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_693(
+  ffi.Pointer<ObjCObject> _objc_msgSend_697(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> date,
     int dstyle,
     int tstyle,
   ) {
-    return __objc_msgSend_693(
+    return __objc_msgSend_697(
       obj,
       sel,
       date,
@@ -19618,7 +19761,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_693Ptr = _lookup<
+  late final __objc_msgSend_697Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
@@ -19626,20 +19769,20 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Int32,
               ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_693 = __objc_msgSend_693Ptr.asFunction<
+  late final __objc_msgSend_697 = __objc_msgSend_697Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>, int, int)>();
 
   late final _sel_dateFormatFromTemplate_options_locale_1 =
       _registerName1("dateFormatFromTemplate:options:locale:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_694(
+  ffi.Pointer<ObjCObject> _objc_msgSend_698(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> tmplate,
     int opts,
     ffi.Pointer<ObjCObject> locale,
   ) {
-    return __objc_msgSend_694(
+    return __objc_msgSend_698(
       obj,
       sel,
       tmplate,
@@ -19648,7 +19791,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_694Ptr = _lookup<
+  late final __objc_msgSend_698Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
@@ -19656,7 +19799,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.UnsignedLong,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_694 = __objc_msgSend_694Ptr.asFunction<
+  late final __objc_msgSend_698 = __objc_msgSend_698Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -19666,42 +19809,42 @@ class SentryCocoa {
 
   late final _sel_defaultFormatterBehavior1 =
       _registerName1("defaultFormatterBehavior");
-  int _objc_msgSend_695(
+  int _objc_msgSend_699(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_695(
+    return __objc_msgSend_699(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_695Ptr = _lookup<
+  late final __objc_msgSend_699Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Int32 Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_695 = __objc_msgSend_695Ptr.asFunction<
+  late final __objc_msgSend_699 = __objc_msgSend_699Ptr.asFunction<
       int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
   late final _sel_setDefaultFormatterBehavior_1 =
       _registerName1("setDefaultFormatterBehavior:");
-  void _objc_msgSend_696(
+  void _objc_msgSend_700(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int value,
   ) {
-    return __objc_msgSend_696(
+    return __objc_msgSend_700(
       obj,
       sel,
       value,
     );
   }
 
-  late final __objc_msgSend_696Ptr = _lookup<
+  late final __objc_msgSend_700Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_696 = __objc_msgSend_696Ptr.asFunction<
+  late final __objc_msgSend_700 = __objc_msgSend_700Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
 
   late final _sel_setLocalizedDateFormatFromTemplate_1 =
@@ -19709,64 +19852,64 @@ class SentryCocoa {
   late final _sel_dateFormat1 = _registerName1("dateFormat");
   late final _sel_setDateFormat_1 = _registerName1("setDateFormat:");
   late final _sel_dateStyle1 = _registerName1("dateStyle");
-  int _objc_msgSend_697(
+  int _objc_msgSend_701(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_697(
+    return __objc_msgSend_701(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_697Ptr = _lookup<
+  late final __objc_msgSend_701Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Int32 Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_697 = __objc_msgSend_697Ptr.asFunction<
+  late final __objc_msgSend_701 = __objc_msgSend_701Ptr.asFunction<
       int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
   late final _sel_setDateStyle_1 = _registerName1("setDateStyle:");
-  void _objc_msgSend_698(
+  void _objc_msgSend_702(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int value,
   ) {
-    return __objc_msgSend_698(
+    return __objc_msgSend_702(
       obj,
       sel,
       value,
     );
   }
 
-  late final __objc_msgSend_698Ptr = _lookup<
+  late final __objc_msgSend_702Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_698 = __objc_msgSend_698Ptr.asFunction<
+  late final __objc_msgSend_702 = __objc_msgSend_702Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
 
   late final _sel_timeStyle1 = _registerName1("timeStyle");
   late final _sel_setTimeStyle_1 = _registerName1("setTimeStyle:");
   late final _sel_locale1 = _registerName1("locale");
   late final _sel_setLocale_1 = _registerName1("setLocale:");
-  void _objc_msgSend_699(
+  void _objc_msgSend_703(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> value,
   ) {
-    return __objc_msgSend_699(
+    return __objc_msgSend_703(
       obj,
       sel,
       value,
     );
   }
 
-  late final __objc_msgSend_699Ptr = _lookup<
+  late final __objc_msgSend_703Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_699 = __objc_msgSend_699Ptr.asFunction<
+  late final __objc_msgSend_703 = __objc_msgSend_703Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>)>();
 
@@ -19779,21 +19922,21 @@ class SentryCocoa {
       _registerName1("setFormatterBehavior:");
   late final _class_NSCalendar1 = _getClass1("NSCalendar");
   late final _sel_currentCalendar1 = _registerName1("currentCalendar");
-  ffi.Pointer<ObjCObject> _objc_msgSend_700(
+  ffi.Pointer<ObjCObject> _objc_msgSend_704(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_700(
+    return __objc_msgSend_704(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_700Ptr = _lookup<
+  late final __objc_msgSend_704Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_700 = __objc_msgSend_700Ptr.asFunction<
+  late final __objc_msgSend_704 = __objc_msgSend_704Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
@@ -19801,23 +19944,23 @@ class SentryCocoa {
       _registerName1("autoupdatingCurrentCalendar");
   late final _sel_calendarWithIdentifier_1 =
       _registerName1("calendarWithIdentifier:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_701(
+  ffi.Pointer<ObjCObject> _objc_msgSend_705(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> calendarIdentifierConstant,
   ) {
-    return __objc_msgSend_701(
+    return __objc_msgSend_705(
       obj,
       sel,
       calendarIdentifierConstant,
     );
   }
 
-  late final __objc_msgSend_701Ptr = _lookup<
+  late final __objc_msgSend_705Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_701 = __objc_msgSend_701Ptr.asFunction<
+  late final __objc_msgSend_705 = __objc_msgSend_705Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
 
@@ -19860,13 +20003,13 @@ class SentryCocoa {
   late final _sel_AMSymbol1 = _registerName1("AMSymbol");
   late final _sel_PMSymbol1 = _registerName1("PMSymbol");
   late final _sel_minimumRangeOfUnit_1 = _registerName1("minimumRangeOfUnit:");
-  void _objc_msgSend_702(
+  void _objc_msgSend_706(
     ffi.Pointer<_NSRange> stret,
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int unit,
   ) {
-    return __objc_msgSend_702(
+    return __objc_msgSend_706(
       stret,
       obj,
       sel,
@@ -19874,18 +20017,18 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_702Ptr = _lookup<
+  late final __objc_msgSend_706Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<_NSRange>, ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>, ffi.Int32)>>('objc_msgSend_stret');
-  late final __objc_msgSend_702 = __objc_msgSend_702Ptr.asFunction<
+  late final __objc_msgSend_706 = __objc_msgSend_706Ptr.asFunction<
       void Function(ffi.Pointer<_NSRange>, ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, int)>();
 
   late final _sel_maximumRangeOfUnit_1 = _registerName1("maximumRangeOfUnit:");
   late final _sel_rangeOfUnit_inUnit_forDate_1 =
       _registerName1("rangeOfUnit:inUnit:forDate:");
-  void _objc_msgSend_703(
+  void _objc_msgSend_707(
     ffi.Pointer<_NSRange> stret,
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
@@ -19893,7 +20036,7 @@ class SentryCocoa {
     int larger,
     ffi.Pointer<ObjCObject> date,
   ) {
-    return __objc_msgSend_703(
+    return __objc_msgSend_707(
       stret,
       obj,
       sel,
@@ -19903,7 +20046,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_703Ptr = _lookup<
+  late final __objc_msgSend_707Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(
               ffi.Pointer<_NSRange>,
@@ -19912,20 +20055,20 @@ class SentryCocoa {
               ffi.Int32,
               ffi.Int32,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend_stret');
-  late final __objc_msgSend_703 = __objc_msgSend_703Ptr.asFunction<
+  late final __objc_msgSend_707 = __objc_msgSend_707Ptr.asFunction<
       void Function(ffi.Pointer<_NSRange>, ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, int, int, ffi.Pointer<ObjCObject>)>();
 
   late final _sel_ordinalityOfUnit_inUnit_forDate_1 =
       _registerName1("ordinalityOfUnit:inUnit:forDate:");
-  int _objc_msgSend_704(
+  int _objc_msgSend_708(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int smaller,
     int larger,
     ffi.Pointer<ObjCObject> date,
   ) {
-    return __objc_msgSend_704(
+    return __objc_msgSend_708(
       obj,
       sel,
       smaller,
@@ -19934,7 +20077,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_704Ptr = _lookup<
+  late final __objc_msgSend_708Ptr = _lookup<
       ffi.NativeFunction<
           ffi.UnsignedLong Function(
               ffi.Pointer<ObjCObject>,
@@ -19942,13 +20085,13 @@ class SentryCocoa {
               ffi.Int32,
               ffi.Int32,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_704 = __objc_msgSend_704Ptr.asFunction<
+  late final __objc_msgSend_708 = __objc_msgSend_708Ptr.asFunction<
       int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int, int,
           ffi.Pointer<ObjCObject>)>();
 
   late final _sel_rangeOfUnit_startDate_interval_forDate_1 =
       _registerName1("rangeOfUnit:startDate:interval:forDate:");
-  bool _objc_msgSend_705(
+  bool _objc_msgSend_709(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int unit,
@@ -19956,7 +20099,7 @@ class SentryCocoa {
     ffi.Pointer<ffi.Double> tip,
     ffi.Pointer<ObjCObject> date,
   ) {
-    return __objc_msgSend_705(
+    return __objc_msgSend_709(
       obj,
       sel,
       unit,
@@ -19966,7 +20109,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_705Ptr = _lookup<
+  late final __objc_msgSend_709Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Bool Function(
               ffi.Pointer<ObjCObject>,
@@ -19975,7 +20118,7 @@ class SentryCocoa {
               ffi.Pointer<ffi.Pointer<ObjCObject>>,
               ffi.Pointer<ffi.Double>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_705 = __objc_msgSend_705Ptr.asFunction<
+  late final __objc_msgSend_709 = __objc_msgSend_709Ptr.asFunction<
       bool Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -19987,23 +20130,23 @@ class SentryCocoa {
   late final _class_NSDateComponents1 = _getClass1("NSDateComponents");
   late final _sel_calendar1 = _registerName1("calendar");
   late final _sel_setCalendar_1 = _registerName1("setCalendar:");
-  void _objc_msgSend_706(
+  void _objc_msgSend_710(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> value,
   ) {
-    return __objc_msgSend_706(
+    return __objc_msgSend_710(
       obj,
       sel,
       value,
     );
   }
 
-  late final __objc_msgSend_706Ptr = _lookup<
+  late final __objc_msgSend_710Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_706 = __objc_msgSend_706Ptr.asFunction<
+  late final __objc_msgSend_710 = __objc_msgSend_710Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>)>();
 
@@ -20042,13 +20185,13 @@ class SentryCocoa {
   late final _sel_setWeek_1 = _registerName1("setWeek:");
   late final _sel_setValue_forComponent_1 =
       _registerName1("setValue:forComponent:");
-  void _objc_msgSend_707(
+  void _objc_msgSend_711(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int value,
     int unit,
   ) {
-    return __objc_msgSend_707(
+    return __objc_msgSend_711(
       obj,
       sel,
       value,
@@ -20056,86 +20199,86 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_707Ptr = _lookup<
+  late final __objc_msgSend_711Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Long, ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_707 = __objc_msgSend_707Ptr.asFunction<
+  late final __objc_msgSend_711 = __objc_msgSend_711Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int, int)>();
 
   late final _sel_valueForComponent_1 = _registerName1("valueForComponent:");
-  int _objc_msgSend_708(
+  int _objc_msgSend_712(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int unit,
   ) {
-    return __objc_msgSend_708(
+    return __objc_msgSend_712(
       obj,
       sel,
       unit,
     );
   }
 
-  late final __objc_msgSend_708Ptr = _lookup<
+  late final __objc_msgSend_712Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Long Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_708 = __objc_msgSend_708Ptr.asFunction<
+  late final __objc_msgSend_712 = __objc_msgSend_712Ptr.asFunction<
       int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
 
   late final _sel_isValidDate1 = _registerName1("isValidDate");
   late final _sel_isValidDateInCalendar_1 =
       _registerName1("isValidDateInCalendar:");
-  bool _objc_msgSend_709(
+  bool _objc_msgSend_713(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> calendar,
   ) {
-    return __objc_msgSend_709(
+    return __objc_msgSend_713(
       obj,
       sel,
       calendar,
     );
   }
 
-  late final __objc_msgSend_709Ptr = _lookup<
+  late final __objc_msgSend_713Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_709 = __objc_msgSend_709Ptr.asFunction<
+  late final __objc_msgSend_713 = __objc_msgSend_713Ptr.asFunction<
       bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>)>();
 
   late final _sel_dateFromComponents_1 = _registerName1("dateFromComponents:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_710(
+  ffi.Pointer<ObjCObject> _objc_msgSend_714(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> comps,
   ) {
-    return __objc_msgSend_710(
+    return __objc_msgSend_714(
       obj,
       sel,
       comps,
     );
   }
 
-  late final __objc_msgSend_710Ptr = _lookup<
+  late final __objc_msgSend_714Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_710 = __objc_msgSend_710Ptr.asFunction<
+  late final __objc_msgSend_714 = __objc_msgSend_714Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
 
   late final _sel_components_fromDate_1 =
       _registerName1("components:fromDate:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_711(
+  ffi.Pointer<ObjCObject> _objc_msgSend_715(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int unitFlags,
     ffi.Pointer<ObjCObject> date,
   ) {
-    return __objc_msgSend_711(
+    return __objc_msgSend_715(
       obj,
       sel,
       unitFlags,
@@ -20143,27 +20286,27 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_711Ptr = _lookup<
+  late final __objc_msgSend_715Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.Int32,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_711 = __objc_msgSend_711Ptr.asFunction<
+  late final __objc_msgSend_715 = __objc_msgSend_715Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, int, ffi.Pointer<ObjCObject>)>();
 
   late final _sel_dateByAddingComponents_toDate_options_1 =
       _registerName1("dateByAddingComponents:toDate:options:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_712(
+  ffi.Pointer<ObjCObject> _objc_msgSend_716(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> comps,
     ffi.Pointer<ObjCObject> date,
     int opts,
   ) {
-    return __objc_msgSend_712(
+    return __objc_msgSend_716(
       obj,
       sel,
       comps,
@@ -20172,7 +20315,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_712Ptr = _lookup<
+  late final __objc_msgSend_716Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
@@ -20180,7 +20323,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>,
               ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_712 = __objc_msgSend_712Ptr.asFunction<
+  late final __objc_msgSend_716 = __objc_msgSend_716Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -20190,7 +20333,7 @@ class SentryCocoa {
 
   late final _sel_components_fromDate_toDate_options_1 =
       _registerName1("components:fromDate:toDate:options:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_713(
+  ffi.Pointer<ObjCObject> _objc_msgSend_717(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int unitFlags,
@@ -20198,7 +20341,7 @@ class SentryCocoa {
     ffi.Pointer<ObjCObject> resultDate,
     int opts,
   ) {
-    return __objc_msgSend_713(
+    return __objc_msgSend_717(
       obj,
       sel,
       unitFlags,
@@ -20208,7 +20351,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_713Ptr = _lookup<
+  late final __objc_msgSend_717Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
@@ -20217,7 +20360,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>,
               ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_713 = __objc_msgSend_713Ptr.asFunction<
+  late final __objc_msgSend_717 = __objc_msgSend_717Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -20228,7 +20371,7 @@ class SentryCocoa {
 
   late final _sel_getEra_year_month_day_fromDate_1 =
       _registerName1("getEra:year:month:day:fromDate:");
-  void _objc_msgSend_714(
+  void _objc_msgSend_718(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ffi.Long> eraValuePointer,
@@ -20237,7 +20380,7 @@ class SentryCocoa {
     ffi.Pointer<ffi.Long> dayValuePointer,
     ffi.Pointer<ObjCObject> date,
   ) {
-    return __objc_msgSend_714(
+    return __objc_msgSend_718(
       obj,
       sel,
       eraValuePointer,
@@ -20248,7 +20391,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_714Ptr = _lookup<
+  late final __objc_msgSend_718Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(
               ffi.Pointer<ObjCObject>,
@@ -20258,7 +20401,7 @@ class SentryCocoa {
               ffi.Pointer<ffi.Long>,
               ffi.Pointer<ffi.Long>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_714 = __objc_msgSend_714Ptr.asFunction<
+  late final __objc_msgSend_718 = __objc_msgSend_718Ptr.asFunction<
       void Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -20273,13 +20416,13 @@ class SentryCocoa {
   late final _sel_getHour_minute_second_nanosecond_fromDate_1 =
       _registerName1("getHour:minute:second:nanosecond:fromDate:");
   late final _sel_component_fromDate_1 = _registerName1("component:fromDate:");
-  int _objc_msgSend_715(
+  int _objc_msgSend_719(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int unit,
     ffi.Pointer<ObjCObject> date,
   ) {
-    return __objc_msgSend_715(
+    return __objc_msgSend_719(
       obj,
       sel,
       unit,
@@ -20287,18 +20430,18 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_715Ptr = _lookup<
+  late final __objc_msgSend_719Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Long Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Int32, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_715 = __objc_msgSend_715Ptr.asFunction<
+  late final __objc_msgSend_719 = __objc_msgSend_719Ptr.asFunction<
       int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int,
           ffi.Pointer<ObjCObject>)>();
 
   late final _sel_dateWithEra_year_month_day_hour_minute_second_nanosecond_1 =
       _registerName1(
           "dateWithEra:year:month:day:hour:minute:second:nanosecond:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_716(
+  ffi.Pointer<ObjCObject> _objc_msgSend_720(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int eraValue,
@@ -20310,7 +20453,7 @@ class SentryCocoa {
     int secondValue,
     int nanosecondValue,
   ) {
-    return __objc_msgSend_716(
+    return __objc_msgSend_720(
       obj,
       sel,
       eraValue,
@@ -20324,7 +20467,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_716Ptr = _lookup<
+  late final __objc_msgSend_720Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
@@ -20337,7 +20480,7 @@ class SentryCocoa {
               ffi.Long,
               ffi.Long,
               ffi.Long)>>('objc_msgSend');
-  late final __objc_msgSend_716 = __objc_msgSend_716Ptr.asFunction<
+  late final __objc_msgSend_720 = __objc_msgSend_720Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, int, int, int, int, int, int, int, int)>();
 
@@ -20347,13 +20490,13 @@ class SentryCocoa {
   late final _sel_startOfDayForDate_1 = _registerName1("startOfDayForDate:");
   late final _sel_componentsInTimeZone_fromDate_1 =
       _registerName1("componentsInTimeZone:fromDate:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_717(
+  ffi.Pointer<ObjCObject> _objc_msgSend_721(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> timezone,
     ffi.Pointer<ObjCObject> date,
   ) {
-    return __objc_msgSend_717(
+    return __objc_msgSend_721(
       obj,
       sel,
       timezone,
@@ -20361,14 +20504,14 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_717Ptr = _lookup<
+  late final __objc_msgSend_721Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_717 = __objc_msgSend_717Ptr.asFunction<
+  late final __objc_msgSend_721 = __objc_msgSend_721Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -20377,14 +20520,14 @@ class SentryCocoa {
 
   late final _sel_compareDate_toDate_toUnitGranularity_1 =
       _registerName1("compareDate:toDate:toUnitGranularity:");
-  int _objc_msgSend_718(
+  int _objc_msgSend_722(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> date1,
     ffi.Pointer<ObjCObject> date2,
     int unit,
   ) {
-    return __objc_msgSend_718(
+    return __objc_msgSend_722(
       obj,
       sel,
       date1,
@@ -20393,7 +20536,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_718Ptr = _lookup<
+  late final __objc_msgSend_722Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Int32 Function(
               ffi.Pointer<ObjCObject>,
@@ -20401,20 +20544,20 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>,
               ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_718 = __objc_msgSend_718Ptr.asFunction<
+  late final __objc_msgSend_722 = __objc_msgSend_722Ptr.asFunction<
       int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCObject>, int)>();
 
   late final _sel_isDate_equalToDate_toUnitGranularity_1 =
       _registerName1("isDate:equalToDate:toUnitGranularity:");
-  bool _objc_msgSend_719(
+  bool _objc_msgSend_723(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> date1,
     ffi.Pointer<ObjCObject> date2,
     int unit,
   ) {
-    return __objc_msgSend_719(
+    return __objc_msgSend_723(
       obj,
       sel,
       date1,
@@ -20423,7 +20566,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_719Ptr = _lookup<
+  late final __objc_msgSend_723Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Bool Function(
               ffi.Pointer<ObjCObject>,
@@ -20431,19 +20574,19 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>,
               ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_719 = __objc_msgSend_719Ptr.asFunction<
+  late final __objc_msgSend_723 = __objc_msgSend_723Ptr.asFunction<
       bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCObject>, int)>();
 
   late final _sel_isDate_inSameDayAsDate_1 =
       _registerName1("isDate:inSameDayAsDate:");
-  bool _objc_msgSend_720(
+  bool _objc_msgSend_724(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> date1,
     ffi.Pointer<ObjCObject> date2,
   ) {
-    return __objc_msgSend_720(
+    return __objc_msgSend_724(
       obj,
       sel,
       date1,
@@ -20451,14 +20594,14 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_720Ptr = _lookup<
+  late final __objc_msgSend_724Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Bool Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_720 = __objc_msgSend_720Ptr.asFunction<
+  late final __objc_msgSend_724 = __objc_msgSend_724Ptr.asFunction<
       bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCObject>)>();
 
@@ -20468,14 +20611,14 @@ class SentryCocoa {
   late final _sel_isDateInWeekend_1 = _registerName1("isDateInWeekend:");
   late final _sel_rangeOfWeekendStartDate_interval_containingDate_1 =
       _registerName1("rangeOfWeekendStartDate:interval:containingDate:");
-  bool _objc_msgSend_721(
+  bool _objc_msgSend_725(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ffi.Pointer<ObjCObject>> datep,
     ffi.Pointer<ffi.Double> tip,
     ffi.Pointer<ObjCObject> date,
   ) {
-    return __objc_msgSend_721(
+    return __objc_msgSend_725(
       obj,
       sel,
       datep,
@@ -20484,7 +20627,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_721Ptr = _lookup<
+  late final __objc_msgSend_725Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Bool Function(
               ffi.Pointer<ObjCObject>,
@@ -20492,7 +20635,7 @@ class SentryCocoa {
               ffi.Pointer<ffi.Pointer<ObjCObject>>,
               ffi.Pointer<ffi.Double>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_721 = __objc_msgSend_721Ptr.asFunction<
+  late final __objc_msgSend_725 = __objc_msgSend_725Ptr.asFunction<
       bool Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -20502,7 +20645,7 @@ class SentryCocoa {
 
   late final _sel_nextWeekendStartDate_interval_options_afterDate_1 =
       _registerName1("nextWeekendStartDate:interval:options:afterDate:");
-  bool _objc_msgSend_722(
+  bool _objc_msgSend_726(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ffi.Pointer<ObjCObject>> datep,
@@ -20510,7 +20653,7 @@ class SentryCocoa {
     int options,
     ffi.Pointer<ObjCObject> date,
   ) {
-    return __objc_msgSend_722(
+    return __objc_msgSend_726(
       obj,
       sel,
       datep,
@@ -20520,7 +20663,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_722Ptr = _lookup<
+  late final __objc_msgSend_726Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Bool Function(
               ffi.Pointer<ObjCObject>,
@@ -20529,7 +20672,7 @@ class SentryCocoa {
               ffi.Pointer<ffi.Double>,
               ffi.Int32,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_722 = __objc_msgSend_722Ptr.asFunction<
+  late final __objc_msgSend_726 = __objc_msgSend_726Ptr.asFunction<
       bool Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -20540,7 +20683,7 @@ class SentryCocoa {
 
   late final _sel_components_fromDateComponents_toDateComponents_options_1 =
       _registerName1("components:fromDateComponents:toDateComponents:options:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_723(
+  ffi.Pointer<ObjCObject> _objc_msgSend_727(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int unitFlags,
@@ -20548,7 +20691,7 @@ class SentryCocoa {
     ffi.Pointer<ObjCObject> resultDateComp,
     int options,
   ) {
-    return __objc_msgSend_723(
+    return __objc_msgSend_727(
       obj,
       sel,
       unitFlags,
@@ -20558,7 +20701,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_723Ptr = _lookup<
+  late final __objc_msgSend_727Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
@@ -20567,7 +20710,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>,
               ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_723 = __objc_msgSend_723Ptr.asFunction<
+  late final __objc_msgSend_727 = __objc_msgSend_727Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -20578,7 +20721,7 @@ class SentryCocoa {
 
   late final _sel_dateByAddingUnit_value_toDate_options_1 =
       _registerName1("dateByAddingUnit:value:toDate:options:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_724(
+  ffi.Pointer<ObjCObject> _objc_msgSend_728(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int unit,
@@ -20586,7 +20729,7 @@ class SentryCocoa {
     ffi.Pointer<ObjCObject> date,
     int options,
   ) {
-    return __objc_msgSend_724(
+    return __objc_msgSend_728(
       obj,
       sel,
       unit,
@@ -20596,7 +20739,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_724Ptr = _lookup<
+  late final __objc_msgSend_728Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
@@ -20605,14 +20748,14 @@ class SentryCocoa {
               ffi.Long,
               ffi.Pointer<ObjCObject>,
               ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_724 = __objc_msgSend_724Ptr.asFunction<
+  late final __objc_msgSend_728 = __objc_msgSend_728Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, int, int, ffi.Pointer<ObjCObject>, int)>();
 
   late final _sel_enumerateDatesStartingAfterDate_matchingComponents_options_usingBlock_1 =
       _registerName1(
           "enumerateDatesStartingAfterDate:matchingComponents:options:usingBlock:");
-  void _objc_msgSend_725(
+  void _objc_msgSend_729(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> start,
@@ -20620,7 +20763,7 @@ class SentryCocoa {
     int opts,
     ffi.Pointer<_ObjCBlock> block,
   ) {
-    return __objc_msgSend_725(
+    return __objc_msgSend_729(
       obj,
       sel,
       start,
@@ -20630,7 +20773,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_725Ptr = _lookup<
+  late final __objc_msgSend_729Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(
               ffi.Pointer<ObjCObject>,
@@ -20639,7 +20782,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Int32,
               ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
-  late final __objc_msgSend_725 = __objc_msgSend_725Ptr.asFunction<
+  late final __objc_msgSend_729 = __objc_msgSend_729Ptr.asFunction<
       void Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -20650,14 +20793,14 @@ class SentryCocoa {
 
   late final _sel_nextDateAfterDate_matchingComponents_options_1 =
       _registerName1("nextDateAfterDate:matchingComponents:options:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_726(
+  ffi.Pointer<ObjCObject> _objc_msgSend_730(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> date,
     ffi.Pointer<ObjCObject> comps,
     int options,
   ) {
-    return __objc_msgSend_726(
+    return __objc_msgSend_730(
       obj,
       sel,
       date,
@@ -20666,7 +20809,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_726Ptr = _lookup<
+  late final __objc_msgSend_730Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
@@ -20674,7 +20817,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>,
               ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_726 = __objc_msgSend_726Ptr.asFunction<
+  late final __objc_msgSend_730 = __objc_msgSend_730Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -20684,7 +20827,7 @@ class SentryCocoa {
 
   late final _sel_nextDateAfterDate_matchingUnit_value_options_1 =
       _registerName1("nextDateAfterDate:matchingUnit:value:options:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_727(
+  ffi.Pointer<ObjCObject> _objc_msgSend_731(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> date,
@@ -20692,7 +20835,7 @@ class SentryCocoa {
     int value,
     int options,
   ) {
-    return __objc_msgSend_727(
+    return __objc_msgSend_731(
       obj,
       sel,
       date,
@@ -20702,7 +20845,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_727Ptr = _lookup<
+  late final __objc_msgSend_731Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
@@ -20711,13 +20854,13 @@ class SentryCocoa {
               ffi.Int32,
               ffi.Long,
               ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_727 = __objc_msgSend_727Ptr.asFunction<
+  late final __objc_msgSend_731 = __objc_msgSend_731Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>, int, int, int)>();
 
   late final _sel_nextDateAfterDate_matchingHour_minute_second_options_1 =
       _registerName1("nextDateAfterDate:matchingHour:minute:second:options:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_728(
+  ffi.Pointer<ObjCObject> _objc_msgSend_732(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> date,
@@ -20726,7 +20869,7 @@ class SentryCocoa {
     int secondValue,
     int options,
   ) {
-    return __objc_msgSend_728(
+    return __objc_msgSend_732(
       obj,
       sel,
       date,
@@ -20737,7 +20880,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_728Ptr = _lookup<
+  late final __objc_msgSend_732Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
@@ -20747,7 +20890,7 @@ class SentryCocoa {
               ffi.Long,
               ffi.Long,
               ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_728 = __objc_msgSend_728Ptr.asFunction<
+  late final __objc_msgSend_732 = __objc_msgSend_732Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>, int, int, int, int)>();
 
@@ -20755,7 +20898,7 @@ class SentryCocoa {
       _registerName1("dateBySettingUnit:value:ofDate:options:");
   late final _sel_dateBySettingHour_minute_second_ofDate_options_1 =
       _registerName1("dateBySettingHour:minute:second:ofDate:options:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_729(
+  ffi.Pointer<ObjCObject> _objc_msgSend_733(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int h,
@@ -20764,7 +20907,7 @@ class SentryCocoa {
     ffi.Pointer<ObjCObject> date,
     int opts,
   ) {
-    return __objc_msgSend_729(
+    return __objc_msgSend_733(
       obj,
       sel,
       h,
@@ -20775,7 +20918,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_729Ptr = _lookup<
+  late final __objc_msgSend_733Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
@@ -20785,19 +20928,19 @@ class SentryCocoa {
               ffi.Long,
               ffi.Pointer<ObjCObject>,
               ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_729 = __objc_msgSend_729Ptr.asFunction<
+  late final __objc_msgSend_733 = __objc_msgSend_733Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, int, int, int, ffi.Pointer<ObjCObject>, int)>();
 
   late final _sel_date_matchesComponents_1 =
       _registerName1("date:matchesComponents:");
-  bool _objc_msgSend_730(
+  bool _objc_msgSend_734(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> date,
     ffi.Pointer<ObjCObject> components,
   ) {
-    return __objc_msgSend_730(
+    return __objc_msgSend_734(
       obj,
       sel,
       date,
@@ -20805,14 +20948,14 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_730Ptr = _lookup<
+  late final __objc_msgSend_734Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Bool Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_730 = __objc_msgSend_730Ptr.asFunction<
+  late final __objc_msgSend_734 = __objc_msgSend_734Ptr.asFunction<
       bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCObject>)>();
 
@@ -20824,23 +20967,23 @@ class SentryCocoa {
   late final _sel_defaultDate1 = _registerName1("defaultDate");
   late final _sel_setDefaultDate_1 = _registerName1("setDefaultDate:");
   late final _sel_setEraSymbols_1 = _registerName1("setEraSymbols:");
-  void _objc_msgSend_731(
+  void _objc_msgSend_735(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> value,
   ) {
-    return __objc_msgSend_731(
+    return __objc_msgSend_735(
       obj,
       sel,
       value,
     );
   }
 
-  late final __objc_msgSend_731Ptr = _lookup<
+  late final __objc_msgSend_735Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_731 = __objc_msgSend_731Ptr.asFunction<
+  late final __objc_msgSend_735 = __objc_msgSend_735Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>)>();
 
@@ -20889,56 +21032,56 @@ class SentryCocoa {
       _registerName1("allowsNaturalLanguage");
   late final _class_NSNumberFormatter1 = _getClass1("NSNumberFormatter");
   late final _sel_stringFromNumber_1 = _registerName1("stringFromNumber:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_732(
+  ffi.Pointer<ObjCObject> _objc_msgSend_736(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> number,
   ) {
-    return __objc_msgSend_732(
+    return __objc_msgSend_736(
       obj,
       sel,
       number,
     );
   }
 
-  late final __objc_msgSend_732Ptr = _lookup<
+  late final __objc_msgSend_736Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_732 = __objc_msgSend_732Ptr.asFunction<
+  late final __objc_msgSend_736 = __objc_msgSend_736Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
 
   late final _sel_numberFromString_1 = _registerName1("numberFromString:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_733(
+  ffi.Pointer<ObjCObject> _objc_msgSend_737(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> string,
   ) {
-    return __objc_msgSend_733(
+    return __objc_msgSend_737(
       obj,
       sel,
       string,
     );
   }
 
-  late final __objc_msgSend_733Ptr = _lookup<
+  late final __objc_msgSend_737Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_733 = __objc_msgSend_733Ptr.asFunction<
+  late final __objc_msgSend_737 = __objc_msgSend_737Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
 
   late final _sel_localizedStringFromNumber_numberStyle_1 =
       _registerName1("localizedStringFromNumber:numberStyle:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_734(
+  ffi.Pointer<ObjCObject> _objc_msgSend_738(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> num,
     int nstyle,
   ) {
-    return __objc_msgSend_734(
+    return __objc_msgSend_738(
       obj,
       sel,
       num,
@@ -20946,112 +21089,112 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_734Ptr = _lookup<
+  late final __objc_msgSend_738Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>,
               ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_734 = __objc_msgSend_734Ptr.asFunction<
+  late final __objc_msgSend_738 = __objc_msgSend_738Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>, int)>();
 
-  int _objc_msgSend_735(
+  int _objc_msgSend_739(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_735(
+    return __objc_msgSend_739(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_735Ptr = _lookup<
+  late final __objc_msgSend_739Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Int32 Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_735 = __objc_msgSend_735Ptr.asFunction<
+  late final __objc_msgSend_739 = __objc_msgSend_739Ptr.asFunction<
       int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
-  void _objc_msgSend_736(
+  void _objc_msgSend_740(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int behavior,
   ) {
-    return __objc_msgSend_736(
+    return __objc_msgSend_740(
       obj,
       sel,
       behavior,
     );
   }
 
-  late final __objc_msgSend_736Ptr = _lookup<
+  late final __objc_msgSend_740Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_736 = __objc_msgSend_736Ptr.asFunction<
+  late final __objc_msgSend_740 = __objc_msgSend_740Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
 
   late final _sel_numberStyle1 = _registerName1("numberStyle");
-  int _objc_msgSend_737(
+  int _objc_msgSend_741(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_737(
+    return __objc_msgSend_741(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_737Ptr = _lookup<
+  late final __objc_msgSend_741Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Int32 Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_737 = __objc_msgSend_737Ptr.asFunction<
+  late final __objc_msgSend_741 = __objc_msgSend_741Ptr.asFunction<
       int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
   late final _sel_setNumberStyle_1 = _registerName1("setNumberStyle:");
-  void _objc_msgSend_738(
+  void _objc_msgSend_742(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int value,
   ) {
-    return __objc_msgSend_738(
+    return __objc_msgSend_742(
       obj,
       sel,
       value,
     );
   }
 
-  late final __objc_msgSend_738Ptr = _lookup<
+  late final __objc_msgSend_742Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_738 = __objc_msgSend_738Ptr.asFunction<
+  late final __objc_msgSend_742 = __objc_msgSend_742Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
 
   late final _sel_generatesDecimalNumbers1 =
       _registerName1("generatesDecimalNumbers");
   late final _sel_setGeneratesDecimalNumbers_1 =
       _registerName1("setGeneratesDecimalNumbers:");
-  void _objc_msgSend_739(
+  void _objc_msgSend_743(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int value,
   ) {
-    return __objc_msgSend_739(
+    return __objc_msgSend_743(
       obj,
       sel,
       value,
     );
   }
 
-  late final __objc_msgSend_739Ptr = _lookup<
+  late final __objc_msgSend_743Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_739 = __objc_msgSend_739Ptr.asFunction<
+  late final __objc_msgSend_743 = __objc_msgSend_743Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
 
   late final _sel_negativeFormat1 = _registerName1("negativeFormat");
@@ -21157,79 +21300,79 @@ class SentryCocoa {
   late final _sel_setPaddingCharacter_1 =
       _registerName1("setPaddingCharacter:");
   late final _sel_paddingPosition1 = _registerName1("paddingPosition");
-  int _objc_msgSend_740(
+  int _objc_msgSend_744(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_740(
+    return __objc_msgSend_744(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_740Ptr = _lookup<
+  late final __objc_msgSend_744Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Int32 Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_740 = __objc_msgSend_740Ptr.asFunction<
+  late final __objc_msgSend_744 = __objc_msgSend_744Ptr.asFunction<
       int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
   late final _sel_setPaddingPosition_1 = _registerName1("setPaddingPosition:");
-  void _objc_msgSend_741(
+  void _objc_msgSend_745(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int value,
   ) {
-    return __objc_msgSend_741(
+    return __objc_msgSend_745(
       obj,
       sel,
       value,
     );
   }
 
-  late final __objc_msgSend_741Ptr = _lookup<
+  late final __objc_msgSend_745Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_741 = __objc_msgSend_741Ptr.asFunction<
+  late final __objc_msgSend_745 = __objc_msgSend_745Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
 
   late final _sel_roundingMode1 = _registerName1("roundingMode");
-  int _objc_msgSend_742(
+  int _objc_msgSend_746(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_742(
+    return __objc_msgSend_746(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_742Ptr = _lookup<
+  late final __objc_msgSend_746Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Int32 Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_742 = __objc_msgSend_742Ptr.asFunction<
+  late final __objc_msgSend_746 = __objc_msgSend_746Ptr.asFunction<
       int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
   late final _sel_setRoundingMode_1 = _registerName1("setRoundingMode:");
-  void _objc_msgSend_743(
+  void _objc_msgSend_747(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int value,
   ) {
-    return __objc_msgSend_743(
+    return __objc_msgSend_747(
       obj,
       sel,
       value,
     );
   }
 
-  late final __objc_msgSend_743Ptr = _lookup<
+  late final __objc_msgSend_747Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_743 = __objc_msgSend_743Ptr.asFunction<
+  late final __objc_msgSend_747 = __objc_msgSend_747Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
 
   late final _sel_roundingIncrement1 = _registerName1("roundingIncrement");
@@ -21290,129 +21433,6 @@ class SentryCocoa {
       _registerName1("attributedStringForZero");
   late final _sel_setAttributedStringForZero_1 =
       _registerName1("setAttributedStringForZero:");
-  void _objc_msgSend_744(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> value,
-  ) {
-    return __objc_msgSend_744(
-      obj,
-      sel,
-      value,
-    );
-  }
-
-  late final __objc_msgSend_744Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_744 = __objc_msgSend_744Ptr.asFunction<
-      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>)>();
-
-  late final _sel_attributedStringForNil1 =
-      _registerName1("attributedStringForNil");
-  late final _sel_setAttributedStringForNil_1 =
-      _registerName1("setAttributedStringForNil:");
-  late final _sel_attributedStringForNotANumber1 =
-      _registerName1("attributedStringForNotANumber");
-  late final _sel_setAttributedStringForNotANumber_1 =
-      _registerName1("setAttributedStringForNotANumber:");
-  late final _class_NSDecimalNumberHandler1 =
-      _getClass1("NSDecimalNumberHandler");
-  late final _sel_defaultDecimalNumberHandler1 =
-      _registerName1("defaultDecimalNumberHandler");
-  ffi.Pointer<ObjCObject> _objc_msgSend_745(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-  ) {
-    return __objc_msgSend_745(
-      obj,
-      sel,
-    );
-  }
-
-  late final __objc_msgSend_745Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(
-              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_745 = __objc_msgSend_745Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(
-          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
-
-  late final _sel_initWithRoundingMode_scale_raiseOnExactness_raiseOnOverflow_raiseOnUnderflow_raiseOnDivideByZero_1 =
-      _registerName1(
-          "initWithRoundingMode:scale:raiseOnExactness:raiseOnOverflow:raiseOnUnderflow:raiseOnDivideByZero:");
-  instancetype _objc_msgSend_746(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    int roundingMode,
-    int scale,
-    bool exact,
-    bool overflow,
-    bool underflow,
-    bool divideByZero,
-  ) {
-    return __objc_msgSend_746(
-      obj,
-      sel,
-      roundingMode,
-      scale,
-      exact,
-      overflow,
-      underflow,
-      divideByZero,
-    );
-  }
-
-  late final __objc_msgSend_746Ptr = _lookup<
-      ffi.NativeFunction<
-          instancetype Function(
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>,
-              ffi.Int32,
-              ffi.Short,
-              ffi.Bool,
-              ffi.Bool,
-              ffi.Bool,
-              ffi.Bool)>>('objc_msgSend');
-  late final __objc_msgSend_746 = __objc_msgSend_746Ptr.asFunction<
-      instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int,
-          int, bool, bool, bool, bool)>();
-
-  late final _sel_decimalNumberHandlerWithRoundingMode_scale_raiseOnExactness_raiseOnOverflow_raiseOnUnderflow_raiseOnDivideByZero_1 =
-      _registerName1(
-          "decimalNumberHandlerWithRoundingMode:scale:raiseOnExactness:raiseOnOverflow:raiseOnUnderflow:raiseOnDivideByZero:");
-  late final _sel_roundingBehavior1 = _registerName1("roundingBehavior");
-  late final _sel_setRoundingBehavior_1 =
-      _registerName1("setRoundingBehavior:");
-  void _objc_msgSend_747(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> value,
-  ) {
-    return __objc_msgSend_747(
-      obj,
-      sel,
-      value,
-    );
-  }
-
-  late final __objc_msgSend_747Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_747 = __objc_msgSend_747Ptr.asFunction<
-      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>)>();
-
-  late final _class_NSScanner1 = _getClass1("NSScanner");
-  late final _sel_scanLocation1 = _registerName1("scanLocation");
-  late final _sel_setScanLocation_1 = _registerName1("setScanLocation:");
-  late final _sel_charactersToBeSkipped1 =
-      _registerName1("charactersToBeSkipped");
-  late final _sel_setCharactersToBeSkipped_1 =
-      _registerName1("setCharactersToBeSkipped:");
   void _objc_msgSend_748(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
@@ -21433,98 +21453,136 @@ class SentryCocoa {
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>)>();
 
-  late final _sel_caseSensitive1 = _registerName1("caseSensitive");
-  late final _sel_setCaseSensitive_1 = _registerName1("setCaseSensitive:");
-  late final _sel_scanInt_1 = _registerName1("scanInt:");
-  bool _objc_msgSend_749(
+  late final _sel_attributedStringForNil1 =
+      _registerName1("attributedStringForNil");
+  late final _sel_setAttributedStringForNil_1 =
+      _registerName1("setAttributedStringForNil:");
+  late final _sel_attributedStringForNotANumber1 =
+      _registerName1("attributedStringForNotANumber");
+  late final _sel_setAttributedStringForNotANumber_1 =
+      _registerName1("setAttributedStringForNotANumber:");
+  late final _class_NSDecimalNumberHandler1 =
+      _getClass1("NSDecimalNumberHandler");
+  late final _sel_defaultDecimalNumberHandler1 =
+      _registerName1("defaultDecimalNumberHandler");
+  ffi.Pointer<ObjCObject> _objc_msgSend_749(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ffi.Int> result,
   ) {
     return __objc_msgSend_749(
       obj,
       sel,
-      result,
     );
   }
 
   late final __objc_msgSend_749Ptr = _lookup<
       ffi.NativeFunction<
-          ffi.Bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ffi.Int>)>>('objc_msgSend');
+          ffi.Pointer<ObjCObject> Function(
+              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
   late final __objc_msgSend_749 = __objc_msgSend_749Ptr.asFunction<
-      bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ffi.Int>)>();
+      ffi.Pointer<ObjCObject> Function(
+          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
-  late final _sel_scanInteger_1 = _registerName1("scanInteger:");
-  bool _objc_msgSend_750(
+  late final _sel_initWithRoundingMode_scale_raiseOnExactness_raiseOnOverflow_raiseOnUnderflow_raiseOnDivideByZero_1 =
+      _registerName1(
+          "initWithRoundingMode:scale:raiseOnExactness:raiseOnOverflow:raiseOnUnderflow:raiseOnDivideByZero:");
+  instancetype _objc_msgSend_750(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ffi.Long> result,
+    int roundingMode,
+    int scale,
+    bool exact,
+    bool overflow,
+    bool underflow,
+    bool divideByZero,
   ) {
     return __objc_msgSend_750(
       obj,
       sel,
-      result,
+      roundingMode,
+      scale,
+      exact,
+      overflow,
+      underflow,
+      divideByZero,
     );
   }
 
   late final __objc_msgSend_750Ptr = _lookup<
       ffi.NativeFunction<
-          ffi.Bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ffi.Long>)>>('objc_msgSend');
+          instancetype Function(
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>,
+              ffi.Int32,
+              ffi.Short,
+              ffi.Bool,
+              ffi.Bool,
+              ffi.Bool,
+              ffi.Bool)>>('objc_msgSend');
   late final __objc_msgSend_750 = __objc_msgSend_750Ptr.asFunction<
-      bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ffi.Long>)>();
+      instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int,
+          int, bool, bool, bool, bool)>();
 
-  late final _sel_scanLongLong_1 = _registerName1("scanLongLong:");
-  bool _objc_msgSend_751(
+  late final _sel_decimalNumberHandlerWithRoundingMode_scale_raiseOnExactness_raiseOnOverflow_raiseOnUnderflow_raiseOnDivideByZero_1 =
+      _registerName1(
+          "decimalNumberHandlerWithRoundingMode:scale:raiseOnExactness:raiseOnOverflow:raiseOnUnderflow:raiseOnDivideByZero:");
+  late final _sel_roundingBehavior1 = _registerName1("roundingBehavior");
+  late final _sel_setRoundingBehavior_1 =
+      _registerName1("setRoundingBehavior:");
+  void _objc_msgSend_751(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ffi.LongLong> result,
+    ffi.Pointer<ObjCObject> value,
   ) {
     return __objc_msgSend_751(
       obj,
       sel,
-      result,
+      value,
     );
   }
 
   late final __objc_msgSend_751Ptr = _lookup<
       ffi.NativeFunction<
-          ffi.Bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ffi.LongLong>)>>('objc_msgSend');
+          ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
   late final __objc_msgSend_751 = __objc_msgSend_751Ptr.asFunction<
-      bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ffi.LongLong>)>();
+      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>)>();
 
-  late final _sel_scanUnsignedLongLong_1 =
-      _registerName1("scanUnsignedLongLong:");
-  bool _objc_msgSend_752(
+  late final _class_NSScanner1 = _getClass1("NSScanner");
+  late final _sel_scanLocation1 = _registerName1("scanLocation");
+  late final _sel_setScanLocation_1 = _registerName1("setScanLocation:");
+  late final _sel_charactersToBeSkipped1 =
+      _registerName1("charactersToBeSkipped");
+  late final _sel_setCharactersToBeSkipped_1 =
+      _registerName1("setCharactersToBeSkipped:");
+  void _objc_msgSend_752(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ffi.UnsignedLongLong> result,
+    ffi.Pointer<ObjCObject> value,
   ) {
     return __objc_msgSend_752(
       obj,
       sel,
-      result,
+      value,
     );
   }
 
   late final __objc_msgSend_752Ptr = _lookup<
       ffi.NativeFunction<
-          ffi.Bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ffi.UnsignedLongLong>)>>('objc_msgSend');
+          ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
   late final __objc_msgSend_752 = __objc_msgSend_752Ptr.asFunction<
-      bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ffi.UnsignedLongLong>)>();
+      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>)>();
 
-  late final _sel_scanFloat_1 = _registerName1("scanFloat:");
+  late final _sel_caseSensitive1 = _registerName1("caseSensitive");
+  late final _sel_setCaseSensitive_1 = _registerName1("setCaseSensitive:");
+  late final _sel_scanInt_1 = _registerName1("scanInt:");
   bool _objc_msgSend_753(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ffi.Float> result,
+    ffi.Pointer<ffi.Int> result,
   ) {
     return __objc_msgSend_753(
       obj,
@@ -21536,16 +21594,16 @@ class SentryCocoa {
   late final __objc_msgSend_753Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ffi.Float>)>>('objc_msgSend');
+              ffi.Pointer<ffi.Int>)>>('objc_msgSend');
   late final __objc_msgSend_753 = __objc_msgSend_753Ptr.asFunction<
       bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ffi.Float>)>();
+          ffi.Pointer<ffi.Int>)>();
 
-  late final _sel_scanDouble_1 = _registerName1("scanDouble:");
+  late final _sel_scanInteger_1 = _registerName1("scanInteger:");
   bool _objc_msgSend_754(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ffi.Double> result,
+    ffi.Pointer<ffi.Long> result,
   ) {
     return __objc_msgSend_754(
       obj,
@@ -21557,16 +21615,16 @@ class SentryCocoa {
   late final __objc_msgSend_754Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ffi.Double>)>>('objc_msgSend');
+              ffi.Pointer<ffi.Long>)>>('objc_msgSend');
   late final __objc_msgSend_754 = __objc_msgSend_754Ptr.asFunction<
       bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ffi.Double>)>();
+          ffi.Pointer<ffi.Long>)>();
 
-  late final _sel_scanHexInt_1 = _registerName1("scanHexInt:");
+  late final _sel_scanLongLong_1 = _registerName1("scanLongLong:");
   bool _objc_msgSend_755(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ffi.UnsignedInt> result,
+    ffi.Pointer<ffi.LongLong> result,
   ) {
     return __objc_msgSend_755(
       obj,
@@ -21578,8 +21636,93 @@ class SentryCocoa {
   late final __objc_msgSend_755Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ffi.UnsignedInt>)>>('objc_msgSend');
+              ffi.Pointer<ffi.LongLong>)>>('objc_msgSend');
   late final __objc_msgSend_755 = __objc_msgSend_755Ptr.asFunction<
+      bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ffi.LongLong>)>();
+
+  late final _sel_scanUnsignedLongLong_1 =
+      _registerName1("scanUnsignedLongLong:");
+  bool _objc_msgSend_756(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ffi.UnsignedLongLong> result,
+  ) {
+    return __objc_msgSend_756(
+      obj,
+      sel,
+      result,
+    );
+  }
+
+  late final __objc_msgSend_756Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ffi.UnsignedLongLong>)>>('objc_msgSend');
+  late final __objc_msgSend_756 = __objc_msgSend_756Ptr.asFunction<
+      bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ffi.UnsignedLongLong>)>();
+
+  late final _sel_scanFloat_1 = _registerName1("scanFloat:");
+  bool _objc_msgSend_757(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ffi.Float> result,
+  ) {
+    return __objc_msgSend_757(
+      obj,
+      sel,
+      result,
+    );
+  }
+
+  late final __objc_msgSend_757Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ffi.Float>)>>('objc_msgSend');
+  late final __objc_msgSend_757 = __objc_msgSend_757Ptr.asFunction<
+      bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ffi.Float>)>();
+
+  late final _sel_scanDouble_1 = _registerName1("scanDouble:");
+  bool _objc_msgSend_758(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ffi.Double> result,
+  ) {
+    return __objc_msgSend_758(
+      obj,
+      sel,
+      result,
+    );
+  }
+
+  late final __objc_msgSend_758Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ffi.Double>)>>('objc_msgSend');
+  late final __objc_msgSend_758 = __objc_msgSend_758Ptr.asFunction<
+      bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ffi.Double>)>();
+
+  late final _sel_scanHexInt_1 = _registerName1("scanHexInt:");
+  bool _objc_msgSend_759(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ffi.UnsignedInt> result,
+  ) {
+    return __objc_msgSend_759(
+      obj,
+      sel,
+      result,
+    );
+  }
+
+  late final __objc_msgSend_759Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ffi.UnsignedInt>)>>('objc_msgSend');
+  late final __objc_msgSend_759 = __objc_msgSend_759Ptr.asFunction<
       bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ffi.UnsignedInt>)>();
 
@@ -21588,13 +21731,13 @@ class SentryCocoa {
   late final _sel_scanHexDouble_1 = _registerName1("scanHexDouble:");
   late final _sel_scanString_intoString_1 =
       _registerName1("scanString:intoString:");
-  bool _objc_msgSend_756(
+  bool _objc_msgSend_760(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> string,
     ffi.Pointer<ffi.Pointer<ObjCObject>> result,
   ) {
-    return __objc_msgSend_756(
+    return __objc_msgSend_760(
       obj,
       sel,
       string,
@@ -21602,26 +21745,26 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_756Ptr = _lookup<
+  late final __objc_msgSend_760Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Bool Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_756 = __objc_msgSend_756Ptr.asFunction<
+  late final __objc_msgSend_760 = __objc_msgSend_760Ptr.asFunction<
       bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>, ffi.Pointer<ffi.Pointer<ObjCObject>>)>();
 
   late final _sel_scanCharactersFromSet_intoString_1 =
       _registerName1("scanCharactersFromSet:intoString:");
-  bool _objc_msgSend_757(
+  bool _objc_msgSend_761(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> set1,
     ffi.Pointer<ffi.Pointer<ObjCObject>> result,
   ) {
-    return __objc_msgSend_757(
+    return __objc_msgSend_761(
       obj,
       sel,
       set1,
@@ -21629,14 +21772,14 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_757Ptr = _lookup<
+  late final __objc_msgSend_761Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Bool Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_757 = __objc_msgSend_757Ptr.asFunction<
+  late final __objc_msgSend_761 = __objc_msgSend_761Ptr.asFunction<
       bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>, ffi.Pointer<ffi.Pointer<ObjCObject>>)>();
 
@@ -21649,37 +21792,37 @@ class SentryCocoa {
   late final _sel_localizedScannerWithString_1 =
       _registerName1("localizedScannerWithString:");
   late final _sel_scanDecimal_1 = _registerName1("scanDecimal:");
-  bool _objc_msgSend_758(
+  bool _objc_msgSend_762(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<NSDecimal> dcm,
   ) {
-    return __objc_msgSend_758(
+    return __objc_msgSend_762(
       obj,
       sel,
       dcm,
     );
   }
 
-  late final __objc_msgSend_758Ptr = _lookup<
+  late final __objc_msgSend_762Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<NSDecimal>)>>('objc_msgSend');
-  late final __objc_msgSend_758 = __objc_msgSend_758Ptr.asFunction<
+  late final __objc_msgSend_762 = __objc_msgSend_762Ptr.asFunction<
       bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<NSDecimal>)>();
 
   late final _class_NSException1 = _getClass1("NSException");
   late final _sel_exceptionWithName_reason_userInfo_1 =
       _registerName1("exceptionWithName:reason:userInfo:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_759(
+  ffi.Pointer<ObjCObject> _objc_msgSend_763(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> name,
     ffi.Pointer<ObjCObject> reason,
     ffi.Pointer<ObjCObject> userInfo,
   ) {
-    return __objc_msgSend_759(
+    return __objc_msgSend_763(
       obj,
       sel,
       name,
@@ -21688,7 +21831,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_759Ptr = _lookup<
+  late final __objc_msgSend_763Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
@@ -21696,7 +21839,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_759 = __objc_msgSend_759Ptr.asFunction<
+  late final __objc_msgSend_763 = __objc_msgSend_763Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -21711,14 +21854,14 @@ class SentryCocoa {
   late final _sel_raise_format_1 = _registerName1("raise:format:");
   late final _sel_raise_format_arguments_1 =
       _registerName1("raise:format:arguments:");
-  void _objc_msgSend_760(
+  void _objc_msgSend_764(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> name,
     ffi.Pointer<ObjCObject> format,
     ffi.Pointer<__va_list_tag> argList,
   ) {
-    return __objc_msgSend_760(
+    return __objc_msgSend_764(
       obj,
       sel,
       name,
@@ -21727,7 +21870,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_760Ptr = _lookup<
+  late final __objc_msgSend_764Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(
               ffi.Pointer<ObjCObject>,
@@ -21735,7 +21878,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<__va_list_tag>)>>('objc_msgSend');
-  late final __objc_msgSend_760 = __objc_msgSend_760Ptr.asFunction<
+  late final __objc_msgSend_764 = __objc_msgSend_764Ptr.asFunction<
       void Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -21747,13 +21890,13 @@ class SentryCocoa {
   late final _sel_availableData1 = _registerName1("availableData");
   late final _sel_initWithFileDescriptor_closeOnDealloc_1 =
       _registerName1("initWithFileDescriptor:closeOnDealloc:");
-  instancetype _objc_msgSend_761(
+  instancetype _objc_msgSend_765(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int fd,
     bool closeopt,
   ) {
-    return __objc_msgSend_761(
+    return __objc_msgSend_765(
       obj,
       sel,
       fd,
@@ -21761,47 +21904,47 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_761Ptr = _lookup<
+  late final __objc_msgSend_765Ptr = _lookup<
       ffi.NativeFunction<
           instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Int, ffi.Bool)>>('objc_msgSend');
-  late final __objc_msgSend_761 = __objc_msgSend_761Ptr.asFunction<
+  late final __objc_msgSend_765 = __objc_msgSend_765Ptr.asFunction<
       instancetype Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int, bool)>();
 
   late final _sel_readDataToEndOfFileAndReturnError_1 =
       _registerName1("readDataToEndOfFileAndReturnError:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_762(
+  ffi.Pointer<ObjCObject> _objc_msgSend_766(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ffi.Pointer<ObjCObject>> error,
   ) {
-    return __objc_msgSend_762(
+    return __objc_msgSend_766(
       obj,
       sel,
       error,
     );
   }
 
-  late final __objc_msgSend_762Ptr = _lookup<
+  late final __objc_msgSend_766Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_762 = __objc_msgSend_762Ptr.asFunction<
+  late final __objc_msgSend_766 = __objc_msgSend_766Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, ffi.Pointer<ffi.Pointer<ObjCObject>>)>();
 
   late final _sel_readDataUpToLength_error_1 =
       _registerName1("readDataUpToLength:error:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_763(
+  ffi.Pointer<ObjCObject> _objc_msgSend_767(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int length,
     ffi.Pointer<ffi.Pointer<ObjCObject>> error,
   ) {
-    return __objc_msgSend_763(
+    return __objc_msgSend_767(
       obj,
       sel,
       length,
@@ -21809,25 +21952,25 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_763Ptr = _lookup<
+  late final __objc_msgSend_767Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.UnsignedLong,
               ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_763 = __objc_msgSend_763Ptr.asFunction<
+  late final __objc_msgSend_767 = __objc_msgSend_767Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, int, ffi.Pointer<ffi.Pointer<ObjCObject>>)>();
 
   late final _sel_writeData_error_1 = _registerName1("writeData:error:");
-  bool _objc_msgSend_764(
+  bool _objc_msgSend_768(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> data,
     ffi.Pointer<ffi.Pointer<ObjCObject>> error,
   ) {
-    return __objc_msgSend_764(
+    return __objc_msgSend_768(
       obj,
       sel,
       data,
@@ -21835,25 +21978,25 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_764Ptr = _lookup<
+  late final __objc_msgSend_768Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Bool Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_764 = __objc_msgSend_764Ptr.asFunction<
+  late final __objc_msgSend_768 = __objc_msgSend_768Ptr.asFunction<
       bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>, ffi.Pointer<ffi.Pointer<ObjCObject>>)>();
 
   late final _sel_getOffset_error_1 = _registerName1("getOffset:error:");
-  bool _objc_msgSend_765(
+  bool _objc_msgSend_769(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ffi.UnsignedLongLong> offsetInFile,
     ffi.Pointer<ffi.Pointer<ObjCObject>> error,
   ) {
-    return __objc_msgSend_765(
+    return __objc_msgSend_769(
       obj,
       sel,
       offsetInFile,
@@ -21861,14 +22004,14 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_765Ptr = _lookup<
+  late final __objc_msgSend_769Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Bool Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.Pointer<ffi.UnsignedLongLong>,
               ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_765 = __objc_msgSend_765Ptr.asFunction<
+  late final __objc_msgSend_769 = __objc_msgSend_769Ptr.asFunction<
       bool Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -21878,13 +22021,13 @@ class SentryCocoa {
   late final _sel_seekToEndReturningOffset_error_1 =
       _registerName1("seekToEndReturningOffset:error:");
   late final _sel_seekToOffset_error_1 = _registerName1("seekToOffset:error:");
-  bool _objc_msgSend_766(
+  bool _objc_msgSend_770(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int offset,
     ffi.Pointer<ffi.Pointer<ObjCObject>> error,
   ) {
-    return __objc_msgSend_766(
+    return __objc_msgSend_770(
       obj,
       sel,
       offset,
@@ -21892,14 +22035,14 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_766Ptr = _lookup<
+  late final __objc_msgSend_770Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Bool Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.UnsignedLongLong,
               ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_766 = __objc_msgSend_766Ptr.asFunction<
+  late final __objc_msgSend_770 = __objc_msgSend_770Ptr.asFunction<
       bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int,
           ffi.Pointer<ffi.Pointer<ObjCObject>>)>();
 
@@ -21911,21 +22054,21 @@ class SentryCocoa {
       _registerName1("closeAndReturnError:");
   late final _sel_fileHandleWithStandardInput1 =
       _registerName1("fileHandleWithStandardInput");
-  ffi.Pointer<ObjCObject> _objc_msgSend_767(
+  ffi.Pointer<ObjCObject> _objc_msgSend_771(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_767(
+    return __objc_msgSend_771(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_767Ptr = _lookup<
+  late final __objc_msgSend_771Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_767 = __objc_msgSend_767Ptr.asFunction<
+  late final __objc_msgSend_771 = __objc_msgSend_771Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
@@ -21943,13 +22086,13 @@ class SentryCocoa {
       _registerName1("fileHandleForUpdatingAtPath:");
   late final _sel_fileHandleForReadingFromURL_error_1 =
       _registerName1("fileHandleForReadingFromURL:error:");
-  instancetype _objc_msgSend_768(
+  instancetype _objc_msgSend_772(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> url,
     ffi.Pointer<ffi.Pointer<ObjCObject>> error,
   ) {
-    return __objc_msgSend_768(
+    return __objc_msgSend_772(
       obj,
       sel,
       url,
@@ -21957,14 +22100,14 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_768Ptr = _lookup<
+  late final __objc_msgSend_772Ptr = _lookup<
       ffi.NativeFunction<
           instancetype Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_768 = __objc_msgSend_768Ptr.asFunction<
+  late final __objc_msgSend_772 = __objc_msgSend_772Ptr.asFunction<
       instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>, ffi.Pointer<ffi.Pointer<ObjCObject>>)>();
 
@@ -21989,104 +22132,7 @@ class SentryCocoa {
   late final _sel_waitForDataInBackgroundAndNotify1 =
       _registerName1("waitForDataInBackgroundAndNotify");
   late final _sel_readabilityHandler1 = _registerName1("readabilityHandler");
-  ffi.Pointer<_ObjCBlock> _objc_msgSend_769(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-  ) {
-    return __objc_msgSend_769(
-      obj,
-      sel,
-    );
-  }
-
-  late final __objc_msgSend_769Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<_ObjCBlock> Function(
-              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_769 = __objc_msgSend_769Ptr.asFunction<
-      ffi.Pointer<_ObjCBlock> Function(
-          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
-
-  late final _sel_setReadabilityHandler_1 =
-      _registerName1("setReadabilityHandler:");
-  void _objc_msgSend_770(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<_ObjCBlock> value,
-  ) {
-    return __objc_msgSend_770(
-      obj,
-      sel,
-      value,
-    );
-  }
-
-  late final __objc_msgSend_770Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
-  late final __objc_msgSend_770 = __objc_msgSend_770Ptr.asFunction<
-      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<_ObjCBlock>)>();
-
-  late final _sel_writeabilityHandler1 = _registerName1("writeabilityHandler");
-  late final _sel_setWriteabilityHandler_1 =
-      _registerName1("setWriteabilityHandler:");
-  late final _sel_initWithFileDescriptor_1 =
-      _registerName1("initWithFileDescriptor:");
-  instancetype _objc_msgSend_771(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    int fd,
-  ) {
-    return __objc_msgSend_771(
-      obj,
-      sel,
-      fd,
-    );
-  }
-
-  late final __objc_msgSend_771Ptr = _lookup<
-      ffi.NativeFunction<
-          instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.Int)>>('objc_msgSend');
-  late final __objc_msgSend_771 = __objc_msgSend_771Ptr.asFunction<
-      instancetype Function(
-          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
-
-  late final _sel_fileDescriptor1 = _registerName1("fileDescriptor");
-  late final _sel_readDataToEndOfFile1 = _registerName1("readDataToEndOfFile");
-  late final _sel_readDataOfLength_1 = _registerName1("readDataOfLength:");
-  late final _sel_offsetInFile1 = _registerName1("offsetInFile");
-  late final _sel_seekToEndOfFile1 = _registerName1("seekToEndOfFile");
-  late final _sel_seekToFileOffset_1 = _registerName1("seekToFileOffset:");
-  void _objc_msgSend_772(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    int offset,
-  ) {
-    return __objc_msgSend_772(
-      obj,
-      sel,
-      offset,
-    );
-  }
-
-  late final __objc_msgSend_772Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.UnsignedLongLong)>>('objc_msgSend');
-  late final __objc_msgSend_772 = __objc_msgSend_772Ptr.asFunction<
-      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
-
-  late final _sel_truncateFileAtOffset_1 =
-      _registerName1("truncateFileAtOffset:");
-  late final _sel_synchronizeFile1 = _registerName1("synchronizeFile");
-  late final _sel_closeFile1 = _registerName1("closeFile");
-  late final _class_NSHTTPCookieStorage1 = _getClass1("NSHTTPCookieStorage");
-  late final _sel_sharedHTTPCookieStorage1 =
-      _registerName1("sharedHTTPCookieStorage");
-  ffi.Pointer<ObjCObject> _objc_msgSend_773(
+  ffi.Pointer<_ObjCBlock> _objc_msgSend_773(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
@@ -22098,31 +22144,128 @@ class SentryCocoa {
 
   late final __objc_msgSend_773Ptr = _lookup<
       ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(
+          ffi.Pointer<_ObjCBlock> Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
   late final __objc_msgSend_773 = __objc_msgSend_773Ptr.asFunction<
+      ffi.Pointer<_ObjCBlock> Function(
+          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
+
+  late final _sel_setReadabilityHandler_1 =
+      _registerName1("setReadabilityHandler:");
+  void _objc_msgSend_774(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<_ObjCBlock> value,
+  ) {
+    return __objc_msgSend_774(
+      obj,
+      sel,
+      value,
+    );
+  }
+
+  late final __objc_msgSend_774Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+              ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
+  late final __objc_msgSend_774 = __objc_msgSend_774Ptr.asFunction<
+      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+          ffi.Pointer<_ObjCBlock>)>();
+
+  late final _sel_writeabilityHandler1 = _registerName1("writeabilityHandler");
+  late final _sel_setWriteabilityHandler_1 =
+      _registerName1("setWriteabilityHandler:");
+  late final _sel_initWithFileDescriptor_1 =
+      _registerName1("initWithFileDescriptor:");
+  instancetype _objc_msgSend_775(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    int fd,
+  ) {
+    return __objc_msgSend_775(
+      obj,
+      sel,
+      fd,
+    );
+  }
+
+  late final __objc_msgSend_775Ptr = _lookup<
+      ffi.NativeFunction<
+          instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+              ffi.Int)>>('objc_msgSend');
+  late final __objc_msgSend_775 = __objc_msgSend_775Ptr.asFunction<
+      instancetype Function(
+          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
+
+  late final _sel_fileDescriptor1 = _registerName1("fileDescriptor");
+  late final _sel_readDataToEndOfFile1 = _registerName1("readDataToEndOfFile");
+  late final _sel_readDataOfLength_1 = _registerName1("readDataOfLength:");
+  late final _sel_offsetInFile1 = _registerName1("offsetInFile");
+  late final _sel_seekToEndOfFile1 = _registerName1("seekToEndOfFile");
+  late final _sel_seekToFileOffset_1 = _registerName1("seekToFileOffset:");
+  void _objc_msgSend_776(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    int offset,
+  ) {
+    return __objc_msgSend_776(
+      obj,
+      sel,
+      offset,
+    );
+  }
+
+  late final __objc_msgSend_776Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+              ffi.UnsignedLongLong)>>('objc_msgSend');
+  late final __objc_msgSend_776 = __objc_msgSend_776Ptr.asFunction<
+      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
+
+  late final _sel_truncateFileAtOffset_1 =
+      _registerName1("truncateFileAtOffset:");
+  late final _sel_synchronizeFile1 = _registerName1("synchronizeFile");
+  late final _sel_closeFile1 = _registerName1("closeFile");
+  late final _class_NSHTTPCookieStorage1 = _getClass1("NSHTTPCookieStorage");
+  late final _sel_sharedHTTPCookieStorage1 =
+      _registerName1("sharedHTTPCookieStorage");
+  ffi.Pointer<ObjCObject> _objc_msgSend_777(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+  ) {
+    return __objc_msgSend_777(
+      obj,
+      sel,
+    );
+  }
+
+  late final __objc_msgSend_777Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<ObjCObject> Function(
+              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
+  late final __objc_msgSend_777 = __objc_msgSend_777Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
   late final _sel_sharedCookieStorageForGroupContainerIdentifier_1 =
       _registerName1("sharedCookieStorageForGroupContainerIdentifier:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_774(
+  ffi.Pointer<ObjCObject> _objc_msgSend_778(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> identifier,
   ) {
-    return __objc_msgSend_774(
+    return __objc_msgSend_778(
       obj,
       sel,
       identifier,
     );
   }
 
-  late final __objc_msgSend_774Ptr = _lookup<
+  late final __objc_msgSend_778Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_774 = __objc_msgSend_774Ptr.asFunction<
+  late final __objc_msgSend_778 = __objc_msgSend_778Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
 
@@ -22131,23 +22274,23 @@ class SentryCocoa {
   late final _sel_initWithProperties_1 = _registerName1("initWithProperties:");
   late final _sel_cookieWithProperties_1 =
       _registerName1("cookieWithProperties:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_775(
+  ffi.Pointer<ObjCObject> _objc_msgSend_779(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> properties,
   ) {
-    return __objc_msgSend_775(
+    return __objc_msgSend_779(
       obj,
       sel,
       properties,
     );
   }
 
-  late final __objc_msgSend_775Ptr = _lookup<
+  late final __objc_msgSend_779Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_775 = __objc_msgSend_775Ptr.asFunction<
+  late final __objc_msgSend_779 = __objc_msgSend_779Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
 
@@ -22155,13 +22298,13 @@ class SentryCocoa {
       _registerName1("requestHeaderFieldsWithCookies:");
   late final _sel_cookiesWithResponseHeaderFields_forURL_1 =
       _registerName1("cookiesWithResponseHeaderFields:forURL:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_776(
+  ffi.Pointer<ObjCObject> _objc_msgSend_780(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> headerFields,
     ffi.Pointer<ObjCObject> URL,
   ) {
-    return __objc_msgSend_776(
+    return __objc_msgSend_780(
       obj,
       sel,
       headerFields,
@@ -22169,14 +22312,14 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_776Ptr = _lookup<
+  late final __objc_msgSend_780Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_776 = __objc_msgSend_776Ptr.asFunction<
+  late final __objc_msgSend_780 = __objc_msgSend_780Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -22194,23 +22337,23 @@ class SentryCocoa {
   late final _sel_portList1 = _registerName1("portList");
   late final _sel_sameSitePolicy1 = _registerName1("sameSitePolicy");
   late final _sel_setCookie_1 = _registerName1("setCookie:");
-  void _objc_msgSend_777(
+  void _objc_msgSend_781(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> cookie,
   ) {
-    return __objc_msgSend_777(
+    return __objc_msgSend_781(
       obj,
       sel,
       cookie,
     );
   }
 
-  late final __objc_msgSend_777Ptr = _lookup<
+  late final __objc_msgSend_781Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_777 = __objc_msgSend_777Ptr.asFunction<
+  late final __objc_msgSend_781 = __objc_msgSend_781Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>)>();
 
@@ -22220,14 +22363,14 @@ class SentryCocoa {
   late final _sel_cookiesForURL_1 = _registerName1("cookiesForURL:");
   late final _sel_setCookies_forURL_mainDocumentURL_1 =
       _registerName1("setCookies:forURL:mainDocumentURL:");
-  void _objc_msgSend_778(
+  void _objc_msgSend_782(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> cookies,
     ffi.Pointer<ObjCObject> URL,
     ffi.Pointer<ObjCObject> mainDocumentURL,
   ) {
-    return __objc_msgSend_778(
+    return __objc_msgSend_782(
       obj,
       sel,
       cookies,
@@ -22236,7 +22379,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_778Ptr = _lookup<
+  late final __objc_msgSend_782Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(
               ffi.Pointer<ObjCObject>,
@@ -22244,7 +22387,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_778 = __objc_msgSend_778Ptr.asFunction<
+  late final __objc_msgSend_782 = __objc_msgSend_782Ptr.asFunction<
       void Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -22253,102 +22396,6 @@ class SentryCocoa {
           ffi.Pointer<ObjCObject>)>();
 
   late final _sel_cookieAcceptPolicy1 = _registerName1("cookieAcceptPolicy");
-  int _objc_msgSend_779(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-  ) {
-    return __objc_msgSend_779(
-      obj,
-      sel,
-    );
-  }
-
-  late final __objc_msgSend_779Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Int32 Function(
-              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_779 = __objc_msgSend_779Ptr.asFunction<
-      int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
-
-  late final _sel_setCookieAcceptPolicy_1 =
-      _registerName1("setCookieAcceptPolicy:");
-  void _objc_msgSend_780(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    int value,
-  ) {
-    return __objc_msgSend_780(
-      obj,
-      sel,
-      value,
-    );
-  }
-
-  late final __objc_msgSend_780Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_780 = __objc_msgSend_780Ptr.asFunction<
-      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
-
-  late final _sel_sortedCookiesUsingDescriptors_1 =
-      _registerName1("sortedCookiesUsingDescriptors:");
-  late final _class_NSURLSessionTask1 = _getClass1("NSURLSessionTask");
-  late final _sel_taskIdentifier1 = _registerName1("taskIdentifier");
-  late final _class_NSURLRequest1 = _getClass1("NSURLRequest");
-  late final _sel_requestWithURL_1 = _registerName1("requestWithURL:");
-  late final _sel_supportsSecureCoding1 =
-      _registerName1("supportsSecureCoding");
-  late final _sel_requestWithURL_cachePolicy_timeoutInterval_1 =
-      _registerName1("requestWithURL:cachePolicy:timeoutInterval:");
-  instancetype _objc_msgSend_781(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> URL,
-    int cachePolicy,
-    double timeoutInterval,
-  ) {
-    return __objc_msgSend_781(
-      obj,
-      sel,
-      URL,
-      cachePolicy,
-      timeoutInterval,
-    );
-  }
-
-  late final __objc_msgSend_781Ptr = _lookup<
-      ffi.NativeFunction<
-          instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>, ffi.Int32, ffi.Double)>>('objc_msgSend');
-  late final __objc_msgSend_781 = __objc_msgSend_781Ptr.asFunction<
-      instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>, int, double)>();
-
-  late final _sel_initWithURL_cachePolicy_timeoutInterval_1 =
-      _registerName1("initWithURL:cachePolicy:timeoutInterval:");
-  late final _sel_URL1 = _registerName1("URL");
-  late final _sel_cachePolicy1 = _registerName1("cachePolicy");
-  int _objc_msgSend_782(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-  ) {
-    return __objc_msgSend_782(
-      obj,
-      sel,
-    );
-  }
-
-  late final __objc_msgSend_782Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Int32 Function(
-              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_782 = __objc_msgSend_782Ptr.asFunction<
-      int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
-
-  late final _sel_timeoutInterval1 = _registerName1("timeoutInterval");
-  late final _sel_mainDocumentURL1 = _registerName1("mainDocumentURL");
-  late final _sel_networkServiceType1 = _registerName1("networkServiceType");
   int _objc_msgSend_783(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
@@ -22366,6 +22413,102 @@ class SentryCocoa {
   late final __objc_msgSend_783 = __objc_msgSend_783Ptr.asFunction<
       int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
+  late final _sel_setCookieAcceptPolicy_1 =
+      _registerName1("setCookieAcceptPolicy:");
+  void _objc_msgSend_784(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    int value,
+  ) {
+    return __objc_msgSend_784(
+      obj,
+      sel,
+      value,
+    );
+  }
+
+  late final __objc_msgSend_784Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+              ffi.Int32)>>('objc_msgSend');
+  late final __objc_msgSend_784 = __objc_msgSend_784Ptr.asFunction<
+      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
+
+  late final _sel_sortedCookiesUsingDescriptors_1 =
+      _registerName1("sortedCookiesUsingDescriptors:");
+  late final _class_NSURLSessionTask1 = _getClass1("NSURLSessionTask");
+  late final _sel_taskIdentifier1 = _registerName1("taskIdentifier");
+  late final _class_NSURLRequest1 = _getClass1("NSURLRequest");
+  late final _sel_requestWithURL_1 = _registerName1("requestWithURL:");
+  late final _sel_supportsSecureCoding1 =
+      _registerName1("supportsSecureCoding");
+  late final _sel_requestWithURL_cachePolicy_timeoutInterval_1 =
+      _registerName1("requestWithURL:cachePolicy:timeoutInterval:");
+  instancetype _objc_msgSend_785(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> URL,
+    int cachePolicy,
+    double timeoutInterval,
+  ) {
+    return __objc_msgSend_785(
+      obj,
+      sel,
+      URL,
+      cachePolicy,
+      timeoutInterval,
+    );
+  }
+
+  late final __objc_msgSend_785Ptr = _lookup<
+      ffi.NativeFunction<
+          instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>, ffi.Int32, ffi.Double)>>('objc_msgSend');
+  late final __objc_msgSend_785 = __objc_msgSend_785Ptr.asFunction<
+      instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>, int, double)>();
+
+  late final _sel_initWithURL_cachePolicy_timeoutInterval_1 =
+      _registerName1("initWithURL:cachePolicy:timeoutInterval:");
+  late final _sel_URL1 = _registerName1("URL");
+  late final _sel_cachePolicy1 = _registerName1("cachePolicy");
+  int _objc_msgSend_786(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+  ) {
+    return __objc_msgSend_786(
+      obj,
+      sel,
+    );
+  }
+
+  late final __objc_msgSend_786Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int32 Function(
+              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
+  late final __objc_msgSend_786 = __objc_msgSend_786Ptr.asFunction<
+      int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
+
+  late final _sel_timeoutInterval1 = _registerName1("timeoutInterval");
+  late final _sel_mainDocumentURL1 = _registerName1("mainDocumentURL");
+  late final _sel_networkServiceType1 = _registerName1("networkServiceType");
+  int _objc_msgSend_787(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+  ) {
+    return __objc_msgSend_787(
+      obj,
+      sel,
+    );
+  }
+
+  late final __objc_msgSend_787Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int32 Function(
+              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
+  late final __objc_msgSend_787 = __objc_msgSend_787Ptr.asFunction<
+      int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
+
   late final _sel_allowsCellularAccess1 =
       _registerName1("allowsCellularAccess");
   late final _sel_allowsExpensiveNetworkAccess1 =
@@ -22374,21 +22517,21 @@ class SentryCocoa {
       _registerName1("allowsConstrainedNetworkAccess");
   late final _sel_assumesHTTP3Capable1 = _registerName1("assumesHTTP3Capable");
   late final _sel_attribution1 = _registerName1("attribution");
-  int _objc_msgSend_784(
+  int _objc_msgSend_788(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_784(
+    return __objc_msgSend_788(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_784Ptr = _lookup<
+  late final __objc_msgSend_788Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Int32 Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_784 = __objc_msgSend_784Ptr.asFunction<
+  late final __objc_msgSend_788 = __objc_msgSend_788Ptr.asFunction<
       int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
   late final _sel_requiresDNSSECValidation1 =
@@ -22403,33 +22546,33 @@ class SentryCocoa {
   late final _sel_open1 = _registerName1("open");
   late final _sel_close1 = _registerName1("close");
   late final _sel_streamStatus1 = _registerName1("streamStatus");
-  int _objc_msgSend_785(
+  int _objc_msgSend_789(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_785(
+    return __objc_msgSend_789(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_785Ptr = _lookup<
+  late final __objc_msgSend_789Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Int32 Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_785 = __objc_msgSend_785Ptr.asFunction<
+  late final __objc_msgSend_789 = __objc_msgSend_789Ptr.asFunction<
       int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
   late final _sel_streamError1 = _registerName1("streamError");
   late final _class_NSOutputStream1 = _getClass1("NSOutputStream");
   late final _sel_write_maxLength_1 = _registerName1("write:maxLength:");
-  int _objc_msgSend_786(
+  int _objc_msgSend_790(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ffi.Uint8> buffer,
     int len,
   ) {
-    return __objc_msgSend_786(
+    return __objc_msgSend_790(
       obj,
       sel,
       buffer,
@@ -22437,11 +22580,11 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_786Ptr = _lookup<
+  late final __objc_msgSend_790Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Long Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<ffi.Uint8>, ffi.UnsignedLong)>>('objc_msgSend');
-  late final __objc_msgSend_786 = __objc_msgSend_786Ptr.asFunction<
+  late final __objc_msgSend_790 = __objc_msgSend_790Ptr.asFunction<
       int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ffi.Uint8>, int)>();
 
@@ -22449,13 +22592,13 @@ class SentryCocoa {
   late final _sel_initToMemory1 = _registerName1("initToMemory");
   late final _sel_initToBuffer_capacity_1 =
       _registerName1("initToBuffer:capacity:");
-  instancetype _objc_msgSend_787(
+  instancetype _objc_msgSend_791(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ffi.Uint8> buffer,
     int capacity,
   ) {
-    return __objc_msgSend_787(
+    return __objc_msgSend_791(
       obj,
       sel,
       buffer,
@@ -22463,11 +22606,11 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_787Ptr = _lookup<
+  late final __objc_msgSend_791Ptr = _lookup<
       ffi.NativeFunction<
           instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<ffi.Uint8>, ffi.UnsignedLong)>>('objc_msgSend');
-  late final __objc_msgSend_787 = __objc_msgSend_787Ptr.asFunction<
+  late final __objc_msgSend_791 = __objc_msgSend_791Ptr.asFunction<
       instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ffi.Uint8>, int)>();
 
@@ -22484,7 +22627,7 @@ class SentryCocoa {
       _registerName1("outputStreamWithURL:append:");
   late final _sel_getStreamsToHostWithName_port_inputStream_outputStream_1 =
       _registerName1("getStreamsToHostWithName:port:inputStream:outputStream:");
-  void _objc_msgSend_788(
+  void _objc_msgSend_792(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> hostname,
@@ -22492,7 +22635,7 @@ class SentryCocoa {
     ffi.Pointer<ffi.Pointer<ObjCObject>> inputStream,
     ffi.Pointer<ffi.Pointer<ObjCObject>> outputStream,
   ) {
-    return __objc_msgSend_788(
+    return __objc_msgSend_792(
       obj,
       sel,
       hostname,
@@ -22502,7 +22645,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_788Ptr = _lookup<
+  late final __objc_msgSend_792Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(
               ffi.Pointer<ObjCObject>,
@@ -22511,7 +22654,7 @@ class SentryCocoa {
               ffi.Long,
               ffi.Pointer<ffi.Pointer<ObjCObject>>,
               ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_788 = __objc_msgSend_788Ptr.asFunction<
+  late final __objc_msgSend_792 = __objc_msgSend_792Ptr.asFunction<
       void Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -22525,23 +22668,23 @@ class SentryCocoa {
   late final _sel_hostWithName_1 = _registerName1("hostWithName:");
   late final _sel_hostWithAddress_1 = _registerName1("hostWithAddress:");
   late final _sel_isEqualToHost_1 = _registerName1("isEqualToHost:");
-  bool _objc_msgSend_789(
+  bool _objc_msgSend_793(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> aHost,
   ) {
-    return __objc_msgSend_789(
+    return __objc_msgSend_793(
       obj,
       sel,
       aHost,
     );
   }
 
-  late final __objc_msgSend_789Ptr = _lookup<
+  late final __objc_msgSend_793Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_789 = __objc_msgSend_789Ptr.asFunction<
+  late final __objc_msgSend_793 = __objc_msgSend_793Ptr.asFunction<
       bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>)>();
 
@@ -22551,30 +22694,30 @@ class SentryCocoa {
   late final _sel_localizedName1 = _registerName1("localizedName");
   late final _sel_setHostCacheEnabled_1 =
       _registerName1("setHostCacheEnabled:");
-  void _objc_msgSend_790(
+  void _objc_msgSend_794(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     bool flag,
   ) {
-    return __objc_msgSend_790(
+    return __objc_msgSend_794(
       obj,
       sel,
       flag,
     );
   }
 
-  late final __objc_msgSend_790Ptr = _lookup<
+  late final __objc_msgSend_794Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Bool)>>('objc_msgSend');
-  late final __objc_msgSend_790 = __objc_msgSend_790Ptr.asFunction<
+  late final __objc_msgSend_794 = __objc_msgSend_794Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, bool)>();
 
   late final _sel_isHostCacheEnabled1 = _registerName1("isHostCacheEnabled");
   late final _sel_flushHostCache1 = _registerName1("flushHostCache");
   late final _sel_getStreamsToHost_port_inputStream_outputStream_1 =
       _registerName1("getStreamsToHost:port:inputStream:outputStream:");
-  void _objc_msgSend_791(
+  void _objc_msgSend_795(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> host,
@@ -22582,7 +22725,7 @@ class SentryCocoa {
     ffi.Pointer<ffi.Pointer<ObjCObject>> inputStream,
     ffi.Pointer<ffi.Pointer<ObjCObject>> outputStream,
   ) {
-    return __objc_msgSend_791(
+    return __objc_msgSend_795(
       obj,
       sel,
       host,
@@ -22592,7 +22735,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_791Ptr = _lookup<
+  late final __objc_msgSend_795Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(
               ffi.Pointer<ObjCObject>,
@@ -22601,7 +22744,7 @@ class SentryCocoa {
               ffi.Long,
               ffi.Pointer<ffi.Pointer<ObjCObject>>,
               ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_791 = __objc_msgSend_791Ptr.asFunction<
+  late final __objc_msgSend_795 = __objc_msgSend_795Ptr.asFunction<
       void Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -22612,14 +22755,14 @@ class SentryCocoa {
 
   late final _sel_getBoundStreamsWithBufferSize_inputStream_outputStream_1 =
       _registerName1("getBoundStreamsWithBufferSize:inputStream:outputStream:");
-  void _objc_msgSend_792(
+  void _objc_msgSend_796(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int bufferSize,
     ffi.Pointer<ffi.Pointer<ObjCObject>> inputStream,
     ffi.Pointer<ffi.Pointer<ObjCObject>> outputStream,
   ) {
-    return __objc_msgSend_792(
+    return __objc_msgSend_796(
       obj,
       sel,
       bufferSize,
@@ -22628,7 +22771,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_792Ptr = _lookup<
+  late final __objc_msgSend_796Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(
               ffi.Pointer<ObjCObject>,
@@ -22636,7 +22779,7 @@ class SentryCocoa {
               ffi.UnsignedLong,
               ffi.Pointer<ffi.Pointer<ObjCObject>>,
               ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_792 = __objc_msgSend_792Ptr.asFunction<
+  late final __objc_msgSend_796 = __objc_msgSend_796Ptr.asFunction<
       void Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -22646,13 +22789,13 @@ class SentryCocoa {
 
   late final _sel_read_maxLength_1 = _registerName1("read:maxLength:");
   late final _sel_getBuffer_length_1 = _registerName1("getBuffer:length:");
-  bool _objc_msgSend_793(
+  bool _objc_msgSend_797(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ffi.Pointer<ffi.Uint8>> buffer,
     ffi.Pointer<ffi.UnsignedLong> len,
   ) {
-    return __objc_msgSend_793(
+    return __objc_msgSend_797(
       obj,
       sel,
       buffer,
@@ -22660,14 +22803,14 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_793Ptr = _lookup<
+  late final __objc_msgSend_797Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Bool Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.Pointer<ffi.Pointer<ffi.Uint8>>,
               ffi.Pointer<ffi.UnsignedLong>)>>('objc_msgSend');
-  late final __objc_msgSend_793 = __objc_msgSend_793Ptr.asFunction<
+  late final __objc_msgSend_797 = __objc_msgSend_797Ptr.asFunction<
       bool Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -22682,21 +22825,21 @@ class SentryCocoa {
       _registerName1("inputStreamWithFileAtPath:");
   late final _sel_inputStreamWithURL_1 = _registerName1("inputStreamWithURL:");
   late final _sel_HTTPBodyStream1 = _registerName1("HTTPBodyStream");
-  ffi.Pointer<ObjCObject> _objc_msgSend_794(
+  ffi.Pointer<ObjCObject> _objc_msgSend_798(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_794(
+    return __objc_msgSend_798(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_794Ptr = _lookup<
+  late final __objc_msgSend_798Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_794 = __objc_msgSend_794Ptr.asFunction<
+  late final __objc_msgSend_798 = __objc_msgSend_798Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
@@ -22705,21 +22848,21 @@ class SentryCocoa {
   late final _sel_HTTPShouldUsePipelining1 =
       _registerName1("HTTPShouldUsePipelining");
   late final _sel_originalRequest1 = _registerName1("originalRequest");
-  ffi.Pointer<ObjCObject> _objc_msgSend_795(
+  ffi.Pointer<ObjCObject> _objc_msgSend_799(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_795(
+    return __objc_msgSend_799(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_795Ptr = _lookup<
+  late final __objc_msgSend_799Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_795 = __objc_msgSend_795Ptr.asFunction<
+  late final __objc_msgSend_799 = __objc_msgSend_799Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
@@ -22728,7 +22871,7 @@ class SentryCocoa {
   late final _sel_initWithURL_MIMEType_expectedContentLength_textEncodingName_1 =
       _registerName1(
           "initWithURL:MIMEType:expectedContentLength:textEncodingName:");
-  instancetype _objc_msgSend_796(
+  instancetype _objc_msgSend_800(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> URL,
@@ -22736,7 +22879,7 @@ class SentryCocoa {
     int length,
     ffi.Pointer<ObjCObject> name,
   ) {
-    return __objc_msgSend_796(
+    return __objc_msgSend_800(
       obj,
       sel,
       URL,
@@ -22746,7 +22889,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_796Ptr = _lookup<
+  late final __objc_msgSend_800Ptr = _lookup<
       ffi.NativeFunction<
           instancetype Function(
               ffi.Pointer<ObjCObject>,
@@ -22755,7 +22898,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Long,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_796 = __objc_msgSend_796Ptr.asFunction<
+  late final __objc_msgSend_800 = __objc_msgSend_800Ptr.asFunction<
       instancetype Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -22770,21 +22913,21 @@ class SentryCocoa {
   late final _sel_textEncodingName1 = _registerName1("textEncodingName");
   late final _sel_suggestedFilename1 = _registerName1("suggestedFilename");
   late final _sel_response1 = _registerName1("response");
-  ffi.Pointer<ObjCObject> _objc_msgSend_797(
+  ffi.Pointer<ObjCObject> _objc_msgSend_801(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_797(
+    return __objc_msgSend_801(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_797Ptr = _lookup<
+  late final __objc_msgSend_801Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_797 = __objc_msgSend_797Ptr.asFunction<
+  late final __objc_msgSend_801 = __objc_msgSend_801Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
@@ -22810,43 +22953,43 @@ class SentryCocoa {
   late final _sel_taskDescription1 = _registerName1("taskDescription");
   late final _sel_setTaskDescription_1 = _registerName1("setTaskDescription:");
   late final _sel_state1 = _registerName1("state");
-  int _objc_msgSend_798(
+  int _objc_msgSend_802(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_798(
+    return __objc_msgSend_802(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_798Ptr = _lookup<
+  late final __objc_msgSend_802Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Int32 Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_798 = __objc_msgSend_798Ptr.asFunction<
+  late final __objc_msgSend_802 = __objc_msgSend_802Ptr.asFunction<
       int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
   late final _sel_suspend1 = _registerName1("suspend");
   late final _sel_priority1 = _registerName1("priority");
   late final _sel_setPriority_1 = _registerName1("setPriority:");
-  void _objc_msgSend_799(
+  void _objc_msgSend_803(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     double value,
   ) {
-    return __objc_msgSend_799(
+    return __objc_msgSend_803(
       obj,
       sel,
       value,
     );
   }
 
-  late final __objc_msgSend_799Ptr = _lookup<
+  late final __objc_msgSend_803Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Float)>>('objc_msgSend');
-  late final __objc_msgSend_799 = __objc_msgSend_799Ptr.asFunction<
+  late final __objc_msgSend_803 = __objc_msgSend_803Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, double)>();
 
   late final _sel_prefersIncrementalDelivery1 =
@@ -22855,13 +22998,13 @@ class SentryCocoa {
       _registerName1("setPrefersIncrementalDelivery:");
   late final _sel_storeCookies_forTask_1 =
       _registerName1("storeCookies:forTask:");
-  void _objc_msgSend_800(
+  void _objc_msgSend_804(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> cookies,
     ffi.Pointer<ObjCObject> task,
   ) {
-    return __objc_msgSend_800(
+    return __objc_msgSend_804(
       obj,
       sel,
       cookies,
@@ -22869,26 +23012,26 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_800Ptr = _lookup<
+  late final __objc_msgSend_804Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_800 = __objc_msgSend_800Ptr.asFunction<
+  late final __objc_msgSend_804 = __objc_msgSend_804Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCObject>)>();
 
   late final _sel_getCookiesForTask_completionHandler_1 =
       _registerName1("getCookiesForTask:completionHandler:");
-  void _objc_msgSend_801(
+  void _objc_msgSend_805(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> task,
     ffi.Pointer<_ObjCBlock> completionHandler,
   ) {
-    return __objc_msgSend_801(
+    return __objc_msgSend_805(
       obj,
       sel,
       task,
@@ -22896,14 +23039,14 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_801Ptr = _lookup<
+  late final __objc_msgSend_805Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
-  late final __objc_msgSend_801 = __objc_msgSend_801Ptr.asFunction<
+  late final __objc_msgSend_805 = __objc_msgSend_805Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>, ffi.Pointer<_ObjCBlock>)>();
 
@@ -22911,13 +23054,13 @@ class SentryCocoa {
   late final _sel_indexPathWithIndex_1 = _registerName1("indexPathWithIndex:");
   late final _sel_indexPathWithIndexes_length_1 =
       _registerName1("indexPathWithIndexes:length:");
-  instancetype _objc_msgSend_802(
+  instancetype _objc_msgSend_806(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ffi.UnsignedLong> indexes,
     int length,
   ) {
-    return __objc_msgSend_802(
+    return __objc_msgSend_806(
       obj,
       sel,
       indexes,
@@ -22925,14 +23068,14 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_802Ptr = _lookup<
+  late final __objc_msgSend_806Ptr = _lookup<
       ffi.NativeFunction<
           instancetype Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.Pointer<ffi.UnsignedLong>,
               ffi.UnsignedLong)>>('objc_msgSend');
-  late final __objc_msgSend_802 = __objc_msgSend_802Ptr.asFunction<
+  late final __objc_msgSend_806 = __objc_msgSend_806Ptr.asFunction<
       instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ffi.UnsignedLong>, int)>();
 
@@ -22940,113 +23083,28 @@ class SentryCocoa {
       _registerName1("initWithIndexes:length:");
   late final _sel_indexPathByAddingIndex_1 =
       _registerName1("indexPathByAddingIndex:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_803(
+  ffi.Pointer<ObjCObject> _objc_msgSend_807(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int index,
   ) {
-    return __objc_msgSend_803(
+    return __objc_msgSend_807(
       obj,
       sel,
       index,
     );
   }
 
-  late final __objc_msgSend_803Ptr = _lookup<
+  late final __objc_msgSend_807Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>, ffi.UnsignedLong)>>('objc_msgSend');
-  late final __objc_msgSend_803 = __objc_msgSend_803Ptr.asFunction<
+  late final __objc_msgSend_807 = __objc_msgSend_807Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
 
   late final _sel_indexPathByRemovingLastIndex1 =
       _registerName1("indexPathByRemovingLastIndex");
-  ffi.Pointer<ObjCObject> _objc_msgSend_804(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-  ) {
-    return __objc_msgSend_804(
-      obj,
-      sel,
-    );
-  }
-
-  late final __objc_msgSend_804Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(
-              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_804 = __objc_msgSend_804Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(
-          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
-
-  late final _sel_indexAtPosition_1 = _registerName1("indexAtPosition:");
-  late final _sel_getIndexes_range_1 = _registerName1("getIndexes:range:");
-  void _objc_msgSend_805(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ffi.UnsignedLong> indexes,
-    _NSRange positionRange,
-  ) {
-    return __objc_msgSend_805(
-      obj,
-      sel,
-      indexes,
-      positionRange,
-    );
-  }
-
-  late final __objc_msgSend_805Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ffi.UnsignedLong>, _NSRange)>>('objc_msgSend');
-  late final __objc_msgSend_805 = __objc_msgSend_805Ptr.asFunction<
-      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ffi.UnsignedLong>, _NSRange)>();
-
-  int _objc_msgSend_806(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> otherObject,
-  ) {
-    return __objc_msgSend_806(
-      obj,
-      sel,
-      otherObject,
-    );
-  }
-
-  late final __objc_msgSend_806Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Int32 Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_806 = __objc_msgSend_806Ptr.asFunction<
-      int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>)>();
-
-  late final _sel_getIndexes_1 = _registerName1("getIndexes:");
-  void _objc_msgSend_807(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ffi.UnsignedLong> indexes,
-  ) {
-    return __objc_msgSend_807(
-      obj,
-      sel,
-      indexes,
-    );
-  }
-
-  late final __objc_msgSend_807Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ffi.UnsignedLong>)>>('objc_msgSend');
-  late final __objc_msgSend_807 = __objc_msgSend_807Ptr.asFunction<
-      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ffi.UnsignedLong>)>();
-
-  late final _class_NSInflectionRule1 = _getClass1("NSInflectionRule");
-  late final _sel_automaticRule1 = _registerName1("automaticRule");
   ffi.Pointer<ObjCObject> _objc_msgSend_808(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
@@ -23065,88 +23123,96 @@ class SentryCocoa {
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
-  late final _sel_canInflectLanguage_1 = _registerName1("canInflectLanguage:");
-  late final _sel_canInflectPreferredLocalization1 =
-      _registerName1("canInflectPreferredLocalization");
-  late final _class_NSMorphology1 = _getClass1("NSMorphology");
-  late final _sel_grammaticalGender1 = _registerName1("grammaticalGender");
-  int _objc_msgSend_809(
+  late final _sel_indexAtPosition_1 = _registerName1("indexAtPosition:");
+  late final _sel_getIndexes_range_1 = _registerName1("getIndexes:range:");
+  void _objc_msgSend_809(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ffi.UnsignedLong> indexes,
+    _NSRange positionRange,
   ) {
     return __objc_msgSend_809(
       obj,
       sel,
+      indexes,
+      positionRange,
     );
   }
 
   late final __objc_msgSend_809Ptr = _lookup<
       ffi.NativeFunction<
-          ffi.Int32 Function(
-              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
+          ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ffi.UnsignedLong>, _NSRange)>>('objc_msgSend');
   late final __objc_msgSend_809 = __objc_msgSend_809Ptr.asFunction<
-      int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
+      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ffi.UnsignedLong>, _NSRange)>();
 
-  late final _sel_setGrammaticalGender_1 =
-      _registerName1("setGrammaticalGender:");
-  void _objc_msgSend_810(
+  int _objc_msgSend_810(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
-    int value,
+    ffi.Pointer<ObjCObject> otherObject,
   ) {
     return __objc_msgSend_810(
       obj,
       sel,
-      value,
+      otherObject,
     );
   }
 
   late final __objc_msgSend_810Ptr = _lookup<
       ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.Int32)>>('objc_msgSend');
+          ffi.Int32 Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
   late final __objc_msgSend_810 = __objc_msgSend_810Ptr.asFunction<
-      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
+      int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>)>();
 
-  late final _sel_partOfSpeech1 = _registerName1("partOfSpeech");
-  int _objc_msgSend_811(
+  late final _sel_getIndexes_1 = _registerName1("getIndexes:");
+  void _objc_msgSend_811(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ffi.UnsignedLong> indexes,
   ) {
     return __objc_msgSend_811(
       obj,
       sel,
+      indexes,
     );
   }
 
   late final __objc_msgSend_811Ptr = _lookup<
       ffi.NativeFunction<
-          ffi.Int32 Function(
-              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
+          ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ffi.UnsignedLong>)>>('objc_msgSend');
   late final __objc_msgSend_811 = __objc_msgSend_811Ptr.asFunction<
-      int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
+      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ffi.UnsignedLong>)>();
 
-  late final _sel_setPartOfSpeech_1 = _registerName1("setPartOfSpeech:");
-  void _objc_msgSend_812(
+  late final _class_NSInflectionRule1 = _getClass1("NSInflectionRule");
+  late final _sel_automaticRule1 = _registerName1("automaticRule");
+  ffi.Pointer<ObjCObject> _objc_msgSend_812(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
-    int value,
   ) {
     return __objc_msgSend_812(
       obj,
       sel,
-      value,
     );
   }
 
   late final __objc_msgSend_812Ptr = _lookup<
       ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.Int32)>>('objc_msgSend');
+          ffi.Pointer<ObjCObject> Function(
+              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
   late final __objc_msgSend_812 = __objc_msgSend_812Ptr.asFunction<
-      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
+      ffi.Pointer<ObjCObject> Function(
+          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
-  late final _sel_number1 = _registerName1("number");
+  late final _sel_canInflectLanguage_1 = _registerName1("canInflectLanguage:");
+  late final _sel_canInflectPreferredLocalization1 =
+      _registerName1("canInflectPreferredLocalization");
+  late final _class_NSMorphology1 = _getClass1("NSMorphology");
+  late final _sel_grammaticalGender1 = _registerName1("grammaticalGender");
   int _objc_msgSend_813(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
@@ -23164,7 +23230,8 @@ class SentryCocoa {
   late final __objc_msgSend_813 = __objc_msgSend_813Ptr.asFunction<
       int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
-  late final _sel_setNumber_1 = _registerName1("setNumber:");
+  late final _sel_setGrammaticalGender_1 =
+      _registerName1("setGrammaticalGender:");
   void _objc_msgSend_814(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
@@ -23182,6 +23249,273 @@ class SentryCocoa {
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Int32)>>('objc_msgSend');
   late final __objc_msgSend_814 = __objc_msgSend_814Ptr.asFunction<
+      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
+
+  late final _sel_partOfSpeech1 = _registerName1("partOfSpeech");
+  int _objc_msgSend_815(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+  ) {
+    return __objc_msgSend_815(
+      obj,
+      sel,
+    );
+  }
+
+  late final __objc_msgSend_815Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int32 Function(
+              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
+  late final __objc_msgSend_815 = __objc_msgSend_815Ptr.asFunction<
+      int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
+
+  late final _sel_setPartOfSpeech_1 = _registerName1("setPartOfSpeech:");
+  void _objc_msgSend_816(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    int value,
+  ) {
+    return __objc_msgSend_816(
+      obj,
+      sel,
+      value,
+    );
+  }
+
+  late final __objc_msgSend_816Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+              ffi.Int32)>>('objc_msgSend');
+  late final __objc_msgSend_816 = __objc_msgSend_816Ptr.asFunction<
+      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
+
+  late final _sel_number1 = _registerName1("number");
+  int _objc_msgSend_817(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+  ) {
+    return __objc_msgSend_817(
+      obj,
+      sel,
+    );
+  }
+
+  late final __objc_msgSend_817Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int32 Function(
+              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
+  late final __objc_msgSend_817 = __objc_msgSend_817Ptr.asFunction<
+      int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
+
+  late final _sel_setNumber_1 = _registerName1("setNumber:");
+  void _objc_msgSend_818(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    int value,
+  ) {
+    return __objc_msgSend_818(
+      obj,
+      sel,
+      value,
+    );
+  }
+
+  late final __objc_msgSend_818Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+              ffi.Int32)>>('objc_msgSend');
+  late final __objc_msgSend_818 = __objc_msgSend_818Ptr.asFunction<
+      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
+
+  late final _sel_grammaticalCase1 = _registerName1("grammaticalCase");
+  int _objc_msgSend_819(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+  ) {
+    return __objc_msgSend_819(
+      obj,
+      sel,
+    );
+  }
+
+  late final __objc_msgSend_819Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int32 Function(
+              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
+  late final __objc_msgSend_819 = __objc_msgSend_819Ptr.asFunction<
+      int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
+
+  late final _sel_setGrammaticalCase_1 = _registerName1("setGrammaticalCase:");
+  void _objc_msgSend_820(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    int value,
+  ) {
+    return __objc_msgSend_820(
+      obj,
+      sel,
+      value,
+    );
+  }
+
+  late final __objc_msgSend_820Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+              ffi.Int32)>>('objc_msgSend');
+  late final __objc_msgSend_820 = __objc_msgSend_820Ptr.asFunction<
+      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
+
+  late final _sel_determination1 = _registerName1("determination");
+  int _objc_msgSend_821(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+  ) {
+    return __objc_msgSend_821(
+      obj,
+      sel,
+    );
+  }
+
+  late final __objc_msgSend_821Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int32 Function(
+              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
+  late final __objc_msgSend_821 = __objc_msgSend_821Ptr.asFunction<
+      int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
+
+  late final _sel_setDetermination_1 = _registerName1("setDetermination:");
+  void _objc_msgSend_822(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    int value,
+  ) {
+    return __objc_msgSend_822(
+      obj,
+      sel,
+      value,
+    );
+  }
+
+  late final __objc_msgSend_822Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+              ffi.Int32)>>('objc_msgSend');
+  late final __objc_msgSend_822 = __objc_msgSend_822Ptr.asFunction<
+      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
+
+  late final _sel_grammaticalPerson1 = _registerName1("grammaticalPerson");
+  int _objc_msgSend_823(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+  ) {
+    return __objc_msgSend_823(
+      obj,
+      sel,
+    );
+  }
+
+  late final __objc_msgSend_823Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int32 Function(
+              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
+  late final __objc_msgSend_823 = __objc_msgSend_823Ptr.asFunction<
+      int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
+
+  late final _sel_setGrammaticalPerson_1 =
+      _registerName1("setGrammaticalPerson:");
+  void _objc_msgSend_824(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    int value,
+  ) {
+    return __objc_msgSend_824(
+      obj,
+      sel,
+      value,
+    );
+  }
+
+  late final __objc_msgSend_824Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+              ffi.Int32)>>('objc_msgSend');
+  late final __objc_msgSend_824 = __objc_msgSend_824Ptr.asFunction<
+      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
+
+  late final _sel_pronounType1 = _registerName1("pronounType");
+  int _objc_msgSend_825(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+  ) {
+    return __objc_msgSend_825(
+      obj,
+      sel,
+    );
+  }
+
+  late final __objc_msgSend_825Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int32 Function(
+              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
+  late final __objc_msgSend_825 = __objc_msgSend_825Ptr.asFunction<
+      int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
+
+  late final _sel_setPronounType_1 = _registerName1("setPronounType:");
+  void _objc_msgSend_826(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    int value,
+  ) {
+    return __objc_msgSend_826(
+      obj,
+      sel,
+      value,
+    );
+  }
+
+  late final __objc_msgSend_826Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+              ffi.Int32)>>('objc_msgSend');
+  late final __objc_msgSend_826 = __objc_msgSend_826Ptr.asFunction<
+      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
+
+  late final _sel_definiteness1 = _registerName1("definiteness");
+  int _objc_msgSend_827(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+  ) {
+    return __objc_msgSend_827(
+      obj,
+      sel,
+    );
+  }
+
+  late final __objc_msgSend_827Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int32 Function(
+              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
+  late final __objc_msgSend_827 = __objc_msgSend_827Ptr.asFunction<
+      int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
+
+  late final _sel_setDefiniteness_1 = _registerName1("setDefiniteness:");
+  void _objc_msgSend_828(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    int value,
+  ) {
+    return __objc_msgSend_828(
+      obj,
+      sel,
+      value,
+    );
+  }
+
+  late final __objc_msgSend_828Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+              ffi.Int32)>>('objc_msgSend');
+  late final __objc_msgSend_828 = __objc_msgSend_828Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
 
   late final _class_NSMorphologyCustomPronoun1 =
@@ -23204,36 +23538,36 @@ class SentryCocoa {
   late final _sel_setReflexiveForm_1 = _registerName1("setReflexiveForm:");
   late final _sel_customPronounForLanguage_1 =
       _registerName1("customPronounForLanguage:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_815(
+  ffi.Pointer<ObjCObject> _objc_msgSend_829(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> language,
   ) {
-    return __objc_msgSend_815(
+    return __objc_msgSend_829(
       obj,
       sel,
       language,
     );
   }
 
-  late final __objc_msgSend_815Ptr = _lookup<
+  late final __objc_msgSend_829Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_815 = __objc_msgSend_815Ptr.asFunction<
+  late final __objc_msgSend_829 = __objc_msgSend_829Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
 
   late final _sel_setCustomPronoun_forLanguage_error_1 =
       _registerName1("setCustomPronoun:forLanguage:error:");
-  bool _objc_msgSend_816(
+  bool _objc_msgSend_830(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> features,
     ffi.Pointer<ObjCObject> language,
     ffi.Pointer<ffi.Pointer<ObjCObject>> error,
   ) {
-    return __objc_msgSend_816(
+    return __objc_msgSend_830(
       obj,
       sel,
       features,
@@ -23242,7 +23576,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_816Ptr = _lookup<
+  late final __objc_msgSend_830Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Bool Function(
               ffi.Pointer<ObjCObject>,
@@ -23250,7 +23584,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_816 = __objc_msgSend_816Ptr.asFunction<
+  late final __objc_msgSend_830 = __objc_msgSend_830Ptr.asFunction<
       bool Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -23260,21 +23594,21 @@ class SentryCocoa {
 
   late final _sel_isUnspecified1 = _registerName1("isUnspecified");
   late final _sel_userMorphology1 = _registerName1("userMorphology");
-  ffi.Pointer<ObjCObject> _objc_msgSend_817(
+  ffi.Pointer<ObjCObject> _objc_msgSend_831(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_817(
+    return __objc_msgSend_831(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_817Ptr = _lookup<
+  late final __objc_msgSend_831Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_817 = __objc_msgSend_817Ptr.asFunction<
+  late final __objc_msgSend_831 = __objc_msgSend_831Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
@@ -23284,64 +23618,64 @@ class SentryCocoa {
   late final _sel_isAsynchronous1 = _registerName1("isAsynchronous");
   late final _sel_isReady1 = _registerName1("isReady");
   late final _sel_addDependency_1 = _registerName1("addDependency:");
-  void _objc_msgSend_818(
+  void _objc_msgSend_832(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> op,
   ) {
-    return __objc_msgSend_818(
+    return __objc_msgSend_832(
       obj,
       sel,
       op,
     );
   }
 
-  late final __objc_msgSend_818Ptr = _lookup<
+  late final __objc_msgSend_832Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_818 = __objc_msgSend_818Ptr.asFunction<
+  late final __objc_msgSend_832 = __objc_msgSend_832Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>)>();
 
   late final _sel_removeDependency_1 = _registerName1("removeDependency:");
   late final _sel_dependencies1 = _registerName1("dependencies");
   late final _sel_queuePriority1 = _registerName1("queuePriority");
-  int _objc_msgSend_819(
+  int _objc_msgSend_833(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_819(
+    return __objc_msgSend_833(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_819Ptr = _lookup<
+  late final __objc_msgSend_833Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Int32 Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_819 = __objc_msgSend_819Ptr.asFunction<
+  late final __objc_msgSend_833 = __objc_msgSend_833Ptr.asFunction<
       int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
   late final _sel_setQueuePriority_1 = _registerName1("setQueuePriority:");
-  void _objc_msgSend_820(
+  void _objc_msgSend_834(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int value,
   ) {
-    return __objc_msgSend_820(
+    return __objc_msgSend_834(
       obj,
       sel,
       value,
     );
   }
 
-  late final __objc_msgSend_820Ptr = _lookup<
+  late final __objc_msgSend_834Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_820 = __objc_msgSend_820Ptr.asFunction<
+  late final __objc_msgSend_834 = __objc_msgSend_834Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
 
   late final _sel_completionBlock1 = _registerName1("completionBlock");
@@ -23350,13 +23684,13 @@ class SentryCocoa {
   late final _sel_addOperation_1 = _registerName1("addOperation:");
   late final _sel_addOperations_waitUntilFinished_1 =
       _registerName1("addOperations:waitUntilFinished:");
-  void _objc_msgSend_821(
+  void _objc_msgSend_835(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> ops,
     bool wait,
   ) {
-    return __objc_msgSend_821(
+    return __objc_msgSend_835(
       obj,
       sel,
       ops,
@@ -23364,11 +23698,11 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_821Ptr = _lookup<
+  late final __objc_msgSend_835Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>, ffi.Bool)>>('objc_msgSend');
-  late final __objc_msgSend_821 = __objc_msgSend_821Ptr.asFunction<
+  late final __objc_msgSend_835 = __objc_msgSend_835Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>, bool)>();
 
@@ -23382,42 +23716,42 @@ class SentryCocoa {
   late final _sel_isSuspended1 = _registerName1("isSuspended");
   late final _sel_setSuspended_1 = _registerName1("setSuspended:");
   late final _sel_underlyingQueue1 = _registerName1("underlyingQueue");
-  ffi.Pointer<ObjCObject> _objc_msgSend_822(
+  ffi.Pointer<ObjCObject> _objc_msgSend_836(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_822(
+    return __objc_msgSend_836(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_822Ptr = _lookup<
+  late final __objc_msgSend_836Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_822 = __objc_msgSend_822Ptr.asFunction<
+  late final __objc_msgSend_836 = __objc_msgSend_836Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
   late final _sel_setUnderlyingQueue_1 = _registerName1("setUnderlyingQueue:");
-  void _objc_msgSend_823(
+  void _objc_msgSend_837(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> value,
   ) {
-    return __objc_msgSend_823(
+    return __objc_msgSend_837(
       obj,
       sel,
       value,
     );
   }
 
-  late final __objc_msgSend_823Ptr = _lookup<
+  late final __objc_msgSend_837Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_823 = __objc_msgSend_823Ptr.asFunction<
+  late final __objc_msgSend_837 = __objc_msgSend_837Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>)>();
 
@@ -23425,21 +23759,21 @@ class SentryCocoa {
   late final _sel_waitUntilAllOperationsAreFinished1 =
       _registerName1("waitUntilAllOperationsAreFinished");
   late final _sel_currentQueue1 = _registerName1("currentQueue");
-  ffi.Pointer<ObjCObject> _objc_msgSend_824(
+  ffi.Pointer<ObjCObject> _objc_msgSend_838(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_824(
+    return __objc_msgSend_838(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_824Ptr = _lookup<
+  late final __objc_msgSend_838Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_824 = __objc_msgSend_824Ptr.asFunction<
+  late final __objc_msgSend_838 = __objc_msgSend_838Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
@@ -23448,46 +23782,46 @@ class SentryCocoa {
   late final _sel_operationCount1 = _registerName1("operationCount");
   late final _class_NSPointerArray1 = _getClass1("NSPointerArray");
   late final _sel_initWithOptions_1 = _registerName1("initWithOptions:");
-  instancetype _objc_msgSend_825(
+  instancetype _objc_msgSend_839(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int options,
   ) {
-    return __objc_msgSend_825(
+    return __objc_msgSend_839(
       obj,
       sel,
       options,
     );
   }
 
-  late final __objc_msgSend_825Ptr = _lookup<
+  late final __objc_msgSend_839Ptr = _lookup<
       ffi.NativeFunction<
           instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_825 = __objc_msgSend_825Ptr.asFunction<
+  late final __objc_msgSend_839 = __objc_msgSend_839Ptr.asFunction<
       instancetype Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
 
   late final _class_NSPointerFunctions1 = _getClass1("NSPointerFunctions");
   late final _sel_pointerFunctionsWithOptions_1 =
       _registerName1("pointerFunctionsWithOptions:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_826(
+  ffi.Pointer<ObjCObject> _objc_msgSend_840(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int options,
   ) {
-    return __objc_msgSend_826(
+    return __objc_msgSend_840(
       obj,
       sel,
       options,
     );
   }
 
-  late final __objc_msgSend_826Ptr = _lookup<
+  late final __objc_msgSend_840Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>, ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_826 = __objc_msgSend_826Ptr.asFunction<
+  late final __objc_msgSend_840 = __objc_msgSend_840Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
 
@@ -23499,17 +23833,17 @@ class SentryCocoa {
                   ffi.Pointer<
                       ffi.NativeFunction<
                           ffi.UnsignedLong Function(ffi.Pointer<ffi.Void>)>>)>>
-      _objc_msgSend_827(
+      _objc_msgSend_841(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_827(
+    return __objc_msgSend_841(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_827Ptr = _lookup<
+  late final __objc_msgSend_841Ptr = _lookup<
           ffi.NativeFunction<
               ffi.Pointer<
                       ffi.NativeFunction<
@@ -23521,7 +23855,7 @@ class SentryCocoa {
                                           ffi.Pointer<ffi.Void>)>>)>>
                   Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>(
       'objc_msgSend');
-  late final __objc_msgSend_827 = __objc_msgSend_827Ptr.asFunction<
+  late final __objc_msgSend_841 = __objc_msgSend_841Ptr.asFunction<
       ffi.Pointer<
               ffi.NativeFunction<
                   ffi.UnsignedLong Function(
@@ -23533,7 +23867,7 @@ class SentryCocoa {
           Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
   late final _sel_setHashFunction_1 = _registerName1("setHashFunction:");
-  void _objc_msgSend_828(
+  void _objc_msgSend_842(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<
@@ -23546,14 +23880,14 @@ class SentryCocoa {
                                 ffi.Pointer<ffi.Void>)>>)>>
         value,
   ) {
-    return __objc_msgSend_828(
+    return __objc_msgSend_842(
       obj,
       sel,
       value,
     );
   }
 
-  late final __objc_msgSend_828Ptr = _lookup<
+  late final __objc_msgSend_842Ptr = _lookup<
           ffi.NativeFunction<
               ffi.Void Function(
                   ffi.Pointer<ObjCObject>,
@@ -23567,7 +23901,7 @@ class SentryCocoa {
                                       ffi.UnsignedLong Function(
                                           ffi.Pointer<ffi.Void>)>>)>>)>>(
       'objc_msgSend');
-  late final __objc_msgSend_828 = __objc_msgSend_828Ptr.asFunction<
+  late final __objc_msgSend_842 = __objc_msgSend_842Ptr.asFunction<
       void Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -23589,17 +23923,17 @@ class SentryCocoa {
                   ffi.Pointer<
                       ffi.NativeFunction<
                           ffi.UnsignedLong Function(ffi.Pointer<ffi.Void>)>>)>>
-      _objc_msgSend_829(
+      _objc_msgSend_843(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_829(
+    return __objc_msgSend_843(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_829Ptr = _lookup<
+  late final __objc_msgSend_843Ptr = _lookup<
           ffi.NativeFunction<
               ffi.Pointer<
                       ffi.NativeFunction<
@@ -23612,7 +23946,7 @@ class SentryCocoa {
                                           ffi.Pointer<ffi.Void>)>>)>>
                   Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>(
       'objc_msgSend');
-  late final __objc_msgSend_829 = __objc_msgSend_829Ptr.asFunction<
+  late final __objc_msgSend_843 = __objc_msgSend_843Ptr.asFunction<
       ffi.Pointer<
               ffi.NativeFunction<
                   ffi.Bool Function(
@@ -23625,7 +23959,7 @@ class SentryCocoa {
           Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
   late final _sel_setIsEqualFunction_1 = _registerName1("setIsEqualFunction:");
-  void _objc_msgSend_830(
+  void _objc_msgSend_844(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<
@@ -23639,14 +23973,14 @@ class SentryCocoa {
                                 ffi.Pointer<ffi.Void>)>>)>>
         value,
   ) {
-    return __objc_msgSend_830(
+    return __objc_msgSend_844(
       obj,
       sel,
       value,
     );
   }
 
-  late final __objc_msgSend_830Ptr = _lookup<
+  late final __objc_msgSend_844Ptr = _lookup<
           ffi.NativeFunction<
               ffi.Void Function(
                   ffi.Pointer<ObjCObject>,
@@ -23661,7 +23995,7 @@ class SentryCocoa {
                                       ffi.UnsignedLong Function(
                                           ffi.Pointer<ffi.Void>)>>)>>)>>(
       'objc_msgSend');
-  late final __objc_msgSend_830 = __objc_msgSend_830Ptr.asFunction<
+  late final __objc_msgSend_844 = __objc_msgSend_844Ptr.asFunction<
       void Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -23678,31 +24012,31 @@ class SentryCocoa {
   late final _sel_sizeFunction1 = _registerName1("sizeFunction");
   ffi.Pointer<
           ffi.NativeFunction<ffi.UnsignedLong Function(ffi.Pointer<ffi.Void>)>>
-      _objc_msgSend_831(
+      _objc_msgSend_845(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_831(
+    return __objc_msgSend_845(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_831Ptr = _lookup<
+  late final __objc_msgSend_845Ptr = _lookup<
           ffi.NativeFunction<
               ffi.Pointer<
                       ffi.NativeFunction<
                           ffi.UnsignedLong Function(ffi.Pointer<ffi.Void>)>>
                   Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>(
       'objc_msgSend');
-  late final __objc_msgSend_831 = __objc_msgSend_831Ptr.asFunction<
+  late final __objc_msgSend_845 = __objc_msgSend_845Ptr.asFunction<
       ffi.Pointer<
               ffi
               .NativeFunction<ffi.UnsignedLong Function(ffi.Pointer<ffi.Void>)>>
           Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
   late final _sel_setSizeFunction_1 = _registerName1("setSizeFunction:");
-  void _objc_msgSend_832(
+  void _objc_msgSend_846(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<
@@ -23710,14 +24044,14 @@ class SentryCocoa {
             .NativeFunction<ffi.UnsignedLong Function(ffi.Pointer<ffi.Void>)>>
         value,
   ) {
-    return __objc_msgSend_832(
+    return __objc_msgSend_846(
       obj,
       sel,
       value,
     );
   }
 
-  late final __objc_msgSend_832Ptr = _lookup<
+  late final __objc_msgSend_846Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(
               ffi.Pointer<ObjCObject>,
@@ -23726,7 +24060,7 @@ class SentryCocoa {
                   ffi.NativeFunction<
                       ffi.UnsignedLong Function(
                           ffi.Pointer<ffi.Void>)>>)>>('objc_msgSend');
-  late final __objc_msgSend_832 = __objc_msgSend_832Ptr.asFunction<
+  late final __objc_msgSend_846 = __objc_msgSend_846Ptr.asFunction<
       void Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -23738,17 +24072,17 @@ class SentryCocoa {
   ffi.Pointer<
           ffi.NativeFunction<
               ffi.Pointer<ObjCObject> Function(ffi.Pointer<ffi.Void>)>>
-      _objc_msgSend_833(
+      _objc_msgSend_847(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_833(
+    return __objc_msgSend_847(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_833Ptr =
+  late final __objc_msgSend_847Ptr =
       _lookup<
               ffi.NativeFunction<
                   ffi.Pointer<
@@ -23757,7 +24091,7 @@ class SentryCocoa {
                                   ffi.Pointer<ffi.Void>)>>
                       Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>(
           'objc_msgSend');
-  late final __objc_msgSend_833 = __objc_msgSend_833Ptr.asFunction<
+  late final __objc_msgSend_847 = __objc_msgSend_847Ptr.asFunction<
       ffi.Pointer<
               ffi.NativeFunction<
                   ffi.Pointer<ObjCObject> Function(ffi.Pointer<ffi.Void>)>>
@@ -23765,7 +24099,7 @@ class SentryCocoa {
 
   late final _sel_setDescriptionFunction_1 =
       _registerName1("setDescriptionFunction:");
-  void _objc_msgSend_834(
+  void _objc_msgSend_848(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<
@@ -23773,14 +24107,14 @@ class SentryCocoa {
                 ffi.Pointer<ObjCObject> Function(ffi.Pointer<ffi.Void>)>>
         value,
   ) {
-    return __objc_msgSend_834(
+    return __objc_msgSend_848(
       obj,
       sel,
       value,
     );
   }
 
-  late final __objc_msgSend_834Ptr = _lookup<
+  late final __objc_msgSend_848Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(
               ffi.Pointer<ObjCObject>,
@@ -23789,7 +24123,7 @@ class SentryCocoa {
                   ffi.NativeFunction<
                       ffi.Pointer<ObjCObject> Function(
                           ffi.Pointer<ffi.Void>)>>)>>('objc_msgSend');
-  late final __objc_msgSend_834 = __objc_msgSend_834Ptr.asFunction<
+  late final __objc_msgSend_848 = __objc_msgSend_848Ptr.asFunction<
       void Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -23805,17 +24139,17 @@ class SentryCocoa {
                   ffi.Pointer<
                       ffi.NativeFunction<
                           ffi.UnsignedLong Function(ffi.Pointer<ffi.Void>)>>)>>
-      _objc_msgSend_835(
+      _objc_msgSend_849(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_835(
+    return __objc_msgSend_849(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_835Ptr = _lookup<
+  late final __objc_msgSend_849Ptr = _lookup<
           ffi.NativeFunction<
               ffi.Pointer<
                       ffi.NativeFunction<
@@ -23827,7 +24161,7 @@ class SentryCocoa {
                                           ffi.Pointer<ffi.Void>)>>)>>
                   Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>(
       'objc_msgSend');
-  late final __objc_msgSend_835 = __objc_msgSend_835Ptr.asFunction<
+  late final __objc_msgSend_849 = __objc_msgSend_849Ptr.asFunction<
       ffi.Pointer<
               ffi.NativeFunction<
                   ffi.Void Function(
@@ -23840,7 +24174,7 @@ class SentryCocoa {
 
   late final _sel_setRelinquishFunction_1 =
       _registerName1("setRelinquishFunction:");
-  void _objc_msgSend_836(
+  void _objc_msgSend_850(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<
@@ -23853,14 +24187,14 @@ class SentryCocoa {
                                 ffi.Pointer<ffi.Void>)>>)>>
         value,
   ) {
-    return __objc_msgSend_836(
+    return __objc_msgSend_850(
       obj,
       sel,
       value,
     );
   }
 
-  late final __objc_msgSend_836Ptr = _lookup<
+  late final __objc_msgSend_850Ptr = _lookup<
           ffi.NativeFunction<
               ffi.Void Function(
                   ffi.Pointer<ObjCObject>,
@@ -23874,7 +24208,7 @@ class SentryCocoa {
                                       ffi.UnsignedLong Function(
                                           ffi.Pointer<ffi.Void>)>>)>>)>>(
       'objc_msgSend');
-  late final __objc_msgSend_836 = __objc_msgSend_836Ptr.asFunction<
+  late final __objc_msgSend_850 = __objc_msgSend_850Ptr.asFunction<
       void Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -23895,17 +24229,17 @@ class SentryCocoa {
               ffi.Pointer<
                   ffi.NativeFunction<
                       ffi.UnsignedLong Function(ffi.Pointer<ffi.Void>)>>,
-              ffi.Bool)>> _objc_msgSend_837(
+              ffi.Bool)>> _objc_msgSend_851(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_837(
+    return __objc_msgSend_851(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_837Ptr = _lookup<
+  late final __objc_msgSend_851Ptr = _lookup<
           ffi.NativeFunction<
               ffi.Pointer<
                       ffi.NativeFunction<
@@ -23918,7 +24252,7 @@ class SentryCocoa {
                               ffi.Bool)>>
                   Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>(
       'objc_msgSend');
-  late final __objc_msgSend_837 = __objc_msgSend_837Ptr.asFunction<
+  late final __objc_msgSend_851 = __objc_msgSend_851Ptr.asFunction<
       ffi.Pointer<
               ffi.NativeFunction<
                   ffi.Pointer<ffi.Void> Function(
@@ -23931,7 +24265,7 @@ class SentryCocoa {
           Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
   late final _sel_setAcquireFunction_1 = _registerName1("setAcquireFunction:");
-  void _objc_msgSend_838(
+  void _objc_msgSend_852(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<
@@ -23944,14 +24278,14 @@ class SentryCocoa {
                     ffi.Bool)>>
         value,
   ) {
-    return __objc_msgSend_838(
+    return __objc_msgSend_852(
       obj,
       sel,
       value,
     );
   }
 
-  late final __objc_msgSend_838Ptr = _lookup<
+  late final __objc_msgSend_852Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(
               ffi.Pointer<ObjCObject>,
@@ -23965,7 +24299,7 @@ class SentryCocoa {
                                   ffi.UnsignedLong Function(
                                       ffi.Pointer<ffi.Void>)>>,
                           ffi.Bool)>>)>>('objc_msgSend');
-  late final __objc_msgSend_838 = __objc_msgSend_838Ptr.asFunction<
+  late final __objc_msgSend_852 = __objc_msgSend_852Ptr.asFunction<
       void Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -23989,107 +24323,107 @@ class SentryCocoa {
       _registerName1("setUsesWeakReadAndWriteBarriers:");
   late final _sel_initWithPointerFunctions_1 =
       _registerName1("initWithPointerFunctions:");
-  instancetype _objc_msgSend_839(
+  instancetype _objc_msgSend_853(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> functions,
   ) {
-    return __objc_msgSend_839(
+    return __objc_msgSend_853(
       obj,
       sel,
       functions,
     );
   }
 
-  late final __objc_msgSend_839Ptr = _lookup<
+  late final __objc_msgSend_853Ptr = _lookup<
       ffi.NativeFunction<
           instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_839 = __objc_msgSend_839Ptr.asFunction<
+  late final __objc_msgSend_853 = __objc_msgSend_853Ptr.asFunction<
       instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>)>();
 
   late final _sel_pointerArrayWithOptions_1 =
       _registerName1("pointerArrayWithOptions:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_840(
+  ffi.Pointer<ObjCObject> _objc_msgSend_854(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int options,
   ) {
-    return __objc_msgSend_840(
+    return __objc_msgSend_854(
       obj,
       sel,
       options,
     );
   }
 
-  late final __objc_msgSend_840Ptr = _lookup<
+  late final __objc_msgSend_854Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>, ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_840 = __objc_msgSend_840Ptr.asFunction<
+  late final __objc_msgSend_854 = __objc_msgSend_854Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
 
   late final _sel_pointerArrayWithPointerFunctions_1 =
       _registerName1("pointerArrayWithPointerFunctions:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_841(
+  ffi.Pointer<ObjCObject> _objc_msgSend_855(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> functions,
   ) {
-    return __objc_msgSend_841(
+    return __objc_msgSend_855(
       obj,
       sel,
       functions,
     );
   }
 
-  late final __objc_msgSend_841Ptr = _lookup<
+  late final __objc_msgSend_855Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_841 = __objc_msgSend_841Ptr.asFunction<
+  late final __objc_msgSend_855 = __objc_msgSend_855Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
 
   late final _sel_pointerFunctions1 = _registerName1("pointerFunctions");
-  ffi.Pointer<ObjCObject> _objc_msgSend_842(
+  ffi.Pointer<ObjCObject> _objc_msgSend_856(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_842(
+    return __objc_msgSend_856(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_842Ptr = _lookup<
+  late final __objc_msgSend_856Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_842 = __objc_msgSend_842Ptr.asFunction<
+  late final __objc_msgSend_856 = __objc_msgSend_856Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
   late final _sel_pointerAtIndex_1 = _registerName1("pointerAtIndex:");
-  ffi.Pointer<ffi.Void> _objc_msgSend_843(
+  ffi.Pointer<ffi.Void> _objc_msgSend_857(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int index,
   ) {
-    return __objc_msgSend_843(
+    return __objc_msgSend_857(
       obj,
       sel,
       index,
     );
   }
 
-  late final __objc_msgSend_843Ptr = _lookup<
+  late final __objc_msgSend_857Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ffi.Void> Function(ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>, ffi.UnsignedLong)>>('objc_msgSend');
-  late final __objc_msgSend_843 = __objc_msgSend_843Ptr.asFunction<
+  late final __objc_msgSend_857 = __objc_msgSend_857Ptr.asFunction<
       ffi.Pointer<ffi.Void> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
 
@@ -24100,13 +24434,13 @@ class SentryCocoa {
       _registerName1("insertPointer:atIndex:");
   late final _sel_replacePointerAtIndex_withPointer_1 =
       _registerName1("replacePointerAtIndex:withPointer:");
-  void _objc_msgSend_844(
+  void _objc_msgSend_858(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int index,
     ffi.Pointer<ffi.Void> item,
   ) {
-    return __objc_msgSend_844(
+    return __objc_msgSend_858(
       obj,
       sel,
       index,
@@ -24114,11 +24448,11 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_844Ptr = _lookup<
+  late final __objc_msgSend_858Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.UnsignedLong, ffi.Pointer<ffi.Void>)>>('objc_msgSend');
-  late final __objc_msgSend_844 = __objc_msgSend_844Ptr.asFunction<
+  late final __objc_msgSend_858 = __objc_msgSend_858Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int,
           ffi.Pointer<ffi.Void>)>();
 
@@ -24130,21 +24464,21 @@ class SentryCocoa {
       _registerName1("pointerArrayWithWeakObjects");
   late final _sel_strongObjectsPointerArray1 =
       _registerName1("strongObjectsPointerArray");
-  ffi.Pointer<ObjCObject> _objc_msgSend_845(
+  ffi.Pointer<ObjCObject> _objc_msgSend_859(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_845(
+    return __objc_msgSend_859(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_845Ptr = _lookup<
+  late final __objc_msgSend_859Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_845 = __objc_msgSend_845Ptr.asFunction<
+  late final __objc_msgSend_859 = __objc_msgSend_859Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
@@ -24152,21 +24486,21 @@ class SentryCocoa {
       _registerName1("weakObjectsPointerArray");
   late final _class_NSProcessInfo1 = _getClass1("NSProcessInfo");
   late final _sel_processInfo1 = _registerName1("processInfo");
-  ffi.Pointer<ObjCObject> _objc_msgSend_846(
+  ffi.Pointer<ObjCObject> _objc_msgSend_860(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_846(
+    return __objc_msgSend_860(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_846Ptr = _lookup<
+  late final __objc_msgSend_860Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_846 = __objc_msgSend_846Ptr.asFunction<
+  late final __objc_msgSend_860 = __objc_msgSend_860Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
@@ -24183,25 +24517,25 @@ class SentryCocoa {
       _registerName1("operatingSystemVersionString");
   late final _sel_operatingSystemVersion1 =
       _registerName1("operatingSystemVersion");
-  void _objc_msgSend_847(
+  void _objc_msgSend_861(
     ffi.Pointer<NSOperatingSystemVersion> stret,
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_847(
+    return __objc_msgSend_861(
       stret,
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_847Ptr = _lookup<
+  late final __objc_msgSend_861Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(
               ffi.Pointer<NSOperatingSystemVersion>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>)>>('objc_msgSend_stret');
-  late final __objc_msgSend_847 = __objc_msgSend_847Ptr.asFunction<
+  late final __objc_msgSend_861 = __objc_msgSend_861Ptr.asFunction<
       void Function(ffi.Pointer<NSOperatingSystemVersion>,
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
@@ -24211,23 +24545,23 @@ class SentryCocoa {
   late final _sel_physicalMemory1 = _registerName1("physicalMemory");
   late final _sel_isOperatingSystemAtLeastVersion_1 =
       _registerName1("isOperatingSystemAtLeastVersion:");
-  bool _objc_msgSend_848(
+  bool _objc_msgSend_862(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     NSOperatingSystemVersion version,
   ) {
-    return __objc_msgSend_848(
+    return __objc_msgSend_862(
       obj,
       sel,
       version,
     );
   }
 
-  late final __objc_msgSend_848Ptr = _lookup<
+  late final __objc_msgSend_862Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               NSOperatingSystemVersion)>>('objc_msgSend');
-  late final __objc_msgSend_848 = __objc_msgSend_848Ptr.asFunction<
+  late final __objc_msgSend_862 = __objc_msgSend_862Ptr.asFunction<
       bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           NSOperatingSystemVersion)>();
 
@@ -24246,423 +24580,17 @@ class SentryCocoa {
       _registerName1("setAutomaticTerminationSupportEnabled:");
   late final _sel_beginActivityWithOptions_reason_1 =
       _registerName1("beginActivityWithOptions:reason:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_849(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    int options,
-    ffi.Pointer<ObjCObject> reason,
-  ) {
-    return __objc_msgSend_849(
-      obj,
-      sel,
-      options,
-      reason,
-    );
-  }
-
-  late final __objc_msgSend_849Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>,
-              ffi.Int32,
-              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_849 = __objc_msgSend_849Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCSel>, int, ffi.Pointer<ObjCObject>)>();
-
-  late final _sel_endActivity_1 = _registerName1("endActivity:");
-  late final _sel_performActivityWithOptions_reason_usingBlock_1 =
-      _registerName1("performActivityWithOptions:reason:usingBlock:");
-  void _objc_msgSend_850(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    int options,
-    ffi.Pointer<ObjCObject> reason,
-    ffi.Pointer<_ObjCBlock> block,
-  ) {
-    return __objc_msgSend_850(
-      obj,
-      sel,
-      options,
-      reason,
-      block,
-    );
-  }
-
-  late final __objc_msgSend_850Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>,
-              ffi.Int32,
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
-  late final __objc_msgSend_850 = __objc_msgSend_850Ptr.asFunction<
-      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int,
-          ffi.Pointer<ObjCObject>, ffi.Pointer<_ObjCBlock>)>();
-
-  late final _sel_performExpiringActivityWithReason_usingBlock_1 =
-      _registerName1("performExpiringActivityWithReason:usingBlock:");
-  void _objc_msgSend_851(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> reason,
-    ffi.Pointer<_ObjCBlock> block,
-  ) {
-    return __objc_msgSend_851(
-      obj,
-      sel,
-      reason,
-      block,
-    );
-  }
-
-  late final __objc_msgSend_851Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
-  late final __objc_msgSend_851 = __objc_msgSend_851Ptr.asFunction<
-      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>, ffi.Pointer<_ObjCBlock>)>();
-
-  late final _sel_userName1 = _registerName1("userName");
-  late final _sel_fullUserName1 = _registerName1("fullUserName");
-  late final _sel_thermalState1 = _registerName1("thermalState");
-  int _objc_msgSend_852(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-  ) {
-    return __objc_msgSend_852(
-      obj,
-      sel,
-    );
-  }
-
-  late final __objc_msgSend_852Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Int32 Function(
-              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_852 = __objc_msgSend_852Ptr.asFunction<
-      int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
-
-  late final _sel_isLowPowerModeEnabled1 =
-      _registerName1("isLowPowerModeEnabled");
-  late final _sel_isMacCatalystApp1 = _registerName1("isMacCatalystApp");
-  late final _sel_isiOSAppOnMac1 = _registerName1("isiOSAppOnMac");
-  late final _class_NSTextCheckingResult1 = _getClass1("NSTextCheckingResult");
-  late final _sel_resultType1 = _registerName1("resultType");
-  int _objc_msgSend_853(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-  ) {
-    return __objc_msgSend_853(
-      obj,
-      sel,
-    );
-  }
-
-  late final __objc_msgSend_853Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Int32 Function(
-              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_853 = __objc_msgSend_853Ptr.asFunction<
-      int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
-
-  late final _sel_range1 = _registerName1("range");
-  late final _sel_orthography1 = _registerName1("orthography");
-  ffi.Pointer<ObjCObject> _objc_msgSend_854(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-  ) {
-    return __objc_msgSend_854(
-      obj,
-      sel,
-    );
-  }
-
-  late final __objc_msgSend_854Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(
-              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_854 = __objc_msgSend_854Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(
-          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
-
-  late final _sel_grammarDetails1 = _registerName1("grammarDetails");
-  late final _sel_duration1 = _registerName1("duration");
-  late final _sel_components1 = _registerName1("components");
-  late final _sel_replacementString1 = _registerName1("replacementString");
-  late final _sel_alternativeStrings1 = _registerName1("alternativeStrings");
-  late final _class_NSRegularExpression1 = _getClass1("NSRegularExpression");
-  late final _sel_regularExpressionWithPattern_options_error_1 =
-      _registerName1("regularExpressionWithPattern:options:error:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_855(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> pattern,
-    int options,
-    ffi.Pointer<ffi.Pointer<ObjCObject>> error,
-  ) {
-    return __objc_msgSend_855(
-      obj,
-      sel,
-      pattern,
-      options,
-      error,
-    );
-  }
-
-  late final __objc_msgSend_855Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Int32,
-              ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_855 = __objc_msgSend_855Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>,
-          int,
-          ffi.Pointer<ffi.Pointer<ObjCObject>>)>();
-
-  late final _sel_initWithPattern_options_error_1 =
-      _registerName1("initWithPattern:options:error:");
-  instancetype _objc_msgSend_856(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> pattern,
-    int options,
-    ffi.Pointer<ffi.Pointer<ObjCObject>> error,
-  ) {
-    return __objc_msgSend_856(
-      obj,
-      sel,
-      pattern,
-      options,
-      error,
-    );
-  }
-
-  late final __objc_msgSend_856Ptr = _lookup<
-      ffi.NativeFunction<
-          instancetype Function(
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Int32,
-              ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_856 = __objc_msgSend_856Ptr.asFunction<
-      instancetype Function(
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>,
-          int,
-          ffi.Pointer<ffi.Pointer<ObjCObject>>)>();
-
-  late final _sel_pattern1 = _registerName1("pattern");
-  late final _sel_options1 = _registerName1("options");
-  int _objc_msgSend_857(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-  ) {
-    return __objc_msgSend_857(
-      obj,
-      sel,
-    );
-  }
-
-  late final __objc_msgSend_857Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Int32 Function(
-              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_857 = __objc_msgSend_857Ptr.asFunction<
-      int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
-
-  late final _sel_numberOfCaptureGroups1 =
-      _registerName1("numberOfCaptureGroups");
-  late final _sel_escapedPatternForString_1 =
-      _registerName1("escapedPatternForString:");
-  late final _sel_enumerateMatchesInString_options_range_usingBlock_1 =
-      _registerName1("enumerateMatchesInString:options:range:usingBlock:");
-  void _objc_msgSend_858(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> string,
-    int options,
-    _NSRange range,
-    ffi.Pointer<_ObjCBlock> block,
-  ) {
-    return __objc_msgSend_858(
-      obj,
-      sel,
-      string,
-      options,
-      range,
-      block,
-    );
-  }
-
-  late final __objc_msgSend_858Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Int32,
-              _NSRange,
-              ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
-  late final __objc_msgSend_858 = __objc_msgSend_858Ptr.asFunction<
-      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>, int, _NSRange, ffi.Pointer<_ObjCBlock>)>();
-
-  late final _sel_matchesInString_options_range_1 =
-      _registerName1("matchesInString:options:range:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_859(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> string,
-    int options,
-    _NSRange range,
-  ) {
-    return __objc_msgSend_859(
-      obj,
-      sel,
-      string,
-      options,
-      range,
-    );
-  }
-
-  late final __objc_msgSend_859Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Int32,
-              _NSRange)>>('objc_msgSend');
-  late final __objc_msgSend_859 = __objc_msgSend_859Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>, int, _NSRange)>();
-
-  late final _sel_numberOfMatchesInString_options_range_1 =
-      _registerName1("numberOfMatchesInString:options:range:");
-  int _objc_msgSend_860(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> string,
-    int options,
-    _NSRange range,
-  ) {
-    return __objc_msgSend_860(
-      obj,
-      sel,
-      string,
-      options,
-      range,
-    );
-  }
-
-  late final __objc_msgSend_860Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.UnsignedLong Function(
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Int32,
-              _NSRange)>>('objc_msgSend');
-  late final __objc_msgSend_860 = __objc_msgSend_860Ptr.asFunction<
-      int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>, int, _NSRange)>();
-
-  late final _sel_firstMatchInString_options_range_1 =
-      _registerName1("firstMatchInString:options:range:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_861(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> string,
-    int options,
-    _NSRange range,
-  ) {
-    return __objc_msgSend_861(
-      obj,
-      sel,
-      string,
-      options,
-      range,
-    );
-  }
-
-  late final __objc_msgSend_861Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Int32,
-              _NSRange)>>('objc_msgSend');
-  late final __objc_msgSend_861 = __objc_msgSend_861Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>, int, _NSRange)>();
-
-  late final _sel_rangeOfFirstMatchInString_options_range_1 =
-      _registerName1("rangeOfFirstMatchInString:options:range:");
-  void _objc_msgSend_862(
-    ffi.Pointer<_NSRange> stret,
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> string,
-    int options,
-    _NSRange range,
-  ) {
-    return __objc_msgSend_862(
-      stret,
-      obj,
-      sel,
-      string,
-      options,
-      range,
-    );
-  }
-
-  late final __objc_msgSend_862Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Pointer<_NSRange>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Int32,
-              _NSRange)>>('objc_msgSend_stret');
-  late final __objc_msgSend_862 = __objc_msgSend_862Ptr.asFunction<
-      void Function(ffi.Pointer<_NSRange>, ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>, int, _NSRange)>();
-
-  late final _sel_stringByReplacingMatchesInString_options_range_withTemplate_1 =
-      _registerName1(
-          "stringByReplacingMatchesInString:options:range:withTemplate:");
   ffi.Pointer<ObjCObject> _objc_msgSend_863(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> string,
     int options,
-    _NSRange range,
-    ffi.Pointer<ObjCObject> templ,
+    ffi.Pointer<ObjCObject> reason,
   ) {
     return __objc_msgSend_863(
       obj,
       sel,
-      string,
       options,
-      range,
-      templ,
+      reason,
     );
   }
 
@@ -24671,94 +24599,74 @@ class SentryCocoa {
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>,
               ffi.Int32,
-              _NSRange,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
   late final __objc_msgSend_863 = __objc_msgSend_863Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>,
-          int,
-          _NSRange,
-          ffi.Pointer<ObjCObject>)>();
+      ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCSel>, int, ffi.Pointer<ObjCObject>)>();
 
-  late final _sel_replaceMatchesInString_options_range_withTemplate_1 =
-      _registerName1("replaceMatchesInString:options:range:withTemplate:");
-  int _objc_msgSend_864(
+  late final _sel_endActivity_1 = _registerName1("endActivity:");
+  late final _sel_performActivityWithOptions_reason_usingBlock_1 =
+      _registerName1("performActivityWithOptions:reason:usingBlock:");
+  void _objc_msgSend_864(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> string,
     int options,
-    _NSRange range,
-    ffi.Pointer<ObjCObject> templ,
+    ffi.Pointer<ObjCObject> reason,
+    ffi.Pointer<_ObjCBlock> block,
   ) {
     return __objc_msgSend_864(
       obj,
       sel,
-      string,
       options,
-      range,
-      templ,
+      reason,
+      block,
     );
   }
 
   late final __objc_msgSend_864Ptr = _lookup<
       ffi.NativeFunction<
-          ffi.UnsignedLong Function(
+          ffi.Void Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>,
               ffi.Int32,
-              _NSRange,
-              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
   late final __objc_msgSend_864 = __objc_msgSend_864Ptr.asFunction<
-      int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>, int, _NSRange, ffi.Pointer<ObjCObject>)>();
+      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int,
+          ffi.Pointer<ObjCObject>, ffi.Pointer<_ObjCBlock>)>();
 
-  late final _sel_replacementStringForResult_inString_offset_template_1 =
-      _registerName1("replacementStringForResult:inString:offset:template:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_865(
+  late final _sel_performExpiringActivityWithReason_usingBlock_1 =
+      _registerName1("performExpiringActivityWithReason:usingBlock:");
+  void _objc_msgSend_865(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> result,
-    ffi.Pointer<ObjCObject> string,
-    int offset,
-    ffi.Pointer<ObjCObject> templ,
+    ffi.Pointer<ObjCObject> reason,
+    ffi.Pointer<_ObjCBlock> block,
   ) {
     return __objc_msgSend_865(
       obj,
       sel,
-      result,
-      string,
-      offset,
-      templ,
+      reason,
+      block,
     );
   }
 
   late final __objc_msgSend_865Ptr = _lookup<
       ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(
+          ffi.Void Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Long,
-              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
+              ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
   late final __objc_msgSend_865 = __objc_msgSend_865Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCObject>,
-          int,
-          ffi.Pointer<ObjCObject>)>();
+      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>, ffi.Pointer<_ObjCBlock>)>();
 
-  late final _sel_escapedTemplateForString_1 =
-      _registerName1("escapedTemplateForString:");
-  late final _sel_regularExpression1 = _registerName1("regularExpression");
-  ffi.Pointer<ObjCObject> _objc_msgSend_866(
+  late final _sel_userName1 = _registerName1("userName");
+  late final _sel_fullUserName1 = _registerName1("fullUserName");
+  late final _sel_thermalState1 = _registerName1("thermalState");
+  int _objc_msgSend_866(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
@@ -24770,9 +24678,435 @@ class SentryCocoa {
 
   late final __objc_msgSend_866Ptr = _lookup<
       ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(
+          ffi.Int32 Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
   late final __objc_msgSend_866 = __objc_msgSend_866Ptr.asFunction<
+      int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
+
+  late final _sel_isLowPowerModeEnabled1 =
+      _registerName1("isLowPowerModeEnabled");
+  late final _sel_isMacCatalystApp1 = _registerName1("isMacCatalystApp");
+  late final _sel_isiOSAppOnMac1 = _registerName1("isiOSAppOnMac");
+  late final _class_NSTextCheckingResult1 = _getClass1("NSTextCheckingResult");
+  late final _sel_resultType1 = _registerName1("resultType");
+  int _objc_msgSend_867(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+  ) {
+    return __objc_msgSend_867(
+      obj,
+      sel,
+    );
+  }
+
+  late final __objc_msgSend_867Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int32 Function(
+              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
+  late final __objc_msgSend_867 = __objc_msgSend_867Ptr.asFunction<
+      int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
+
+  late final _sel_range1 = _registerName1("range");
+  late final _sel_orthography1 = _registerName1("orthography");
+  ffi.Pointer<ObjCObject> _objc_msgSend_868(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+  ) {
+    return __objc_msgSend_868(
+      obj,
+      sel,
+    );
+  }
+
+  late final __objc_msgSend_868Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<ObjCObject> Function(
+              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
+  late final __objc_msgSend_868 = __objc_msgSend_868Ptr.asFunction<
+      ffi.Pointer<ObjCObject> Function(
+          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
+
+  late final _sel_grammarDetails1 = _registerName1("grammarDetails");
+  late final _sel_duration1 = _registerName1("duration");
+  late final _sel_components1 = _registerName1("components");
+  late final _sel_replacementString1 = _registerName1("replacementString");
+  late final _sel_alternativeStrings1 = _registerName1("alternativeStrings");
+  late final _class_NSRegularExpression1 = _getClass1("NSRegularExpression");
+  late final _sel_regularExpressionWithPattern_options_error_1 =
+      _registerName1("regularExpressionWithPattern:options:error:");
+  ffi.Pointer<ObjCObject> _objc_msgSend_869(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> pattern,
+    int options,
+    ffi.Pointer<ffi.Pointer<ObjCObject>> error,
+  ) {
+    return __objc_msgSend_869(
+      obj,
+      sel,
+      pattern,
+      options,
+      error,
+    );
+  }
+
+  late final __objc_msgSend_869Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<ObjCObject> Function(
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Int32,
+              ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
+  late final __objc_msgSend_869 = __objc_msgSend_869Ptr.asFunction<
+      ffi.Pointer<ObjCObject> Function(
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>,
+          int,
+          ffi.Pointer<ffi.Pointer<ObjCObject>>)>();
+
+  late final _sel_initWithPattern_options_error_1 =
+      _registerName1("initWithPattern:options:error:");
+  instancetype _objc_msgSend_870(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> pattern,
+    int options,
+    ffi.Pointer<ffi.Pointer<ObjCObject>> error,
+  ) {
+    return __objc_msgSend_870(
+      obj,
+      sel,
+      pattern,
+      options,
+      error,
+    );
+  }
+
+  late final __objc_msgSend_870Ptr = _lookup<
+      ffi.NativeFunction<
+          instancetype Function(
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Int32,
+              ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
+  late final __objc_msgSend_870 = __objc_msgSend_870Ptr.asFunction<
+      instancetype Function(
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>,
+          int,
+          ffi.Pointer<ffi.Pointer<ObjCObject>>)>();
+
+  late final _sel_pattern1 = _registerName1("pattern");
+  late final _sel_options1 = _registerName1("options");
+  int _objc_msgSend_871(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+  ) {
+    return __objc_msgSend_871(
+      obj,
+      sel,
+    );
+  }
+
+  late final __objc_msgSend_871Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int32 Function(
+              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
+  late final __objc_msgSend_871 = __objc_msgSend_871Ptr.asFunction<
+      int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
+
+  late final _sel_numberOfCaptureGroups1 =
+      _registerName1("numberOfCaptureGroups");
+  late final _sel_escapedPatternForString_1 =
+      _registerName1("escapedPatternForString:");
+  late final _sel_enumerateMatchesInString_options_range_usingBlock_1 =
+      _registerName1("enumerateMatchesInString:options:range:usingBlock:");
+  void _objc_msgSend_872(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> string,
+    int options,
+    _NSRange range,
+    ffi.Pointer<_ObjCBlock> block,
+  ) {
+    return __objc_msgSend_872(
+      obj,
+      sel,
+      string,
+      options,
+      range,
+      block,
+    );
+  }
+
+  late final __objc_msgSend_872Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Int32,
+              _NSRange,
+              ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
+  late final __objc_msgSend_872 = __objc_msgSend_872Ptr.asFunction<
+      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>, int, _NSRange, ffi.Pointer<_ObjCBlock>)>();
+
+  late final _sel_matchesInString_options_range_1 =
+      _registerName1("matchesInString:options:range:");
+  ffi.Pointer<ObjCObject> _objc_msgSend_873(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> string,
+    int options,
+    _NSRange range,
+  ) {
+    return __objc_msgSend_873(
+      obj,
+      sel,
+      string,
+      options,
+      range,
+    );
+  }
+
+  late final __objc_msgSend_873Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<ObjCObject> Function(
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Int32,
+              _NSRange)>>('objc_msgSend');
+  late final __objc_msgSend_873 = __objc_msgSend_873Ptr.asFunction<
+      ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>, int, _NSRange)>();
+
+  late final _sel_numberOfMatchesInString_options_range_1 =
+      _registerName1("numberOfMatchesInString:options:range:");
+  int _objc_msgSend_874(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> string,
+    int options,
+    _NSRange range,
+  ) {
+    return __objc_msgSend_874(
+      obj,
+      sel,
+      string,
+      options,
+      range,
+    );
+  }
+
+  late final __objc_msgSend_874Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.UnsignedLong Function(
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Int32,
+              _NSRange)>>('objc_msgSend');
+  late final __objc_msgSend_874 = __objc_msgSend_874Ptr.asFunction<
+      int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>, int, _NSRange)>();
+
+  late final _sel_firstMatchInString_options_range_1 =
+      _registerName1("firstMatchInString:options:range:");
+  ffi.Pointer<ObjCObject> _objc_msgSend_875(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> string,
+    int options,
+    _NSRange range,
+  ) {
+    return __objc_msgSend_875(
+      obj,
+      sel,
+      string,
+      options,
+      range,
+    );
+  }
+
+  late final __objc_msgSend_875Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<ObjCObject> Function(
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Int32,
+              _NSRange)>>('objc_msgSend');
+  late final __objc_msgSend_875 = __objc_msgSend_875Ptr.asFunction<
+      ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>, int, _NSRange)>();
+
+  late final _sel_rangeOfFirstMatchInString_options_range_1 =
+      _registerName1("rangeOfFirstMatchInString:options:range:");
+  void _objc_msgSend_876(
+    ffi.Pointer<_NSRange> stret,
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> string,
+    int options,
+    _NSRange range,
+  ) {
+    return __objc_msgSend_876(
+      stret,
+      obj,
+      sel,
+      string,
+      options,
+      range,
+    );
+  }
+
+  late final __objc_msgSend_876Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+              ffi.Pointer<_NSRange>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Int32,
+              _NSRange)>>('objc_msgSend_stret');
+  late final __objc_msgSend_876 = __objc_msgSend_876Ptr.asFunction<
+      void Function(ffi.Pointer<_NSRange>, ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>, int, _NSRange)>();
+
+  late final _sel_stringByReplacingMatchesInString_options_range_withTemplate_1 =
+      _registerName1(
+          "stringByReplacingMatchesInString:options:range:withTemplate:");
+  ffi.Pointer<ObjCObject> _objc_msgSend_877(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> string,
+    int options,
+    _NSRange range,
+    ffi.Pointer<ObjCObject> templ,
+  ) {
+    return __objc_msgSend_877(
+      obj,
+      sel,
+      string,
+      options,
+      range,
+      templ,
+    );
+  }
+
+  late final __objc_msgSend_877Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<ObjCObject> Function(
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Int32,
+              _NSRange,
+              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
+  late final __objc_msgSend_877 = __objc_msgSend_877Ptr.asFunction<
+      ffi.Pointer<ObjCObject> Function(
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>,
+          int,
+          _NSRange,
+          ffi.Pointer<ObjCObject>)>();
+
+  late final _sel_replaceMatchesInString_options_range_withTemplate_1 =
+      _registerName1("replaceMatchesInString:options:range:withTemplate:");
+  int _objc_msgSend_878(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> string,
+    int options,
+    _NSRange range,
+    ffi.Pointer<ObjCObject> templ,
+  ) {
+    return __objc_msgSend_878(
+      obj,
+      sel,
+      string,
+      options,
+      range,
+      templ,
+    );
+  }
+
+  late final __objc_msgSend_878Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.UnsignedLong Function(
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Int32,
+              _NSRange,
+              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
+  late final __objc_msgSend_878 = __objc_msgSend_878Ptr.asFunction<
+      int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>, int, _NSRange, ffi.Pointer<ObjCObject>)>();
+
+  late final _sel_replacementStringForResult_inString_offset_template_1 =
+      _registerName1("replacementStringForResult:inString:offset:template:");
+  ffi.Pointer<ObjCObject> _objc_msgSend_879(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> result,
+    ffi.Pointer<ObjCObject> string,
+    int offset,
+    ffi.Pointer<ObjCObject> templ,
+  ) {
+    return __objc_msgSend_879(
+      obj,
+      sel,
+      result,
+      string,
+      offset,
+      templ,
+    );
+  }
+
+  late final __objc_msgSend_879Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<ObjCObject> Function(
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Long,
+              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
+  late final __objc_msgSend_879 = __objc_msgSend_879Ptr.asFunction<
+      ffi.Pointer<ObjCObject> Function(
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCObject>,
+          int,
+          ffi.Pointer<ObjCObject>)>();
+
+  late final _sel_escapedTemplateForString_1 =
+      _registerName1("escapedTemplateForString:");
+  late final _sel_regularExpression1 = _registerName1("regularExpression");
+  ffi.Pointer<ObjCObject> _objc_msgSend_880(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+  ) {
+    return __objc_msgSend_880(
+      obj,
+      sel,
+    );
+  }
+
+  late final __objc_msgSend_880Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<ObjCObject> Function(
+              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
+  late final __objc_msgSend_880 = __objc_msgSend_880Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
@@ -24782,36 +25116,36 @@ class SentryCocoa {
   late final _sel_rangeWithName_1 = _registerName1("rangeWithName:");
   late final _sel_resultByAdjustingRangesWithOffset_1 =
       _registerName1("resultByAdjustingRangesWithOffset:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_867(
+  ffi.Pointer<ObjCObject> _objc_msgSend_881(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int offset,
   ) {
-    return __objc_msgSend_867(
+    return __objc_msgSend_881(
       obj,
       sel,
       offset,
     );
   }
 
-  late final __objc_msgSend_867Ptr = _lookup<
+  late final __objc_msgSend_881Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>, ffi.Long)>>('objc_msgSend');
-  late final __objc_msgSend_867 = __objc_msgSend_867Ptr.asFunction<
+  late final __objc_msgSend_881 = __objc_msgSend_881Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
 
   late final _sel_addressComponents1 = _registerName1("addressComponents");
   late final _sel_orthographyCheckingResultWithRange_orthography_1 =
       _registerName1("orthographyCheckingResultWithRange:orthography:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_868(
+  ffi.Pointer<ObjCObject> _objc_msgSend_882(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     _NSRange range,
     ffi.Pointer<ObjCObject> orthography,
   ) {
-    return __objc_msgSend_868(
+    return __objc_msgSend_882(
       obj,
       sel,
       range,
@@ -24819,48 +25153,48 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_868Ptr = _lookup<
+  late final __objc_msgSend_882Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               _NSRange,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_868 = __objc_msgSend_868Ptr.asFunction<
+  late final __objc_msgSend_882 = __objc_msgSend_882Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, _NSRange, ffi.Pointer<ObjCObject>)>();
 
   late final _sel_spellCheckingResultWithRange_1 =
       _registerName1("spellCheckingResultWithRange:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_869(
+  ffi.Pointer<ObjCObject> _objc_msgSend_883(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     _NSRange range,
   ) {
-    return __objc_msgSend_869(
+    return __objc_msgSend_883(
       obj,
       sel,
       range,
     );
   }
 
-  late final __objc_msgSend_869Ptr = _lookup<
+  late final __objc_msgSend_883Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>, _NSRange)>>('objc_msgSend');
-  late final __objc_msgSend_869 = __objc_msgSend_869Ptr.asFunction<
+  late final __objc_msgSend_883 = __objc_msgSend_883Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, _NSRange)>();
 
   late final _sel_grammarCheckingResultWithRange_details_1 =
       _registerName1("grammarCheckingResultWithRange:details:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_870(
+  ffi.Pointer<ObjCObject> _objc_msgSend_884(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     _NSRange range,
     ffi.Pointer<ObjCObject> details,
   ) {
-    return __objc_msgSend_870(
+    return __objc_msgSend_884(
       obj,
       sel,
       range,
@@ -24868,26 +25202,26 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_870Ptr = _lookup<
+  late final __objc_msgSend_884Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               _NSRange,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_870 = __objc_msgSend_870Ptr.asFunction<
+  late final __objc_msgSend_884 = __objc_msgSend_884Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, _NSRange, ffi.Pointer<ObjCObject>)>();
 
   late final _sel_dateCheckingResultWithRange_date_1 =
       _registerName1("dateCheckingResultWithRange:date:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_871(
+  ffi.Pointer<ObjCObject> _objc_msgSend_885(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     _NSRange range,
     ffi.Pointer<ObjCObject> date,
   ) {
-    return __objc_msgSend_871(
+    return __objc_msgSend_885(
       obj,
       sel,
       range,
@@ -24895,20 +25229,20 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_871Ptr = _lookup<
+  late final __objc_msgSend_885Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               _NSRange,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_871 = __objc_msgSend_871Ptr.asFunction<
+  late final __objc_msgSend_885 = __objc_msgSend_885Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, _NSRange, ffi.Pointer<ObjCObject>)>();
 
   late final _sel_dateCheckingResultWithRange_date_timeZone_duration_1 =
       _registerName1("dateCheckingResultWithRange:date:timeZone:duration:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_872(
+  ffi.Pointer<ObjCObject> _objc_msgSend_886(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     _NSRange range,
@@ -24916,7 +25250,7 @@ class SentryCocoa {
     ffi.Pointer<ObjCObject> timeZone,
     double duration,
   ) {
-    return __objc_msgSend_872(
+    return __objc_msgSend_886(
       obj,
       sel,
       range,
@@ -24926,7 +25260,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_872Ptr = _lookup<
+  late final __objc_msgSend_886Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
@@ -24935,7 +25269,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>,
               ffi.Double)>>('objc_msgSend');
-  late final __objc_msgSend_872 = __objc_msgSend_872Ptr.asFunction<
+  late final __objc_msgSend_886 = __objc_msgSend_886Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -24946,13 +25280,13 @@ class SentryCocoa {
 
   late final _sel_addressCheckingResultWithRange_components_1 =
       _registerName1("addressCheckingResultWithRange:components:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_873(
+  ffi.Pointer<ObjCObject> _objc_msgSend_887(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     _NSRange range,
     ffi.Pointer<ObjCObject> components,
   ) {
-    return __objc_msgSend_873(
+    return __objc_msgSend_887(
       obj,
       sel,
       range,
@@ -24960,26 +25294,26 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_873Ptr = _lookup<
+  late final __objc_msgSend_887Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               _NSRange,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_873 = __objc_msgSend_873Ptr.asFunction<
+  late final __objc_msgSend_887 = __objc_msgSend_887Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, _NSRange, ffi.Pointer<ObjCObject>)>();
 
   late final _sel_linkCheckingResultWithRange_URL_1 =
       _registerName1("linkCheckingResultWithRange:URL:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_874(
+  ffi.Pointer<ObjCObject> _objc_msgSend_888(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     _NSRange range,
     ffi.Pointer<ObjCObject> url,
   ) {
-    return __objc_msgSend_874(
+    return __objc_msgSend_888(
       obj,
       sel,
       range,
@@ -24987,26 +25321,26 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_874Ptr = _lookup<
+  late final __objc_msgSend_888Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               _NSRange,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_874 = __objc_msgSend_874Ptr.asFunction<
+  late final __objc_msgSend_888 = __objc_msgSend_888Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, _NSRange, ffi.Pointer<ObjCObject>)>();
 
   late final _sel_quoteCheckingResultWithRange_replacementString_1 =
       _registerName1("quoteCheckingResultWithRange:replacementString:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_875(
+  ffi.Pointer<ObjCObject> _objc_msgSend_889(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     _NSRange range,
     ffi.Pointer<ObjCObject> replacementString,
   ) {
-    return __objc_msgSend_875(
+    return __objc_msgSend_889(
       obj,
       sel,
       range,
@@ -25014,14 +25348,14 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_875Ptr = _lookup<
+  late final __objc_msgSend_889Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               _NSRange,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_875 = __objc_msgSend_875Ptr.asFunction<
+  late final __objc_msgSend_889 = __objc_msgSend_889Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, _NSRange, ffi.Pointer<ObjCObject>)>();
 
@@ -25034,14 +25368,14 @@ class SentryCocoa {
   late final _sel_correctionCheckingResultWithRange_replacementString_alternativeStrings_1 =
       _registerName1(
           "correctionCheckingResultWithRange:replacementString:alternativeStrings:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_876(
+  ffi.Pointer<ObjCObject> _objc_msgSend_890(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     _NSRange range,
     ffi.Pointer<ObjCObject> replacementString,
     ffi.Pointer<ObjCObject> alternativeStrings,
   ) {
-    return __objc_msgSend_876(
+    return __objc_msgSend_890(
       obj,
       sel,
       range,
@@ -25050,7 +25384,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_876Ptr = _lookup<
+  late final __objc_msgSend_890Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
@@ -25058,7 +25392,7 @@ class SentryCocoa {
               _NSRange,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_876 = __objc_msgSend_876Ptr.asFunction<
+  late final __objc_msgSend_890 = __objc_msgSend_890Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -25069,14 +25403,14 @@ class SentryCocoa {
   late final _sel_regularExpressionCheckingResultWithRanges_count_regularExpression_1 =
       _registerName1(
           "regularExpressionCheckingResultWithRanges:count:regularExpression:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_877(
+  ffi.Pointer<ObjCObject> _objc_msgSend_891(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<_NSRange> ranges,
     int count,
     ffi.Pointer<ObjCObject> regularExpression,
   ) {
-    return __objc_msgSend_877(
+    return __objc_msgSend_891(
       obj,
       sel,
       ranges,
@@ -25085,7 +25419,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_877Ptr = _lookup<
+  late final __objc_msgSend_891Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
@@ -25093,7 +25427,7 @@ class SentryCocoa {
               ffi.Pointer<_NSRange>,
               ffi.UnsignedLong,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_877 = __objc_msgSend_877Ptr.asFunction<
+  late final __objc_msgSend_891 = __objc_msgSend_891Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -25107,55 +25441,55 @@ class SentryCocoa {
       _registerName1("transitInformationCheckingResultWithRange:components:");
   late final _class_NSURLCache1 = _getClass1("NSURLCache");
   late final _sel_sharedURLCache1 = _registerName1("sharedURLCache");
-  ffi.Pointer<ObjCObject> _objc_msgSend_878(
+  ffi.Pointer<ObjCObject> _objc_msgSend_892(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_878(
+    return __objc_msgSend_892(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_878Ptr = _lookup<
+  late final __objc_msgSend_892Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_878 = __objc_msgSend_878Ptr.asFunction<
+  late final __objc_msgSend_892 = __objc_msgSend_892Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
   late final _sel_setSharedURLCache_1 = _registerName1("setSharedURLCache:");
-  void _objc_msgSend_879(
+  void _objc_msgSend_893(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> value,
   ) {
-    return __objc_msgSend_879(
+    return __objc_msgSend_893(
       obj,
       sel,
       value,
     );
   }
 
-  late final __objc_msgSend_879Ptr = _lookup<
+  late final __objc_msgSend_893Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_879 = __objc_msgSend_879Ptr.asFunction<
+  late final __objc_msgSend_893 = __objc_msgSend_893Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>)>();
 
   late final _sel_initWithMemoryCapacity_diskCapacity_diskPath_1 =
       _registerName1("initWithMemoryCapacity:diskCapacity:diskPath:");
-  instancetype _objc_msgSend_880(
+  instancetype _objc_msgSend_894(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int memoryCapacity,
     int diskCapacity,
     ffi.Pointer<ObjCObject> path,
   ) {
-    return __objc_msgSend_880(
+    return __objc_msgSend_894(
       obj,
       sel,
       memoryCapacity,
@@ -25164,7 +25498,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_880Ptr = _lookup<
+  late final __objc_msgSend_894Ptr = _lookup<
       ffi.NativeFunction<
           instancetype Function(
               ffi.Pointer<ObjCObject>,
@@ -25172,20 +25506,20 @@ class SentryCocoa {
               ffi.UnsignedLong,
               ffi.UnsignedLong,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_880 = __objc_msgSend_880Ptr.asFunction<
+  late final __objc_msgSend_894 = __objc_msgSend_894Ptr.asFunction<
       instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int,
           int, ffi.Pointer<ObjCObject>)>();
 
   late final _sel_initWithMemoryCapacity_diskCapacity_directoryURL_1 =
       _registerName1("initWithMemoryCapacity:diskCapacity:directoryURL:");
-  instancetype _objc_msgSend_881(
+  instancetype _objc_msgSend_895(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int memoryCapacity,
     int diskCapacity,
     ffi.Pointer<ObjCObject> directoryURL,
   ) {
-    return __objc_msgSend_881(
+    return __objc_msgSend_895(
       obj,
       sel,
       memoryCapacity,
@@ -25194,7 +25528,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_881Ptr = _lookup<
+  late final __objc_msgSend_895Ptr = _lookup<
       ffi.NativeFunction<
           instancetype Function(
               ffi.Pointer<ObjCObject>,
@@ -25202,20 +25536,20 @@ class SentryCocoa {
               ffi.UnsignedLong,
               ffi.UnsignedLong,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_881 = __objc_msgSend_881Ptr.asFunction<
+  late final __objc_msgSend_895 = __objc_msgSend_895Ptr.asFunction<
       instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int,
           int, ffi.Pointer<ObjCObject>)>();
 
   late final _class_NSCachedURLResponse1 = _getClass1("NSCachedURLResponse");
   late final _sel_initWithResponse_data_1 =
       _registerName1("initWithResponse:data:");
-  instancetype _objc_msgSend_882(
+  instancetype _objc_msgSend_896(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> response,
     ffi.Pointer<ObjCObject> data,
   ) {
-    return __objc_msgSend_882(
+    return __objc_msgSend_896(
       obj,
       sel,
       response,
@@ -25223,20 +25557,20 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_882Ptr = _lookup<
+  late final __objc_msgSend_896Ptr = _lookup<
       ffi.NativeFunction<
           instancetype Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_882 = __objc_msgSend_882Ptr.asFunction<
+  late final __objc_msgSend_896 = __objc_msgSend_896Ptr.asFunction<
       instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCObject>)>();
 
   late final _sel_initWithResponse_data_userInfo_storagePolicy_1 =
       _registerName1("initWithResponse:data:userInfo:storagePolicy:");
-  instancetype _objc_msgSend_883(
+  instancetype _objc_msgSend_897(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> response,
@@ -25244,7 +25578,7 @@ class SentryCocoa {
     ffi.Pointer<ObjCObject> userInfo,
     int storagePolicy,
   ) {
-    return __objc_msgSend_883(
+    return __objc_msgSend_897(
       obj,
       sel,
       response,
@@ -25254,7 +25588,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_883Ptr = _lookup<
+  late final __objc_msgSend_897Ptr = _lookup<
       ffi.NativeFunction<
           instancetype Function(
               ffi.Pointer<ObjCObject>,
@@ -25263,7 +25597,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>,
               ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_883 = __objc_msgSend_883Ptr.asFunction<
+  late final __objc_msgSend_897 = __objc_msgSend_897Ptr.asFunction<
       instancetype Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -25273,383 +25607,6 @@ class SentryCocoa {
           int)>();
 
   late final _sel_storagePolicy1 = _registerName1("storagePolicy");
-  int _objc_msgSend_884(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-  ) {
-    return __objc_msgSend_884(
-      obj,
-      sel,
-    );
-  }
-
-  late final __objc_msgSend_884Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Int32 Function(
-              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_884 = __objc_msgSend_884Ptr.asFunction<
-      int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
-
-  late final _sel_cachedResponseForRequest_1 =
-      _registerName1("cachedResponseForRequest:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_885(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> request,
-  ) {
-    return __objc_msgSend_885(
-      obj,
-      sel,
-      request,
-    );
-  }
-
-  late final __objc_msgSend_885Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_885 = __objc_msgSend_885Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
-
-  late final _sel_storeCachedResponse_forRequest_1 =
-      _registerName1("storeCachedResponse:forRequest:");
-  void _objc_msgSend_886(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> cachedResponse,
-    ffi.Pointer<ObjCObject> request,
-  ) {
-    return __objc_msgSend_886(
-      obj,
-      sel,
-      cachedResponse,
-      request,
-    );
-  }
-
-  late final __objc_msgSend_886Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_886 = __objc_msgSend_886Ptr.asFunction<
-      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCObject>)>();
-
-  late final _sel_removeCachedResponseForRequest_1 =
-      _registerName1("removeCachedResponseForRequest:");
-  void _objc_msgSend_887(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> request,
-  ) {
-    return __objc_msgSend_887(
-      obj,
-      sel,
-      request,
-    );
-  }
-
-  late final __objc_msgSend_887Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_887 = __objc_msgSend_887Ptr.asFunction<
-      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>)>();
-
-  late final _sel_removeAllCachedResponses1 =
-      _registerName1("removeAllCachedResponses");
-  late final _sel_removeCachedResponsesSinceDate_1 =
-      _registerName1("removeCachedResponsesSinceDate:");
-  late final _sel_memoryCapacity1 = _registerName1("memoryCapacity");
-  late final _sel_setMemoryCapacity_1 = _registerName1("setMemoryCapacity:");
-  late final _sel_diskCapacity1 = _registerName1("diskCapacity");
-  late final _sel_setDiskCapacity_1 = _registerName1("setDiskCapacity:");
-  late final _sel_currentMemoryUsage1 = _registerName1("currentMemoryUsage");
-  late final _sel_currentDiskUsage1 = _registerName1("currentDiskUsage");
-  late final _class_NSURLSessionDataTask1 = _getClass1("NSURLSessionDataTask");
-  late final _sel_storeCachedResponse_forDataTask_1 =
-      _registerName1("storeCachedResponse:forDataTask:");
-  void _objc_msgSend_888(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> cachedResponse,
-    ffi.Pointer<ObjCObject> dataTask,
-  ) {
-    return __objc_msgSend_888(
-      obj,
-      sel,
-      cachedResponse,
-      dataTask,
-    );
-  }
-
-  late final __objc_msgSend_888Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_888 = __objc_msgSend_888Ptr.asFunction<
-      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCObject>)>();
-
-  late final _sel_getCachedResponseForDataTask_completionHandler_1 =
-      _registerName1("getCachedResponseForDataTask:completionHandler:");
-  void _objc_msgSend_889(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> dataTask,
-    ffi.Pointer<_ObjCBlock> completionHandler,
-  ) {
-    return __objc_msgSend_889(
-      obj,
-      sel,
-      dataTask,
-      completionHandler,
-    );
-  }
-
-  late final __objc_msgSend_889Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
-  late final __objc_msgSend_889 = __objc_msgSend_889Ptr.asFunction<
-      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>, ffi.Pointer<_ObjCBlock>)>();
-
-  late final _sel_removeCachedResponseForDataTask_1 =
-      _registerName1("removeCachedResponseForDataTask:");
-  void _objc_msgSend_890(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> dataTask,
-  ) {
-    return __objc_msgSend_890(
-      obj,
-      sel,
-      dataTask,
-    );
-  }
-
-  late final __objc_msgSend_890Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_890 = __objc_msgSend_890Ptr.asFunction<
-      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>)>();
-
-  late final _class_NSURLConnection1 = _getClass1("NSURLConnection");
-  late final _sel_initWithRequest_delegate_startImmediately_1 =
-      _registerName1("initWithRequest:delegate:startImmediately:");
-  instancetype _objc_msgSend_891(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> request,
-    ffi.Pointer<ObjCObject> delegate,
-    bool startImmediately,
-  ) {
-    return __objc_msgSend_891(
-      obj,
-      sel,
-      request,
-      delegate,
-      startImmediately,
-    );
-  }
-
-  late final __objc_msgSend_891Ptr = _lookup<
-      ffi.NativeFunction<
-          instancetype Function(
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Bool)>>('objc_msgSend');
-  late final __objc_msgSend_891 = __objc_msgSend_891Ptr.asFunction<
-      instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCObject>, bool)>();
-
-  late final _sel_initWithRequest_delegate_1 =
-      _registerName1("initWithRequest:delegate:");
-  instancetype _objc_msgSend_892(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> request,
-    ffi.Pointer<ObjCObject> delegate,
-  ) {
-    return __objc_msgSend_892(
-      obj,
-      sel,
-      request,
-      delegate,
-    );
-  }
-
-  late final __objc_msgSend_892Ptr = _lookup<
-      ffi.NativeFunction<
-          instancetype Function(
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_892 = __objc_msgSend_892Ptr.asFunction<
-      instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCObject>)>();
-
-  late final _sel_connectionWithRequest_delegate_1 =
-      _registerName1("connectionWithRequest:delegate:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_893(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> request,
-    ffi.Pointer<ObjCObject> delegate,
-  ) {
-    return __objc_msgSend_893(
-      obj,
-      sel,
-      request,
-      delegate,
-    );
-  }
-
-  late final __objc_msgSend_893Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_893 = __objc_msgSend_893Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCObject>)>();
-
-  late final _sel_unscheduleFromRunLoop_forMode_1 =
-      _registerName1("unscheduleFromRunLoop:forMode:");
-  late final _sel_setDelegateQueue_1 = _registerName1("setDelegateQueue:");
-  void _objc_msgSend_894(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> queue,
-  ) {
-    return __objc_msgSend_894(
-      obj,
-      sel,
-      queue,
-    );
-  }
-
-  late final __objc_msgSend_894Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_894 = __objc_msgSend_894Ptr.asFunction<
-      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>)>();
-
-  late final _sel_canHandleRequest_1 = _registerName1("canHandleRequest:");
-  bool _objc_msgSend_895(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> request,
-  ) {
-    return __objc_msgSend_895(
-      obj,
-      sel,
-      request,
-    );
-  }
-
-  late final __objc_msgSend_895Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_895 = __objc_msgSend_895Ptr.asFunction<
-      bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>)>();
-
-  late final _sel_sendSynchronousRequest_returningResponse_error_1 =
-      _registerName1("sendSynchronousRequest:returningResponse:error:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_896(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> request,
-    ffi.Pointer<ffi.Pointer<ObjCObject>> response,
-    ffi.Pointer<ffi.Pointer<ObjCObject>> error,
-  ) {
-    return __objc_msgSend_896(
-      obj,
-      sel,
-      request,
-      response,
-      error,
-    );
-  }
-
-  late final __objc_msgSend_896Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ffi.Pointer<ObjCObject>>,
-              ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_896 = __objc_msgSend_896Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ffi.Pointer<ObjCObject>>,
-          ffi.Pointer<ffi.Pointer<ObjCObject>>)>();
-
-  late final _sel_sendAsynchronousRequest_queue_completionHandler_1 =
-      _registerName1("sendAsynchronousRequest:queue:completionHandler:");
-  void _objc_msgSend_897(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> request,
-    ffi.Pointer<ObjCObject> queue,
-    ffi.Pointer<_ObjCBlock> handler,
-  ) {
-    return __objc_msgSend_897(
-      obj,
-      sel,
-      request,
-      queue,
-      handler,
-    );
-  }
-
-  late final __objc_msgSend_897Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
-  late final __objc_msgSend_897 = __objc_msgSend_897Ptr.asFunction<
-      void Function(
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<_ObjCBlock>)>();
-
-  late final _class_NSURLCredential1 = _getClass1("NSURLCredential");
-  late final _sel_persistence1 = _registerName1("persistence");
   int _objc_msgSend_898(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
@@ -25667,16 +25624,393 @@ class SentryCocoa {
   late final __objc_msgSend_898 = __objc_msgSend_898Ptr.asFunction<
       int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
+  late final _sel_cachedResponseForRequest_1 =
+      _registerName1("cachedResponseForRequest:");
+  ffi.Pointer<ObjCObject> _objc_msgSend_899(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> request,
+  ) {
+    return __objc_msgSend_899(
+      obj,
+      sel,
+      request,
+    );
+  }
+
+  late final __objc_msgSend_899Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
+  late final __objc_msgSend_899 = __objc_msgSend_899Ptr.asFunction<
+      ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
+
+  late final _sel_storeCachedResponse_forRequest_1 =
+      _registerName1("storeCachedResponse:forRequest:");
+  void _objc_msgSend_900(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> cachedResponse,
+    ffi.Pointer<ObjCObject> request,
+  ) {
+    return __objc_msgSend_900(
+      obj,
+      sel,
+      cachedResponse,
+      request,
+    );
+  }
+
+  late final __objc_msgSend_900Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
+  late final __objc_msgSend_900 = __objc_msgSend_900Ptr.asFunction<
+      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCObject>)>();
+
+  late final _sel_removeCachedResponseForRequest_1 =
+      _registerName1("removeCachedResponseForRequest:");
+  void _objc_msgSend_901(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> request,
+  ) {
+    return __objc_msgSend_901(
+      obj,
+      sel,
+      request,
+    );
+  }
+
+  late final __objc_msgSend_901Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
+  late final __objc_msgSend_901 = __objc_msgSend_901Ptr.asFunction<
+      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>)>();
+
+  late final _sel_removeAllCachedResponses1 =
+      _registerName1("removeAllCachedResponses");
+  late final _sel_removeCachedResponsesSinceDate_1 =
+      _registerName1("removeCachedResponsesSinceDate:");
+  late final _sel_memoryCapacity1 = _registerName1("memoryCapacity");
+  late final _sel_setMemoryCapacity_1 = _registerName1("setMemoryCapacity:");
+  late final _sel_diskCapacity1 = _registerName1("diskCapacity");
+  late final _sel_setDiskCapacity_1 = _registerName1("setDiskCapacity:");
+  late final _sel_currentMemoryUsage1 = _registerName1("currentMemoryUsage");
+  late final _sel_currentDiskUsage1 = _registerName1("currentDiskUsage");
+  late final _class_NSURLSessionDataTask1 = _getClass1("NSURLSessionDataTask");
+  late final _sel_storeCachedResponse_forDataTask_1 =
+      _registerName1("storeCachedResponse:forDataTask:");
+  void _objc_msgSend_902(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> cachedResponse,
+    ffi.Pointer<ObjCObject> dataTask,
+  ) {
+    return __objc_msgSend_902(
+      obj,
+      sel,
+      cachedResponse,
+      dataTask,
+    );
+  }
+
+  late final __objc_msgSend_902Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
+  late final __objc_msgSend_902 = __objc_msgSend_902Ptr.asFunction<
+      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCObject>)>();
+
+  late final _sel_getCachedResponseForDataTask_completionHandler_1 =
+      _registerName1("getCachedResponseForDataTask:completionHandler:");
+  void _objc_msgSend_903(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> dataTask,
+    ffi.Pointer<_ObjCBlock> completionHandler,
+  ) {
+    return __objc_msgSend_903(
+      obj,
+      sel,
+      dataTask,
+      completionHandler,
+    );
+  }
+
+  late final __objc_msgSend_903Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
+  late final __objc_msgSend_903 = __objc_msgSend_903Ptr.asFunction<
+      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>, ffi.Pointer<_ObjCBlock>)>();
+
+  late final _sel_removeCachedResponseForDataTask_1 =
+      _registerName1("removeCachedResponseForDataTask:");
+  void _objc_msgSend_904(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> dataTask,
+  ) {
+    return __objc_msgSend_904(
+      obj,
+      sel,
+      dataTask,
+    );
+  }
+
+  late final __objc_msgSend_904Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
+  late final __objc_msgSend_904 = __objc_msgSend_904Ptr.asFunction<
+      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>)>();
+
+  late final _class_NSURLConnection1 = _getClass1("NSURLConnection");
+  late final _sel_initWithRequest_delegate_startImmediately_1 =
+      _registerName1("initWithRequest:delegate:startImmediately:");
+  instancetype _objc_msgSend_905(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> request,
+    ffi.Pointer<ObjCObject> delegate,
+    bool startImmediately,
+  ) {
+    return __objc_msgSend_905(
+      obj,
+      sel,
+      request,
+      delegate,
+      startImmediately,
+    );
+  }
+
+  late final __objc_msgSend_905Ptr = _lookup<
+      ffi.NativeFunction<
+          instancetype Function(
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Bool)>>('objc_msgSend');
+  late final __objc_msgSend_905 = __objc_msgSend_905Ptr.asFunction<
+      instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCObject>, bool)>();
+
+  late final _sel_initWithRequest_delegate_1 =
+      _registerName1("initWithRequest:delegate:");
+  instancetype _objc_msgSend_906(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> request,
+    ffi.Pointer<ObjCObject> delegate,
+  ) {
+    return __objc_msgSend_906(
+      obj,
+      sel,
+      request,
+      delegate,
+    );
+  }
+
+  late final __objc_msgSend_906Ptr = _lookup<
+      ffi.NativeFunction<
+          instancetype Function(
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
+  late final __objc_msgSend_906 = __objc_msgSend_906Ptr.asFunction<
+      instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCObject>)>();
+
+  late final _sel_connectionWithRequest_delegate_1 =
+      _registerName1("connectionWithRequest:delegate:");
+  ffi.Pointer<ObjCObject> _objc_msgSend_907(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> request,
+    ffi.Pointer<ObjCObject> delegate,
+  ) {
+    return __objc_msgSend_907(
+      obj,
+      sel,
+      request,
+      delegate,
+    );
+  }
+
+  late final __objc_msgSend_907Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<ObjCObject> Function(
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
+  late final __objc_msgSend_907 = __objc_msgSend_907Ptr.asFunction<
+      ffi.Pointer<ObjCObject> Function(
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCObject>)>();
+
+  late final _sel_unscheduleFromRunLoop_forMode_1 =
+      _registerName1("unscheduleFromRunLoop:forMode:");
+  late final _sel_setDelegateQueue_1 = _registerName1("setDelegateQueue:");
+  void _objc_msgSend_908(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> queue,
+  ) {
+    return __objc_msgSend_908(
+      obj,
+      sel,
+      queue,
+    );
+  }
+
+  late final __objc_msgSend_908Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
+  late final __objc_msgSend_908 = __objc_msgSend_908Ptr.asFunction<
+      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>)>();
+
+  late final _sel_canHandleRequest_1 = _registerName1("canHandleRequest:");
+  bool _objc_msgSend_909(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> request,
+  ) {
+    return __objc_msgSend_909(
+      obj,
+      sel,
+      request,
+    );
+  }
+
+  late final __objc_msgSend_909Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
+  late final __objc_msgSend_909 = __objc_msgSend_909Ptr.asFunction<
+      bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>)>();
+
+  late final _sel_sendSynchronousRequest_returningResponse_error_1 =
+      _registerName1("sendSynchronousRequest:returningResponse:error:");
+  ffi.Pointer<ObjCObject> _objc_msgSend_910(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> request,
+    ffi.Pointer<ffi.Pointer<ObjCObject>> response,
+    ffi.Pointer<ffi.Pointer<ObjCObject>> error,
+  ) {
+    return __objc_msgSend_910(
+      obj,
+      sel,
+      request,
+      response,
+      error,
+    );
+  }
+
+  late final __objc_msgSend_910Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<ObjCObject> Function(
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ffi.Pointer<ObjCObject>>,
+              ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
+  late final __objc_msgSend_910 = __objc_msgSend_910Ptr.asFunction<
+      ffi.Pointer<ObjCObject> Function(
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ffi.Pointer<ObjCObject>>,
+          ffi.Pointer<ffi.Pointer<ObjCObject>>)>();
+
+  late final _sel_sendAsynchronousRequest_queue_completionHandler_1 =
+      _registerName1("sendAsynchronousRequest:queue:completionHandler:");
+  void _objc_msgSend_911(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> request,
+    ffi.Pointer<ObjCObject> queue,
+    ffi.Pointer<_ObjCBlock> handler,
+  ) {
+    return __objc_msgSend_911(
+      obj,
+      sel,
+      request,
+      queue,
+      handler,
+    );
+  }
+
+  late final __objc_msgSend_911Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
+  late final __objc_msgSend_911 = __objc_msgSend_911Ptr.asFunction<
+      void Function(
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<_ObjCBlock>)>();
+
+  late final _class_NSURLCredential1 = _getClass1("NSURLCredential");
+  late final _sel_persistence1 = _registerName1("persistence");
+  int _objc_msgSend_912(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+  ) {
+    return __objc_msgSend_912(
+      obj,
+      sel,
+    );
+  }
+
+  late final __objc_msgSend_912Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int32 Function(
+              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
+  late final __objc_msgSend_912 = __objc_msgSend_912Ptr.asFunction<
+      int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
+
   late final _sel_initWithUser_password_persistence_1 =
       _registerName1("initWithUser:password:persistence:");
-  instancetype _objc_msgSend_899(
+  instancetype _objc_msgSend_913(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> user,
     ffi.Pointer<ObjCObject> password,
     int persistence,
   ) {
-    return __objc_msgSend_899(
+    return __objc_msgSend_913(
       obj,
       sel,
       user,
@@ -25685,7 +26019,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_899Ptr = _lookup<
+  late final __objc_msgSend_913Ptr = _lookup<
       ffi.NativeFunction<
           instancetype Function(
               ffi.Pointer<ObjCObject>,
@@ -25693,20 +26027,20 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>,
               ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_899 = __objc_msgSend_899Ptr.asFunction<
+  late final __objc_msgSend_913 = __objc_msgSend_913Ptr.asFunction<
       instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCObject>, int)>();
 
   late final _sel_credentialWithUser_password_persistence_1 =
       _registerName1("credentialWithUser:password:persistence:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_900(
+  ffi.Pointer<ObjCObject> _objc_msgSend_914(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> user,
     ffi.Pointer<ObjCObject> password,
     int persistence,
   ) {
-    return __objc_msgSend_900(
+    return __objc_msgSend_914(
       obj,
       sel,
       user,
@@ -25715,7 +26049,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_900Ptr = _lookup<
+  late final __objc_msgSend_914Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
@@ -25723,7 +26057,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>,
               ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_900 = __objc_msgSend_900Ptr.asFunction<
+  late final __objc_msgSend_914 = __objc_msgSend_914Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -25734,14 +26068,14 @@ class SentryCocoa {
   late final _sel_hasPassword1 = _registerName1("hasPassword");
   late final _sel_initWithIdentity_certificates_persistence_1 =
       _registerName1("initWithIdentity:certificates:persistence:");
-  instancetype _objc_msgSend_901(
+  instancetype _objc_msgSend_915(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<__SecIdentity> identity,
     ffi.Pointer<ObjCObject> certArray,
     int persistence,
   ) {
-    return __objc_msgSend_901(
+    return __objc_msgSend_915(
       obj,
       sel,
       identity,
@@ -25750,7 +26084,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_901Ptr = _lookup<
+  late final __objc_msgSend_915Ptr = _lookup<
       ffi.NativeFunction<
           instancetype Function(
               ffi.Pointer<ObjCObject>,
@@ -25758,20 +26092,20 @@ class SentryCocoa {
               ffi.Pointer<__SecIdentity>,
               ffi.Pointer<ObjCObject>,
               ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_901 = __objc_msgSend_901Ptr.asFunction<
+  late final __objc_msgSend_915 = __objc_msgSend_915Ptr.asFunction<
       instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<__SecIdentity>, ffi.Pointer<ObjCObject>, int)>();
 
   late final _sel_credentialWithIdentity_certificates_persistence_1 =
       _registerName1("credentialWithIdentity:certificates:persistence:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_902(
+  ffi.Pointer<ObjCObject> _objc_msgSend_916(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<__SecIdentity> identity,
     ffi.Pointer<ObjCObject> certArray,
     int persistence,
   ) {
-    return __objc_msgSend_902(
+    return __objc_msgSend_916(
       obj,
       sel,
       identity,
@@ -25780,7 +26114,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_902Ptr = _lookup<
+  late final __objc_msgSend_916Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
@@ -25788,7 +26122,7 @@ class SentryCocoa {
               ffi.Pointer<__SecIdentity>,
               ffi.Pointer<ObjCObject>,
               ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_902 = __objc_msgSend_902Ptr.asFunction<
+  late final __objc_msgSend_916 = __objc_msgSend_916Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -25797,71 +26131,71 @@ class SentryCocoa {
           int)>();
 
   late final _sel_identity1 = _registerName1("identity");
-  ffi.Pointer<__SecIdentity> _objc_msgSend_903(
+  ffi.Pointer<__SecIdentity> _objc_msgSend_917(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_903(
+    return __objc_msgSend_917(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_903Ptr = _lookup<
+  late final __objc_msgSend_917Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<__SecIdentity> Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_903 = __objc_msgSend_903Ptr.asFunction<
+  late final __objc_msgSend_917 = __objc_msgSend_917Ptr.asFunction<
       ffi.Pointer<__SecIdentity> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
   late final _sel_certificates1 = _registerName1("certificates");
   late final _sel_initWithTrust_1 = _registerName1("initWithTrust:");
-  instancetype _objc_msgSend_904(
+  instancetype _objc_msgSend_918(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<__SecTrust> trust,
   ) {
-    return __objc_msgSend_904(
+    return __objc_msgSend_918(
       obj,
       sel,
       trust,
     );
   }
 
-  late final __objc_msgSend_904Ptr = _lookup<
+  late final __objc_msgSend_918Ptr = _lookup<
       ffi.NativeFunction<
           instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<__SecTrust>)>>('objc_msgSend');
-  late final __objc_msgSend_904 = __objc_msgSend_904Ptr.asFunction<
+  late final __objc_msgSend_918 = __objc_msgSend_918Ptr.asFunction<
       instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<__SecTrust>)>();
 
   late final _sel_credentialForTrust_1 = _registerName1("credentialForTrust:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_905(
+  ffi.Pointer<ObjCObject> _objc_msgSend_919(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<__SecTrust> trust,
   ) {
-    return __objc_msgSend_905(
+    return __objc_msgSend_919(
       obj,
       sel,
       trust,
     );
   }
 
-  late final __objc_msgSend_905Ptr = _lookup<
+  late final __objc_msgSend_919Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>, ffi.Pointer<__SecTrust>)>>('objc_msgSend');
-  late final __objc_msgSend_905 = __objc_msgSend_905Ptr.asFunction<
+  late final __objc_msgSend_919 = __objc_msgSend_919Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, ffi.Pointer<__SecTrust>)>();
 
   late final _class_NSURLProtectionSpace1 = _getClass1("NSURLProtectionSpace");
   late final _sel_initWithHost_port_protocol_realm_authenticationMethod_1 =
       _registerName1("initWithHost:port:protocol:realm:authenticationMethod:");
-  instancetype _objc_msgSend_906(
+  instancetype _objc_msgSend_920(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> host,
@@ -25870,7 +26204,7 @@ class SentryCocoa {
     ffi.Pointer<ObjCObject> realm,
     ffi.Pointer<ObjCObject> authenticationMethod,
   ) {
-    return __objc_msgSend_906(
+    return __objc_msgSend_920(
       obj,
       sel,
       host,
@@ -25881,7 +26215,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_906Ptr = _lookup<
+  late final __objc_msgSend_920Ptr = _lookup<
       ffi.NativeFunction<
           instancetype Function(
               ffi.Pointer<ObjCObject>,
@@ -25891,7 +26225,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_906 = __objc_msgSend_906Ptr.asFunction<
+  late final __objc_msgSend_920 = __objc_msgSend_920Ptr.asFunction<
       instancetype Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -25913,21 +26247,21 @@ class SentryCocoa {
       _registerName1("authenticationMethod");
   late final _sel_distinguishedNames1 = _registerName1("distinguishedNames");
   late final _sel_serverTrust1 = _registerName1("serverTrust");
-  ffi.Pointer<__SecTrust> _objc_msgSend_907(
+  ffi.Pointer<__SecTrust> _objc_msgSend_921(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_907(
+    return __objc_msgSend_921(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_907Ptr = _lookup<
+  late final __objc_msgSend_921Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<__SecTrust> Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_907 = __objc_msgSend_907Ptr.asFunction<
+  late final __objc_msgSend_921 = __objc_msgSend_921Ptr.asFunction<
       ffi.Pointer<__SecTrust> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
@@ -25935,56 +26269,56 @@ class SentryCocoa {
       _getClass1("NSURLCredentialStorage");
   late final _sel_sharedCredentialStorage1 =
       _registerName1("sharedCredentialStorage");
-  ffi.Pointer<ObjCObject> _objc_msgSend_908(
+  ffi.Pointer<ObjCObject> _objc_msgSend_922(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_908(
+    return __objc_msgSend_922(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_908Ptr = _lookup<
+  late final __objc_msgSend_922Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_908 = __objc_msgSend_908Ptr.asFunction<
+  late final __objc_msgSend_922 = __objc_msgSend_922Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
   late final _sel_credentialsForProtectionSpace_1 =
       _registerName1("credentialsForProtectionSpace:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_909(
+  ffi.Pointer<ObjCObject> _objc_msgSend_923(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> space,
   ) {
-    return __objc_msgSend_909(
+    return __objc_msgSend_923(
       obj,
       sel,
       space,
     );
   }
 
-  late final __objc_msgSend_909Ptr = _lookup<
+  late final __objc_msgSend_923Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_909 = __objc_msgSend_909Ptr.asFunction<
+  late final __objc_msgSend_923 = __objc_msgSend_923Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
 
   late final _sel_allCredentials1 = _registerName1("allCredentials");
   late final _sel_setCredential_forProtectionSpace_1 =
       _registerName1("setCredential:forProtectionSpace:");
-  void _objc_msgSend_910(
+  void _objc_msgSend_924(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> credential,
     ffi.Pointer<ObjCObject> space,
   ) {
-    return __objc_msgSend_910(
+    return __objc_msgSend_924(
       obj,
       sel,
       credential,
@@ -25992,14 +26326,14 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_910Ptr = _lookup<
+  late final __objc_msgSend_924Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_910 = __objc_msgSend_910Ptr.asFunction<
+  late final __objc_msgSend_924 = __objc_msgSend_924Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCObject>)>();
 
@@ -26007,14 +26341,14 @@ class SentryCocoa {
       _registerName1("removeCredential:forProtectionSpace:");
   late final _sel_removeCredential_forProtectionSpace_options_1 =
       _registerName1("removeCredential:forProtectionSpace:options:");
-  void _objc_msgSend_911(
+  void _objc_msgSend_925(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> credential,
     ffi.Pointer<ObjCObject> space,
     ffi.Pointer<ObjCObject> options,
   ) {
-    return __objc_msgSend_911(
+    return __objc_msgSend_925(
       obj,
       sel,
       credential,
@@ -26023,7 +26357,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_911Ptr = _lookup<
+  late final __objc_msgSend_925Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(
               ffi.Pointer<ObjCObject>,
@@ -26031,7 +26365,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_911 = __objc_msgSend_911Ptr.asFunction<
+  late final __objc_msgSend_925 = __objc_msgSend_925Ptr.asFunction<
       void Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -26041,23 +26375,23 @@ class SentryCocoa {
 
   late final _sel_defaultCredentialForProtectionSpace_1 =
       _registerName1("defaultCredentialForProtectionSpace:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_912(
+  ffi.Pointer<ObjCObject> _objc_msgSend_926(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> space,
   ) {
-    return __objc_msgSend_912(
+    return __objc_msgSend_926(
       obj,
       sel,
       space,
     );
   }
 
-  late final __objc_msgSend_912Ptr = _lookup<
+  late final __objc_msgSend_926Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_912 = __objc_msgSend_912Ptr.asFunction<
+  late final __objc_msgSend_926 = __objc_msgSend_926Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
 
@@ -26066,14 +26400,14 @@ class SentryCocoa {
   late final _sel_getCredentialsForProtectionSpace_task_completionHandler_1 =
       _registerName1(
           "getCredentialsForProtectionSpace:task:completionHandler:");
-  void _objc_msgSend_913(
+  void _objc_msgSend_927(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> protectionSpace,
     ffi.Pointer<ObjCObject> task,
     ffi.Pointer<_ObjCBlock> completionHandler,
   ) {
-    return __objc_msgSend_913(
+    return __objc_msgSend_927(
       obj,
       sel,
       protectionSpace,
@@ -26082,7 +26416,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_913Ptr = _lookup<
+  late final __objc_msgSend_927Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(
               ffi.Pointer<ObjCObject>,
@@ -26090,7 +26424,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
-  late final __objc_msgSend_913 = __objc_msgSend_913Ptr.asFunction<
+  late final __objc_msgSend_927 = __objc_msgSend_927Ptr.asFunction<
       void Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -26100,14 +26434,14 @@ class SentryCocoa {
 
   late final _sel_setCredential_forProtectionSpace_task_1 =
       _registerName1("setCredential:forProtectionSpace:task:");
-  void _objc_msgSend_914(
+  void _objc_msgSend_928(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> credential,
     ffi.Pointer<ObjCObject> protectionSpace,
     ffi.Pointer<ObjCObject> task,
   ) {
-    return __objc_msgSend_914(
+    return __objc_msgSend_928(
       obj,
       sel,
       credential,
@@ -26116,7 +26450,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_914Ptr = _lookup<
+  late final __objc_msgSend_928Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(
               ffi.Pointer<ObjCObject>,
@@ -26124,7 +26458,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_914 = __objc_msgSend_914Ptr.asFunction<
+  late final __objc_msgSend_928 = __objc_msgSend_928Ptr.asFunction<
       void Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -26134,7 +26468,7 @@ class SentryCocoa {
 
   late final _sel_removeCredential_forProtectionSpace_options_task_1 =
       _registerName1("removeCredential:forProtectionSpace:options:task:");
-  void _objc_msgSend_915(
+  void _objc_msgSend_929(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> credential,
@@ -26142,7 +26476,7 @@ class SentryCocoa {
     ffi.Pointer<ObjCObject> options,
     ffi.Pointer<ObjCObject> task,
   ) {
-    return __objc_msgSend_915(
+    return __objc_msgSend_929(
       obj,
       sel,
       credential,
@@ -26152,7 +26486,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_915Ptr = _lookup<
+  late final __objc_msgSend_929Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(
               ffi.Pointer<ObjCObject>,
@@ -26161,7 +26495,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_915 = __objc_msgSend_915Ptr.asFunction<
+  late final __objc_msgSend_929 = __objc_msgSend_929Ptr.asFunction<
       void Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -26173,14 +26507,14 @@ class SentryCocoa {
   late final _sel_getDefaultCredentialForProtectionSpace_task_completionHandler_1 =
       _registerName1(
           "getDefaultCredentialForProtectionSpace:task:completionHandler:");
-  void _objc_msgSend_916(
+  void _objc_msgSend_930(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> space,
     ffi.Pointer<ObjCObject> task,
     ffi.Pointer<_ObjCBlock> completionHandler,
   ) {
-    return __objc_msgSend_916(
+    return __objc_msgSend_930(
       obj,
       sel,
       space,
@@ -26189,7 +26523,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_916Ptr = _lookup<
+  late final __objc_msgSend_930Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(
               ffi.Pointer<ObjCObject>,
@@ -26197,7 +26531,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
-  late final __objc_msgSend_916 = __objc_msgSend_916Ptr.asFunction<
+  late final __objc_msgSend_930 = __objc_msgSend_930Ptr.asFunction<
       void Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -26210,14 +26544,14 @@ class SentryCocoa {
   late final _class_NSURLProtocol1 = _getClass1("NSURLProtocol");
   late final _sel_initWithRequest_cachedResponse_client_1 =
       _registerName1("initWithRequest:cachedResponse:client:");
-  instancetype _objc_msgSend_917(
+  instancetype _objc_msgSend_931(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> request,
     ffi.Pointer<ObjCObject> cachedResponse,
     ffi.Pointer<ObjCObject> client,
   ) {
-    return __objc_msgSend_917(
+    return __objc_msgSend_931(
       obj,
       sel,
       request,
@@ -26226,7 +26560,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_917Ptr = _lookup<
+  late final __objc_msgSend_931Ptr = _lookup<
       ffi.NativeFunction<
           instancetype Function(
               ffi.Pointer<ObjCObject>,
@@ -26234,7 +26568,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_917 = __objc_msgSend_917Ptr.asFunction<
+  late final __objc_msgSend_931 = __objc_msgSend_931Ptr.asFunction<
       instancetype Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -26245,56 +26579,56 @@ class SentryCocoa {
   late final _sel_client1 = _registerName1("client");
   late final _sel_request1 = _registerName1("request");
   late final _sel_cachedResponse1 = _registerName1("cachedResponse");
-  ffi.Pointer<ObjCObject> _objc_msgSend_918(
+  ffi.Pointer<ObjCObject> _objc_msgSend_932(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_918(
+    return __objc_msgSend_932(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_918Ptr = _lookup<
+  late final __objc_msgSend_932Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_918 = __objc_msgSend_918Ptr.asFunction<
+  late final __objc_msgSend_932 = __objc_msgSend_932Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
   late final _sel_canInitWithRequest_1 = _registerName1("canInitWithRequest:");
   late final _sel_canonicalRequestForRequest_1 =
       _registerName1("canonicalRequestForRequest:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_919(
+  ffi.Pointer<ObjCObject> _objc_msgSend_933(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> request,
   ) {
-    return __objc_msgSend_919(
+    return __objc_msgSend_933(
       obj,
       sel,
       request,
     );
   }
 
-  late final __objc_msgSend_919Ptr = _lookup<
+  late final __objc_msgSend_933Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_919 = __objc_msgSend_919Ptr.asFunction<
+  late final __objc_msgSend_933 = __objc_msgSend_933Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
 
   late final _sel_requestIsCacheEquivalent_toRequest_1 =
       _registerName1("requestIsCacheEquivalent:toRequest:");
-  bool _objc_msgSend_920(
+  bool _objc_msgSend_934(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> a,
     ffi.Pointer<ObjCObject> b,
   ) {
-    return __objc_msgSend_920(
+    return __objc_msgSend_934(
       obj,
       sel,
       a,
@@ -26302,14 +26636,14 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_920Ptr = _lookup<
+  late final __objc_msgSend_934Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Bool Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_920 = __objc_msgSend_920Ptr.asFunction<
+  late final __objc_msgSend_934 = __objc_msgSend_934Ptr.asFunction<
       bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCObject>)>();
 
@@ -26317,13 +26651,13 @@ class SentryCocoa {
   late final _sel_stopLoading1 = _registerName1("stopLoading");
   late final _sel_propertyForKey_inRequest_1 =
       _registerName1("propertyForKey:inRequest:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_921(
+  ffi.Pointer<ObjCObject> _objc_msgSend_935(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> key,
     ffi.Pointer<ObjCObject> request,
   ) {
-    return __objc_msgSend_921(
+    return __objc_msgSend_935(
       obj,
       sel,
       key,
@@ -26331,14 +26665,14 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_921Ptr = _lookup<
+  late final __objc_msgSend_935Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_921 = __objc_msgSend_921Ptr.asFunction<
+  late final __objc_msgSend_935 = __objc_msgSend_935Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -26348,46 +26682,46 @@ class SentryCocoa {
   late final _class_NSMutableURLRequest1 = _getClass1("NSMutableURLRequest");
   late final _sel_setURL_1 = _registerName1("setURL:");
   late final _sel_setCachePolicy_1 = _registerName1("setCachePolicy:");
-  void _objc_msgSend_922(
+  void _objc_msgSend_936(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int value,
   ) {
-    return __objc_msgSend_922(
+    return __objc_msgSend_936(
       obj,
       sel,
       value,
     );
   }
 
-  late final __objc_msgSend_922Ptr = _lookup<
+  late final __objc_msgSend_936Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_922 = __objc_msgSend_922Ptr.asFunction<
+  late final __objc_msgSend_936 = __objc_msgSend_936Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
 
   late final _sel_setTimeoutInterval_1 = _registerName1("setTimeoutInterval:");
   late final _sel_setMainDocumentURL_1 = _registerName1("setMainDocumentURL:");
   late final _sel_setNetworkServiceType_1 =
       _registerName1("setNetworkServiceType:");
-  void _objc_msgSend_923(
+  void _objc_msgSend_937(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int value,
   ) {
-    return __objc_msgSend_923(
+    return __objc_msgSend_937(
       obj,
       sel,
       value,
     );
   }
 
-  late final __objc_msgSend_923Ptr = _lookup<
+  late final __objc_msgSend_937Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_923 = __objc_msgSend_923Ptr.asFunction<
+  late final __objc_msgSend_937 = __objc_msgSend_937Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
 
   late final _sel_setAllowsCellularAccess_1 =
@@ -26399,23 +26733,23 @@ class SentryCocoa {
   late final _sel_setAssumesHTTP3Capable_1 =
       _registerName1("setAssumesHTTP3Capable:");
   late final _sel_setAttribution_1 = _registerName1("setAttribution:");
-  void _objc_msgSend_924(
+  void _objc_msgSend_938(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int value,
   ) {
-    return __objc_msgSend_924(
+    return __objc_msgSend_938(
       obj,
       sel,
       value,
     );
   }
 
-  late final __objc_msgSend_924Ptr = _lookup<
+  late final __objc_msgSend_938Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_924 = __objc_msgSend_924Ptr.asFunction<
+  late final __objc_msgSend_938 = __objc_msgSend_938Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
 
   late final _sel_setRequiresDNSSECValidation_1 =
@@ -26428,44 +26762,44 @@ class SentryCocoa {
   late final _sel_addValue_forHTTPHeaderField_1 =
       _registerName1("addValue:forHTTPHeaderField:");
   late final _sel_setHTTPBody_1 = _registerName1("setHTTPBody:");
-  void _objc_msgSend_925(
+  void _objc_msgSend_939(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> value,
   ) {
-    return __objc_msgSend_925(
+    return __objc_msgSend_939(
       obj,
       sel,
       value,
     );
   }
 
-  late final __objc_msgSend_925Ptr = _lookup<
+  late final __objc_msgSend_939Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_925 = __objc_msgSend_925Ptr.asFunction<
+  late final __objc_msgSend_939 = __objc_msgSend_939Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>)>();
 
   late final _sel_setHTTPBodyStream_1 = _registerName1("setHTTPBodyStream:");
-  void _objc_msgSend_926(
+  void _objc_msgSend_940(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> value,
   ) {
-    return __objc_msgSend_926(
+    return __objc_msgSend_940(
       obj,
       sel,
       value,
     );
   }
 
-  late final __objc_msgSend_926Ptr = _lookup<
+  late final __objc_msgSend_940Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_926 = __objc_msgSend_926Ptr.asFunction<
+  late final __objc_msgSend_940 = __objc_msgSend_940Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>)>();
 
@@ -26475,14 +26809,14 @@ class SentryCocoa {
       _registerName1("setHTTPShouldUsePipelining:");
   late final _sel_setProperty_forKey_inRequest_1 =
       _registerName1("setProperty:forKey:inRequest:");
-  void _objc_msgSend_927(
+  void _objc_msgSend_941(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> value,
     ffi.Pointer<ObjCObject> key,
     ffi.Pointer<ObjCObject> request,
   ) {
-    return __objc_msgSend_927(
+    return __objc_msgSend_941(
       obj,
       sel,
       value,
@@ -26491,7 +26825,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_927Ptr = _lookup<
+  late final __objc_msgSend_941Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(
               ffi.Pointer<ObjCObject>,
@@ -26499,7 +26833,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_927 = __objc_msgSend_927Ptr.asFunction<
+  late final __objc_msgSend_941 = __objc_msgSend_941Ptr.asFunction<
       void Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -26509,13 +26843,13 @@ class SentryCocoa {
 
   late final _sel_removePropertyForKey_inRequest_1 =
       _registerName1("removePropertyForKey:inRequest:");
-  void _objc_msgSend_928(
+  void _objc_msgSend_942(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> key,
     ffi.Pointer<ObjCObject> request,
   ) {
-    return __objc_msgSend_928(
+    return __objc_msgSend_942(
       obj,
       sel,
       key,
@@ -26523,50 +26857,50 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_928Ptr = _lookup<
+  late final __objc_msgSend_942Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_928 = __objc_msgSend_928Ptr.asFunction<
+  late final __objc_msgSend_942 = __objc_msgSend_942Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCObject>)>();
 
   late final _sel_registerClass_1 = _registerName1("registerClass:");
   late final _sel_unregisterClass_1 = _registerName1("unregisterClass:");
   late final _sel_canInitWithTask_1 = _registerName1("canInitWithTask:");
-  bool _objc_msgSend_929(
+  bool _objc_msgSend_943(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> task,
   ) {
-    return __objc_msgSend_929(
+    return __objc_msgSend_943(
       obj,
       sel,
       task,
     );
   }
 
-  late final __objc_msgSend_929Ptr = _lookup<
+  late final __objc_msgSend_943Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_929 = __objc_msgSend_929Ptr.asFunction<
+  late final __objc_msgSend_943 = __objc_msgSend_943Ptr.asFunction<
       bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>)>();
 
   late final _sel_initWithTask_cachedResponse_client_1 =
       _registerName1("initWithTask:cachedResponse:client:");
-  instancetype _objc_msgSend_930(
+  instancetype _objc_msgSend_944(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> task,
     ffi.Pointer<ObjCObject> cachedResponse,
     ffi.Pointer<ObjCObject> client,
   ) {
-    return __objc_msgSend_930(
+    return __objc_msgSend_944(
       obj,
       sel,
       task,
@@ -26575,7 +26909,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_930Ptr = _lookup<
+  late final __objc_msgSend_944Ptr = _lookup<
       ffi.NativeFunction<
           instancetype Function(
               ffi.Pointer<ObjCObject>,
@@ -26583,7 +26917,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_930 = __objc_msgSend_930Ptr.asFunction<
+  late final __objc_msgSend_944 = __objc_msgSend_944Ptr.asFunction<
       instancetype Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -26592,43 +26926,43 @@ class SentryCocoa {
           ffi.Pointer<ObjCObject>)>();
 
   late final _sel_task1 = _registerName1("task");
-  ffi.Pointer<ObjCObject> _objc_msgSend_931(
+  ffi.Pointer<ObjCObject> _objc_msgSend_945(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_931(
+    return __objc_msgSend_945(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_931Ptr = _lookup<
+  late final __objc_msgSend_945Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_931 = __objc_msgSend_931Ptr.asFunction<
+  late final __objc_msgSend_945 = __objc_msgSend_945Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
   late final _class_NSXMLParser1 = _getClass1("NSXMLParser");
   late final _sel_initWithStream_1 = _registerName1("initWithStream:");
-  instancetype _objc_msgSend_932(
+  instancetype _objc_msgSend_946(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> stream,
   ) {
-    return __objc_msgSend_932(
+    return __objc_msgSend_946(
       obj,
       sel,
       stream,
     );
   }
 
-  late final __objc_msgSend_932Ptr = _lookup<
+  late final __objc_msgSend_946Ptr = _lookup<
       ffi.NativeFunction<
           instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_932 = __objc_msgSend_932Ptr.asFunction<
+  late final __objc_msgSend_946 = __objc_msgSend_946Ptr.asFunction<
       instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>)>();
 
@@ -26642,65 +26976,65 @@ class SentryCocoa {
       _registerName1("setShouldReportNamespacePrefixes:");
   late final _sel_externalEntityResolvingPolicy1 =
       _registerName1("externalEntityResolvingPolicy");
-  int _objc_msgSend_933(
+  int _objc_msgSend_947(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_933(
+    return __objc_msgSend_947(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_933Ptr = _lookup<
+  late final __objc_msgSend_947Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Int32 Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_933 = __objc_msgSend_933Ptr.asFunction<
+  late final __objc_msgSend_947 = __objc_msgSend_947Ptr.asFunction<
       int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
   late final _sel_setExternalEntityResolvingPolicy_1 =
       _registerName1("setExternalEntityResolvingPolicy:");
-  void _objc_msgSend_934(
+  void _objc_msgSend_948(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int value,
   ) {
-    return __objc_msgSend_934(
+    return __objc_msgSend_948(
       obj,
       sel,
       value,
     );
   }
 
-  late final __objc_msgSend_934Ptr = _lookup<
+  late final __objc_msgSend_948Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_934 = __objc_msgSend_934Ptr.asFunction<
+  late final __objc_msgSend_948 = __objc_msgSend_948Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
 
   late final _sel_allowedExternalEntityURLs1 =
       _registerName1("allowedExternalEntityURLs");
   late final _sel_setAllowedExternalEntityURLs_1 =
       _registerName1("setAllowedExternalEntityURLs:");
-  void _objc_msgSend_935(
+  void _objc_msgSend_949(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> value,
   ) {
-    return __objc_msgSend_935(
+    return __objc_msgSend_949(
       obj,
       sel,
       value,
     );
   }
 
-  late final __objc_msgSend_935Ptr = _lookup<
+  late final __objc_msgSend_949Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_935 = __objc_msgSend_935Ptr.asFunction<
+  late final __objc_msgSend_949 = __objc_msgSend_949Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>)>();
 
@@ -26718,14 +27052,14 @@ class SentryCocoa {
   late final _class_NSFileWrapper1 = _getClass1("NSFileWrapper");
   late final _sel_initWithURL_options_error_1 =
       _registerName1("initWithURL:options:error:");
-  instancetype _objc_msgSend_936(
+  instancetype _objc_msgSend_950(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> url,
     int options,
     ffi.Pointer<ffi.Pointer<ObjCObject>> outError,
   ) {
-    return __objc_msgSend_936(
+    return __objc_msgSend_950(
       obj,
       sel,
       url,
@@ -26734,7 +27068,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_936Ptr = _lookup<
+  late final __objc_msgSend_950Ptr = _lookup<
       ffi.NativeFunction<
           instancetype Function(
               ffi.Pointer<ObjCObject>,
@@ -26742,7 +27076,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Int32,
               ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_936 = __objc_msgSend_936Ptr.asFunction<
+  late final __objc_msgSend_950 = __objc_msgSend_950Ptr.asFunction<
       instancetype Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -26772,14 +27106,14 @@ class SentryCocoa {
       _registerName1("matchesContentsOfURL:");
   late final _sel_readFromURL_options_error_1 =
       _registerName1("readFromURL:options:error:");
-  bool _objc_msgSend_937(
+  bool _objc_msgSend_951(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> url,
     int options,
     ffi.Pointer<ffi.Pointer<ObjCObject>> outError,
   ) {
-    return __objc_msgSend_937(
+    return __objc_msgSend_951(
       obj,
       sel,
       url,
@@ -26788,7 +27122,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_937Ptr = _lookup<
+  late final __objc_msgSend_951Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Bool Function(
               ffi.Pointer<ObjCObject>,
@@ -26796,7 +27130,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Int32,
               ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_937 = __objc_msgSend_937Ptr.asFunction<
+  late final __objc_msgSend_951 = __objc_msgSend_951Ptr.asFunction<
       bool Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -26806,7 +27140,7 @@ class SentryCocoa {
 
   late final _sel_writeToURL_options_originalContentsURL_error_1 =
       _registerName1("writeToURL:options:originalContentsURL:error:");
-  bool _objc_msgSend_938(
+  bool _objc_msgSend_952(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> url,
@@ -26814,7 +27148,7 @@ class SentryCocoa {
     ffi.Pointer<ObjCObject> originalContentsURL,
     ffi.Pointer<ffi.Pointer<ObjCObject>> outError,
   ) {
-    return __objc_msgSend_938(
+    return __objc_msgSend_952(
       obj,
       sel,
       url,
@@ -26824,7 +27158,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_938Ptr = _lookup<
+  late final __objc_msgSend_952Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Bool Function(
               ffi.Pointer<ObjCObject>,
@@ -26833,7 +27167,7 @@ class SentryCocoa {
               ffi.Int32,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_938 = __objc_msgSend_938Ptr.asFunction<
+  late final __objc_msgSend_952 = __objc_msgSend_952Ptr.asFunction<
       bool Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -26845,35 +27179,35 @@ class SentryCocoa {
   late final _sel_serializedRepresentation1 =
       _registerName1("serializedRepresentation");
   late final _sel_addFileWrapper_1 = _registerName1("addFileWrapper:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_939(
+  ffi.Pointer<ObjCObject> _objc_msgSend_953(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> child,
   ) {
-    return __objc_msgSend_939(
+    return __objc_msgSend_953(
       obj,
       sel,
       child,
     );
   }
 
-  late final __objc_msgSend_939Ptr = _lookup<
+  late final __objc_msgSend_953Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_939 = __objc_msgSend_939Ptr.asFunction<
+  late final __objc_msgSend_953 = __objc_msgSend_953Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
 
   late final _sel_addRegularFileWithContents_preferredFilename_1 =
       _registerName1("addRegularFileWithContents:preferredFilename:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_940(
+  ffi.Pointer<ObjCObject> _objc_msgSend_954(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> data,
     ffi.Pointer<ObjCObject> fileName,
   ) {
-    return __objc_msgSend_940(
+    return __objc_msgSend_954(
       obj,
       sel,
       data,
@@ -26881,14 +27215,14 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_940Ptr = _lookup<
+  late final __objc_msgSend_954Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_940 = __objc_msgSend_940Ptr.asFunction<
+  late final __objc_msgSend_954 = __objc_msgSend_954Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -26896,23 +27230,23 @@ class SentryCocoa {
           ffi.Pointer<ObjCObject>)>();
 
   late final _sel_removeFileWrapper_1 = _registerName1("removeFileWrapper:");
-  void _objc_msgSend_941(
+  void _objc_msgSend_955(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> child,
   ) {
-    return __objc_msgSend_941(
+    return __objc_msgSend_955(
       obj,
       sel,
       child,
     );
   }
 
-  late final __objc_msgSend_941Ptr = _lookup<
+  late final __objc_msgSend_955Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_941 = __objc_msgSend_941Ptr.asFunction<
+  late final __objc_msgSend_955 = __objc_msgSend_955Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>)>();
 
@@ -26928,14 +27262,14 @@ class SentryCocoa {
   late final _sel_updateFromPath_1 = _registerName1("updateFromPath:");
   late final _sel_writeToFile_atomically_updateFilenames_1 =
       _registerName1("writeToFile:atomically:updateFilenames:");
-  bool _objc_msgSend_942(
+  bool _objc_msgSend_956(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> path,
     bool atomicFlag,
     bool updateFilenamesFlag,
   ) {
-    return __objc_msgSend_942(
+    return __objc_msgSend_956(
       obj,
       sel,
       path,
@@ -26944,11 +27278,11 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_942Ptr = _lookup<
+  late final __objc_msgSend_956Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>, ffi.Bool, ffi.Bool)>>('objc_msgSend');
-  late final __objc_msgSend_942 = __objc_msgSend_942Ptr.asFunction<
+  late final __objc_msgSend_956 = __objc_msgSend_956Ptr.asFunction<
       bool Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>, bool, bool)>();
 
@@ -26959,21 +27293,21 @@ class SentryCocoa {
       _registerName1("symbolicLinkDestination");
   late final _class_NSURLSession1 = _getClass1("NSURLSession");
   late final _sel_sharedSession1 = _registerName1("sharedSession");
-  ffi.Pointer<ObjCObject> _objc_msgSend_943(
+  ffi.Pointer<ObjCObject> _objc_msgSend_957(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_943(
+    return __objc_msgSend_957(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_943Ptr = _lookup<
+  late final __objc_msgSend_957Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_943 = __objc_msgSend_943Ptr.asFunction<
+  late final __objc_msgSend_957 = __objc_msgSend_957Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
@@ -26981,21 +27315,21 @@ class SentryCocoa {
       _getClass1("NSURLSessionConfiguration");
   late final _sel_defaultSessionConfiguration1 =
       _registerName1("defaultSessionConfiguration");
-  ffi.Pointer<ObjCObject> _objc_msgSend_944(
+  ffi.Pointer<ObjCObject> _objc_msgSend_958(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_944(
+    return __objc_msgSend_958(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_944Ptr = _lookup<
+  late final __objc_msgSend_958Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_944 = __objc_msgSend_944Ptr.asFunction<
+  late final __objc_msgSend_958 = __objc_msgSend_958Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
@@ -27003,23 +27337,23 @@ class SentryCocoa {
       _registerName1("ephemeralSessionConfiguration");
   late final _sel_backgroundSessionConfigurationWithIdentifier_1 =
       _registerName1("backgroundSessionConfigurationWithIdentifier:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_945(
+  ffi.Pointer<ObjCObject> _objc_msgSend_959(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> identifier,
   ) {
-    return __objc_msgSend_945(
+    return __objc_msgSend_959(
       obj,
       sel,
       identifier,
     );
   }
 
-  late final __objc_msgSend_945Ptr = _lookup<
+  late final __objc_msgSend_959Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_945 = __objc_msgSend_945Ptr.asFunction<
+  late final __objc_msgSend_959 = __objc_msgSend_959Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
 
@@ -27055,42 +27389,42 @@ class SentryCocoa {
       _registerName1("setConnectionProxyDictionary:");
   late final _sel_TLSMinimumSupportedProtocol1 =
       _registerName1("TLSMinimumSupportedProtocol");
-  int _objc_msgSend_946(
+  int _objc_msgSend_960(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_946(
+    return __objc_msgSend_960(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_946Ptr = _lookup<
+  late final __objc_msgSend_960Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Int32 Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_946 = __objc_msgSend_946Ptr.asFunction<
+  late final __objc_msgSend_960 = __objc_msgSend_960Ptr.asFunction<
       int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
   late final _sel_setTLSMinimumSupportedProtocol_1 =
       _registerName1("setTLSMinimumSupportedProtocol:");
-  void _objc_msgSend_947(
+  void _objc_msgSend_961(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int value,
   ) {
-    return __objc_msgSend_947(
+    return __objc_msgSend_961(
       obj,
       sel,
       value,
     );
   }
 
-  late final __objc_msgSend_947Ptr = _lookup<
+  late final __objc_msgSend_961Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_947 = __objc_msgSend_947Ptr.asFunction<
+  late final __objc_msgSend_961 = __objc_msgSend_961Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
 
   late final _sel_TLSMaximumSupportedProtocol1 =
@@ -27099,42 +27433,42 @@ class SentryCocoa {
       _registerName1("setTLSMaximumSupportedProtocol:");
   late final _sel_TLSMinimumSupportedProtocolVersion1 =
       _registerName1("TLSMinimumSupportedProtocolVersion");
-  int _objc_msgSend_948(
+  int _objc_msgSend_962(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_948(
+    return __objc_msgSend_962(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_948Ptr = _lookup<
+  late final __objc_msgSend_962Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Int32 Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_948 = __objc_msgSend_948Ptr.asFunction<
+  late final __objc_msgSend_962 = __objc_msgSend_962Ptr.asFunction<
       int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
   late final _sel_setTLSMinimumSupportedProtocolVersion_1 =
       _registerName1("setTLSMinimumSupportedProtocolVersion:");
-  void _objc_msgSend_949(
+  void _objc_msgSend_963(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int value,
   ) {
-    return __objc_msgSend_949(
+    return __objc_msgSend_963(
       obj,
       sel,
       value,
     );
   }
 
-  late final __objc_msgSend_949Ptr = _lookup<
+  late final __objc_msgSend_963Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_949 = __objc_msgSend_949Ptr.asFunction<
+  late final __objc_msgSend_963 = __objc_msgSend_963Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
 
   late final _sel_TLSMaximumSupportedProtocolVersion1 =
@@ -27160,23 +27494,23 @@ class SentryCocoa {
   late final _sel_HTTPCookieStorage1 = _registerName1("HTTPCookieStorage");
   late final _sel_setHTTPCookieStorage_1 =
       _registerName1("setHTTPCookieStorage:");
-  void _objc_msgSend_950(
+  void _objc_msgSend_964(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> value,
   ) {
-    return __objc_msgSend_950(
+    return __objc_msgSend_964(
       obj,
       sel,
       value,
     );
   }
 
-  late final __objc_msgSend_950Ptr = _lookup<
+  late final __objc_msgSend_964Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_950 = __objc_msgSend_950Ptr.asFunction<
+  late final __objc_msgSend_964 = __objc_msgSend_964Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>)>();
 
@@ -27184,23 +27518,23 @@ class SentryCocoa {
       _registerName1("URLCredentialStorage");
   late final _sel_setURLCredentialStorage_1 =
       _registerName1("setURLCredentialStorage:");
-  void _objc_msgSend_951(
+  void _objc_msgSend_965(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> value,
   ) {
-    return __objc_msgSend_951(
+    return __objc_msgSend_965(
       obj,
       sel,
       value,
     );
   }
 
-  late final __objc_msgSend_951Ptr = _lookup<
+  late final __objc_msgSend_965Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_951 = __objc_msgSend_951Ptr.asFunction<
+  late final __objc_msgSend_965 = __objc_msgSend_965Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>)>();
 
@@ -27214,78 +27548,78 @@ class SentryCocoa {
   late final _sel_setProtocolClasses_1 = _registerName1("setProtocolClasses:");
   late final _sel_multipathServiceType1 =
       _registerName1("multipathServiceType");
-  int _objc_msgSend_952(
+  int _objc_msgSend_966(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_952(
+    return __objc_msgSend_966(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_952Ptr = _lookup<
+  late final __objc_msgSend_966Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Int32 Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_952 = __objc_msgSend_952Ptr.asFunction<
+  late final __objc_msgSend_966 = __objc_msgSend_966Ptr.asFunction<
       int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
   late final _sel_setMultipathServiceType_1 =
       _registerName1("setMultipathServiceType:");
-  void _objc_msgSend_953(
+  void _objc_msgSend_967(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int value,
   ) {
-    return __objc_msgSend_953(
+    return __objc_msgSend_967(
       obj,
       sel,
       value,
     );
   }
 
-  late final __objc_msgSend_953Ptr = _lookup<
+  late final __objc_msgSend_967Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_953 = __objc_msgSend_953Ptr.asFunction<
+  late final __objc_msgSend_967 = __objc_msgSend_967Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
 
   late final _sel_backgroundSessionConfiguration_1 =
       _registerName1("backgroundSessionConfiguration:");
   late final _sel_sessionWithConfiguration_1 =
       _registerName1("sessionWithConfiguration:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_954(
+  ffi.Pointer<ObjCObject> _objc_msgSend_968(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> configuration,
   ) {
-    return __objc_msgSend_954(
+    return __objc_msgSend_968(
       obj,
       sel,
       configuration,
     );
   }
 
-  late final __objc_msgSend_954Ptr = _lookup<
+  late final __objc_msgSend_968Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_954 = __objc_msgSend_954Ptr.asFunction<
+  late final __objc_msgSend_968 = __objc_msgSend_968Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
 
   late final _sel_sessionWithConfiguration_delegate_delegateQueue_1 =
       _registerName1("sessionWithConfiguration:delegate:delegateQueue:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_955(
+  ffi.Pointer<ObjCObject> _objc_msgSend_969(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> configuration,
     ffi.Pointer<ObjCObject> delegate,
     ffi.Pointer<ObjCObject> queue,
   ) {
-    return __objc_msgSend_955(
+    return __objc_msgSend_969(
       obj,
       sel,
       configuration,
@@ -27294,7 +27628,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_955Ptr = _lookup<
+  late final __objc_msgSend_969Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
@@ -27302,7 +27636,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_955 = __objc_msgSend_955Ptr.asFunction<
+  late final __objc_msgSend_969 = __objc_msgSend_969Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -27324,102 +27658,124 @@ class SentryCocoa {
       _registerName1("flushWithCompletionHandler:");
   late final _sel_getTasksWithCompletionHandler_1 =
       _registerName1("getTasksWithCompletionHandler:");
-  void _objc_msgSend_956(
+  void _objc_msgSend_970(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<_ObjCBlock> completionHandler,
   ) {
-    return __objc_msgSend_956(
+    return __objc_msgSend_970(
       obj,
       sel,
       completionHandler,
     );
   }
 
-  late final __objc_msgSend_956Ptr = _lookup<
+  late final __objc_msgSend_970Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
-  late final __objc_msgSend_956 = __objc_msgSend_956Ptr.asFunction<
+  late final __objc_msgSend_970 = __objc_msgSend_970Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<_ObjCBlock>)>();
 
   late final _sel_getAllTasksWithCompletionHandler_1 =
       _registerName1("getAllTasksWithCompletionHandler:");
-  void _objc_msgSend_957(
+  void _objc_msgSend_971(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<_ObjCBlock> completionHandler,
   ) {
-    return __objc_msgSend_957(
+    return __objc_msgSend_971(
       obj,
       sel,
       completionHandler,
     );
   }
 
-  late final __objc_msgSend_957Ptr = _lookup<
+  late final __objc_msgSend_971Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
-  late final __objc_msgSend_957 = __objc_msgSend_957Ptr.asFunction<
+  late final __objc_msgSend_971 = __objc_msgSend_971Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<_ObjCBlock>)>();
 
   late final _sel_dataTaskWithRequest_1 =
       _registerName1("dataTaskWithRequest:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_958(
+  ffi.Pointer<ObjCObject> _objc_msgSend_972(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> request,
   ) {
-    return __objc_msgSend_958(
+    return __objc_msgSend_972(
       obj,
       sel,
       request,
     );
   }
 
-  late final __objc_msgSend_958Ptr = _lookup<
+  late final __objc_msgSend_972Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_958 = __objc_msgSend_958Ptr.asFunction<
+  late final __objc_msgSend_972 = __objc_msgSend_972Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
 
   late final _sel_dataTaskWithURL_1 = _registerName1("dataTaskWithURL:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_959(
+  ffi.Pointer<ObjCObject> _objc_msgSend_973(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> url,
   ) {
-    return __objc_msgSend_959(
+    return __objc_msgSend_973(
       obj,
       sel,
       url,
     );
   }
 
-  late final __objc_msgSend_959Ptr = _lookup<
+  late final __objc_msgSend_973Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_959 = __objc_msgSend_959Ptr.asFunction<
+  late final __objc_msgSend_973 = __objc_msgSend_973Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
 
   late final _class_NSURLSessionUploadTask1 =
       _getClass1("NSURLSessionUploadTask");
+  late final _sel_cancelByProducingResumeData_1 =
+      _registerName1("cancelByProducingResumeData:");
+  void _objc_msgSend_974(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<_ObjCBlock> completionHandler,
+  ) {
+    return __objc_msgSend_974(
+      obj,
+      sel,
+      completionHandler,
+    );
+  }
+
+  late final __objc_msgSend_974Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+              ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
+  late final __objc_msgSend_974 = __objc_msgSend_974Ptr.asFunction<
+      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+          ffi.Pointer<_ObjCBlock>)>();
+
   late final _sel_uploadTaskWithRequest_fromFile_1 =
       _registerName1("uploadTaskWithRequest:fromFile:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_960(
+  ffi.Pointer<ObjCObject> _objc_msgSend_975(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> request,
     ffi.Pointer<ObjCObject> fileURL,
   ) {
-    return __objc_msgSend_960(
+    return __objc_msgSend_975(
       obj,
       sel,
       request,
@@ -27427,14 +27783,14 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_960Ptr = _lookup<
+  late final __objc_msgSend_975Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_960 = __objc_msgSend_960Ptr.asFunction<
+  late final __objc_msgSend_975 = __objc_msgSend_975Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -27443,13 +27799,13 @@ class SentryCocoa {
 
   late final _sel_uploadTaskWithRequest_fromData_1 =
       _registerName1("uploadTaskWithRequest:fromData:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_961(
+  ffi.Pointer<ObjCObject> _objc_msgSend_976(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> request,
     ffi.Pointer<ObjCObject> bodyData,
   ) {
-    return __objc_msgSend_961(
+    return __objc_msgSend_976(
       obj,
       sel,
       request,
@@ -27457,129 +27813,129 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_961Ptr = _lookup<
+  late final __objc_msgSend_976Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_961 = __objc_msgSend_961Ptr.asFunction<
+  late final __objc_msgSend_976 = __objc_msgSend_976Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCObject>)>();
 
-  late final _sel_uploadTaskWithStreamedRequest_1 =
-      _registerName1("uploadTaskWithStreamedRequest:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_962(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> request,
-  ) {
-    return __objc_msgSend_962(
-      obj,
-      sel,
-      request,
-    );
-  }
-
-  late final __objc_msgSend_962Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_962 = __objc_msgSend_962Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
-
-  late final _class_NSURLSessionDownloadTask1 =
-      _getClass1("NSURLSessionDownloadTask");
-  late final _sel_cancelByProducingResumeData_1 =
-      _registerName1("cancelByProducingResumeData:");
-  void _objc_msgSend_963(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<_ObjCBlock> completionHandler,
-  ) {
-    return __objc_msgSend_963(
-      obj,
-      sel,
-      completionHandler,
-    );
-  }
-
-  late final __objc_msgSend_963Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
-  late final __objc_msgSend_963 = __objc_msgSend_963Ptr.asFunction<
-      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<_ObjCBlock>)>();
-
-  late final _sel_downloadTaskWithRequest_1 =
-      _registerName1("downloadTaskWithRequest:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_964(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> request,
-  ) {
-    return __objc_msgSend_964(
-      obj,
-      sel,
-      request,
-    );
-  }
-
-  late final __objc_msgSend_964Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_964 = __objc_msgSend_964Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
-
-  late final _sel_downloadTaskWithURL_1 =
-      _registerName1("downloadTaskWithURL:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_965(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> url,
-  ) {
-    return __objc_msgSend_965(
-      obj,
-      sel,
-      url,
-    );
-  }
-
-  late final __objc_msgSend_965Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_965 = __objc_msgSend_965Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
-
-  late final _sel_downloadTaskWithResumeData_1 =
-      _registerName1("downloadTaskWithResumeData:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_966(
+  late final _sel_uploadTaskWithResumeData_1 =
+      _registerName1("uploadTaskWithResumeData:");
+  ffi.Pointer<ObjCObject> _objc_msgSend_977(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> resumeData,
   ) {
-    return __objc_msgSend_966(
+    return __objc_msgSend_977(
       obj,
       sel,
       resumeData,
     );
   }
 
-  late final __objc_msgSend_966Ptr = _lookup<
+  late final __objc_msgSend_977Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_966 = __objc_msgSend_966Ptr.asFunction<
+  late final __objc_msgSend_977 = __objc_msgSend_977Ptr.asFunction<
+      ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
+
+  late final _sel_uploadTaskWithStreamedRequest_1 =
+      _registerName1("uploadTaskWithStreamedRequest:");
+  ffi.Pointer<ObjCObject> _objc_msgSend_978(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> request,
+  ) {
+    return __objc_msgSend_978(
+      obj,
+      sel,
+      request,
+    );
+  }
+
+  late final __objc_msgSend_978Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
+  late final __objc_msgSend_978 = __objc_msgSend_978Ptr.asFunction<
+      ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
+
+  late final _class_NSURLSessionDownloadTask1 =
+      _getClass1("NSURLSessionDownloadTask");
+  late final _sel_downloadTaskWithRequest_1 =
+      _registerName1("downloadTaskWithRequest:");
+  ffi.Pointer<ObjCObject> _objc_msgSend_979(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> request,
+  ) {
+    return __objc_msgSend_979(
+      obj,
+      sel,
+      request,
+    );
+  }
+
+  late final __objc_msgSend_979Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
+  late final __objc_msgSend_979 = __objc_msgSend_979Ptr.asFunction<
+      ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
+
+  late final _sel_downloadTaskWithURL_1 =
+      _registerName1("downloadTaskWithURL:");
+  ffi.Pointer<ObjCObject> _objc_msgSend_980(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> url,
+  ) {
+    return __objc_msgSend_980(
+      obj,
+      sel,
+      url,
+    );
+  }
+
+  late final __objc_msgSend_980Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
+  late final __objc_msgSend_980 = __objc_msgSend_980Ptr.asFunction<
+      ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
+
+  late final _sel_downloadTaskWithResumeData_1 =
+      _registerName1("downloadTaskWithResumeData:");
+  ffi.Pointer<ObjCObject> _objc_msgSend_981(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> resumeData,
+  ) {
+    return __objc_msgSend_981(
+      obj,
+      sel,
+      resumeData,
+    );
+  }
+
+  late final __objc_msgSend_981Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
+  late final __objc_msgSend_981 = __objc_msgSend_981Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
 
@@ -27588,7 +27944,7 @@ class SentryCocoa {
   late final _sel_readDataOfMinLength_maxLength_timeout_completionHandler_1 =
       _registerName1(
           "readDataOfMinLength:maxLength:timeout:completionHandler:");
-  void _objc_msgSend_967(
+  void _objc_msgSend_982(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int minBytes,
@@ -27596,7 +27952,7 @@ class SentryCocoa {
     double timeout,
     ffi.Pointer<_ObjCBlock> completionHandler,
   ) {
-    return __objc_msgSend_967(
+    return __objc_msgSend_982(
       obj,
       sel,
       minBytes,
@@ -27606,7 +27962,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_967Ptr = _lookup<
+  late final __objc_msgSend_982Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(
               ffi.Pointer<ObjCObject>,
@@ -27615,20 +27971,20 @@ class SentryCocoa {
               ffi.UnsignedLong,
               ffi.Double,
               ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
-  late final __objc_msgSend_967 = __objc_msgSend_967Ptr.asFunction<
+  late final __objc_msgSend_982 = __objc_msgSend_982Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int, int,
           double, ffi.Pointer<_ObjCBlock>)>();
 
   late final _sel_writeData_timeout_completionHandler_1 =
       _registerName1("writeData:timeout:completionHandler:");
-  void _objc_msgSend_968(
+  void _objc_msgSend_983(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> data,
     double timeout,
     ffi.Pointer<_ObjCBlock> completionHandler,
   ) {
-    return __objc_msgSend_968(
+    return __objc_msgSend_983(
       obj,
       sel,
       data,
@@ -27637,7 +27993,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_968Ptr = _lookup<
+  late final __objc_msgSend_983Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(
               ffi.Pointer<ObjCObject>,
@@ -27645,7 +28001,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Double,
               ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
-  late final __objc_msgSend_968 = __objc_msgSend_968Ptr.asFunction<
+  late final __objc_msgSend_983 = __objc_msgSend_983Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>, double, ffi.Pointer<_ObjCBlock>)>();
 
@@ -27658,13 +28014,13 @@ class SentryCocoa {
       _registerName1("stopSecureConnection");
   late final _sel_streamTaskWithHostName_port_1 =
       _registerName1("streamTaskWithHostName:port:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_969(
+  ffi.Pointer<ObjCObject> _objc_msgSend_984(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> hostname,
     int port,
   ) {
-    return __objc_msgSend_969(
+    return __objc_msgSend_984(
       obj,
       sel,
       hostname,
@@ -27672,21 +28028,21 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_969Ptr = _lookup<
+  late final __objc_msgSend_984Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>,
               ffi.Long)>>('objc_msgSend');
-  late final __objc_msgSend_969 = __objc_msgSend_969Ptr.asFunction<
+  late final __objc_msgSend_984 = __objc_msgSend_984Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>, int)>();
 
   late final _class_NSNetService1 = _getClass1("NSNetService");
   late final _sel_initWithDomain_type_name_port_1 =
       _registerName1("initWithDomain:type:name:port:");
-  instancetype _objc_msgSend_970(
+  instancetype _objc_msgSend_985(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> domain,
@@ -27694,7 +28050,7 @@ class SentryCocoa {
     ffi.Pointer<ObjCObject> name,
     int port,
   ) {
-    return __objc_msgSend_970(
+    return __objc_msgSend_985(
       obj,
       sel,
       domain,
@@ -27704,7 +28060,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_970Ptr = _lookup<
+  late final __objc_msgSend_985Ptr = _lookup<
       ffi.NativeFunction<
           instancetype Function(
               ffi.Pointer<ObjCObject>,
@@ -27713,7 +28069,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>,
               ffi.Int)>>('objc_msgSend');
-  late final __objc_msgSend_970 = __objc_msgSend_970Ptr.asFunction<
+  late final __objc_msgSend_985 = __objc_msgSend_985Ptr.asFunction<
       instancetype Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -27729,81 +28085,81 @@ class SentryCocoa {
       _registerName1("setIncludesPeerToPeer:");
   late final _sel_type1 = _registerName1("type");
   late final _sel_publishWithOptions_1 = _registerName1("publishWithOptions:");
-  void _objc_msgSend_971(
+  void _objc_msgSend_986(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int options,
   ) {
-    return __objc_msgSend_971(
+    return __objc_msgSend_986(
       obj,
       sel,
       options,
     );
   }
 
-  late final __objc_msgSend_971Ptr = _lookup<
+  late final __objc_msgSend_986Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_971 = __objc_msgSend_971Ptr.asFunction<
+  late final __objc_msgSend_986 = __objc_msgSend_986Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
 
   late final _sel_resolve1 = _registerName1("resolve");
   late final _sel_stop1 = _registerName1("stop");
   late final _sel_dictionaryFromTXTRecordData_1 =
       _registerName1("dictionaryFromTXTRecordData:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_972(
+  ffi.Pointer<ObjCObject> _objc_msgSend_987(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> txtData,
   ) {
-    return __objc_msgSend_972(
+    return __objc_msgSend_987(
       obj,
       sel,
       txtData,
     );
   }
 
-  late final __objc_msgSend_972Ptr = _lookup<
+  late final __objc_msgSend_987Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_972 = __objc_msgSend_972Ptr.asFunction<
+  late final __objc_msgSend_987 = __objc_msgSend_987Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
 
   late final _sel_dataFromTXTRecordDictionary_1 =
       _registerName1("dataFromTXTRecordDictionary:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_973(
+  ffi.Pointer<ObjCObject> _objc_msgSend_988(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> txtDictionary,
   ) {
-    return __objc_msgSend_973(
+    return __objc_msgSend_988(
       obj,
       sel,
       txtDictionary,
     );
   }
 
-  late final __objc_msgSend_973Ptr = _lookup<
+  late final __objc_msgSend_988Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_973 = __objc_msgSend_973Ptr.asFunction<
+  late final __objc_msgSend_988 = __objc_msgSend_988Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
 
   late final _sel_resolveWithTimeout_1 = _registerName1("resolveWithTimeout:");
   late final _sel_getInputStream_outputStream_1 =
       _registerName1("getInputStream:outputStream:");
-  bool _objc_msgSend_974(
+  bool _objc_msgSend_989(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ffi.Pointer<ObjCObject>> inputStream,
     ffi.Pointer<ffi.Pointer<ObjCObject>> outputStream,
   ) {
-    return __objc_msgSend_974(
+    return __objc_msgSend_989(
       obj,
       sel,
       inputStream,
@@ -27811,14 +28167,14 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_974Ptr = _lookup<
+  late final __objc_msgSend_989Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Bool Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.Pointer<ffi.Pointer<ObjCObject>>,
               ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_974 = __objc_msgSend_974Ptr.asFunction<
+  late final __objc_msgSend_989 = __objc_msgSend_989Ptr.asFunction<
       bool Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -27831,23 +28187,23 @@ class SentryCocoa {
   late final _sel_stopMonitoring1 = _registerName1("stopMonitoring");
   late final _sel_streamTaskWithNetService_1 =
       _registerName1("streamTaskWithNetService:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_975(
+  ffi.Pointer<ObjCObject> _objc_msgSend_990(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> service,
   ) {
-    return __objc_msgSend_975(
+    return __objc_msgSend_990(
       obj,
       sel,
       service,
     );
   }
 
-  late final __objc_msgSend_975Ptr = _lookup<
+  late final __objc_msgSend_990Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_975 = __objc_msgSend_975Ptr.asFunction<
+  late final __objc_msgSend_990 = __objc_msgSend_990Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
 
@@ -27855,32 +28211,32 @@ class SentryCocoa {
       _getClass1("NSURLSessionWebSocketTask");
   late final _class_NSURLSessionWebSocketMessage1 =
       _getClass1("NSURLSessionWebSocketMessage");
-  int _objc_msgSend_976(
+  int _objc_msgSend_991(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_976(
+    return __objc_msgSend_991(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_976Ptr = _lookup<
+  late final __objc_msgSend_991Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Int32 Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_976 = __objc_msgSend_976Ptr.asFunction<
+  late final __objc_msgSend_991 = __objc_msgSend_991Ptr.asFunction<
       int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
   late final _sel_sendMessage_completionHandler_1 =
       _registerName1("sendMessage:completionHandler:");
-  void _objc_msgSend_977(
+  void _objc_msgSend_992(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> message,
     ffi.Pointer<_ObjCBlock> completionHandler,
   ) {
-    return __objc_msgSend_977(
+    return __objc_msgSend_992(
       obj,
       sel,
       message,
@@ -27888,70 +28244,70 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_977Ptr = _lookup<
+  late final __objc_msgSend_992Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
-  late final __objc_msgSend_977 = __objc_msgSend_977Ptr.asFunction<
+  late final __objc_msgSend_992 = __objc_msgSend_992Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>, ffi.Pointer<_ObjCBlock>)>();
 
   late final _sel_receiveMessageWithCompletionHandler_1 =
       _registerName1("receiveMessageWithCompletionHandler:");
-  void _objc_msgSend_978(
+  void _objc_msgSend_993(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<_ObjCBlock> completionHandler,
   ) {
-    return __objc_msgSend_978(
+    return __objc_msgSend_993(
       obj,
       sel,
       completionHandler,
     );
   }
 
-  late final __objc_msgSend_978Ptr = _lookup<
+  late final __objc_msgSend_993Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
-  late final __objc_msgSend_978 = __objc_msgSend_978Ptr.asFunction<
+  late final __objc_msgSend_993 = __objc_msgSend_993Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<_ObjCBlock>)>();
 
   late final _sel_sendPingWithPongReceiveHandler_1 =
       _registerName1("sendPingWithPongReceiveHandler:");
-  void _objc_msgSend_979(
+  void _objc_msgSend_994(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<_ObjCBlock> pongReceiveHandler,
   ) {
-    return __objc_msgSend_979(
+    return __objc_msgSend_994(
       obj,
       sel,
       pongReceiveHandler,
     );
   }
 
-  late final __objc_msgSend_979Ptr = _lookup<
+  late final __objc_msgSend_994Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
-  late final __objc_msgSend_979 = __objc_msgSend_979Ptr.asFunction<
+  late final __objc_msgSend_994 = __objc_msgSend_994Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<_ObjCBlock>)>();
 
   late final _sel_cancelWithCloseCode_reason_1 =
       _registerName1("cancelWithCloseCode:reason:");
-  void _objc_msgSend_980(
+  void _objc_msgSend_995(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int closeCode,
     ffi.Pointer<ObjCObject> reason,
   ) {
-    return __objc_msgSend_980(
+    return __objc_msgSend_995(
       obj,
       sel,
       closeCode,
@@ -27959,11 +28315,11 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_980Ptr = _lookup<
+  late final __objc_msgSend_995Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Int32, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_980 = __objc_msgSend_980Ptr.asFunction<
+  late final __objc_msgSend_995 = __objc_msgSend_995Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int,
           ffi.Pointer<ObjCObject>)>();
 
@@ -27971,499 +28327,59 @@ class SentryCocoa {
   late final _sel_setMaximumMessageSize_1 =
       _registerName1("setMaximumMessageSize:");
   late final _sel_closeCode1 = _registerName1("closeCode");
-  int _objc_msgSend_981(
+  int _objc_msgSend_996(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
-  ) {
-    return __objc_msgSend_981(
-      obj,
-      sel,
-    );
-  }
-
-  late final __objc_msgSend_981Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Int32 Function(
-              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_981 = __objc_msgSend_981Ptr.asFunction<
-      int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
-
-  late final _sel_closeReason1 = _registerName1("closeReason");
-  late final _sel_webSocketTaskWithURL_1 =
-      _registerName1("webSocketTaskWithURL:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_982(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> url,
-  ) {
-    return __objc_msgSend_982(
-      obj,
-      sel,
-      url,
-    );
-  }
-
-  late final __objc_msgSend_982Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_982 = __objc_msgSend_982Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
-
-  late final _sel_webSocketTaskWithURL_protocols_1 =
-      _registerName1("webSocketTaskWithURL:protocols:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_983(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> url,
-    ffi.Pointer<ObjCObject> protocols,
-  ) {
-    return __objc_msgSend_983(
-      obj,
-      sel,
-      url,
-      protocols,
-    );
-  }
-
-  late final __objc_msgSend_983Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_983 = __objc_msgSend_983Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCObject>)>();
-
-  late final _sel_webSocketTaskWithRequest_1 =
-      _registerName1("webSocketTaskWithRequest:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_984(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> request,
-  ) {
-    return __objc_msgSend_984(
-      obj,
-      sel,
-      request,
-    );
-  }
-
-  late final __objc_msgSend_984Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_984 = __objc_msgSend_984Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
-
-  late final _sel_dataTaskWithRequest_completionHandler_1 =
-      _registerName1("dataTaskWithRequest:completionHandler:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_985(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> request,
-    ffi.Pointer<_ObjCBlock> completionHandler,
-  ) {
-    return __objc_msgSend_985(
-      obj,
-      sel,
-      request,
-      completionHandler,
-    );
-  }
-
-  late final __objc_msgSend_985Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
-  late final __objc_msgSend_985 = __objc_msgSend_985Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<_ObjCBlock>)>();
-
-  late final _sel_dataTaskWithURL_completionHandler_1 =
-      _registerName1("dataTaskWithURL:completionHandler:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_986(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> url,
-    ffi.Pointer<_ObjCBlock> completionHandler,
-  ) {
-    return __objc_msgSend_986(
-      obj,
-      sel,
-      url,
-      completionHandler,
-    );
-  }
-
-  late final __objc_msgSend_986Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
-  late final __objc_msgSend_986 = __objc_msgSend_986Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<_ObjCBlock>)>();
-
-  late final _sel_uploadTaskWithRequest_fromFile_completionHandler_1 =
-      _registerName1("uploadTaskWithRequest:fromFile:completionHandler:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_987(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> request,
-    ffi.Pointer<ObjCObject> fileURL,
-    ffi.Pointer<_ObjCBlock> completionHandler,
-  ) {
-    return __objc_msgSend_987(
-      obj,
-      sel,
-      request,
-      fileURL,
-      completionHandler,
-    );
-  }
-
-  late final __objc_msgSend_987Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
-  late final __objc_msgSend_987 = __objc_msgSend_987Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<_ObjCBlock>)>();
-
-  late final _sel_uploadTaskWithRequest_fromData_completionHandler_1 =
-      _registerName1("uploadTaskWithRequest:fromData:completionHandler:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_988(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> request,
-    ffi.Pointer<ObjCObject> bodyData,
-    ffi.Pointer<_ObjCBlock> completionHandler,
-  ) {
-    return __objc_msgSend_988(
-      obj,
-      sel,
-      request,
-      bodyData,
-      completionHandler,
-    );
-  }
-
-  late final __objc_msgSend_988Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
-  late final __objc_msgSend_988 = __objc_msgSend_988Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<_ObjCBlock>)>();
-
-  late final _sel_downloadTaskWithRequest_completionHandler_1 =
-      _registerName1("downloadTaskWithRequest:completionHandler:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_989(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> request,
-    ffi.Pointer<_ObjCBlock> completionHandler,
-  ) {
-    return __objc_msgSend_989(
-      obj,
-      sel,
-      request,
-      completionHandler,
-    );
-  }
-
-  late final __objc_msgSend_989Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
-  late final __objc_msgSend_989 = __objc_msgSend_989Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<_ObjCBlock>)>();
-
-  late final _sel_downloadTaskWithURL_completionHandler_1 =
-      _registerName1("downloadTaskWithURL:completionHandler:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_990(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> url,
-    ffi.Pointer<_ObjCBlock> completionHandler,
-  ) {
-    return __objc_msgSend_990(
-      obj,
-      sel,
-      url,
-      completionHandler,
-    );
-  }
-
-  late final __objc_msgSend_990Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
-  late final __objc_msgSend_990 = __objc_msgSend_990Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<_ObjCBlock>)>();
-
-  late final _sel_downloadTaskWithResumeData_completionHandler_1 =
-      _registerName1("downloadTaskWithResumeData:completionHandler:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_991(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> resumeData,
-    ffi.Pointer<_ObjCBlock> completionHandler,
-  ) {
-    return __objc_msgSend_991(
-      obj,
-      sel,
-      resumeData,
-      completionHandler,
-    );
-  }
-
-  late final __objc_msgSend_991Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
-  late final __objc_msgSend_991 = __objc_msgSend_991Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<_ObjCBlock>)>();
-
-  late final _class_NSProtocolChecker1 = _getClass1("NSProtocolChecker");
-  ffi.Pointer<ObjCObject> _objc_msgSend_992(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-  ) {
-    return __objc_msgSend_992(
-      obj,
-      sel,
-    );
-  }
-
-  late final __objc_msgSend_992Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(
-              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_992 = __objc_msgSend_992Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(
-          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
-
-  late final _sel_protocolCheckerWithTarget_protocol_1 =
-      _registerName1("protocolCheckerWithTarget:protocol:");
-  instancetype _objc_msgSend_993(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> anObject,
-    ffi.Pointer<ObjCObject> aProtocol,
-  ) {
-    return __objc_msgSend_993(
-      obj,
-      sel,
-      anObject,
-      aProtocol,
-    );
-  }
-
-  late final __objc_msgSend_993Ptr = _lookup<
-      ffi.NativeFunction<
-          instancetype Function(
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_993 = __objc_msgSend_993Ptr.asFunction<
-      instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCObject>)>();
-
-  late final _sel_initWithTarget_protocol_1 =
-      _registerName1("initWithTarget:protocol:");
-  late final _class_NSTask1 = _getClass1("NSTask");
-  late final _sel_setExecutableURL_1 = _registerName1("setExecutableURL:");
-  late final _sel_setEnvironment_1 = _registerName1("setEnvironment:");
-  late final _sel_currentDirectoryURL1 = _registerName1("currentDirectoryURL");
-  late final _sel_setCurrentDirectoryURL_1 =
-      _registerName1("setCurrentDirectoryURL:");
-  late final _sel_standardInput1 = _registerName1("standardInput");
-  late final _sel_setStandardInput_1 = _registerName1("setStandardInput:");
-  late final _sel_standardOutput1 = _registerName1("standardOutput");
-  late final _sel_setStandardOutput_1 = _registerName1("setStandardOutput:");
-  late final _sel_standardError1 = _registerName1("standardError");
-  late final _sel_setStandardError_1 = _registerName1("setStandardError:");
-  late final _sel_launchAndReturnError_1 =
-      _registerName1("launchAndReturnError:");
-  late final _sel_interrupt1 = _registerName1("interrupt");
-  late final _sel_terminate1 = _registerName1("terminate");
-  late final _sel_isRunning1 = _registerName1("isRunning");
-  late final _sel_terminationStatus1 = _registerName1("terminationStatus");
-  late final _sel_terminationReason1 = _registerName1("terminationReason");
-  int _objc_msgSend_994(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-  ) {
-    return __objc_msgSend_994(
-      obj,
-      sel,
-    );
-  }
-
-  late final __objc_msgSend_994Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Int32 Function(
-              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_994 = __objc_msgSend_994Ptr.asFunction<
-      int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
-
-  late final _sel_terminationHandler1 = _registerName1("terminationHandler");
-  ffi.Pointer<_ObjCBlock> _objc_msgSend_995(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-  ) {
-    return __objc_msgSend_995(
-      obj,
-      sel,
-    );
-  }
-
-  late final __objc_msgSend_995Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<_ObjCBlock> Function(
-              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_995 = __objc_msgSend_995Ptr.asFunction<
-      ffi.Pointer<_ObjCBlock> Function(
-          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
-
-  late final _sel_setTerminationHandler_1 =
-      _registerName1("setTerminationHandler:");
-  void _objc_msgSend_996(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<_ObjCBlock> value,
   ) {
     return __objc_msgSend_996(
       obj,
       sel,
-      value,
     );
   }
 
   late final __objc_msgSend_996Ptr = _lookup<
       ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
+          ffi.Int32 Function(
+              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
   late final __objc_msgSend_996 = __objc_msgSend_996Ptr.asFunction<
-      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<_ObjCBlock>)>();
+      int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
-  late final _sel_launchedTaskWithExecutableURL_arguments_error_terminationHandler_1 =
-      _registerName1(
-          "launchedTaskWithExecutableURL:arguments:error:terminationHandler:");
+  late final _sel_closeReason1 = _registerName1("closeReason");
+  late final _sel_webSocketTaskWithURL_1 =
+      _registerName1("webSocketTaskWithURL:");
   ffi.Pointer<ObjCObject> _objc_msgSend_997(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> url,
-    ffi.Pointer<ObjCObject> arguments,
-    ffi.Pointer<ffi.Pointer<ObjCObject>> error,
-    ffi.Pointer<_ObjCBlock> terminationHandler,
   ) {
     return __objc_msgSend_997(
       obj,
       sel,
       url,
-      arguments,
-      error,
-      terminationHandler,
     );
   }
 
   late final __objc_msgSend_997Ptr = _lookup<
       ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ffi.Pointer<ObjCObject>>,
-              ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
+          ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
   late final __objc_msgSend_997 = __objc_msgSend_997Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ffi.Pointer<ObjCObject>>,
-          ffi.Pointer<_ObjCBlock>)>();
+      ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
 
-  late final _sel_waitUntilExit1 = _registerName1("waitUntilExit");
-  late final _sel_launchPath1 = _registerName1("launchPath");
-  late final _sel_setLaunchPath_1 = _registerName1("setLaunchPath:");
-  late final _sel_setCurrentDirectoryPath_1 =
-      _registerName1("setCurrentDirectoryPath:");
-  late final _sel_launch1 = _registerName1("launch");
-  late final _sel_launchedTaskWithLaunchPath_arguments_1 =
-      _registerName1("launchedTaskWithLaunchPath:arguments:");
+  late final _sel_webSocketTaskWithURL_protocols_1 =
+      _registerName1("webSocketTaskWithURL:protocols:");
   ffi.Pointer<ObjCObject> _objc_msgSend_998(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> path,
-    ffi.Pointer<ObjCObject> arguments,
+    ffi.Pointer<ObjCObject> url,
+    ffi.Pointer<ObjCObject> protocols,
   ) {
     return __objc_msgSend_998(
       obj,
       sel,
-      path,
-      arguments,
+      url,
+      protocols,
     );
   }
 
@@ -28481,96 +28397,103 @@ class SentryCocoa {
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCObject>)>();
 
-  late final _class_NSXMLElement1 = _getClass1("NSXMLElement");
-  late final _class_NSXMLNode1 = _getClass1("NSXMLNode");
-  late final _sel_initWithKind_1 = _registerName1("initWithKind:");
-  instancetype _objc_msgSend_999(
+  late final _sel_webSocketTaskWithRequest_1 =
+      _registerName1("webSocketTaskWithRequest:");
+  ffi.Pointer<ObjCObject> _objc_msgSend_999(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
-    int kind,
+    ffi.Pointer<ObjCObject> request,
   ) {
     return __objc_msgSend_999(
       obj,
       sel,
-      kind,
+      request,
     );
   }
 
   late final __objc_msgSend_999Ptr = _lookup<
       ffi.NativeFunction<
-          instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.Int32)>>('objc_msgSend');
+          ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
   late final __objc_msgSend_999 = __objc_msgSend_999Ptr.asFunction<
-      instancetype Function(
-          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
+      ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
 
-  late final _sel_initWithKind_options_1 =
-      _registerName1("initWithKind:options:");
-  instancetype _objc_msgSend_1000(
+  late final _sel_dataTaskWithRequest_completionHandler_1 =
+      _registerName1("dataTaskWithRequest:completionHandler:");
+  ffi.Pointer<ObjCObject> _objc_msgSend_1000(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
-    int kind,
-    int options,
+    ffi.Pointer<ObjCObject> request,
+    ffi.Pointer<_ObjCBlock> completionHandler,
   ) {
     return __objc_msgSend_1000(
       obj,
       sel,
-      kind,
-      options,
+      request,
+      completionHandler,
     );
   }
 
   late final __objc_msgSend_1000Ptr = _lookup<
       ffi.NativeFunction<
-          instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.Int32, ffi.Int32)>>('objc_msgSend');
+          ffi.Pointer<ObjCObject> Function(
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
   late final __objc_msgSend_1000 = __objc_msgSend_1000Ptr.asFunction<
-      instancetype Function(
-          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int, int)>();
+      ffi.Pointer<ObjCObject> Function(
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<_ObjCBlock>)>();
 
-  late final _sel_document1 = _registerName1("document");
-  late final _sel_documentWithRootElement_1 =
-      _registerName1("documentWithRootElement:");
+  late final _sel_dataTaskWithURL_completionHandler_1 =
+      _registerName1("dataTaskWithURL:completionHandler:");
   ffi.Pointer<ObjCObject> _objc_msgSend_1001(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> element,
+    ffi.Pointer<ObjCObject> url,
+    ffi.Pointer<_ObjCBlock> completionHandler,
   ) {
     return __objc_msgSend_1001(
       obj,
       sel,
-      element,
+      url,
+      completionHandler,
     );
   }
 
   late final __objc_msgSend_1001Ptr = _lookup<
       ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
+          ffi.Pointer<ObjCObject> Function(
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
   late final __objc_msgSend_1001 = __objc_msgSend_1001Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
+      ffi.Pointer<ObjCObject> Function(
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<_ObjCBlock>)>();
 
-  late final _sel_elementWithName_1 = _registerName1("elementWithName:");
-  late final _sel_elementWithName_URI_1 =
-      _registerName1("elementWithName:URI:");
-  late final _sel_elementWithName_stringValue_1 =
-      _registerName1("elementWithName:stringValue:");
-  late final _sel_elementWithName_children_attributes_1 =
-      _registerName1("elementWithName:children:attributes:");
+  late final _sel_uploadTaskWithRequest_fromFile_completionHandler_1 =
+      _registerName1("uploadTaskWithRequest:fromFile:completionHandler:");
   ffi.Pointer<ObjCObject> _objc_msgSend_1002(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> name,
-    ffi.Pointer<ObjCObject> children,
-    ffi.Pointer<ObjCObject> attributes,
+    ffi.Pointer<ObjCObject> request,
+    ffi.Pointer<ObjCObject> fileURL,
+    ffi.Pointer<_ObjCBlock> completionHandler,
   ) {
     return __objc_msgSend_1002(
       obj,
       sel,
-      name,
-      children,
-      attributes,
+      request,
+      fileURL,
+      completionHandler,
     );
   }
 
@@ -28581,8 +28504,475 @@ class SentryCocoa {
               ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
+              ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
   late final __objc_msgSend_1002 = __objc_msgSend_1002Ptr.asFunction<
+      ffi.Pointer<ObjCObject> Function(
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<_ObjCBlock>)>();
+
+  late final _sel_uploadTaskWithRequest_fromData_completionHandler_1 =
+      _registerName1("uploadTaskWithRequest:fromData:completionHandler:");
+  ffi.Pointer<ObjCObject> _objc_msgSend_1003(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> request,
+    ffi.Pointer<ObjCObject> bodyData,
+    ffi.Pointer<_ObjCBlock> completionHandler,
+  ) {
+    return __objc_msgSend_1003(
+      obj,
+      sel,
+      request,
+      bodyData,
+      completionHandler,
+    );
+  }
+
+  late final __objc_msgSend_1003Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<ObjCObject> Function(
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
+  late final __objc_msgSend_1003 = __objc_msgSend_1003Ptr.asFunction<
+      ffi.Pointer<ObjCObject> Function(
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<_ObjCBlock>)>();
+
+  late final _sel_uploadTaskWithResumeData_completionHandler_1 =
+      _registerName1("uploadTaskWithResumeData:completionHandler:");
+  ffi.Pointer<ObjCObject> _objc_msgSend_1004(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> resumeData,
+    ffi.Pointer<_ObjCBlock> completionHandler,
+  ) {
+    return __objc_msgSend_1004(
+      obj,
+      sel,
+      resumeData,
+      completionHandler,
+    );
+  }
+
+  late final __objc_msgSend_1004Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<ObjCObject> Function(
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
+  late final __objc_msgSend_1004 = __objc_msgSend_1004Ptr.asFunction<
+      ffi.Pointer<ObjCObject> Function(
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<_ObjCBlock>)>();
+
+  late final _sel_downloadTaskWithRequest_completionHandler_1 =
+      _registerName1("downloadTaskWithRequest:completionHandler:");
+  ffi.Pointer<ObjCObject> _objc_msgSend_1005(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> request,
+    ffi.Pointer<_ObjCBlock> completionHandler,
+  ) {
+    return __objc_msgSend_1005(
+      obj,
+      sel,
+      request,
+      completionHandler,
+    );
+  }
+
+  late final __objc_msgSend_1005Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<ObjCObject> Function(
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
+  late final __objc_msgSend_1005 = __objc_msgSend_1005Ptr.asFunction<
+      ffi.Pointer<ObjCObject> Function(
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<_ObjCBlock>)>();
+
+  late final _sel_downloadTaskWithURL_completionHandler_1 =
+      _registerName1("downloadTaskWithURL:completionHandler:");
+  ffi.Pointer<ObjCObject> _objc_msgSend_1006(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> url,
+    ffi.Pointer<_ObjCBlock> completionHandler,
+  ) {
+    return __objc_msgSend_1006(
+      obj,
+      sel,
+      url,
+      completionHandler,
+    );
+  }
+
+  late final __objc_msgSend_1006Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<ObjCObject> Function(
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
+  late final __objc_msgSend_1006 = __objc_msgSend_1006Ptr.asFunction<
+      ffi.Pointer<ObjCObject> Function(
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<_ObjCBlock>)>();
+
+  late final _sel_downloadTaskWithResumeData_completionHandler_1 =
+      _registerName1("downloadTaskWithResumeData:completionHandler:");
+  ffi.Pointer<ObjCObject> _objc_msgSend_1007(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> resumeData,
+    ffi.Pointer<_ObjCBlock> completionHandler,
+  ) {
+    return __objc_msgSend_1007(
+      obj,
+      sel,
+      resumeData,
+      completionHandler,
+    );
+  }
+
+  late final __objc_msgSend_1007Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<ObjCObject> Function(
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
+  late final __objc_msgSend_1007 = __objc_msgSend_1007Ptr.asFunction<
+      ffi.Pointer<ObjCObject> Function(
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<_ObjCBlock>)>();
+
+  late final _class_NSProtocolChecker1 = _getClass1("NSProtocolChecker");
+  ffi.Pointer<ObjCObject> _objc_msgSend_1008(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+  ) {
+    return __objc_msgSend_1008(
+      obj,
+      sel,
+    );
+  }
+
+  late final __objc_msgSend_1008Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<ObjCObject> Function(
+              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
+  late final __objc_msgSend_1008 = __objc_msgSend_1008Ptr.asFunction<
+      ffi.Pointer<ObjCObject> Function(
+          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
+
+  late final _sel_protocolCheckerWithTarget_protocol_1 =
+      _registerName1("protocolCheckerWithTarget:protocol:");
+  instancetype _objc_msgSend_1009(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> anObject,
+    ffi.Pointer<ObjCObject> aProtocol,
+  ) {
+    return __objc_msgSend_1009(
+      obj,
+      sel,
+      anObject,
+      aProtocol,
+    );
+  }
+
+  late final __objc_msgSend_1009Ptr = _lookup<
+      ffi.NativeFunction<
+          instancetype Function(
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
+  late final __objc_msgSend_1009 = __objc_msgSend_1009Ptr.asFunction<
+      instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCObject>)>();
+
+  late final _sel_initWithTarget_protocol_1 =
+      _registerName1("initWithTarget:protocol:");
+  late final _class_NSTask1 = _getClass1("NSTask");
+  late final _sel_setExecutableURL_1 = _registerName1("setExecutableURL:");
+  late final _sel_setEnvironment_1 = _registerName1("setEnvironment:");
+  late final _sel_currentDirectoryURL1 = _registerName1("currentDirectoryURL");
+  late final _sel_setCurrentDirectoryURL_1 =
+      _registerName1("setCurrentDirectoryURL:");
+  late final _sel_launchRequirementData1 =
+      _registerName1("launchRequirementData");
+  late final _sel_setLaunchRequirementData_1 =
+      _registerName1("setLaunchRequirementData:");
+  late final _sel_standardInput1 = _registerName1("standardInput");
+  late final _sel_setStandardInput_1 = _registerName1("setStandardInput:");
+  late final _sel_standardOutput1 = _registerName1("standardOutput");
+  late final _sel_setStandardOutput_1 = _registerName1("setStandardOutput:");
+  late final _sel_standardError1 = _registerName1("standardError");
+  late final _sel_setStandardError_1 = _registerName1("setStandardError:");
+  late final _sel_launchAndReturnError_1 =
+      _registerName1("launchAndReturnError:");
+  late final _sel_interrupt1 = _registerName1("interrupt");
+  late final _sel_terminate1 = _registerName1("terminate");
+  late final _sel_isRunning1 = _registerName1("isRunning");
+  late final _sel_terminationStatus1 = _registerName1("terminationStatus");
+  late final _sel_terminationReason1 = _registerName1("terminationReason");
+  int _objc_msgSend_1010(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+  ) {
+    return __objc_msgSend_1010(
+      obj,
+      sel,
+    );
+  }
+
+  late final __objc_msgSend_1010Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int32 Function(
+              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
+  late final __objc_msgSend_1010 = __objc_msgSend_1010Ptr.asFunction<
+      int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
+
+  late final _sel_terminationHandler1 = _registerName1("terminationHandler");
+  ffi.Pointer<_ObjCBlock> _objc_msgSend_1011(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+  ) {
+    return __objc_msgSend_1011(
+      obj,
+      sel,
+    );
+  }
+
+  late final __objc_msgSend_1011Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<_ObjCBlock> Function(
+              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
+  late final __objc_msgSend_1011 = __objc_msgSend_1011Ptr.asFunction<
+      ffi.Pointer<_ObjCBlock> Function(
+          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
+
+  late final _sel_setTerminationHandler_1 =
+      _registerName1("setTerminationHandler:");
+  void _objc_msgSend_1012(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<_ObjCBlock> value,
+  ) {
+    return __objc_msgSend_1012(
+      obj,
+      sel,
+      value,
+    );
+  }
+
+  late final __objc_msgSend_1012Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+              ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
+  late final __objc_msgSend_1012 = __objc_msgSend_1012Ptr.asFunction<
+      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+          ffi.Pointer<_ObjCBlock>)>();
+
+  late final _sel_launchedTaskWithExecutableURL_arguments_error_terminationHandler_1 =
+      _registerName1(
+          "launchedTaskWithExecutableURL:arguments:error:terminationHandler:");
+  ffi.Pointer<ObjCObject> _objc_msgSend_1013(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> url,
+    ffi.Pointer<ObjCObject> arguments,
+    ffi.Pointer<ffi.Pointer<ObjCObject>> error,
+    ffi.Pointer<_ObjCBlock> terminationHandler,
+  ) {
+    return __objc_msgSend_1013(
+      obj,
+      sel,
+      url,
+      arguments,
+      error,
+      terminationHandler,
+    );
+  }
+
+  late final __objc_msgSend_1013Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<ObjCObject> Function(
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ffi.Pointer<ObjCObject>>,
+              ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
+  late final __objc_msgSend_1013 = __objc_msgSend_1013Ptr.asFunction<
+      ffi.Pointer<ObjCObject> Function(
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ffi.Pointer<ObjCObject>>,
+          ffi.Pointer<_ObjCBlock>)>();
+
+  late final _sel_waitUntilExit1 = _registerName1("waitUntilExit");
+  late final _sel_launchPath1 = _registerName1("launchPath");
+  late final _sel_setLaunchPath_1 = _registerName1("setLaunchPath:");
+  late final _sel_setCurrentDirectoryPath_1 =
+      _registerName1("setCurrentDirectoryPath:");
+  late final _sel_launch1 = _registerName1("launch");
+  late final _sel_launchedTaskWithLaunchPath_arguments_1 =
+      _registerName1("launchedTaskWithLaunchPath:arguments:");
+  ffi.Pointer<ObjCObject> _objc_msgSend_1014(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> path,
+    ffi.Pointer<ObjCObject> arguments,
+  ) {
+    return __objc_msgSend_1014(
+      obj,
+      sel,
+      path,
+      arguments,
+    );
+  }
+
+  late final __objc_msgSend_1014Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<ObjCObject> Function(
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
+  late final __objc_msgSend_1014 = __objc_msgSend_1014Ptr.asFunction<
+      ffi.Pointer<ObjCObject> Function(
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCObject>)>();
+
+  late final _class_NSXMLElement1 = _getClass1("NSXMLElement");
+  late final _class_NSXMLNode1 = _getClass1("NSXMLNode");
+  late final _sel_initWithKind_1 = _registerName1("initWithKind:");
+  instancetype _objc_msgSend_1015(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    int kind,
+  ) {
+    return __objc_msgSend_1015(
+      obj,
+      sel,
+      kind,
+    );
+  }
+
+  late final __objc_msgSend_1015Ptr = _lookup<
+      ffi.NativeFunction<
+          instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+              ffi.Int32)>>('objc_msgSend');
+  late final __objc_msgSend_1015 = __objc_msgSend_1015Ptr.asFunction<
+      instancetype Function(
+          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
+
+  late final _sel_initWithKind_options_1 =
+      _registerName1("initWithKind:options:");
+  instancetype _objc_msgSend_1016(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    int kind,
+    int options,
+  ) {
+    return __objc_msgSend_1016(
+      obj,
+      sel,
+      kind,
+      options,
+    );
+  }
+
+  late final __objc_msgSend_1016Ptr = _lookup<
+      ffi.NativeFunction<
+          instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+              ffi.Int32, ffi.Int32)>>('objc_msgSend');
+  late final __objc_msgSend_1016 = __objc_msgSend_1016Ptr.asFunction<
+      instancetype Function(
+          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int, int)>();
+
+  late final _sel_document1 = _registerName1("document");
+  late final _sel_documentWithRootElement_1 =
+      _registerName1("documentWithRootElement:");
+  ffi.Pointer<ObjCObject> _objc_msgSend_1017(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> element,
+  ) {
+    return __objc_msgSend_1017(
+      obj,
+      sel,
+      element,
+    );
+  }
+
+  late final __objc_msgSend_1017Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
+  late final __objc_msgSend_1017 = __objc_msgSend_1017Ptr.asFunction<
+      ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
+
+  late final _sel_elementWithName_1 = _registerName1("elementWithName:");
+  late final _sel_elementWithName_URI_1 =
+      _registerName1("elementWithName:URI:");
+  late final _sel_elementWithName_stringValue_1 =
+      _registerName1("elementWithName:stringValue:");
+  late final _sel_elementWithName_children_attributes_1 =
+      _registerName1("elementWithName:children:attributes:");
+  ffi.Pointer<ObjCObject> _objc_msgSend_1018(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> name,
+    ffi.Pointer<ObjCObject> children,
+    ffi.Pointer<ObjCObject> attributes,
+  ) {
+    return __objc_msgSend_1018(
+      obj,
+      sel,
+      name,
+      children,
+      attributes,
+    );
+  }
+
+  late final __objc_msgSend_1018Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<ObjCObject> Function(
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
+  late final __objc_msgSend_1018 = __objc_msgSend_1018Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -28604,21 +28994,21 @@ class SentryCocoa {
       _registerName1("textWithStringValue:");
   late final _sel_DTDNodeWithXMLString_1 =
       _registerName1("DTDNodeWithXMLString:");
-  int _objc_msgSend_1003(
+  int _objc_msgSend_1019(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_1003(
+    return __objc_msgSend_1019(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_1003Ptr = _lookup<
+  late final __objc_msgSend_1019Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Int32 Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_1003 = __objc_msgSend_1003Ptr.asFunction<
+  late final __objc_msgSend_1019 = __objc_msgSend_1019Ptr.asFunction<
       int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
   late final _sel_objectValue1 = _registerName1("objectValue");
@@ -28626,13 +29016,13 @@ class SentryCocoa {
   late final _sel_setStringValue_1 = _registerName1("setStringValue:");
   late final _sel_setStringValue_resolvingEntities_1 =
       _registerName1("setStringValue:resolvingEntities:");
-  void _objc_msgSend_1004(
+  void _objc_msgSend_1020(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> string,
     bool resolve,
   ) {
-    return __objc_msgSend_1004(
+    return __objc_msgSend_1020(
       obj,
       sel,
       string,
@@ -28640,11 +29030,11 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_1004Ptr = _lookup<
+  late final __objc_msgSend_1020Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>, ffi.Bool)>>('objc_msgSend');
-  late final __objc_msgSend_1004 = __objc_msgSend_1004Ptr.asFunction<
+  late final __objc_msgSend_1020 = __objc_msgSend_1020Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>, bool)>();
 
@@ -28653,14 +29043,14 @@ class SentryCocoa {
   late final _class_NSXMLDocument1 = _getClass1("NSXMLDocument");
   late final _sel_initWithXMLString_options_error_1 =
       _registerName1("initWithXMLString:options:error:");
-  instancetype _objc_msgSend_1005(
+  instancetype _objc_msgSend_1021(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> string,
     int mask,
     ffi.Pointer<ffi.Pointer<ObjCObject>> error,
   ) {
-    return __objc_msgSend_1005(
+    return __objc_msgSend_1021(
       obj,
       sel,
       string,
@@ -28669,7 +29059,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_1005Ptr = _lookup<
+  late final __objc_msgSend_1021Ptr = _lookup<
       ffi.NativeFunction<
           instancetype Function(
               ffi.Pointer<ObjCObject>,
@@ -28677,7 +29067,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Int32,
               ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_1005 = __objc_msgSend_1005Ptr.asFunction<
+  late final __objc_msgSend_1021 = __objc_msgSend_1021Ptr.asFunction<
       instancetype Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -28685,14 +29075,14 @@ class SentryCocoa {
           int,
           ffi.Pointer<ffi.Pointer<ObjCObject>>)>();
 
-  instancetype _objc_msgSend_1006(
+  instancetype _objc_msgSend_1022(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> url,
     int mask,
     ffi.Pointer<ffi.Pointer<ObjCObject>> error,
   ) {
-    return __objc_msgSend_1006(
+    return __objc_msgSend_1022(
       obj,
       sel,
       url,
@@ -28701,7 +29091,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_1006Ptr = _lookup<
+  late final __objc_msgSend_1022Ptr = _lookup<
       ffi.NativeFunction<
           instancetype Function(
               ffi.Pointer<ObjCObject>,
@@ -28709,7 +29099,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Int32,
               ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_1006 = __objc_msgSend_1006Ptr.asFunction<
+  late final __objc_msgSend_1022 = __objc_msgSend_1022Ptr.asFunction<
       instancetype Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -28719,14 +29109,14 @@ class SentryCocoa {
 
   late final _sel_initWithData_options_error_1 =
       _registerName1("initWithData:options:error:");
-  instancetype _objc_msgSend_1007(
+  instancetype _objc_msgSend_1023(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> data,
     int mask,
     ffi.Pointer<ffi.Pointer<ObjCObject>> error,
   ) {
-    return __objc_msgSend_1007(
+    return __objc_msgSend_1023(
       obj,
       sel,
       data,
@@ -28735,7 +29125,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_1007Ptr = _lookup<
+  late final __objc_msgSend_1023Ptr = _lookup<
       ffi.NativeFunction<
           instancetype Function(
               ffi.Pointer<ObjCObject>,
@@ -28743,7 +29133,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Int32,
               ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_1007 = __objc_msgSend_1007Ptr.asFunction<
+  late final __objc_msgSend_1023 = __objc_msgSend_1023Ptr.asFunction<
       instancetype Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -28761,42 +29151,42 @@ class SentryCocoa {
   late final _sel_isStandalone1 = _registerName1("isStandalone");
   late final _sel_setStandalone_1 = _registerName1("setStandalone:");
   late final _sel_documentContentKind1 = _registerName1("documentContentKind");
-  int _objc_msgSend_1008(
+  int _objc_msgSend_1024(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_1008(
+    return __objc_msgSend_1024(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_1008Ptr = _lookup<
+  late final __objc_msgSend_1024Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Int32 Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_1008 = __objc_msgSend_1008Ptr.asFunction<
+  late final __objc_msgSend_1024 = __objc_msgSend_1024Ptr.asFunction<
       int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
   late final _sel_setDocumentContentKind_1 =
       _registerName1("setDocumentContentKind:");
-  void _objc_msgSend_1009(
+  void _objc_msgSend_1025(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int value,
   ) {
-    return __objc_msgSend_1009(
+    return __objc_msgSend_1025(
       obj,
       sel,
       value,
     );
   }
 
-  late final __objc_msgSend_1009Ptr = _lookup<
+  late final __objc_msgSend_1025Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_1009 = __objc_msgSend_1009Ptr.asFunction<
+  late final __objc_msgSend_1025 = __objc_msgSend_1025Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
 
   late final _sel_setMIMEType_1 = _registerName1("setMIMEType:");
@@ -28805,13 +29195,13 @@ class SentryCocoa {
   late final _sel_setSystemID_1 = _registerName1("setSystemID:");
   late final _sel_insertChild_atIndex_1 =
       _registerName1("insertChild:atIndex:");
-  void _objc_msgSend_1010(
+  void _objc_msgSend_1026(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> child,
     int index,
   ) {
-    return __objc_msgSend_1010(
+    return __objc_msgSend_1026(
       obj,
       sel,
       child,
@@ -28819,23 +29209,23 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_1010Ptr = _lookup<
+  late final __objc_msgSend_1026Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>, ffi.UnsignedLong)>>('objc_msgSend');
-  late final __objc_msgSend_1010 = __objc_msgSend_1010Ptr.asFunction<
+  late final __objc_msgSend_1026 = __objc_msgSend_1026Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>, int)>();
 
   late final _sel_insertChildren_atIndex_1 =
       _registerName1("insertChildren:atIndex:");
-  void _objc_msgSend_1011(
+  void _objc_msgSend_1027(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> children,
     int index,
   ) {
-    return __objc_msgSend_1011(
+    return __objc_msgSend_1027(
       obj,
       sel,
       children,
@@ -28843,46 +29233,46 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_1011Ptr = _lookup<
+  late final __objc_msgSend_1027Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>, ffi.UnsignedLong)>>('objc_msgSend');
-  late final __objc_msgSend_1011 = __objc_msgSend_1011Ptr.asFunction<
+  late final __objc_msgSend_1027 = __objc_msgSend_1027Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>, int)>();
 
   late final _sel_removeChildAtIndex_1 = _registerName1("removeChildAtIndex:");
   late final _sel_setChildren_1 = _registerName1("setChildren:");
   late final _sel_addChild_1 = _registerName1("addChild:");
-  void _objc_msgSend_1012(
+  void _objc_msgSend_1028(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> child,
   ) {
-    return __objc_msgSend_1012(
+    return __objc_msgSend_1028(
       obj,
       sel,
       child,
     );
   }
 
-  late final __objc_msgSend_1012Ptr = _lookup<
+  late final __objc_msgSend_1028Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_1012 = __objc_msgSend_1012Ptr.asFunction<
+  late final __objc_msgSend_1028 = __objc_msgSend_1028Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>)>();
 
   late final _sel_replaceChildAtIndex_withNode_1 =
       _registerName1("replaceChildAtIndex:withNode:");
-  void _objc_msgSend_1013(
+  void _objc_msgSend_1029(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int index,
     ffi.Pointer<ObjCObject> node,
   ) {
-    return __objc_msgSend_1013(
+    return __objc_msgSend_1029(
       obj,
       sel,
       index,
@@ -28890,52 +29280,52 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_1013Ptr = _lookup<
+  late final __objc_msgSend_1029Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.UnsignedLong, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_1013 = __objc_msgSend_1013Ptr.asFunction<
+  late final __objc_msgSend_1029 = __objc_msgSend_1029Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int,
           ffi.Pointer<ObjCObject>)>();
 
   late final _class_NSXMLDTDNode1 = _getClass1("NSXMLDTDNode");
   late final _sel_initWithXMLString_1 = _registerName1("initWithXMLString:");
   late final _sel_DTDKind1 = _registerName1("DTDKind");
-  int _objc_msgSend_1014(
+  int _objc_msgSend_1030(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_1014(
+    return __objc_msgSend_1030(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_1014Ptr = _lookup<
+  late final __objc_msgSend_1030Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Int32 Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_1014 = __objc_msgSend_1014Ptr.asFunction<
+  late final __objc_msgSend_1030 = __objc_msgSend_1030Ptr.asFunction<
       int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
   late final _sel_setDTDKind_1 = _registerName1("setDTDKind:");
-  void _objc_msgSend_1015(
+  void _objc_msgSend_1031(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int value,
   ) {
-    return __objc_msgSend_1015(
+    return __objc_msgSend_1031(
       obj,
       sel,
       value,
     );
   }
 
-  late final __objc_msgSend_1015Ptr = _lookup<
+  late final __objc_msgSend_1031Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_1015 = __objc_msgSend_1015Ptr.asFunction<
+  late final __objc_msgSend_1031 = __objc_msgSend_1031Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
 
   late final _sel_isExternal1 = _registerName1("isExternal");
@@ -28945,45 +29335,45 @@ class SentryCocoa {
   late final _sel_prefixForName_1 = _registerName1("prefixForName:");
   late final _sel_predefinedNamespaceForPrefix_1 =
       _registerName1("predefinedNamespaceForPrefix:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_1016(
+  ffi.Pointer<ObjCObject> _objc_msgSend_1032(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> name,
   ) {
-    return __objc_msgSend_1016(
+    return __objc_msgSend_1032(
       obj,
       sel,
       name,
     );
   }
 
-  late final __objc_msgSend_1016Ptr = _lookup<
+  late final __objc_msgSend_1032Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_1016 = __objc_msgSend_1016Ptr.asFunction<
+  late final __objc_msgSend_1032 = __objc_msgSend_1032Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
 
   late final _sel_entityDeclarationForName_1 =
       _registerName1("entityDeclarationForName:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_1017(
+  ffi.Pointer<ObjCObject> _objc_msgSend_1033(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> name,
   ) {
-    return __objc_msgSend_1017(
+    return __objc_msgSend_1033(
       obj,
       sel,
       name,
     );
   }
 
-  late final __objc_msgSend_1017Ptr = _lookup<
+  late final __objc_msgSend_1033Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_1017 = __objc_msgSend_1017Ptr.asFunction<
+  late final __objc_msgSend_1033 = __objc_msgSend_1033Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
 
@@ -28993,13 +29383,13 @@ class SentryCocoa {
       _registerName1("elementDeclarationForName:");
   late final _sel_attributeDeclarationForName_elementName_1 =
       _registerName1("attributeDeclarationForName:elementName:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_1018(
+  ffi.Pointer<ObjCObject> _objc_msgSend_1034(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> name,
     ffi.Pointer<ObjCObject> elementName,
   ) {
-    return __objc_msgSend_1018(
+    return __objc_msgSend_1034(
       obj,
       sel,
       name,
@@ -29007,14 +29397,14 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_1018Ptr = _lookup<
+  late final __objc_msgSend_1034Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_1018 = __objc_msgSend_1018Ptr.asFunction<
+  late final __objc_msgSend_1034 = __objc_msgSend_1034Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -29024,117 +29414,117 @@ class SentryCocoa {
   late final _sel_predefinedEntityDeclarationForName_1 =
       _registerName1("predefinedEntityDeclarationForName:");
   late final _sel_DTD1 = _registerName1("DTD");
-  ffi.Pointer<ObjCObject> _objc_msgSend_1019(
+  ffi.Pointer<ObjCObject> _objc_msgSend_1035(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_1019(
+    return __objc_msgSend_1035(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_1019Ptr = _lookup<
+  late final __objc_msgSend_1035Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_1019 = __objc_msgSend_1019Ptr.asFunction<
+  late final __objc_msgSend_1035 = __objc_msgSend_1035Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
   late final _sel_setDTD_1 = _registerName1("setDTD:");
-  void _objc_msgSend_1020(
+  void _objc_msgSend_1036(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> value,
   ) {
-    return __objc_msgSend_1020(
+    return __objc_msgSend_1036(
       obj,
       sel,
       value,
     );
   }
 
-  late final __objc_msgSend_1020Ptr = _lookup<
+  late final __objc_msgSend_1036Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_1020 = __objc_msgSend_1020Ptr.asFunction<
+  late final __objc_msgSend_1036 = __objc_msgSend_1036Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>)>();
 
   late final _sel_setRootElement_1 = _registerName1("setRootElement:");
-  void _objc_msgSend_1021(
+  void _objc_msgSend_1037(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> root,
   ) {
-    return __objc_msgSend_1021(
+    return __objc_msgSend_1037(
       obj,
       sel,
       root,
     );
   }
 
-  late final __objc_msgSend_1021Ptr = _lookup<
+  late final __objc_msgSend_1037Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_1021 = __objc_msgSend_1021Ptr.asFunction<
+  late final __objc_msgSend_1037 = __objc_msgSend_1037Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>)>();
 
   late final _sel_rootElement1 = _registerName1("rootElement");
-  ffi.Pointer<ObjCObject> _objc_msgSend_1022(
+  ffi.Pointer<ObjCObject> _objc_msgSend_1038(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_1022(
+    return __objc_msgSend_1038(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_1022Ptr = _lookup<
+  late final __objc_msgSend_1038Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_1022 = __objc_msgSend_1022Ptr.asFunction<
+  late final __objc_msgSend_1038 = __objc_msgSend_1038Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
   late final _sel_XMLData1 = _registerName1("XMLData");
   late final _sel_XMLDataWithOptions_1 = _registerName1("XMLDataWithOptions:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_1023(
+  ffi.Pointer<ObjCObject> _objc_msgSend_1039(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int options,
   ) {
-    return __objc_msgSend_1023(
+    return __objc_msgSend_1039(
       obj,
       sel,
       options,
     );
   }
 
-  late final __objc_msgSend_1023Ptr = _lookup<
+  late final __objc_msgSend_1039Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>, ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_1023 = __objc_msgSend_1023Ptr.asFunction<
+  late final __objc_msgSend_1039 = __objc_msgSend_1039Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
 
   late final _sel_objectByApplyingXSLT_arguments_error_1 =
       _registerName1("objectByApplyingXSLT:arguments:error:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_1024(
+  ffi.Pointer<ObjCObject> _objc_msgSend_1040(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> xslt,
     ffi.Pointer<ObjCObject> arguments,
     ffi.Pointer<ffi.Pointer<ObjCObject>> error,
   ) {
-    return __objc_msgSend_1024(
+    return __objc_msgSend_1040(
       obj,
       sel,
       xslt,
@@ -29143,7 +29533,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_1024Ptr = _lookup<
+  late final __objc_msgSend_1040Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
@@ -29151,7 +29541,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_1024 = __objc_msgSend_1024Ptr.asFunction<
+  late final __objc_msgSend_1040 = __objc_msgSend_1040Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -29161,14 +29551,14 @@ class SentryCocoa {
 
   late final _sel_objectByApplyingXSLTString_arguments_error_1 =
       _registerName1("objectByApplyingXSLTString:arguments:error:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_1025(
+  ffi.Pointer<ObjCObject> _objc_msgSend_1041(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> xslt,
     ffi.Pointer<ObjCObject> arguments,
     ffi.Pointer<ffi.Pointer<ObjCObject>> error,
   ) {
-    return __objc_msgSend_1025(
+    return __objc_msgSend_1041(
       obj,
       sel,
       xslt,
@@ -29177,7 +29567,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_1025Ptr = _lookup<
+  late final __objc_msgSend_1041Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
@@ -29185,7 +29575,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_1025 = __objc_msgSend_1025Ptr.asFunction<
+  late final __objc_msgSend_1041 = __objc_msgSend_1041Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -29195,14 +29585,14 @@ class SentryCocoa {
 
   late final _sel_objectByApplyingXSLTAtURL_arguments_error_1 =
       _registerName1("objectByApplyingXSLTAtURL:arguments:error:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_1026(
+  ffi.Pointer<ObjCObject> _objc_msgSend_1042(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> xsltURL,
     ffi.Pointer<ObjCObject> argument,
     ffi.Pointer<ffi.Pointer<ObjCObject>> error,
   ) {
-    return __objc_msgSend_1026(
+    return __objc_msgSend_1042(
       obj,
       sel,
       xsltURL,
@@ -29211,7 +29601,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_1026Ptr = _lookup<
+  late final __objc_msgSend_1042Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
@@ -29219,7 +29609,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_1026 = __objc_msgSend_1026Ptr.asFunction<
+  late final __objc_msgSend_1042 = __objc_msgSend_1042Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -29230,63 +29620,63 @@ class SentryCocoa {
   late final _sel_validateAndReturnError_1 =
       _registerName1("validateAndReturnError:");
   late final _sel_rootDocument1 = _registerName1("rootDocument");
-  ffi.Pointer<ObjCObject> _objc_msgSend_1027(
+  ffi.Pointer<ObjCObject> _objc_msgSend_1043(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_1027(
+    return __objc_msgSend_1043(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_1027Ptr = _lookup<
+  late final __objc_msgSend_1043Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_1027 = __objc_msgSend_1027Ptr.asFunction<
+  late final __objc_msgSend_1043 = __objc_msgSend_1043Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
   late final _sel_parent1 = _registerName1("parent");
-  ffi.Pointer<ObjCObject> _objc_msgSend_1028(
+  ffi.Pointer<ObjCObject> _objc_msgSend_1044(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
   ) {
-    return __objc_msgSend_1028(
+    return __objc_msgSend_1044(
       obj,
       sel,
     );
   }
 
-  late final __objc_msgSend_1028Ptr = _lookup<
+  late final __objc_msgSend_1044Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_1028 = __objc_msgSend_1028Ptr.asFunction<
+  late final __objc_msgSend_1044 = __objc_msgSend_1044Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
   late final _sel_childCount1 = _registerName1("childCount");
   late final _sel_children1 = _registerName1("children");
   late final _sel_childAtIndex_1 = _registerName1("childAtIndex:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_1029(
+  ffi.Pointer<ObjCObject> _objc_msgSend_1045(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int index,
   ) {
-    return __objc_msgSend_1029(
+    return __objc_msgSend_1045(
       obj,
       sel,
       index,
     );
   }
 
-  late final __objc_msgSend_1029Ptr = _lookup<
+  late final __objc_msgSend_1045Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>, ffi.UnsignedLong)>>('objc_msgSend');
-  late final __objc_msgSend_1029 = __objc_msgSend_1029Ptr.asFunction<
+  late final __objc_msgSend_1045 = __objc_msgSend_1045Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
 
@@ -29303,45 +29693,45 @@ class SentryCocoa {
   late final _sel_XMLString1 = _registerName1("XMLString");
   late final _sel_XMLStringWithOptions_1 =
       _registerName1("XMLStringWithOptions:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_1030(
+  ffi.Pointer<ObjCObject> _objc_msgSend_1046(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     int options,
   ) {
-    return __objc_msgSend_1030(
+    return __objc_msgSend_1046(
       obj,
       sel,
       options,
     );
   }
 
-  late final __objc_msgSend_1030Ptr = _lookup<
+  late final __objc_msgSend_1046Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>, ffi.Int32)>>('objc_msgSend');
-  late final __objc_msgSend_1030 = __objc_msgSend_1030Ptr.asFunction<
+  late final __objc_msgSend_1046 = __objc_msgSend_1046Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, int)>();
 
   late final _sel_canonicalXMLStringPreservingComments_1 =
       _registerName1("canonicalXMLStringPreservingComments:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_1031(
+  ffi.Pointer<ObjCObject> _objc_msgSend_1047(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     bool comments,
   ) {
-    return __objc_msgSend_1031(
+    return __objc_msgSend_1047(
       obj,
       sel,
       comments,
     );
   }
 
-  late final __objc_msgSend_1031Ptr = _lookup<
+  late final __objc_msgSend_1047Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>, ffi.Bool)>>('objc_msgSend');
-  late final __objc_msgSend_1031 = __objc_msgSend_1031Ptr.asFunction<
+  late final __objc_msgSend_1047 = __objc_msgSend_1047Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, bool)>();
 
@@ -29349,14 +29739,14 @@ class SentryCocoa {
       _registerName1("nodesForXPath:error:");
   late final _sel_objectsForXQuery_constants_error_1 =
       _registerName1("objectsForXQuery:constants:error:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_1032(
+  ffi.Pointer<ObjCObject> _objc_msgSend_1048(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> xquery,
     ffi.Pointer<ObjCObject> constants,
     ffi.Pointer<ffi.Pointer<ObjCObject>> error,
   ) {
-    return __objc_msgSend_1032(
+    return __objc_msgSend_1048(
       obj,
       sel,
       xquery,
@@ -29365,7 +29755,7 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_1032Ptr = _lookup<
+  late final __objc_msgSend_1048Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
@@ -29373,7 +29763,7 @@ class SentryCocoa {
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ffi.Pointer<ObjCObject>>)>>('objc_msgSend');
-  late final __objc_msgSend_1032 = __objc_msgSend_1032Ptr.asFunction<
+  late final __objc_msgSend_1048 = __objc_msgSend_1048Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -29401,13 +29791,13 @@ class SentryCocoa {
   late final _sel_attributeForName_1 = _registerName1("attributeForName:");
   late final _sel_attributeForLocalName_URI_1 =
       _registerName1("attributeForLocalName:URI:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_1033(
+  ffi.Pointer<ObjCObject> _objc_msgSend_1049(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<ObjCObject> localName,
     ffi.Pointer<ObjCObject> URI,
   ) {
-    return __objc_msgSend_1033(
+    return __objc_msgSend_1049(
       obj,
       sel,
       localName,
@@ -29415,14 +29805,14 @@ class SentryCocoa {
     );
   }
 
-  late final __objc_msgSend_1033Ptr = _lookup<
+  late final __objc_msgSend_1049Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_1033 = __objc_msgSend_1033Ptr.asFunction<
+  late final __objc_msgSend_1049 = __objc_msgSend_1049Ptr.asFunction<
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>,
           ffi.Pointer<ObjCSel>,
@@ -29445,518 +29835,142 @@ class SentryCocoa {
       _registerName1("setAttributesAsDictionary:");
   late final _class_PrivateSentrySDKOnly1 = _getClass1("PrivateSentrySDKOnly");
   late final _class_SentryEnvelope1 = _getClass1("SentryEnvelope");
-  late final _class_SentryId1 = _getClass1("SentryId");
-  late final _class_NSUUID1 = _getClass1("NSUUID");
-  late final _sel_UUID1 = _registerName1("UUID");
-  late final _sel_initWithUUIDString_1 = _registerName1("initWithUUIDString:");
-  late final _sel_initWithUUIDBytes_1 = _registerName1("initWithUUIDBytes:");
-  instancetype _objc_msgSend_1034(
+  late final _sel_storeEnvelope_1 = _registerName1("storeEnvelope:");
+  void _objc_msgSend_1050(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ffi.UnsignedChar> bytes,
-  ) {
-    return __objc_msgSend_1034(
-      obj,
-      sel,
-      bytes,
-    );
-  }
-
-  late final __objc_msgSend_1034Ptr = _lookup<
-      ffi.NativeFunction<
-          instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ffi.UnsignedChar>)>>('objc_msgSend');
-  late final __objc_msgSend_1034 = __objc_msgSend_1034Ptr.asFunction<
-      instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ffi.UnsignedChar>)>();
-
-  late final _sel_getUUIDBytes_1 = _registerName1("getUUIDBytes:");
-  void _objc_msgSend_1035(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ffi.UnsignedChar> uuid,
-  ) {
-    return __objc_msgSend_1035(
-      obj,
-      sel,
-      uuid,
-    );
-  }
-
-  late final __objc_msgSend_1035Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ffi.UnsignedChar>)>>('objc_msgSend');
-  late final __objc_msgSend_1035 = __objc_msgSend_1035Ptr.asFunction<
-      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ffi.UnsignedChar>)>();
-
-  int _objc_msgSend_1036(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> otherUUID,
-  ) {
-    return __objc_msgSend_1036(
-      obj,
-      sel,
-      otherUUID,
-    );
-  }
-
-  late final __objc_msgSend_1036Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Int32 Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_1036 = __objc_msgSend_1036Ptr.asFunction<
-      int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>)>();
-
-  late final _sel_UUIDString1 = _registerName1("UUIDString");
-  late final _sel_initWithUUID_1 = _registerName1("initWithUUID:");
-  instancetype _objc_msgSend_1037(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> uuid,
-  ) {
-    return __objc_msgSend_1037(
-      obj,
-      sel,
-      uuid,
-    );
-  }
-
-  late final __objc_msgSend_1037Ptr = _lookup<
-      ffi.NativeFunction<
-          instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_1037 = __objc_msgSend_1037Ptr.asFunction<
-      instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>)>();
-
-  late final _sel_sentryIdString1 = _registerName1("sentryIdString");
-  late final _sel_empty1 = _registerName1("empty");
-  ffi.Pointer<ObjCObject> _objc_msgSend_1038(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-  ) {
-    return __objc_msgSend_1038(
-      obj,
-      sel,
-    );
-  }
-
-  late final __objc_msgSend_1038Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(
-              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_1038 = __objc_msgSend_1038Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(
-          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
-
-  late final _class_SentryEnvelopeItem1 = _getClass1("SentryEnvelopeItem");
-  late final _class_SentryEvent1 = _getClass1("SentryEvent");
-  late final _sel_initWithEvent_1 = _registerName1("initWithEvent:");
-  instancetype _objc_msgSend_1039(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> event,
-  ) {
-    return __objc_msgSend_1039(
-      obj,
-      sel,
-      event,
-    );
-  }
-
-  late final __objc_msgSend_1039Ptr = _lookup<
-      ffi.NativeFunction<
-          instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_1039 = __objc_msgSend_1039Ptr.asFunction<
-      instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>)>();
-
-  late final _class_SentrySession1 = _getClass1("SentrySession");
-  late final _sel_initWithSession_1 = _registerName1("initWithSession:");
-  instancetype _objc_msgSend_1040(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> session,
-  ) {
-    return __objc_msgSend_1040(
-      obj,
-      sel,
-      session,
-    );
-  }
-
-  late final __objc_msgSend_1040Ptr = _lookup<
-      ffi.NativeFunction<
-          instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_1040 = __objc_msgSend_1040Ptr.asFunction<
-      instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>)>();
-
-  late final _class_SentryUserFeedback1 = _getClass1("SentryUserFeedback");
-  late final _sel_initWithUserFeedback_1 =
-      _registerName1("initWithUserFeedback:");
-  instancetype _objc_msgSend_1041(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> userFeedback,
-  ) {
-    return __objc_msgSend_1041(
-      obj,
-      sel,
-      userFeedback,
-    );
-  }
-
-  late final __objc_msgSend_1041Ptr = _lookup<
-      ffi.NativeFunction<
-          instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_1041 = __objc_msgSend_1041Ptr.asFunction<
-      instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>)>();
-
-  late final _class_SentryAttachment1 = _getClass1("SentryAttachment");
-  late final _sel_initWithAttachment_maxAttachmentSize_1 =
-      _registerName1("initWithAttachment:maxAttachmentSize:");
-  instancetype _objc_msgSend_1042(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> attachment,
-    int maxAttachmentSize,
-  ) {
-    return __objc_msgSend_1042(
-      obj,
-      sel,
-      attachment,
-      maxAttachmentSize,
-    );
-  }
-
-  late final __objc_msgSend_1042Ptr = _lookup<
-      ffi.NativeFunction<
-          instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>, ffi.UnsignedLong)>>('objc_msgSend');
-  late final __objc_msgSend_1042 = __objc_msgSend_1042Ptr.asFunction<
-      instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>, int)>();
-
-  late final _class_SentryEnvelopeItemHeader1 =
-      _getClass1("SentryEnvelopeItemHeader");
-  late final _sel_initWithHeader_data_1 =
-      _registerName1("initWithHeader:data:");
-  instancetype _objc_msgSend_1043(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> header,
-    ffi.Pointer<ObjCObject> data,
-  ) {
-    return __objc_msgSend_1043(
-      obj,
-      sel,
-      header,
-      data,
-    );
-  }
-
-  late final __objc_msgSend_1043Ptr = _lookup<
-      ffi.NativeFunction<
-          instancetype Function(
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_1043 = __objc_msgSend_1043Ptr.asFunction<
-      instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCObject>)>();
-
-  late final _sel_header1 = _registerName1("header");
-  ffi.Pointer<ObjCObject> _objc_msgSend_1044(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-  ) {
-    return __objc_msgSend_1044(
-      obj,
-      sel,
-    );
-  }
-
-  late final __objc_msgSend_1044Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(
-              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_1044 = __objc_msgSend_1044Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(
-          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
-
-  late final _sel_initWithId_singleItem_1 =
-      _registerName1("initWithId:singleItem:");
-  instancetype _objc_msgSend_1045(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> id,
-    ffi.Pointer<ObjCObject> item,
-  ) {
-    return __objc_msgSend_1045(
-      obj,
-      sel,
-      id,
-      item,
-    );
-  }
-
-  late final __objc_msgSend_1045Ptr = _lookup<
-      ffi.NativeFunction<
-          instancetype Function(
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_1045 = __objc_msgSend_1045Ptr.asFunction<
-      instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCObject>)>();
-
-  late final _class_SentryEnvelopeHeader1 = _getClass1("SentryEnvelopeHeader");
-  late final _sel_initWithId_1 = _registerName1("initWithId:");
-  instancetype _objc_msgSend_1046(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> eventId,
-  ) {
-    return __objc_msgSend_1046(
-      obj,
-      sel,
-      eventId,
-    );
-  }
-
-  late final __objc_msgSend_1046Ptr = _lookup<
-      ffi.NativeFunction<
-          instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_1046 = __objc_msgSend_1046Ptr.asFunction<
-      instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>)>();
-
-  late final _class_SentryTraceContext1 = _getClass1("SentryTraceContext");
-  late final _sel_initWithId_traceContext_1 =
-      _registerName1("initWithId:traceContext:");
-  instancetype _objc_msgSend_1047(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> eventId,
-    ffi.Pointer<ObjCObject> traceContext,
-  ) {
-    return __objc_msgSend_1047(
-      obj,
-      sel,
-      eventId,
-      traceContext,
-    );
-  }
-
-  late final __objc_msgSend_1047Ptr = _lookup<
-      ffi.NativeFunction<
-          instancetype Function(
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_1047 = __objc_msgSend_1047Ptr.asFunction<
-      instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCObject>)>();
-
-  late final _class_SentrySdkInfo1 = _getClass1("SentrySdkInfo");
-  late final _sel_initWithId_sdkInfo_traceContext_1 =
-      _registerName1("initWithId:sdkInfo:traceContext:");
-  instancetype _objc_msgSend_1048(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> eventId,
-    ffi.Pointer<ObjCObject> sdkInfo,
-    ffi.Pointer<ObjCObject> traceContext,
-  ) {
-    return __objc_msgSend_1048(
-      obj,
-      sel,
-      eventId,
-      sdkInfo,
-      traceContext,
-    );
-  }
-
-  late final __objc_msgSend_1048Ptr = _lookup<
-      ffi.NativeFunction<
-          instancetype Function(
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_1048 = __objc_msgSend_1048Ptr.asFunction<
-      instancetype Function(
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCObject>)>();
-
-  late final _sel_eventId1 = _registerName1("eventId");
-  late final _sel_sdkInfo1 = _registerName1("sdkInfo");
-  ffi.Pointer<ObjCObject> _objc_msgSend_1049(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-  ) {
-    return __objc_msgSend_1049(
-      obj,
-      sel,
-    );
-  }
-
-  late final __objc_msgSend_1049Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(
-              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_1049 = __objc_msgSend_1049Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(
-          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
-
-  late final _sel_traceContext1 = _registerName1("traceContext");
-  ffi.Pointer<ObjCObject> _objc_msgSend_1050(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> envelope,
   ) {
     return __objc_msgSend_1050(
       obj,
       sel,
+      envelope,
     );
   }
 
   late final __objc_msgSend_1050Ptr = _lookup<
       ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(
-              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
+          ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
   late final __objc_msgSend_1050 = __objc_msgSend_1050Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(
-          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
+      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>)>();
 
-  late final _sel_sentAt1 = _registerName1("sentAt");
-  late final _sel_setSentAt_1 = _registerName1("setSentAt:");
-  late final _sel_initWithHeader_singleItem_1 =
-      _registerName1("initWithHeader:singleItem:");
-  instancetype _objc_msgSend_1051(
+  late final _sel_captureEnvelope_1 = _registerName1("captureEnvelope:");
+  late final _sel_envelopeWithData_1 = _registerName1("envelopeWithData:");
+  ffi.Pointer<ObjCObject> _objc_msgSend_1051(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> header,
-    ffi.Pointer<ObjCObject> item,
+    ffi.Pointer<ObjCObject> data,
   ) {
     return __objc_msgSend_1051(
       obj,
       sel,
-      header,
-      item,
+      data,
     );
   }
 
   late final __objc_msgSend_1051Ptr = _lookup<
       ffi.NativeFunction<
-          instancetype Function(
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
+          ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
   late final __objc_msgSend_1051 = __objc_msgSend_1051Ptr.asFunction<
-      instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCObject>)>();
+      ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
 
-  late final _sel_initWithId_items_1 = _registerName1("initWithId:items:");
-  instancetype _objc_msgSend_1052(
+  late final _sel_getDebugImages1 = _registerName1("getDebugImages");
+  late final _sel_getDebugImagesCrashed_1 =
+      _registerName1("getDebugImagesCrashed:");
+  ffi.Pointer<ObjCObject> _objc_msgSend_1052(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> id,
-    ffi.Pointer<ObjCObject> items,
+    bool isCrash,
   ) {
     return __objc_msgSend_1052(
       obj,
       sel,
-      id,
-      items,
+      isCrash,
     );
   }
 
   late final __objc_msgSend_1052Ptr = _lookup<
       ffi.NativeFunction<
-          instancetype Function(
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
+          ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>, ffi.Bool)>>('objc_msgSend');
   late final __objc_msgSend_1052 = __objc_msgSend_1052Ptr.asFunction<
-      instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCObject>)>();
+      ffi.Pointer<ObjCObject> Function(
+          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, bool)>();
 
-  late final _sel_initWithSessions_1 = _registerName1("initWithSessions:");
-  late final _sel_initWithHeader_items_1 =
-      _registerName1("initWithHeader:items:");
-  instancetype _objc_msgSend_1053(
+  late final _sel_setSdkName_andVersionString_1 =
+      _registerName1("setSdkName:andVersionString:");
+  late final _sel_setSdkName_1 = _registerName1("setSdkName:");
+  late final _sel_getSdkName1 = _registerName1("getSdkName");
+  late final _sel_getSdkVersionString1 = _registerName1("getSdkVersionString");
+  late final _sel_getExtraContext1 = _registerName1("getExtraContext");
+  late final _class_SentryId2 = _getClass1("Sentry.SentryId");
+  late final _sel_startProfilerForTrace_1 =
+      _registerName1("startProfilerForTrace:");
+  int _objc_msgSend_1053(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> header,
-    ffi.Pointer<ObjCObject> items,
+    ffi.Pointer<ObjCObject> traceId,
   ) {
     return __objc_msgSend_1053(
       obj,
       sel,
-      header,
-      items,
+      traceId,
     );
   }
 
   late final __objc_msgSend_1053Ptr = _lookup<
       ffi.NativeFunction<
-          instancetype Function(
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>,
+          ffi.Uint64 Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<ObjCObject>)>>('objc_msgSend');
   late final __objc_msgSend_1053 = __objc_msgSend_1053Ptr.asFunction<
-      instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCObject>)>();
+      int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>)>();
 
+  late final _sel_collectProfileBetween_and_forTrace_1 =
+      _registerName1("collectProfileBetween:and:forTrace:");
   ffi.Pointer<ObjCObject> _objc_msgSend_1054(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
+    int startSystemTime,
+    int endSystemTime,
+    ffi.Pointer<ObjCObject> traceId,
   ) {
     return __objc_msgSend_1054(
       obj,
       sel,
+      startSystemTime,
+      endSystemTime,
+      traceId,
     );
   }
 
   late final __objc_msgSend_1054Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<ObjCObject> Function(
-              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
+              ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>,
+              ffi.Uint64,
+              ffi.Uint64,
+              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
   late final __objc_msgSend_1054 = __objc_msgSend_1054Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(
-          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
+      ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCSel>, int, int, ffi.Pointer<ObjCObject>)>();
 
-  late final _sel_items1 = _registerName1("items");
-  late final _sel_storeEnvelope_1 = _registerName1("storeEnvelope:");
+  late final _sel_discardProfilerForTrace_1 =
+      _registerName1("discardProfilerForTrace:");
   void _objc_msgSend_1055(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> envelope,
+    ffi.Pointer<ObjCObject> traceId,
   ) {
     return __objc_msgSend_1055(
       obj,
       sel,
-      envelope,
+      traceId,
     );
   }
 
@@ -29968,176 +29982,168 @@ class SentryCocoa {
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<ObjCObject>)>();
 
-  late final _sel_captureEnvelope_1 = _registerName1("captureEnvelope:");
-  late final _sel_envelopeWithData_1 = _registerName1("envelopeWithData:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_1056(
+  late final _class_SentryAppStartMeasurement1 =
+      _getClass1("SentryAppStartMeasurement");
+  late final _sel_onAppStartMeasurementAvailable1 =
+      _registerName1("onAppStartMeasurementAvailable");
+  ffi.Pointer<_ObjCBlock> _objc_msgSend_1056(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> data,
   ) {
     return __objc_msgSend_1056(
       obj,
       sel,
-      data,
     );
   }
 
   late final __objc_msgSend_1056Ptr = _lookup<
       ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_1056 = __objc_msgSend_1056Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
-
-  late final _sel_getDebugImages1 = _registerName1("getDebugImages");
-  late final _sel_getDebugImagesCrashed_1 =
-      _registerName1("getDebugImagesCrashed:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_1057(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    bool isCrash,
-  ) {
-    return __objc_msgSend_1057(
-      obj,
-      sel,
-      isCrash,
-    );
-  }
-
-  late final __objc_msgSend_1057Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>, ffi.Bool)>>('objc_msgSend');
-  late final __objc_msgSend_1057 = __objc_msgSend_1057Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(
-          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>, bool)>();
-
-  late final _sel_setSdkName_andVersionString_1 =
-      _registerName1("setSdkName:andVersionString:");
-  late final _sel_setSdkName_1 = _registerName1("setSdkName:");
-  late final _sel_getSdkName1 = _registerName1("getSdkName");
-  late final _sel_getSdkVersionString1 = _registerName1("getSdkVersionString");
-  late final _sel_getExtraContext1 = _registerName1("getExtraContext");
-  late final _sel_startProfilerForTrace_1 =
-      _registerName1("startProfilerForTrace:");
-  int _objc_msgSend_1058(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> traceId,
-  ) {
-    return __objc_msgSend_1058(
-      obj,
-      sel,
-      traceId,
-    );
-  }
-
-  late final __objc_msgSend_1058Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Uint64 Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_1058 = __objc_msgSend_1058Ptr.asFunction<
-      int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>)>();
-
-  late final _sel_collectProfileBetween_and_forTrace_1 =
-      _registerName1("collectProfileBetween:and:forTrace:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_1059(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    int startSystemTime,
-    int endSystemTime,
-    ffi.Pointer<ObjCObject> traceId,
-  ) {
-    return __objc_msgSend_1059(
-      obj,
-      sel,
-      startSystemTime,
-      endSystemTime,
-      traceId,
-    );
-  }
-
-  late final __objc_msgSend_1059Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(
-              ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>,
-              ffi.Uint64,
-              ffi.Uint64,
-              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_1059 = __objc_msgSend_1059Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCSel>, int, int, ffi.Pointer<ObjCObject>)>();
-
-  late final _sel_discardProfilerForTrace_1 =
-      _registerName1("discardProfilerForTrace:");
-  void _objc_msgSend_1060(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> traceId,
-  ) {
-    return __objc_msgSend_1060(
-      obj,
-      sel,
-      traceId,
-    );
-  }
-
-  late final __objc_msgSend_1060Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
-  late final __objc_msgSend_1060 = __objc_msgSend_1060Ptr.asFunction<
-      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
-          ffi.Pointer<ObjCObject>)>();
-
-  late final _class_SentryAppStartMeasurement1 =
-      _getClass1("SentryAppStartMeasurement");
-  late final _sel_onAppStartMeasurementAvailable1 =
-      _registerName1("onAppStartMeasurementAvailable");
-  ffi.Pointer<_ObjCBlock> _objc_msgSend_1061(
-    ffi.Pointer<ObjCObject> obj,
-    ffi.Pointer<ObjCSel> sel,
-  ) {
-    return __objc_msgSend_1061(
-      obj,
-      sel,
-    );
-  }
-
-  late final __objc_msgSend_1061Ptr = _lookup<
-      ffi.NativeFunction<
           ffi.Pointer<_ObjCBlock> Function(
               ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
-  late final __objc_msgSend_1061 = __objc_msgSend_1061Ptr.asFunction<
+  late final __objc_msgSend_1056 = __objc_msgSend_1056Ptr.asFunction<
       ffi.Pointer<_ObjCBlock> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
   late final _sel_setOnAppStartMeasurementAvailable_1 =
       _registerName1("setOnAppStartMeasurementAvailable:");
-  void _objc_msgSend_1062(
+  void _objc_msgSend_1057(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
     ffi.Pointer<_ObjCBlock> value,
   ) {
-    return __objc_msgSend_1062(
+    return __objc_msgSend_1057(
       obj,
       sel,
       value,
     );
   }
 
-  late final __objc_msgSend_1062Ptr = _lookup<
+  late final __objc_msgSend_1057Ptr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
               ffi.Pointer<_ObjCBlock>)>>('objc_msgSend');
-  late final __objc_msgSend_1062 = __objc_msgSend_1062Ptr.asFunction<
+  late final __objc_msgSend_1057 = __objc_msgSend_1057Ptr.asFunction<
       void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
           ffi.Pointer<_ObjCBlock>)>();
 
   late final _sel_appStartMeasurement1 = _registerName1("appStartMeasurement");
+  ffi.Pointer<ObjCObject> _objc_msgSend_1058(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+  ) {
+    return __objc_msgSend_1058(
+      obj,
+      sel,
+    );
+  }
+
+  late final __objc_msgSend_1058Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<ObjCObject> Function(
+              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
+  late final __objc_msgSend_1058 = __objc_msgSend_1058Ptr.asFunction<
+      ffi.Pointer<ObjCObject> Function(
+          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
+
+  late final _sel_installationID1 = _registerName1("installationID");
+  late final _class_SentryOptions1 = _getClass1("SentryOptions");
+  ffi.Pointer<ObjCObject> _objc_msgSend_1059(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+  ) {
+    return __objc_msgSend_1059(
+      obj,
+      sel,
+    );
+  }
+
+  late final __objc_msgSend_1059Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<ObjCObject> Function(
+              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
+  late final __objc_msgSend_1059 = __objc_msgSend_1059Ptr.asFunction<
+      ffi.Pointer<ObjCObject> Function(
+          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
+
+  late final _sel_appStartMeasurementHybridSDKMode1 =
+      _registerName1("appStartMeasurementHybridSDKMode");
+  late final _sel_setAppStartMeasurementHybridSDKMode_1 =
+      _registerName1("setAppStartMeasurementHybridSDKMode:");
+  late final _class_SentryUser1 = _getClass1("SentryUser");
+  late final _sel_userWithDictionary_1 = _registerName1("userWithDictionary:");
+  ffi.Pointer<ObjCObject> _objc_msgSend_1060(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> dictionary,
+  ) {
+    return __objc_msgSend_1060(
+      obj,
+      sel,
+      dictionary,
+    );
+  }
+
+  late final __objc_msgSend_1060Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
+  late final __objc_msgSend_1060 = __objc_msgSend_1060Ptr.asFunction<
+      ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
+
+  late final _class_SentryBreadcrumb1 = _getClass1("SentryBreadcrumb");
+  late final _sel_breadcrumbWithDictionary_1 =
+      _registerName1("breadcrumbWithDictionary:");
+  ffi.Pointer<ObjCObject> _objc_msgSend_1061(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> dictionary,
+  ) {
+    return __objc_msgSend_1061(
+      obj,
+      sel,
+      dictionary,
+    );
+  }
+
+  late final __objc_msgSend_1061Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
+              ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
+  late final __objc_msgSend_1061 = __objc_msgSend_1061Ptr.asFunction<
+      ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
+          ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
+
+  late final _sel_captureReplay1 = _registerName1("captureReplay");
+  late final _sel_getReplayId1 = _registerName1("getReplayId");
+  late final _sel_addReplayIgnoreClasses_1 =
+      _registerName1("addReplayIgnoreClasses:");
+  late final _sel_addReplayRedactClasses_1 =
+      _registerName1("addReplayRedactClasses:");
+  late final _class_SentryCurrentDateProvider1 =
+      _getClass1("SentryCurrentDateProvider");
+  late final _sel_timezoneOffset1 = _registerName1("timezoneOffset");
+  late final _sel_systemTime1 = _registerName1("systemTime");
+  int _objc_msgSend_1062(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+  ) {
+    return __objc_msgSend_1062(
+      obj,
+      sel,
+    );
+  }
+
+  late final __objc_msgSend_1062Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Uint64 Function(
+              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
+  late final __objc_msgSend_1062 = __objc_msgSend_1062Ptr.asFunction<
+      int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
+
+  late final _sel_bucketTimestamp1 = _registerName1("bucketTimestamp");
+  late final _class_SentryId11 = _getClass1("Sentry.SentryId");
+  late final _sel_empty1 = _registerName1("empty");
   ffi.Pointer<ObjCObject> _objc_msgSend_1063(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
@@ -30156,74 +30162,116 @@ class SentryCocoa {
       ffi.Pointer<ObjCObject> Function(
           ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
 
-  late final _sel_installationID1 = _registerName1("installationID");
-  late final _class_SentryOptions1 = _getClass1("SentryOptions");
-  ffi.Pointer<ObjCObject> _objc_msgSend_1064(
+  late final _sel_setEmpty_1 = _registerName1("setEmpty:");
+  void _objc_msgSend_1064(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> value,
   ) {
     return __objc_msgSend_1064(
       obj,
       sel,
+      value,
     );
   }
 
   late final __objc_msgSend_1064Ptr = _lookup<
       ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(
-              ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>>('objc_msgSend');
+          ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
   late final __objc_msgSend_1064 = __objc_msgSend_1064Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(
-          ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>)>();
+      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>)>();
 
-  late final _sel_appStartMeasurementHybridSDKMode1 =
-      _registerName1("appStartMeasurementHybridSDKMode");
-  late final _sel_setAppStartMeasurementHybridSDKMode_1 =
-      _registerName1("setAppStartMeasurementHybridSDKMode:");
-  late final _class_SentryUser1 = _getClass1("SentryUser");
-  late final _sel_userWithDictionary_1 = _registerName1("userWithDictionary:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_1065(
+  late final _sel_sentryIdString1 = _registerName1("sentryIdString");
+  late final _class_NSUUID1 = _getClass1("NSUUID");
+  late final _sel_UUID1 = _registerName1("UUID");
+  late final _sel_initWithUUIDString_1 = _registerName1("initWithUUIDString:");
+  late final _sel_initWithUUIDBytes_1 = _registerName1("initWithUUIDBytes:");
+  instancetype _objc_msgSend_1065(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> dictionary,
+    ffi.Pointer<ffi.UnsignedChar> bytes,
   ) {
     return __objc_msgSend_1065(
       obj,
       sel,
-      dictionary,
+      bytes,
     );
   }
 
   late final __objc_msgSend_1065Ptr = _lookup<
       ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
+          instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ffi.UnsignedChar>)>>('objc_msgSend');
   late final __objc_msgSend_1065 = __objc_msgSend_1065Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
+      instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ffi.UnsignedChar>)>();
 
-  late final _class_SentryBreadcrumb1 = _getClass1("SentryBreadcrumb");
-  late final _sel_breadcrumbWithDictionary_1 =
-      _registerName1("breadcrumbWithDictionary:");
-  ffi.Pointer<ObjCObject> _objc_msgSend_1066(
+  late final _sel_getUUIDBytes_1 = _registerName1("getUUIDBytes:");
+  void _objc_msgSend_1066(
     ffi.Pointer<ObjCObject> obj,
     ffi.Pointer<ObjCSel> sel,
-    ffi.Pointer<ObjCObject> dictionary,
+    ffi.Pointer<ffi.UnsignedChar> uuid,
   ) {
     return __objc_msgSend_1066(
       obj,
       sel,
-      dictionary,
+      uuid,
     );
   }
 
   late final __objc_msgSend_1066Ptr = _lookup<
       ffi.NativeFunction<
-          ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
-              ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>>('objc_msgSend');
+          ffi.Void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ffi.UnsignedChar>)>>('objc_msgSend');
   late final __objc_msgSend_1066 = __objc_msgSend_1066Ptr.asFunction<
-      ffi.Pointer<ObjCObject> Function(ffi.Pointer<ObjCObject>,
-          ffi.Pointer<ObjCSel>, ffi.Pointer<ObjCObject>)>();
+      void Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ffi.UnsignedChar>)>();
+
+  int _objc_msgSend_1067(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> otherUUID,
+  ) {
+    return __objc_msgSend_1067(
+      obj,
+      sel,
+      otherUUID,
+    );
+  }
+
+  late final __objc_msgSend_1067Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int32 Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
+  late final __objc_msgSend_1067 = __objc_msgSend_1067Ptr.asFunction<
+      int Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>)>();
+
+  late final _sel_UUIDString1 = _registerName1("UUIDString");
+  late final _sel_initWithUuid_1 = _registerName1("initWithUuid:");
+  instancetype _objc_msgSend_1068(
+    ffi.Pointer<ObjCObject> obj,
+    ffi.Pointer<ObjCSel> sel,
+    ffi.Pointer<ObjCObject> uuid,
+  ) {
+    return __objc_msgSend_1068(
+      obj,
+      sel,
+      uuid,
+    );
+  }
+
+  late final __objc_msgSend_1068Ptr = _lookup<
+      ffi.NativeFunction<
+          instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+              ffi.Pointer<ObjCObject>)>>('objc_msgSend');
+  late final __objc_msgSend_1068 = __objc_msgSend_1068Ptr.asFunction<
+      instancetype Function(ffi.Pointer<ObjCObject>, ffi.Pointer<ObjCSel>,
+          ffi.Pointer<ObjCObject>)>();
+
+  late final _sel_isEqual_1 = _registerName1("isEqual:");
 }
 
 class _ObjCWrapper implements ffi.Finalizable {
@@ -30614,7 +30662,7 @@ class NSObject extends _ObjCWrapper {
 
   bool validateValue_forKey_error_(ffi.Pointer<ffi.Pointer<ObjCObject>> ioValue,
       NSString? inKey, ffi.Pointer<ffi.Pointer<ObjCObject>> outError) {
-    return _lib._objc_msgSend_226(_id, _lib._sel_validateValue_forKey_error_1,
+    return _lib._objc_msgSend_225(_id, _lib._sel_validateValue_forKey_error_1,
         ioValue, inKey?._id ?? ffi.nullptr, outError);
   }
 
@@ -30651,7 +30699,7 @@ class NSObject extends _ObjCWrapper {
       ffi.Pointer<ffi.Pointer<ObjCObject>> ioValue,
       NSString? inKeyPath,
       ffi.Pointer<ffi.Pointer<ObjCObject>> outError) {
-    return _lib._objc_msgSend_226(
+    return _lib._objc_msgSend_225(
         _id,
         _lib._sel_validateValue_forKeyPath_error_1,
         ioValue,
@@ -34563,6 +34611,26 @@ class NSURL extends NSObject {
     return NSURL._(_ret, _lib, retain: true, release: true);
   }
 
+  NSURL initWithString_encodingInvalidCharacters_(
+      NSString? URLString, bool encodingInvalidCharacters) {
+    final _ret = _lib._objc_msgSend_29(
+        _id,
+        _lib._sel_initWithString_encodingInvalidCharacters_1,
+        URLString?._id ?? ffi.nullptr,
+        encodingInvalidCharacters);
+    return NSURL._(_ret, _lib, retain: true, release: true);
+  }
+
+  static NSURL URLWithString_encodingInvalidCharacters_(
+      SentryCocoa _lib, NSString? URLString, bool encodingInvalidCharacters) {
+    final _ret = _lib._objc_msgSend_29(
+        _lib._class_NSURL1,
+        _lib._sel_URLWithString_encodingInvalidCharacters_1,
+        URLString?._id ?? ffi.nullptr,
+        encodingInvalidCharacters);
+    return NSURL._(_ret, _lib, retain: true, release: true);
+  }
+
   NSURL initWithDataRepresentation_relativeToURL_(
       NSData? data, NSURL? baseURL) {
     final _ret = _lib._objc_msgSend_37(
@@ -34743,12 +34811,6 @@ class NSURL extends NSObject {
         : NSURL._(_ret, _lib, retain: true, release: true);
   }
 
-  bool checkResourceIsReachableAndReturnError_(
-      ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    return _lib._objc_msgSend_225(
-        _id, _lib._sel_checkResourceIsReachableAndReturnError_1, error);
-  }
-
   bool isFileReferenceURL() {
     return _lib._objc_msgSend_12(_id, _lib._sel_isFileReferenceURL1);
   }
@@ -34769,13 +34831,13 @@ class NSURL extends NSObject {
       ffi.Pointer<ffi.Pointer<ObjCObject>> value,
       NSString key,
       ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    return _lib._objc_msgSend_226(
+    return _lib._objc_msgSend_225(
         _id, _lib._sel_getResourceValue_forKey_error_1, value, key._id, error);
   }
 
   NSObject resourceValuesForKeys_error_(
       NSArray? keys, ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    final _ret = _lib._objc_msgSend_227(
+    final _ret = _lib._objc_msgSend_226(
         _id,
         _lib._sel_resourceValuesForKeys_error_1,
         keys?._id ?? ffi.nullptr,
@@ -34785,13 +34847,13 @@ class NSURL extends NSObject {
 
   bool setResourceValue_forKey_error_(NSObject value, NSString key,
       ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    return _lib._objc_msgSend_228(_id,
+    return _lib._objc_msgSend_227(_id,
         _lib._sel_setResourceValue_forKey_error_1, value._id, key._id, error);
   }
 
   bool setResourceValues_error_(
       NSObject? keyedValues, ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    return _lib._objc_msgSend_229(_id, _lib._sel_setResourceValues_error_1,
+    return _lib._objc_msgSend_228(_id, _lib._sel_setResourceValues_error_1,
         keyedValues?._id ?? ffi.nullptr, error);
   }
 
@@ -34815,7 +34877,7 @@ class NSURL extends NSObject {
           NSArray? keys,
           NSURL? relativeURL,
           ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    final _ret = _lib._objc_msgSend_230(
+    final _ret = _lib._objc_msgSend_229(
         _id,
         _lib._sel_bookmarkDataWithOptions_includingResourceValuesForKeys_relativeToURL_error_1,
         options,
@@ -34832,7 +34894,7 @@ class NSURL extends NSObject {
           NSURL? relativeURL,
           ffi.Pointer<ffi.Bool> isStale,
           ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    final _ret = _lib._objc_msgSend_231(
+    final _ret = _lib._objc_msgSend_230(
         _id,
         _lib._sel_initByResolvingBookmarkData_options_relativeToURL_bookmarkDataIsStale_error_1,
         bookmarkData?._id ?? ffi.nullptr,
@@ -34851,7 +34913,7 @@ class NSURL extends NSObject {
           NSURL? relativeURL,
           ffi.Pointer<ffi.Bool> isStale,
           ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    final _ret = _lib._objc_msgSend_231(
+    final _ret = _lib._objc_msgSend_230(
         _lib._class_NSURL1,
         _lib._sel_URLByResolvingBookmarkData_options_relativeToURL_bookmarkDataIsStale_error_1,
         bookmarkData?._id ?? ffi.nullptr,
@@ -34864,7 +34926,7 @@ class NSURL extends NSObject {
 
   static NSObject resourceValuesForKeys_fromBookmarkData_(
       SentryCocoa _lib, NSArray? keys, NSData? bookmarkData) {
-    final _ret = _lib._objc_msgSend_232(
+    final _ret = _lib._objc_msgSend_231(
         _lib._class_NSURL1,
         _lib._sel_resourceValuesForKeys_fromBookmarkData_1,
         keys?._id ?? ffi.nullptr,
@@ -34878,7 +34940,7 @@ class NSURL extends NSObject {
       NSURL? bookmarkFileURL,
       int options,
       ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    return _lib._objc_msgSend_233(
+    return _lib._objc_msgSend_232(
         _lib._class_NSURL1,
         _lib._sel_writeBookmarkData_toURL_options_error_1,
         bookmarkData?._id ?? ffi.nullptr,
@@ -34889,7 +34951,7 @@ class NSURL extends NSObject {
 
   static NSData bookmarkDataWithContentsOfURL_error_(SentryCocoa _lib,
       NSURL? bookmarkFileURL, ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    final _ret = _lib._objc_msgSend_234(
+    final _ret = _lib._objc_msgSend_233(
         _lib._class_NSURL1,
         _lib._sel_bookmarkDataWithContentsOfURL_error_1,
         bookmarkFileURL?._id ?? ffi.nullptr,
@@ -34899,7 +34961,7 @@ class NSURL extends NSObject {
 
   static NSURL URLByResolvingAliasFileAtURL_options_error_(SentryCocoa _lib,
       NSURL? url, int options, ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    final _ret = _lib._objc_msgSend_235(
+    final _ret = _lib._objc_msgSend_234(
         _lib._class_NSURL1,
         _lib._sel_URLByResolvingAliasFileAtURL_options_error_1,
         url?._id ?? ffi.nullptr,
@@ -34921,7 +34983,7 @@ class NSURL extends NSObject {
       ffi.Pointer<ffi.Pointer<ObjCObject>> value,
       NSString key,
       ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    return _lib._objc_msgSend_226(
+    return _lib._objc_msgSend_225(
         _id,
         _lib._sel_getPromisedItemResourceValue_forKey_error_1,
         value,
@@ -34931,7 +34993,7 @@ class NSURL extends NSObject {
 
   NSDictionary promisedItemResourceValuesForKeys_error_(
       NSArray? keys, ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    final _ret = _lib._objc_msgSend_236(
+    final _ret = _lib._objc_msgSend_235(
         _id,
         _lib._sel_promisedItemResourceValuesForKeys_error_1,
         keys?._id ?? ffi.nullptr,
@@ -34941,7 +35003,7 @@ class NSURL extends NSObject {
 
   bool checkPromisedItemIsReachableAndReturnError_(
       ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    return _lib._objc_msgSend_225(
+    return _lib._objc_msgSend_236(
         _id, _lib._sel_checkPromisedItemIsReachableAndReturnError_1, error);
   }
 
@@ -35013,6 +35075,12 @@ class NSURL extends NSObject {
     return _ret.address == 0
         ? null
         : NSURL._(_ret, _lib, retain: true, release: true);
+  }
+
+  bool checkResourceIsReachableAndReturnError_(
+      ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
+    return _lib._objc_msgSend_236(
+        _id, _lib._sel_checkResourceIsReachableAndReturnError_1, error);
   }
 
   NSURL? get URLByStandardizingPath {
@@ -40105,6 +40173,13 @@ class NSLocale extends NSObject {
     return NSString._(_ret, _lib, retain: true, release: true);
   }
 
+  NSString? get languageIdentifier {
+    final _ret = _lib._objc_msgSend_20(_id, _lib._sel_languageIdentifier1);
+    return _ret.address == 0
+        ? null
+        : NSString._(_ret, _lib, retain: true, release: true);
+  }
+
   NSString? get countryCode {
     final _ret = _lib._objc_msgSend_20(_id, _lib._sel_countryCode1);
     return _ret.address == 0
@@ -40118,6 +40193,13 @@ class NSLocale extends NSObject {
         _lib._sel_localizedStringForCountryCode_1,
         countryCode?._id ?? ffi.nullptr);
     return NSString._(_ret, _lib, retain: true, release: true);
+  }
+
+  NSString? get regionCode {
+    final _ret = _lib._objc_msgSend_20(_id, _lib._sel_regionCode1);
+    return _ret.address == 0
+        ? null
+        : NSString._(_ret, _lib, retain: true, release: true);
   }
 
   NSString? get scriptCode {
@@ -41133,6 +41215,8 @@ abstract class NSDataWritingOptions {
   static const int
       NSDataWritingFileProtectionCompleteUntilFirstUserAuthentication =
       1073741824;
+  static const int NSDataWritingFileProtectionCompleteWhenUserInactive =
+      1342177280;
   static const int NSDataWritingFileProtectionMask = 4026531840;
   static const int NSAtomicWrite = 1;
 }
@@ -52095,12 +52179,12 @@ class NSBundle extends NSObject {
   }
 
   bool preflightAndReturnError_(ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    return _lib._objc_msgSend_225(
+    return _lib._objc_msgSend_236(
         _id, _lib._sel_preflightAndReturnError_1, error);
   }
 
   bool loadAndReturnError_(ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    return _lib._objc_msgSend_225(_id, _lib._sel_loadAndReturnError_1, error);
+    return _lib._objc_msgSend_236(_id, _lib._sel_loadAndReturnError_1, error);
   }
 
   NSURL? get bundleURL {
@@ -52367,7 +52451,7 @@ class NSBundle extends NSObject {
 
   NSAttributedString localizedAttributedStringForKey_value_table_(
       NSString? key, NSString? value, NSString? tableName) {
-    final _ret = _lib._objc_msgSend_676(
+    final _ret = _lib._objc_msgSend_680(
         _id,
         _lib._sel_localizedAttributedStringForKey_value_table_1,
         key?._id ?? ffi.nullptr,
@@ -52449,7 +52533,7 @@ class NSBundle extends NSObject {
       SentryCocoa _lib,
       NSArray? localizationsArray,
       NSArray? preferencesArray) {
-    final _ret = _lib._objc_msgSend_677(
+    final _ret = _lib._objc_msgSend_681(
         _lib._class_NSBundle1,
         _lib._sel_preferredLocalizationsFromArray_forPreferences_1,
         localizationsArray?._id ?? ffi.nullptr,
@@ -52465,7 +52549,7 @@ class NSBundle extends NSObject {
   }
 
   void setPreservationPriority_forTags_(double priority, NSSet? tags) {
-    _lib._objc_msgSend_678(_id, _lib._sel_setPreservationPriority_forTags_1,
+    _lib._objc_msgSend_682(_id, _lib._sel_setPreservationPriority_forTags_1,
         priority, tags?._id ?? ffi.nullptr);
   }
 
@@ -52787,8 +52871,62 @@ class NSAttributedString extends NSObject {
     return NSAttributedString._(_ret, _lib, retain: true, release: true);
   }
 
-  NSAttributedString attributedStringByInflectingString() {
+  NSAttributedString initWithFormat_options_locale_context_(
+      NSAttributedString? format,
+      int options,
+      NSLocale? locale,
+      NSDictionary? context) {
     final _ret = _lib._objc_msgSend_675(
+        _id,
+        _lib._sel_initWithFormat_options_locale_context_1,
+        format?._id ?? ffi.nullptr,
+        options,
+        locale?._id ?? ffi.nullptr,
+        context?._id ?? ffi.nullptr);
+    return NSAttributedString._(_ret, _lib, retain: true, release: true);
+  }
+
+  NSAttributedString initWithFormat_options_locale_context_arguments_(
+      NSAttributedString? format,
+      int options,
+      NSLocale? locale,
+      NSDictionary? context,
+      ffi.Pointer<__va_list_tag> arguments) {
+    final _ret = _lib._objc_msgSend_676(
+        _id,
+        _lib._sel_initWithFormat_options_locale_context_arguments_1,
+        format?._id ?? ffi.nullptr,
+        options,
+        locale?._id ?? ffi.nullptr,
+        context?._id ?? ffi.nullptr,
+        arguments);
+    return NSAttributedString._(_ret, _lib, retain: true, release: true);
+  }
+
+  static NSAttributedString localizedAttributedStringWithFormat_context_(
+      SentryCocoa _lib, NSAttributedString? format, NSDictionary? context) {
+    final _ret = _lib._objc_msgSend_677(
+        _lib._class_NSAttributedString1,
+        _lib._sel_localizedAttributedStringWithFormat_context_1,
+        format?._id ?? ffi.nullptr,
+        context?._id ?? ffi.nullptr);
+    return NSAttributedString._(_ret, _lib, retain: true, release: true);
+  }
+
+  static NSAttributedString
+      localizedAttributedStringWithFormat_options_context_(SentryCocoa _lib,
+          NSAttributedString? format, int options, NSDictionary? context) {
+    final _ret = _lib._objc_msgSend_678(
+        _lib._class_NSAttributedString1,
+        _lib._sel_localizedAttributedStringWithFormat_options_context_1,
+        format?._id ?? ffi.nullptr,
+        options,
+        context?._id ?? ffi.nullptr);
+    return NSAttributedString._(_ret, _lib, retain: true, release: true);
+  }
+
+  NSAttributedString attributedStringByInflectingString() {
+    final _ret = _lib._objc_msgSend_679(
         _id, _lib._sel_attributedStringByInflectingString1);
     return NSAttributedString._(_ret, _lib, retain: true, release: true);
   }
@@ -53327,12 +53465,12 @@ class NSMutableAttributedString extends NSAttributedString {
   }
 
   void setAttributes_range_(NSDictionary? attrs, _NSRange range) {
-    _lib._objc_msgSend_679(
+    _lib._objc_msgSend_683(
         _id, _lib._sel_setAttributes_range_1, attrs?._id ?? ffi.nullptr, range);
   }
 
   NSMutableString? get mutableString {
-    final _ret = _lib._objc_msgSend_680(_id, _lib._sel_mutableString1);
+    final _ret = _lib._objc_msgSend_684(_id, _lib._sel_mutableString1);
     return _ret.address == 0
         ? null
         : NSMutableString._(_ret, _lib, retain: true, release: true);
@@ -53340,23 +53478,23 @@ class NSMutableAttributedString extends NSAttributedString {
 
   void addAttribute_value_range_(
       NSString name, NSObject value, _NSRange range) {
-    _lib._objc_msgSend_681(
+    _lib._objc_msgSend_685(
         _id, _lib._sel_addAttribute_value_range_1, name._id, value._id, range);
   }
 
   void addAttributes_range_(NSDictionary? attrs, _NSRange range) {
-    _lib._objc_msgSend_679(
+    _lib._objc_msgSend_683(
         _id, _lib._sel_addAttributes_range_1, attrs?._id ?? ffi.nullptr, range);
   }
 
   void removeAttribute_range_(NSString name, _NSRange range) {
-    _lib._objc_msgSend_682(
+    _lib._objc_msgSend_686(
         _id, _lib._sel_removeAttribute_range_1, name._id, range);
   }
 
   void replaceCharactersInRange_withAttributedString_(
       _NSRange range, NSAttributedString? attrString) {
-    _lib._objc_msgSend_683(
+    _lib._objc_msgSend_687(
         _id,
         _lib._sel_replaceCharactersInRange_withAttributedString_1,
         range,
@@ -53365,12 +53503,12 @@ class NSMutableAttributedString extends NSAttributedString {
 
   void insertAttributedString_atIndex_(
       NSAttributedString? attrString, int loc) {
-    _lib._objc_msgSend_684(_id, _lib._sel_insertAttributedString_atIndex_1,
+    _lib._objc_msgSend_688(_id, _lib._sel_insertAttributedString_atIndex_1,
         attrString?._id ?? ffi.nullptr, loc);
   }
 
   void appendAttributedString_(NSAttributedString? attrString) {
-    _lib._objc_msgSend_685(_id, _lib._sel_appendAttributedString_1,
+    _lib._objc_msgSend_689(_id, _lib._sel_appendAttributedString_1,
         attrString?._id ?? ffi.nullptr);
   }
 
@@ -53379,7 +53517,7 @@ class NSMutableAttributedString extends NSAttributedString {
   }
 
   void setAttributedString_(NSAttributedString? attrString) {
-    _lib._objc_msgSend_685(
+    _lib._objc_msgSend_689(
         _id, _lib._sel_setAttributedString_1, attrString?._id ?? ffi.nullptr);
   }
 
@@ -53392,7 +53530,7 @@ class NSMutableAttributedString extends NSAttributedString {
   }
 
   void appendLocalizedFormat_(NSAttributedString? format) {
-    _lib._objc_msgSend_685(
+    _lib._objc_msgSend_689(
         _id, _lib._sel_appendLocalizedFormat_1, format?._id ?? ffi.nullptr);
   }
 
@@ -53519,6 +53657,62 @@ class NSMutableAttributedString extends NSAttributedString {
   }
 
   @override
+  NSMutableAttributedString initWithFormat_options_locale_context_(
+      NSAttributedString? format,
+      int options,
+      NSLocale? locale,
+      NSDictionary? context) {
+    final _ret = _lib._objc_msgSend_675(
+        _id,
+        _lib._sel_initWithFormat_options_locale_context_1,
+        format?._id ?? ffi.nullptr,
+        options,
+        locale?._id ?? ffi.nullptr,
+        context?._id ?? ffi.nullptr);
+    return NSMutableAttributedString._(_ret, _lib, retain: true, release: true);
+  }
+
+  @override
+  NSMutableAttributedString initWithFormat_options_locale_context_arguments_(
+      NSAttributedString? format,
+      int options,
+      NSLocale? locale,
+      NSDictionary? context,
+      ffi.Pointer<__va_list_tag> arguments) {
+    final _ret = _lib._objc_msgSend_676(
+        _id,
+        _lib._sel_initWithFormat_options_locale_context_arguments_1,
+        format?._id ?? ffi.nullptr,
+        options,
+        locale?._id ?? ffi.nullptr,
+        context?._id ?? ffi.nullptr,
+        arguments);
+    return NSMutableAttributedString._(_ret, _lib, retain: true, release: true);
+  }
+
+  static NSMutableAttributedString localizedAttributedStringWithFormat_context_(
+      SentryCocoa _lib, NSAttributedString? format, NSDictionary? context) {
+    final _ret = _lib._objc_msgSend_677(
+        _lib._class_NSMutableAttributedString1,
+        _lib._sel_localizedAttributedStringWithFormat_context_1,
+        format?._id ?? ffi.nullptr,
+        context?._id ?? ffi.nullptr);
+    return NSMutableAttributedString._(_ret, _lib, retain: true, release: true);
+  }
+
+  static NSMutableAttributedString
+      localizedAttributedStringWithFormat_options_context_(SentryCocoa _lib,
+          NSAttributedString? format, int options, NSDictionary? context) {
+    final _ret = _lib._objc_msgSend_678(
+        _lib._class_NSMutableAttributedString1,
+        _lib._sel_localizedAttributedStringWithFormat_options_context_1,
+        format?._id ?? ffi.nullptr,
+        options,
+        context?._id ?? ffi.nullptr);
+    return NSMutableAttributedString._(_ret, _lib, retain: true, release: true);
+  }
+
+  @override
   NSMutableAttributedString init() {
     final _ret = _lib._objc_msgSend_2(_id, _lib._sel_init1);
     return NSMutableAttributedString._(_ret, _lib, retain: true, release: true);
@@ -53639,11 +53833,11 @@ class NSDateFormatter extends NSFormatter {
   }
 
   int get formattingContext {
-    return _lib._objc_msgSend_690(_id, _lib._sel_formattingContext1);
+    return _lib._objc_msgSend_694(_id, _lib._sel_formattingContext1);
   }
 
   set formattingContext(int value) {
-    return _lib._objc_msgSend_691(_id, _lib._sel_setFormattingContext_1, value);
+    return _lib._objc_msgSend_695(_id, _lib._sel_setFormattingContext_1, value);
   }
 
   bool getObjectValue_forString_range_error_(
@@ -53651,7 +53845,7 @@ class NSDateFormatter extends NSFormatter {
       NSString? string,
       ffi.Pointer<_NSRange> rangep,
       ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    return _lib._objc_msgSend_692(
+    return _lib._objc_msgSend_696(
         _id,
         _lib._sel_getObjectValue_forString_range_error_1,
         obj,
@@ -53674,7 +53868,7 @@ class NSDateFormatter extends NSFormatter {
 
   static NSString localizedStringFromDate_dateStyle_timeStyle_(
       SentryCocoa _lib, NSDate? date, int dstyle, int tstyle) {
-    final _ret = _lib._objc_msgSend_693(
+    final _ret = _lib._objc_msgSend_697(
         _lib._class_NSDateFormatter1,
         _lib._sel_localizedStringFromDate_dateStyle_timeStyle_1,
         date?._id ?? ffi.nullptr,
@@ -53685,7 +53879,7 @@ class NSDateFormatter extends NSFormatter {
 
   static NSString dateFormatFromTemplate_options_locale_(
       SentryCocoa _lib, NSString? tmplate, int opts, NSLocale? locale) {
-    final _ret = _lib._objc_msgSend_694(
+    final _ret = _lib._objc_msgSend_698(
         _lib._class_NSDateFormatter1,
         _lib._sel_dateFormatFromTemplate_options_locale_1,
         tmplate?._id ?? ffi.nullptr,
@@ -53695,12 +53889,12 @@ class NSDateFormatter extends NSFormatter {
   }
 
   static int getDefaultFormatterBehavior(SentryCocoa _lib) {
-    return _lib._objc_msgSend_695(
+    return _lib._objc_msgSend_699(
         _lib._class_NSDateFormatter1, _lib._sel_defaultFormatterBehavior1);
   }
 
   static void setDefaultFormatterBehavior(SentryCocoa _lib, int value) {
-    return _lib._objc_msgSend_696(_lib._class_NSDateFormatter1,
+    return _lib._objc_msgSend_700(_lib._class_NSDateFormatter1,
         _lib._sel_setDefaultFormatterBehavior_1, value);
   }
 
@@ -53722,19 +53916,19 @@ class NSDateFormatter extends NSFormatter {
   }
 
   int get dateStyle {
-    return _lib._objc_msgSend_697(_id, _lib._sel_dateStyle1);
+    return _lib._objc_msgSend_701(_id, _lib._sel_dateStyle1);
   }
 
   set dateStyle(int value) {
-    return _lib._objc_msgSend_698(_id, _lib._sel_setDateStyle_1, value);
+    return _lib._objc_msgSend_702(_id, _lib._sel_setDateStyle_1, value);
   }
 
   int get timeStyle {
-    return _lib._objc_msgSend_697(_id, _lib._sel_timeStyle1);
+    return _lib._objc_msgSend_701(_id, _lib._sel_timeStyle1);
   }
 
   set timeStyle(int value) {
-    return _lib._objc_msgSend_698(_id, _lib._sel_setTimeStyle_1, value);
+    return _lib._objc_msgSend_702(_id, _lib._sel_setTimeStyle_1, value);
   }
 
   NSLocale? get locale {
@@ -53745,7 +53939,7 @@ class NSDateFormatter extends NSFormatter {
   }
 
   set locale(NSLocale? value) {
-    return _lib._objc_msgSend_699(
+    return _lib._objc_msgSend_703(
         _id, _lib._sel_setLocale_1, value?._id ?? ffi.nullptr);
   }
 
@@ -53759,11 +53953,11 @@ class NSDateFormatter extends NSFormatter {
   }
 
   int get formatterBehavior {
-    return _lib._objc_msgSend_695(_id, _lib._sel_formatterBehavior1);
+    return _lib._objc_msgSend_699(_id, _lib._sel_formatterBehavior1);
   }
 
   set formatterBehavior(int value) {
-    return _lib._objc_msgSend_696(_id, _lib._sel_setFormatterBehavior_1, value);
+    return _lib._objc_msgSend_700(_id, _lib._sel_setFormatterBehavior_1, value);
   }
 
   NSTimeZone? get timeZone {
@@ -53779,14 +53973,14 @@ class NSDateFormatter extends NSFormatter {
   }
 
   NSCalendar? get calendar {
-    final _ret = _lib._objc_msgSend_700(_id, _lib._sel_calendar1);
+    final _ret = _lib._objc_msgSend_704(_id, _lib._sel_calendar1);
     return _ret.address == 0
         ? null
         : NSCalendar._(_ret, _lib, retain: true, release: true);
   }
 
   set calendar(NSCalendar? value) {
-    return _lib._objc_msgSend_706(
+    return _lib._objc_msgSend_710(
         _id, _lib._sel_setCalendar_1, value?._id ?? ffi.nullptr);
   }
 
@@ -53830,7 +54024,7 @@ class NSDateFormatter extends NSFormatter {
   }
 
   set eraSymbols(NSArray? value) {
-    return _lib._objc_msgSend_731(
+    return _lib._objc_msgSend_735(
         _id, _lib._sel_setEraSymbols_1, value?._id ?? ffi.nullptr);
   }
 
@@ -53842,7 +54036,7 @@ class NSDateFormatter extends NSFormatter {
   }
 
   set monthSymbols(NSArray? value) {
-    return _lib._objc_msgSend_731(
+    return _lib._objc_msgSend_735(
         _id, _lib._sel_setMonthSymbols_1, value?._id ?? ffi.nullptr);
   }
 
@@ -53854,7 +54048,7 @@ class NSDateFormatter extends NSFormatter {
   }
 
   set shortMonthSymbols(NSArray? value) {
-    return _lib._objc_msgSend_731(
+    return _lib._objc_msgSend_735(
         _id, _lib._sel_setShortMonthSymbols_1, value?._id ?? ffi.nullptr);
   }
 
@@ -53866,7 +54060,7 @@ class NSDateFormatter extends NSFormatter {
   }
 
   set weekdaySymbols(NSArray? value) {
-    return _lib._objc_msgSend_731(
+    return _lib._objc_msgSend_735(
         _id, _lib._sel_setWeekdaySymbols_1, value?._id ?? ffi.nullptr);
   }
 
@@ -53878,7 +54072,7 @@ class NSDateFormatter extends NSFormatter {
   }
 
   set shortWeekdaySymbols(NSArray? value) {
-    return _lib._objc_msgSend_731(
+    return _lib._objc_msgSend_735(
         _id, _lib._sel_setShortWeekdaySymbols_1, value?._id ?? ffi.nullptr);
   }
 
@@ -53914,7 +54108,7 @@ class NSDateFormatter extends NSFormatter {
   }
 
   set longEraSymbols(NSArray? value) {
-    return _lib._objc_msgSend_731(
+    return _lib._objc_msgSend_735(
         _id, _lib._sel_setLongEraSymbols_1, value?._id ?? ffi.nullptr);
   }
 
@@ -53926,7 +54120,7 @@ class NSDateFormatter extends NSFormatter {
   }
 
   set veryShortMonthSymbols(NSArray? value) {
-    return _lib._objc_msgSend_731(
+    return _lib._objc_msgSend_735(
         _id, _lib._sel_setVeryShortMonthSymbols_1, value?._id ?? ffi.nullptr);
   }
 
@@ -53938,7 +54132,7 @@ class NSDateFormatter extends NSFormatter {
   }
 
   set standaloneMonthSymbols(NSArray? value) {
-    return _lib._objc_msgSend_731(
+    return _lib._objc_msgSend_735(
         _id, _lib._sel_setStandaloneMonthSymbols_1, value?._id ?? ffi.nullptr);
   }
 
@@ -53951,7 +54145,7 @@ class NSDateFormatter extends NSFormatter {
   }
 
   set shortStandaloneMonthSymbols(NSArray? value) {
-    return _lib._objc_msgSend_731(_id,
+    return _lib._objc_msgSend_735(_id,
         _lib._sel_setShortStandaloneMonthSymbols_1, value?._id ?? ffi.nullptr);
   }
 
@@ -53964,7 +54158,7 @@ class NSDateFormatter extends NSFormatter {
   }
 
   set veryShortStandaloneMonthSymbols(NSArray? value) {
-    return _lib._objc_msgSend_731(
+    return _lib._objc_msgSend_735(
         _id,
         _lib._sel_setVeryShortStandaloneMonthSymbols_1,
         value?._id ?? ffi.nullptr);
@@ -53978,7 +54172,7 @@ class NSDateFormatter extends NSFormatter {
   }
 
   set veryShortWeekdaySymbols(NSArray? value) {
-    return _lib._objc_msgSend_731(
+    return _lib._objc_msgSend_735(
         _id, _lib._sel_setVeryShortWeekdaySymbols_1, value?._id ?? ffi.nullptr);
   }
 
@@ -53991,7 +54185,7 @@ class NSDateFormatter extends NSFormatter {
   }
 
   set standaloneWeekdaySymbols(NSArray? value) {
-    return _lib._objc_msgSend_731(_id, _lib._sel_setStandaloneWeekdaySymbols_1,
+    return _lib._objc_msgSend_735(_id, _lib._sel_setStandaloneWeekdaySymbols_1,
         value?._id ?? ffi.nullptr);
   }
 
@@ -54004,7 +54198,7 @@ class NSDateFormatter extends NSFormatter {
   }
 
   set shortStandaloneWeekdaySymbols(NSArray? value) {
-    return _lib._objc_msgSend_731(
+    return _lib._objc_msgSend_735(
         _id,
         _lib._sel_setShortStandaloneWeekdaySymbols_1,
         value?._id ?? ffi.nullptr);
@@ -54019,7 +54213,7 @@ class NSDateFormatter extends NSFormatter {
   }
 
   set veryShortStandaloneWeekdaySymbols(NSArray? value) {
-    return _lib._objc_msgSend_731(
+    return _lib._objc_msgSend_735(
         _id,
         _lib._sel_setVeryShortStandaloneWeekdaySymbols_1,
         value?._id ?? ffi.nullptr);
@@ -54033,7 +54227,7 @@ class NSDateFormatter extends NSFormatter {
   }
 
   set quarterSymbols(NSArray? value) {
-    return _lib._objc_msgSend_731(
+    return _lib._objc_msgSend_735(
         _id, _lib._sel_setQuarterSymbols_1, value?._id ?? ffi.nullptr);
   }
 
@@ -54045,7 +54239,7 @@ class NSDateFormatter extends NSFormatter {
   }
 
   set shortQuarterSymbols(NSArray? value) {
-    return _lib._objc_msgSend_731(
+    return _lib._objc_msgSend_735(
         _id, _lib._sel_setShortQuarterSymbols_1, value?._id ?? ffi.nullptr);
   }
 
@@ -54058,7 +54252,7 @@ class NSDateFormatter extends NSFormatter {
   }
 
   set standaloneQuarterSymbols(NSArray? value) {
-    return _lib._objc_msgSend_731(_id, _lib._sel_setStandaloneQuarterSymbols_1,
+    return _lib._objc_msgSend_735(_id, _lib._sel_setStandaloneQuarterSymbols_1,
         value?._id ?? ffi.nullptr);
   }
 
@@ -54071,7 +54265,7 @@ class NSDateFormatter extends NSFormatter {
   }
 
   set shortStandaloneQuarterSymbols(NSArray? value) {
-    return _lib._objc_msgSend_731(
+    return _lib._objc_msgSend_735(
         _id,
         _lib._sel_setShortStandaloneQuarterSymbols_1,
         value?._id ?? ffi.nullptr);
@@ -54236,7 +54430,7 @@ class NSFormatter extends NSObject {
 
   NSAttributedString attributedStringForObjectValue_withDefaultAttributes_(
       NSObject obj, NSDictionary? attrs) {
-    final _ret = _lib._objc_msgSend_686(
+    final _ret = _lib._objc_msgSend_690(
         _id,
         _lib._sel_attributedStringForObjectValue_withDefaultAttributes_1,
         obj._id,
@@ -54254,7 +54448,7 @@ class NSFormatter extends NSObject {
       ffi.Pointer<ffi.Pointer<ObjCObject>> obj,
       NSString? string,
       ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    return _lib._objc_msgSend_687(
+    return _lib._objc_msgSend_691(
         _id,
         _lib._sel_getObjectValue_forString_errorDescription_1,
         obj,
@@ -54266,7 +54460,7 @@ class NSFormatter extends NSObject {
       NSString? partialString,
       ffi.Pointer<ffi.Pointer<ObjCObject>> newString,
       ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    return _lib._objc_msgSend_688(
+    return _lib._objc_msgSend_692(
         _id,
         _lib._sel_isPartialStringValid_newEditingString_errorDescription_1,
         partialString?._id ?? ffi.nullptr,
@@ -54281,7 +54475,7 @@ class NSFormatter extends NSObject {
           NSString? origString,
           _NSRange origSelRange,
           ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    return _lib._objc_msgSend_689(
+    return _lib._objc_msgSend_693(
         _id,
         _lib._sel_isPartialStringValid_proposedSelectedRange_originalString_originalSelectedRange_errorDescription_1,
         partialStringPtr,
@@ -54430,7 +54624,7 @@ class NSCalendar extends NSObject {
   }
 
   static NSCalendar? getCurrentCalendar(SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_700(
+    final _ret = _lib._objc_msgSend_704(
         _lib._class_NSCalendar1, _lib._sel_currentCalendar1);
     return _ret.address == 0
         ? null
@@ -54438,7 +54632,7 @@ class NSCalendar extends NSObject {
   }
 
   static NSCalendar? getAutoupdatingCurrentCalendar(SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_700(
+    final _ret = _lib._objc_msgSend_704(
         _lib._class_NSCalendar1, _lib._sel_autoupdatingCurrentCalendar1);
     return _ret.address == 0
         ? null
@@ -54447,7 +54641,7 @@ class NSCalendar extends NSObject {
 
   static NSCalendar calendarWithIdentifier_(
       SentryCocoa _lib, NSString calendarIdentifierConstant) {
-    final _ret = _lib._objc_msgSend_701(_lib._class_NSCalendar1,
+    final _ret = _lib._objc_msgSend_705(_lib._class_NSCalendar1,
         _lib._sel_calendarWithIdentifier_1, calendarIdentifierConstant._id);
     return NSCalendar._(_ret, _lib, retain: true, release: true);
   }
@@ -54477,7 +54671,7 @@ class NSCalendar extends NSObject {
   }
 
   set locale(NSLocale? value) {
-    return _lib._objc_msgSend_699(
+    return _lib._objc_msgSend_703(
         _id, _lib._sel_setLocale_1, value?._id ?? ffi.nullptr);
   }
 
@@ -54658,21 +54852,21 @@ class NSCalendar extends NSObject {
   }
 
   void minimumRangeOfUnit_(ffi.Pointer<_NSRange> stret, int unit) {
-    _lib._objc_msgSend_702(stret, _id, _lib._sel_minimumRangeOfUnit_1, unit);
+    _lib._objc_msgSend_706(stret, _id, _lib._sel_minimumRangeOfUnit_1, unit);
   }
 
   void maximumRangeOfUnit_(ffi.Pointer<_NSRange> stret, int unit) {
-    _lib._objc_msgSend_702(stret, _id, _lib._sel_maximumRangeOfUnit_1, unit);
+    _lib._objc_msgSend_706(stret, _id, _lib._sel_maximumRangeOfUnit_1, unit);
   }
 
   void rangeOfUnit_inUnit_forDate_(
       ffi.Pointer<_NSRange> stret, int smaller, int larger, NSDate? date) {
-    _lib._objc_msgSend_703(stret, _id, _lib._sel_rangeOfUnit_inUnit_forDate_1,
+    _lib._objc_msgSend_707(stret, _id, _lib._sel_rangeOfUnit_inUnit_forDate_1,
         smaller, larger, date?._id ?? ffi.nullptr);
   }
 
   int ordinalityOfUnit_inUnit_forDate_(int smaller, int larger, NSDate? date) {
-    return _lib._objc_msgSend_704(
+    return _lib._objc_msgSend_708(
         _id,
         _lib._sel_ordinalityOfUnit_inUnit_forDate_1,
         smaller,
@@ -54685,7 +54879,7 @@ class NSCalendar extends NSObject {
       ffi.Pointer<ffi.Pointer<ObjCObject>> datep,
       ffi.Pointer<ffi.Double> tip,
       NSDate? date) {
-    return _lib._objc_msgSend_705(
+    return _lib._objc_msgSend_709(
         _id,
         _lib._sel_rangeOfUnit_startDate_interval_forDate_1,
         unit,
@@ -54695,20 +54889,20 @@ class NSCalendar extends NSObject {
   }
 
   NSDate dateFromComponents_(NSDateComponents? comps) {
-    final _ret = _lib._objc_msgSend_710(
+    final _ret = _lib._objc_msgSend_714(
         _id, _lib._sel_dateFromComponents_1, comps?._id ?? ffi.nullptr);
     return NSDate._(_ret, _lib, retain: true, release: true);
   }
 
   NSDateComponents components_fromDate_(int unitFlags, NSDate? date) {
-    final _ret = _lib._objc_msgSend_711(_id, _lib._sel_components_fromDate_1,
+    final _ret = _lib._objc_msgSend_715(_id, _lib._sel_components_fromDate_1,
         unitFlags, date?._id ?? ffi.nullptr);
     return NSDateComponents._(_ret, _lib, retain: true, release: true);
   }
 
   NSDate dateByAddingComponents_toDate_options_(
       NSDateComponents? comps, NSDate? date, int opts) {
-    final _ret = _lib._objc_msgSend_712(
+    final _ret = _lib._objc_msgSend_716(
         _id,
         _lib._sel_dateByAddingComponents_toDate_options_1,
         comps?._id ?? ffi.nullptr,
@@ -54719,7 +54913,7 @@ class NSCalendar extends NSObject {
 
   NSDateComponents components_fromDate_toDate_options_(
       int unitFlags, NSDate? startingDate, NSDate? resultDate, int opts) {
-    final _ret = _lib._objc_msgSend_713(
+    final _ret = _lib._objc_msgSend_717(
         _id,
         _lib._sel_components_fromDate_toDate_options_1,
         unitFlags,
@@ -54735,7 +54929,7 @@ class NSCalendar extends NSObject {
       ffi.Pointer<ffi.Long> monthValuePointer,
       ffi.Pointer<ffi.Long> dayValuePointer,
       NSDate? date) {
-    _lib._objc_msgSend_714(
+    _lib._objc_msgSend_718(
         _id,
         _lib._sel_getEra_year_month_day_fromDate_1,
         eraValuePointer,
@@ -54751,7 +54945,7 @@ class NSCalendar extends NSObject {
       ffi.Pointer<ffi.Long> weekValuePointer,
       ffi.Pointer<ffi.Long> weekdayValuePointer,
       NSDate? date) {
-    _lib._objc_msgSend_714(
+    _lib._objc_msgSend_718(
         _id,
         _lib._sel_getEra_yearForWeekOfYear_weekOfYear_weekday_fromDate_1,
         eraValuePointer,
@@ -54767,7 +54961,7 @@ class NSCalendar extends NSObject {
       ffi.Pointer<ffi.Long> secondValuePointer,
       ffi.Pointer<ffi.Long> nanosecondValuePointer,
       NSDate? date) {
-    _lib._objc_msgSend_714(
+    _lib._objc_msgSend_718(
         _id,
         _lib._sel_getHour_minute_second_nanosecond_fromDate_1,
         hourValuePointer,
@@ -54778,7 +54972,7 @@ class NSCalendar extends NSObject {
   }
 
   int component_fromDate_(int unit, NSDate? date) {
-    return _lib._objc_msgSend_715(
+    return _lib._objc_msgSend_719(
         _id, _lib._sel_component_fromDate_1, unit, date?._id ?? ffi.nullptr);
   }
 
@@ -54791,7 +54985,7 @@ class NSCalendar extends NSObject {
       int minuteValue,
       int secondValue,
       int nanosecondValue) {
-    final _ret = _lib._objc_msgSend_716(
+    final _ret = _lib._objc_msgSend_720(
         _id,
         _lib._sel_dateWithEra_year_month_day_hour_minute_second_nanosecond_1,
         eraValue,
@@ -54815,7 +55009,7 @@ class NSCalendar extends NSObject {
           int minuteValue,
           int secondValue,
           int nanosecondValue) {
-    final _ret = _lib._objc_msgSend_716(
+    final _ret = _lib._objc_msgSend_720(
         _id,
         _lib._sel_dateWithEra_yearForWeekOfYear_weekOfYear_weekday_hour_minute_second_nanosecond_1,
         eraValue,
@@ -54837,7 +55031,7 @@ class NSCalendar extends NSObject {
 
   NSDateComponents componentsInTimeZone_fromDate_(
       NSTimeZone? timezone, NSDate? date) {
-    final _ret = _lib._objc_msgSend_717(
+    final _ret = _lib._objc_msgSend_721(
         _id,
         _lib._sel_componentsInTimeZone_fromDate_1,
         timezone?._id ?? ffi.nullptr,
@@ -54847,7 +55041,7 @@ class NSCalendar extends NSObject {
 
   int compareDate_toDate_toUnitGranularity_(
       NSDate? date1, NSDate? date2, int unit) {
-    return _lib._objc_msgSend_718(
+    return _lib._objc_msgSend_722(
         _id,
         _lib._sel_compareDate_toDate_toUnitGranularity_1,
         date1?._id ?? ffi.nullptr,
@@ -54857,7 +55051,7 @@ class NSCalendar extends NSObject {
 
   bool isDate_equalToDate_toUnitGranularity_(
       NSDate? date1, NSDate? date2, int unit) {
-    return _lib._objc_msgSend_719(
+    return _lib._objc_msgSend_723(
         _id,
         _lib._sel_isDate_equalToDate_toUnitGranularity_1,
         date1?._id ?? ffi.nullptr,
@@ -54866,7 +55060,7 @@ class NSCalendar extends NSObject {
   }
 
   bool isDate_inSameDayAsDate_(NSDate? date1, NSDate? date2) {
-    return _lib._objc_msgSend_720(_id, _lib._sel_isDate_inSameDayAsDate_1,
+    return _lib._objc_msgSend_724(_id, _lib._sel_isDate_inSameDayAsDate_1,
         date1?._id ?? ffi.nullptr, date2?._id ?? ffi.nullptr);
   }
 
@@ -54894,7 +55088,7 @@ class NSCalendar extends NSObject {
       ffi.Pointer<ffi.Pointer<ObjCObject>> datep,
       ffi.Pointer<ffi.Double> tip,
       NSDate? date) {
-    return _lib._objc_msgSend_721(
+    return _lib._objc_msgSend_725(
         _id,
         _lib._sel_rangeOfWeekendStartDate_interval_containingDate_1,
         datep,
@@ -54907,7 +55101,7 @@ class NSCalendar extends NSObject {
       ffi.Pointer<ffi.Double> tip,
       int options,
       NSDate? date) {
-    return _lib._objc_msgSend_722(
+    return _lib._objc_msgSend_726(
         _id,
         _lib._sel_nextWeekendStartDate_interval_options_afterDate_1,
         datep,
@@ -54921,7 +55115,7 @@ class NSCalendar extends NSObject {
       NSDateComponents? startingDateComp,
       NSDateComponents? resultDateComp,
       int options) {
-    final _ret = _lib._objc_msgSend_723(
+    final _ret = _lib._objc_msgSend_727(
         _id,
         _lib._sel_components_fromDateComponents_toDateComponents_options_1,
         unitFlags,
@@ -54933,7 +55127,7 @@ class NSCalendar extends NSObject {
 
   NSDate dateByAddingUnit_value_toDate_options_(
       int unit, int value, NSDate? date, int options) {
-    final _ret = _lib._objc_msgSend_724(
+    final _ret = _lib._objc_msgSend_728(
         _id,
         _lib._sel_dateByAddingUnit_value_toDate_options_1,
         unit,
@@ -54948,7 +55142,7 @@ class NSCalendar extends NSObject {
       NSDateComponents? comps,
       int opts,
       ObjCBlock_ffiVoid_NSDate_bool_bool block) {
-    _lib._objc_msgSend_725(
+    _lib._objc_msgSend_729(
         _id,
         _lib._sel_enumerateDatesStartingAfterDate_matchingComponents_options_usingBlock_1,
         start?._id ?? ffi.nullptr,
@@ -54959,7 +55153,7 @@ class NSCalendar extends NSObject {
 
   NSDate nextDateAfterDate_matchingComponents_options_(
       NSDate? date, NSDateComponents? comps, int options) {
-    final _ret = _lib._objc_msgSend_726(
+    final _ret = _lib._objc_msgSend_730(
         _id,
         _lib._sel_nextDateAfterDate_matchingComponents_options_1,
         date?._id ?? ffi.nullptr,
@@ -54970,7 +55164,7 @@ class NSCalendar extends NSObject {
 
   NSDate nextDateAfterDate_matchingUnit_value_options_(
       NSDate? date, int unit, int value, int options) {
-    final _ret = _lib._objc_msgSend_727(
+    final _ret = _lib._objc_msgSend_731(
         _id,
         _lib._sel_nextDateAfterDate_matchingUnit_value_options_1,
         date?._id ?? ffi.nullptr,
@@ -54982,7 +55176,7 @@ class NSCalendar extends NSObject {
 
   NSDate nextDateAfterDate_matchingHour_minute_second_options_(NSDate? date,
       int hourValue, int minuteValue, int secondValue, int options) {
-    final _ret = _lib._objc_msgSend_728(
+    final _ret = _lib._objc_msgSend_732(
         _id,
         _lib._sel_nextDateAfterDate_matchingHour_minute_second_options_1,
         date?._id ?? ffi.nullptr,
@@ -54995,7 +55189,7 @@ class NSCalendar extends NSObject {
 
   NSDate dateBySettingUnit_value_ofDate_options_(
       int unit, int v, NSDate? date, int opts) {
-    final _ret = _lib._objc_msgSend_724(
+    final _ret = _lib._objc_msgSend_728(
         _id,
         _lib._sel_dateBySettingUnit_value_ofDate_options_1,
         unit,
@@ -55007,7 +55201,7 @@ class NSCalendar extends NSObject {
 
   NSDate dateBySettingHour_minute_second_ofDate_options_(
       int h, int m, int s, NSDate? date, int opts) {
-    final _ret = _lib._objc_msgSend_729(
+    final _ret = _lib._objc_msgSend_733(
         _id,
         _lib._sel_dateBySettingHour_minute_second_ofDate_options_1,
         h,
@@ -55019,7 +55213,7 @@ class NSCalendar extends NSObject {
   }
 
   bool date_matchesComponents_(NSDate? date, NSDateComponents? components) {
-    return _lib._objc_msgSend_730(_id, _lib._sel_date_matchesComponents_1,
+    return _lib._objc_msgSend_734(_id, _lib._sel_date_matchesComponents_1,
         date?._id ?? ffi.nullptr, components?._id ?? ffi.nullptr);
   }
 
@@ -55169,14 +55363,14 @@ class NSDateComponents extends NSObject {
   }
 
   NSCalendar? get calendar {
-    final _ret = _lib._objc_msgSend_700(_id, _lib._sel_calendar1);
+    final _ret = _lib._objc_msgSend_704(_id, _lib._sel_calendar1);
     return _ret.address == 0
         ? null
         : NSCalendar._(_ret, _lib, retain: true, release: true);
   }
 
   set calendar(NSCalendar? value) {
-    return _lib._objc_msgSend_706(
+    return _lib._objc_msgSend_710(
         _id, _lib._sel_setCalendar_1, value?._id ?? ffi.nullptr);
   }
 
@@ -55328,11 +55522,11 @@ class NSDateComponents extends NSObject {
   }
 
   void setValue_forComponent_(int value, int unit) {
-    _lib._objc_msgSend_707(_id, _lib._sel_setValue_forComponent_1, value, unit);
+    _lib._objc_msgSend_711(_id, _lib._sel_setValue_forComponent_1, value, unit);
   }
 
   int valueForComponent_(int unit) {
-    return _lib._objc_msgSend_708(_id, _lib._sel_valueForComponent_1, unit);
+    return _lib._objc_msgSend_712(_id, _lib._sel_valueForComponent_1, unit);
   }
 
   bool get validDate {
@@ -55340,7 +55534,7 @@ class NSDateComponents extends NSObject {
   }
 
   bool isValidDateInCalendar_(NSCalendar? calendar) {
-    return _lib._objc_msgSend_709(
+    return _lib._objc_msgSend_713(
         _id, _lib._sel_isValidDateInCalendar_1, calendar?._id ?? ffi.nullptr);
   }
 
@@ -55573,11 +55767,11 @@ class NSNumberFormatter extends NSFormatter {
   }
 
   int get formattingContext {
-    return _lib._objc_msgSend_690(_id, _lib._sel_formattingContext1);
+    return _lib._objc_msgSend_694(_id, _lib._sel_formattingContext1);
   }
 
   set formattingContext(int value) {
-    return _lib._objc_msgSend_691(_id, _lib._sel_setFormattingContext_1, value);
+    return _lib._objc_msgSend_695(_id, _lib._sel_setFormattingContext_1, value);
   }
 
   bool getObjectValue_forString_range_error_(
@@ -55585,7 +55779,7 @@ class NSNumberFormatter extends NSFormatter {
       NSString? string,
       ffi.Pointer<_NSRange> rangep,
       ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    return _lib._objc_msgSend_692(
+    return _lib._objc_msgSend_696(
         _id,
         _lib._sel_getObjectValue_forString_range_error_1,
         obj,
@@ -55595,20 +55789,20 @@ class NSNumberFormatter extends NSFormatter {
   }
 
   NSString stringFromNumber_(NSNumber? number) {
-    final _ret = _lib._objc_msgSend_732(
+    final _ret = _lib._objc_msgSend_736(
         _id, _lib._sel_stringFromNumber_1, number?._id ?? ffi.nullptr);
     return NSString._(_ret, _lib, retain: true, release: true);
   }
 
   NSNumber numberFromString_(NSString? string) {
-    final _ret = _lib._objc_msgSend_733(
+    final _ret = _lib._objc_msgSend_737(
         _id, _lib._sel_numberFromString_1, string?._id ?? ffi.nullptr);
     return NSNumber._(_ret, _lib, retain: true, release: true);
   }
 
   static NSString localizedStringFromNumber_numberStyle_(
       SentryCocoa _lib, NSNumber? num, int nstyle) {
-    final _ret = _lib._objc_msgSend_734(
+    final _ret = _lib._objc_msgSend_738(
         _lib._class_NSNumberFormatter1,
         _lib._sel_localizedStringFromNumber_numberStyle_1,
         num?._id ?? ffi.nullptr,
@@ -55617,21 +55811,21 @@ class NSNumberFormatter extends NSFormatter {
   }
 
   static int defaultFormatterBehavior(SentryCocoa _lib) {
-    return _lib._objc_msgSend_735(
+    return _lib._objc_msgSend_739(
         _lib._class_NSNumberFormatter1, _lib._sel_defaultFormatterBehavior1);
   }
 
   static void setDefaultFormatterBehavior_(SentryCocoa _lib, int behavior) {
-    _lib._objc_msgSend_736(_lib._class_NSNumberFormatter1,
+    _lib._objc_msgSend_740(_lib._class_NSNumberFormatter1,
         _lib._sel_setDefaultFormatterBehavior_1, behavior);
   }
 
   int get numberStyle {
-    return _lib._objc_msgSend_737(_id, _lib._sel_numberStyle1);
+    return _lib._objc_msgSend_741(_id, _lib._sel_numberStyle1);
   }
 
   set numberStyle(int value) {
-    return _lib._objc_msgSend_738(_id, _lib._sel_setNumberStyle_1, value);
+    return _lib._objc_msgSend_742(_id, _lib._sel_setNumberStyle_1, value);
   }
 
   NSLocale? get locale {
@@ -55642,7 +55836,7 @@ class NSNumberFormatter extends NSFormatter {
   }
 
   set locale(NSLocale? value) {
-    return _lib._objc_msgSend_699(
+    return _lib._objc_msgSend_703(
         _id, _lib._sel_setLocale_1, value?._id ?? ffi.nullptr);
   }
 
@@ -55656,11 +55850,11 @@ class NSNumberFormatter extends NSFormatter {
   }
 
   int get formatterBehavior {
-    return _lib._objc_msgSend_735(_id, _lib._sel_formatterBehavior1);
+    return _lib._objc_msgSend_739(_id, _lib._sel_formatterBehavior1);
   }
 
   set formatterBehavior(int value) {
-    return _lib._objc_msgSend_739(_id, _lib._sel_setFormatterBehavior_1, value);
+    return _lib._objc_msgSend_743(_id, _lib._sel_setFormatterBehavior_1, value);
   }
 
   NSString? get negativeFormat {
@@ -56102,19 +56296,19 @@ class NSNumberFormatter extends NSFormatter {
   }
 
   int get paddingPosition {
-    return _lib._objc_msgSend_740(_id, _lib._sel_paddingPosition1);
+    return _lib._objc_msgSend_744(_id, _lib._sel_paddingPosition1);
   }
 
   set paddingPosition(int value) {
-    return _lib._objc_msgSend_741(_id, _lib._sel_setPaddingPosition_1, value);
+    return _lib._objc_msgSend_745(_id, _lib._sel_setPaddingPosition_1, value);
   }
 
   int get roundingMode {
-    return _lib._objc_msgSend_742(_id, _lib._sel_roundingMode1);
+    return _lib._objc_msgSend_746(_id, _lib._sel_roundingMode1);
   }
 
   set roundingMode(int value) {
-    return _lib._objc_msgSend_743(_id, _lib._sel_setRoundingMode_1, value);
+    return _lib._objc_msgSend_747(_id, _lib._sel_setRoundingMode_1, value);
   }
 
   NSNumber? get roundingIncrement {
@@ -56290,53 +56484,53 @@ class NSNumberFormatter extends NSFormatter {
 
   NSAttributedString? get attributedStringForZero {
     final _ret =
-        _lib._objc_msgSend_675(_id, _lib._sel_attributedStringForZero1);
+        _lib._objc_msgSend_679(_id, _lib._sel_attributedStringForZero1);
     return _ret.address == 0
         ? null
         : NSAttributedString._(_ret, _lib, retain: true, release: true);
   }
 
   set attributedStringForZero(NSAttributedString? value) {
-    return _lib._objc_msgSend_744(
+    return _lib._objc_msgSend_748(
         _id, _lib._sel_setAttributedStringForZero_1, value?._id ?? ffi.nullptr);
   }
 
   NSAttributedString? get attributedStringForNil {
-    final _ret = _lib._objc_msgSend_675(_id, _lib._sel_attributedStringForNil1);
+    final _ret = _lib._objc_msgSend_679(_id, _lib._sel_attributedStringForNil1);
     return _ret.address == 0
         ? null
         : NSAttributedString._(_ret, _lib, retain: true, release: true);
   }
 
   set attributedStringForNil(NSAttributedString? value) {
-    return _lib._objc_msgSend_744(
+    return _lib._objc_msgSend_748(
         _id, _lib._sel_setAttributedStringForNil_1, value?._id ?? ffi.nullptr);
   }
 
   NSAttributedString? get attributedStringForNotANumber {
     final _ret =
-        _lib._objc_msgSend_675(_id, _lib._sel_attributedStringForNotANumber1);
+        _lib._objc_msgSend_679(_id, _lib._sel_attributedStringForNotANumber1);
     return _ret.address == 0
         ? null
         : NSAttributedString._(_ret, _lib, retain: true, release: true);
   }
 
   set attributedStringForNotANumber(NSAttributedString? value) {
-    return _lib._objc_msgSend_744(
+    return _lib._objc_msgSend_748(
         _id,
         _lib._sel_setAttributedStringForNotANumber_1,
         value?._id ?? ffi.nullptr);
   }
 
   NSDecimalNumberHandler? get roundingBehavior {
-    final _ret = _lib._objc_msgSend_745(_id, _lib._sel_roundingBehavior1);
+    final _ret = _lib._objc_msgSend_749(_id, _lib._sel_roundingBehavior1);
     return _ret.address == 0
         ? null
         : NSDecimalNumberHandler._(_ret, _lib, retain: true, release: true);
   }
 
   set roundingBehavior(NSDecimalNumberHandler? value) {
-    return _lib._objc_msgSend_747(
+    return _lib._objc_msgSend_751(
         _id, _lib._sel_setRoundingBehavior_1, value?._id ?? ffi.nullptr);
   }
 
@@ -56496,7 +56690,7 @@ class NSDecimalNumberHandler extends NSObject {
 
   static NSDecimalNumberHandler? getDefaultDecimalNumberHandler(
       SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_745(_lib._class_NSDecimalNumberHandler1,
+    final _ret = _lib._objc_msgSend_749(_lib._class_NSDecimalNumberHandler1,
         _lib._sel_defaultDecimalNumberHandler1);
     return _ret.address == 0
         ? null
@@ -56511,7 +56705,7 @@ class NSDecimalNumberHandler extends NSObject {
           bool overflow,
           bool underflow,
           bool divideByZero) {
-    final _ret = _lib._objc_msgSend_746(
+    final _ret = _lib._objc_msgSend_750(
         _id,
         _lib._sel_initWithRoundingMode_scale_raiseOnExactness_raiseOnOverflow_raiseOnUnderflow_raiseOnDivideByZero_1,
         roundingMode,
@@ -56532,7 +56726,7 @@ class NSDecimalNumberHandler extends NSObject {
           bool overflow,
           bool underflow,
           bool divideByZero) {
-    final _ret = _lib._objc_msgSend_746(
+    final _ret = _lib._objc_msgSend_750(
         _lib._class_NSDecimalNumberHandler1,
         _lib._sel_decimalNumberHandlerWithRoundingMode_scale_raiseOnExactness_raiseOnOverflow_raiseOnUnderflow_raiseOnDivideByZero_1,
         roundingMode,
@@ -56690,7 +56884,7 @@ class NSScanner extends NSObject {
   }
 
   set charactersToBeSkipped(NSCharacterSet? value) {
-    return _lib._objc_msgSend_748(
+    return _lib._objc_msgSend_752(
         _id, _lib._sel_setCharactersToBeSkipped_1, value?._id ?? ffi.nullptr);
   }
 
@@ -56718,55 +56912,55 @@ class NSScanner extends NSObject {
   }
 
   bool scanInt_(ffi.Pointer<ffi.Int> result) {
-    return _lib._objc_msgSend_749(_id, _lib._sel_scanInt_1, result);
+    return _lib._objc_msgSend_753(_id, _lib._sel_scanInt_1, result);
   }
 
   bool scanInteger_(ffi.Pointer<ffi.Long> result) {
-    return _lib._objc_msgSend_750(_id, _lib._sel_scanInteger_1, result);
+    return _lib._objc_msgSend_754(_id, _lib._sel_scanInteger_1, result);
   }
 
   bool scanLongLong_(ffi.Pointer<ffi.LongLong> result) {
-    return _lib._objc_msgSend_751(_id, _lib._sel_scanLongLong_1, result);
+    return _lib._objc_msgSend_755(_id, _lib._sel_scanLongLong_1, result);
   }
 
   bool scanUnsignedLongLong_(ffi.Pointer<ffi.UnsignedLongLong> result) {
-    return _lib._objc_msgSend_752(
+    return _lib._objc_msgSend_756(
         _id, _lib._sel_scanUnsignedLongLong_1, result);
   }
 
   bool scanFloat_(ffi.Pointer<ffi.Float> result) {
-    return _lib._objc_msgSend_753(_id, _lib._sel_scanFloat_1, result);
+    return _lib._objc_msgSend_757(_id, _lib._sel_scanFloat_1, result);
   }
 
   bool scanDouble_(ffi.Pointer<ffi.Double> result) {
-    return _lib._objc_msgSend_754(_id, _lib._sel_scanDouble_1, result);
+    return _lib._objc_msgSend_758(_id, _lib._sel_scanDouble_1, result);
   }
 
   bool scanHexInt_(ffi.Pointer<ffi.UnsignedInt> result) {
-    return _lib._objc_msgSend_755(_id, _lib._sel_scanHexInt_1, result);
+    return _lib._objc_msgSend_759(_id, _lib._sel_scanHexInt_1, result);
   }
 
   bool scanHexLongLong_(ffi.Pointer<ffi.UnsignedLongLong> result) {
-    return _lib._objc_msgSend_752(_id, _lib._sel_scanHexLongLong_1, result);
+    return _lib._objc_msgSend_756(_id, _lib._sel_scanHexLongLong_1, result);
   }
 
   bool scanHexFloat_(ffi.Pointer<ffi.Float> result) {
-    return _lib._objc_msgSend_753(_id, _lib._sel_scanHexFloat_1, result);
+    return _lib._objc_msgSend_757(_id, _lib._sel_scanHexFloat_1, result);
   }
 
   bool scanHexDouble_(ffi.Pointer<ffi.Double> result) {
-    return _lib._objc_msgSend_754(_id, _lib._sel_scanHexDouble_1, result);
+    return _lib._objc_msgSend_758(_id, _lib._sel_scanHexDouble_1, result);
   }
 
   bool scanString_intoString_(
       NSString? string, ffi.Pointer<ffi.Pointer<ObjCObject>> result) {
-    return _lib._objc_msgSend_756(_id, _lib._sel_scanString_intoString_1,
+    return _lib._objc_msgSend_760(_id, _lib._sel_scanString_intoString_1,
         string?._id ?? ffi.nullptr, result);
   }
 
   bool scanCharactersFromSet_intoString_(
       NSCharacterSet? set, ffi.Pointer<ffi.Pointer<ObjCObject>> result) {
-    return _lib._objc_msgSend_757(
+    return _lib._objc_msgSend_761(
         _id,
         _lib._sel_scanCharactersFromSet_intoString_1,
         set?._id ?? ffi.nullptr,
@@ -56775,13 +56969,13 @@ class NSScanner extends NSObject {
 
   bool scanUpToString_intoString_(
       NSString? string, ffi.Pointer<ffi.Pointer<ObjCObject>> result) {
-    return _lib._objc_msgSend_756(_id, _lib._sel_scanUpToString_intoString_1,
+    return _lib._objc_msgSend_760(_id, _lib._sel_scanUpToString_intoString_1,
         string?._id ?? ffi.nullptr, result);
   }
 
   bool scanUpToCharactersFromSet_intoString_(
       NSCharacterSet? set, ffi.Pointer<ffi.Pointer<ObjCObject>> result) {
-    return _lib._objc_msgSend_757(
+    return _lib._objc_msgSend_761(
         _id,
         _lib._sel_scanUpToCharactersFromSet_intoString_1,
         set?._id ?? ffi.nullptr,
@@ -56806,7 +57000,7 @@ class NSScanner extends NSObject {
   }
 
   bool scanDecimal_(ffi.Pointer<NSDecimal> dcm) {
-    return _lib._objc_msgSend_758(_id, _lib._sel_scanDecimal_1, dcm);
+    return _lib._objc_msgSend_762(_id, _lib._sel_scanDecimal_1, dcm);
   }
 
   @override
@@ -56926,7 +57120,7 @@ class NSException extends NSObject {
 
   static NSException exceptionWithName_reason_userInfo_(SentryCocoa _lib,
       NSString name, NSString? reason, NSDictionary? userInfo) {
-    final _ret = _lib._objc_msgSend_759(
+    final _ret = _lib._objc_msgSend_763(
         _lib._class_NSException1,
         _lib._sel_exceptionWithName_reason_userInfo_1,
         name._id,
@@ -56991,7 +57185,7 @@ class NSException extends NSObject {
 
   static void raise_format_arguments_(SentryCocoa _lib, NSString name,
       NSString? format, ffi.Pointer<__va_list_tag> argList) {
-    _lib._objc_msgSend_760(
+    _lib._objc_msgSend_764(
         _lib._class_NSException1,
         _lib._sel_raise_format_arguments_1,
         name._id,
@@ -57122,7 +57316,7 @@ class NSFileHandle extends NSObject {
   }
 
   NSFileHandle initWithFileDescriptor_closeOnDealloc_(int fd, bool closeopt) {
-    final _ret = _lib._objc_msgSend_761(
+    final _ret = _lib._objc_msgSend_765(
         _id, _lib._sel_initWithFileDescriptor_closeOnDealloc_1, fd, closeopt);
     return NSFileHandle._(_ret, _lib, retain: true, release: true);
   }
@@ -57135,60 +57329,60 @@ class NSFileHandle extends NSObject {
 
   NSData readDataToEndOfFileAndReturnError_(
       ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    final _ret = _lib._objc_msgSend_762(
+    final _ret = _lib._objc_msgSend_766(
         _id, _lib._sel_readDataToEndOfFileAndReturnError_1, error);
     return NSData._(_ret, _lib, retain: true, release: true);
   }
 
   NSData readDataUpToLength_error_(
       int length, ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    final _ret = _lib._objc_msgSend_763(
+    final _ret = _lib._objc_msgSend_767(
         _id, _lib._sel_readDataUpToLength_error_1, length, error);
     return NSData._(_ret, _lib, retain: true, release: true);
   }
 
   bool writeData_error_(
       NSData? data, ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    return _lib._objc_msgSend_764(
+    return _lib._objc_msgSend_768(
         _id, _lib._sel_writeData_error_1, data?._id ?? ffi.nullptr, error);
   }
 
   bool getOffset_error_(ffi.Pointer<ffi.UnsignedLongLong> offsetInFile,
       ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    return _lib._objc_msgSend_765(
+    return _lib._objc_msgSend_769(
         _id, _lib._sel_getOffset_error_1, offsetInFile, error);
   }
 
   bool seekToEndReturningOffset_error_(
       ffi.Pointer<ffi.UnsignedLongLong> offsetInFile,
       ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    return _lib._objc_msgSend_765(
+    return _lib._objc_msgSend_769(
         _id, _lib._sel_seekToEndReturningOffset_error_1, offsetInFile, error);
   }
 
   bool seekToOffset_error_(
       int offset, ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    return _lib._objc_msgSend_766(
+    return _lib._objc_msgSend_770(
         _id, _lib._sel_seekToOffset_error_1, offset, error);
   }
 
   bool truncateAtOffset_error_(
       int offset, ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    return _lib._objc_msgSend_766(
+    return _lib._objc_msgSend_770(
         _id, _lib._sel_truncateAtOffset_error_1, offset, error);
   }
 
   bool synchronizeAndReturnError_(ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    return _lib._objc_msgSend_225(
+    return _lib._objc_msgSend_236(
         _id, _lib._sel_synchronizeAndReturnError_1, error);
   }
 
   bool closeAndReturnError_(ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    return _lib._objc_msgSend_225(_id, _lib._sel_closeAndReturnError_1, error);
+    return _lib._objc_msgSend_236(_id, _lib._sel_closeAndReturnError_1, error);
   }
 
   static NSFileHandle? getFileHandleWithStandardInput(SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_767(
+    final _ret = _lib._objc_msgSend_771(
         _lib._class_NSFileHandle1, _lib._sel_fileHandleWithStandardInput1);
     return _ret.address == 0
         ? null
@@ -57196,7 +57390,7 @@ class NSFileHandle extends NSObject {
   }
 
   static NSFileHandle? getFileHandleWithStandardOutput(SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_767(
+    final _ret = _lib._objc_msgSend_771(
         _lib._class_NSFileHandle1, _lib._sel_fileHandleWithStandardOutput1);
     return _ret.address == 0
         ? null
@@ -57204,7 +57398,7 @@ class NSFileHandle extends NSObject {
   }
 
   static NSFileHandle? getFileHandleWithStandardError(SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_767(
+    final _ret = _lib._objc_msgSend_771(
         _lib._class_NSFileHandle1, _lib._sel_fileHandleWithStandardError1);
     return _ret.address == 0
         ? null
@@ -57212,7 +57406,7 @@ class NSFileHandle extends NSObject {
   }
 
   static NSFileHandle? getFileHandleWithNullDevice(SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_767(
+    final _ret = _lib._objc_msgSend_771(
         _lib._class_NSFileHandle1, _lib._sel_fileHandleWithNullDevice1);
     return _ret.address == 0
         ? null
@@ -57242,7 +57436,7 @@ class NSFileHandle extends NSObject {
 
   static NSFileHandle fileHandleForReadingFromURL_error_(SentryCocoa _lib,
       NSURL? url, ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    final _ret = _lib._objc_msgSend_768(
+    final _ret = _lib._objc_msgSend_772(
         _lib._class_NSFileHandle1,
         _lib._sel_fileHandleForReadingFromURL_error_1,
         url?._id ?? ffi.nullptr,
@@ -57252,7 +57446,7 @@ class NSFileHandle extends NSObject {
 
   static NSFileHandle fileHandleForWritingToURL_error_(SentryCocoa _lib,
       NSURL? url, ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    final _ret = _lib._objc_msgSend_768(
+    final _ret = _lib._objc_msgSend_772(
         _lib._class_NSFileHandle1,
         _lib._sel_fileHandleForWritingToURL_error_1,
         url?._id ?? ffi.nullptr,
@@ -57262,7 +57456,7 @@ class NSFileHandle extends NSObject {
 
   static NSFileHandle fileHandleForUpdatingURL_error_(SentryCocoa _lib,
       NSURL? url, ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    final _ret = _lib._objc_msgSend_768(
+    final _ret = _lib._objc_msgSend_772(
         _lib._class_NSFileHandle1,
         _lib._sel_fileHandleForUpdatingURL_error_1,
         url?._id ?? ffi.nullptr,
@@ -57313,28 +57507,28 @@ class NSFileHandle extends NSObject {
   }
 
   ObjCBlock_ffiVoid_NSFileHandle get readabilityHandler {
-    final _ret = _lib._objc_msgSend_769(_id, _lib._sel_readabilityHandler1);
+    final _ret = _lib._objc_msgSend_773(_id, _lib._sel_readabilityHandler1);
     return ObjCBlock_ffiVoid_NSFileHandle._(_ret, _lib);
   }
 
   set readabilityHandler(ObjCBlock_ffiVoid_NSFileHandle value) {
-    return _lib._objc_msgSend_770(
+    return _lib._objc_msgSend_774(
         _id, _lib._sel_setReadabilityHandler_1, value._id);
   }
 
   ObjCBlock_ffiVoid_NSFileHandle get writeabilityHandler {
-    final _ret = _lib._objc_msgSend_769(_id, _lib._sel_writeabilityHandler1);
+    final _ret = _lib._objc_msgSend_773(_id, _lib._sel_writeabilityHandler1);
     return ObjCBlock_ffiVoid_NSFileHandle._(_ret, _lib);
   }
 
   set writeabilityHandler(ObjCBlock_ffiVoid_NSFileHandle value) {
-    return _lib._objc_msgSend_770(
+    return _lib._objc_msgSend_774(
         _id, _lib._sel_setWriteabilityHandler_1, value._id);
   }
 
   NSFileHandle initWithFileDescriptor_(int fd) {
     final _ret =
-        _lib._objc_msgSend_771(_id, _lib._sel_initWithFileDescriptor_1, fd);
+        _lib._objc_msgSend_775(_id, _lib._sel_initWithFileDescriptor_1, fd);
     return NSFileHandle._(_ret, _lib, retain: true, release: true);
   }
 
@@ -57367,11 +57561,11 @@ class NSFileHandle extends NSObject {
   }
 
   void seekToFileOffset_(int offset) {
-    _lib._objc_msgSend_772(_id, _lib._sel_seekToFileOffset_1, offset);
+    _lib._objc_msgSend_776(_id, _lib._sel_seekToFileOffset_1, offset);
   }
 
   void truncateFileAtOffset_(int offset) {
-    _lib._objc_msgSend_772(_id, _lib._sel_truncateFileAtOffset_1, offset);
+    _lib._objc_msgSend_776(_id, _lib._sel_truncateFileAtOffset_1, offset);
   }
 
   void synchronizeFile() {
@@ -57570,7 +57764,7 @@ class NSHTTPCookieStorage extends NSObject {
   }
 
   static NSHTTPCookieStorage? getSharedHTTPCookieStorage(SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_773(
+    final _ret = _lib._objc_msgSend_777(
         _lib._class_NSHTTPCookieStorage1, _lib._sel_sharedHTTPCookieStorage1);
     return _ret.address == 0
         ? null
@@ -57579,7 +57773,7 @@ class NSHTTPCookieStorage extends NSObject {
 
   static NSHTTPCookieStorage sharedCookieStorageForGroupContainerIdentifier_(
       SentryCocoa _lib, NSString? identifier) {
-    final _ret = _lib._objc_msgSend_774(
+    final _ret = _lib._objc_msgSend_778(
         _lib._class_NSHTTPCookieStorage1,
         _lib._sel_sharedCookieStorageForGroupContainerIdentifier_1,
         identifier?._id ?? ffi.nullptr);
@@ -57594,12 +57788,12 @@ class NSHTTPCookieStorage extends NSObject {
   }
 
   void setCookie_(NSHTTPCookie? cookie) {
-    _lib._objc_msgSend_777(
+    _lib._objc_msgSend_781(
         _id, _lib._sel_setCookie_1, cookie?._id ?? ffi.nullptr);
   }
 
   void deleteCookie_(NSHTTPCookie? cookie) {
-    _lib._objc_msgSend_777(
+    _lib._objc_msgSend_781(
         _id, _lib._sel_deleteCookie_1, cookie?._id ?? ffi.nullptr);
   }
 
@@ -57616,7 +57810,7 @@ class NSHTTPCookieStorage extends NSObject {
 
   void setCookies_forURL_mainDocumentURL_(
       NSArray? cookies, NSURL? URL, NSURL? mainDocumentURL) {
-    _lib._objc_msgSend_778(
+    _lib._objc_msgSend_782(
         _id,
         _lib._sel_setCookies_forURL_mainDocumentURL_1,
         cookies?._id ?? ffi.nullptr,
@@ -57625,11 +57819,11 @@ class NSHTTPCookieStorage extends NSObject {
   }
 
   int get cookieAcceptPolicy {
-    return _lib._objc_msgSend_779(_id, _lib._sel_cookieAcceptPolicy1);
+    return _lib._objc_msgSend_783(_id, _lib._sel_cookieAcceptPolicy1);
   }
 
   set cookieAcceptPolicy(int value) {
-    return _lib._objc_msgSend_780(
+    return _lib._objc_msgSend_784(
         _id, _lib._sel_setCookieAcceptPolicy_1, value);
   }
 
@@ -57642,13 +57836,13 @@ class NSHTTPCookieStorage extends NSObject {
   }
 
   void storeCookies_forTask_(NSArray? cookies, NSURLSessionTask? task) {
-    _lib._objc_msgSend_800(_id, _lib._sel_storeCookies_forTask_1,
+    _lib._objc_msgSend_804(_id, _lib._sel_storeCookies_forTask_1,
         cookies?._id ?? ffi.nullptr, task?._id ?? ffi.nullptr);
   }
 
   void getCookiesForTask_completionHandler_(
       NSURLSessionTask? task, ObjCBlock_ffiVoid_NSArray completionHandler) {
-    _lib._objc_msgSend_801(_id, _lib._sel_getCookiesForTask_completionHandler_1,
+    _lib._objc_msgSend_805(_id, _lib._sel_getCookiesForTask_completionHandler_1,
         task?._id ?? ffi.nullptr, completionHandler._id);
   }
 
@@ -57776,7 +57970,7 @@ class NSHTTPCookie extends NSObject {
 
   static NSHTTPCookie cookieWithProperties_(
       SentryCocoa _lib, NSDictionary? properties) {
-    final _ret = _lib._objc_msgSend_775(_lib._class_NSHTTPCookie1,
+    final _ret = _lib._objc_msgSend_779(_lib._class_NSHTTPCookie1,
         _lib._sel_cookieWithProperties_1, properties?._id ?? ffi.nullptr);
     return NSHTTPCookie._(_ret, _lib, retain: true, release: true);
   }
@@ -57792,7 +57986,7 @@ class NSHTTPCookie extends NSObject {
 
   static NSArray cookiesWithResponseHeaderFields_forURL_(
       SentryCocoa _lib, NSDictionary? headerFields, NSURL? URL) {
-    final _ret = _lib._objc_msgSend_776(
+    final _ret = _lib._objc_msgSend_780(
         _lib._class_NSHTTPCookie1,
         _lib._sel_cookiesWithResponseHeaderFields_forURL_1,
         headerFields?._id ?? ffi.nullptr,
@@ -58012,21 +58206,21 @@ class NSURLSessionTask extends NSObject {
   }
 
   NSURLRequest? get originalRequest {
-    final _ret = _lib._objc_msgSend_795(_id, _lib._sel_originalRequest1);
+    final _ret = _lib._objc_msgSend_799(_id, _lib._sel_originalRequest1);
     return _ret.address == 0
         ? null
         : NSURLRequest._(_ret, _lib, retain: true, release: true);
   }
 
   NSURLRequest? get currentRequest {
-    final _ret = _lib._objc_msgSend_795(_id, _lib._sel_currentRequest1);
+    final _ret = _lib._objc_msgSend_799(_id, _lib._sel_currentRequest1);
     return _ret.address == 0
         ? null
         : NSURLRequest._(_ret, _lib, retain: true, release: true);
   }
 
   NSURLResponse? get response {
-    final _ret = _lib._objc_msgSend_797(_id, _lib._sel_response1);
+    final _ret = _lib._objc_msgSend_801(_id, _lib._sel_response1);
     return _ret.address == 0
         ? null
         : NSURLResponse._(_ret, _lib, retain: true, release: true);
@@ -58117,7 +58311,7 @@ class NSURLSessionTask extends NSObject {
   }
 
   int get state {
-    return _lib._objc_msgSend_798(_id, _lib._sel_state1);
+    return _lib._objc_msgSend_802(_id, _lib._sel_state1);
   }
 
   NSError? get error {
@@ -58140,7 +58334,7 @@ class NSURLSessionTask extends NSObject {
   }
 
   set priority(double value) {
-    return _lib._objc_msgSend_799(_id, _lib._sel_setPriority_1, value);
+    return _lib._objc_msgSend_803(_id, _lib._sel_setPriority_1, value);
   }
 
   bool get prefersIncrementalDelivery {
@@ -58281,7 +58475,7 @@ class NSURLRequest extends NSObject {
 
   static NSURLRequest requestWithURL_cachePolicy_timeoutInterval_(
       SentryCocoa _lib, NSURL? URL, int cachePolicy, double timeoutInterval) {
-    final _ret = _lib._objc_msgSend_781(
+    final _ret = _lib._objc_msgSend_785(
         _lib._class_NSURLRequest1,
         _lib._sel_requestWithURL_cachePolicy_timeoutInterval_1,
         URL?._id ?? ffi.nullptr,
@@ -58298,7 +58492,7 @@ class NSURLRequest extends NSObject {
 
   NSURLRequest initWithURL_cachePolicy_timeoutInterval_(
       NSURL? URL, int cachePolicy, double timeoutInterval) {
-    final _ret = _lib._objc_msgSend_781(
+    final _ret = _lib._objc_msgSend_785(
         _id,
         _lib._sel_initWithURL_cachePolicy_timeoutInterval_1,
         URL?._id ?? ffi.nullptr,
@@ -58315,7 +58509,7 @@ class NSURLRequest extends NSObject {
   }
 
   int get cachePolicy {
-    return _lib._objc_msgSend_782(_id, _lib._sel_cachePolicy1);
+    return _lib._objc_msgSend_786(_id, _lib._sel_cachePolicy1);
   }
 
   double get timeoutInterval {
@@ -58330,7 +58524,7 @@ class NSURLRequest extends NSObject {
   }
 
   int get networkServiceType {
-    return _lib._objc_msgSend_783(_id, _lib._sel_networkServiceType1);
+    return _lib._objc_msgSend_787(_id, _lib._sel_networkServiceType1);
   }
 
   bool get allowsCellularAccess {
@@ -58351,7 +58545,7 @@ class NSURLRequest extends NSObject {
   }
 
   int get attribution {
-    return _lib._objc_msgSend_784(_id, _lib._sel_attribution1);
+    return _lib._objc_msgSend_788(_id, _lib._sel_attribution1);
   }
 
   bool get requiresDNSSECValidation {
@@ -58386,7 +58580,7 @@ class NSURLRequest extends NSObject {
   }
 
   NSInputStream? get HTTPBodyStream {
-    final _ret = _lib._objc_msgSend_794(_id, _lib._sel_HTTPBodyStream1);
+    final _ret = _lib._objc_msgSend_798(_id, _lib._sel_HTTPBodyStream1);
     return _ret.address == 0
         ? null
         : NSInputStream._(_ret, _lib, retain: true, release: true);
@@ -58544,12 +58738,12 @@ class NSInputStream extends NSStream {
   }
 
   int read_maxLength_(ffi.Pointer<ffi.Uint8> buffer, int len) {
-    return _lib._objc_msgSend_786(_id, _lib._sel_read_maxLength_1, buffer, len);
+    return _lib._objc_msgSend_790(_id, _lib._sel_read_maxLength_1, buffer, len);
   }
 
   bool getBuffer_length_(ffi.Pointer<ffi.Pointer<ffi.Uint8>> buffer,
       ffi.Pointer<ffi.UnsignedLong> len) {
-    return _lib._objc_msgSend_793(
+    return _lib._objc_msgSend_797(
         _id, _lib._sel_getBuffer_length_1, buffer, len);
   }
 
@@ -58600,7 +58794,7 @@ class NSInputStream extends NSStream {
       int port,
       ffi.Pointer<ffi.Pointer<ObjCObject>> inputStream,
       ffi.Pointer<ffi.Pointer<ObjCObject>> outputStream) {
-    _lib._objc_msgSend_788(
+    _lib._objc_msgSend_792(
         _lib._class_NSInputStream1,
         _lib._sel_getStreamsToHostWithName_port_inputStream_outputStream_1,
         hostname?._id ?? ffi.nullptr,
@@ -58615,7 +58809,7 @@ class NSInputStream extends NSStream {
       int port,
       ffi.Pointer<ffi.Pointer<ObjCObject>> inputStream,
       ffi.Pointer<ffi.Pointer<ObjCObject>> outputStream) {
-    _lib._objc_msgSend_791(
+    _lib._objc_msgSend_795(
         _lib._class_NSInputStream1,
         _lib._sel_getStreamsToHost_port_inputStream_outputStream_1,
         host?._id ?? ffi.nullptr,
@@ -58629,7 +58823,7 @@ class NSInputStream extends NSStream {
       int bufferSize,
       ffi.Pointer<ffi.Pointer<ObjCObject>> inputStream,
       ffi.Pointer<ffi.Pointer<ObjCObject>> outputStream) {
-    _lib._objc_msgSend_792(
+    _lib._objc_msgSend_796(
         _lib._class_NSInputStream1,
         _lib._sel_getBoundStreamsWithBufferSize_inputStream_outputStream_1,
         bufferSize,
@@ -58795,7 +58989,7 @@ class NSStream extends NSObject {
   }
 
   int get streamStatus {
-    return _lib._objc_msgSend_785(_id, _lib._sel_streamStatus1);
+    return _lib._objc_msgSend_789(_id, _lib._sel_streamStatus1);
   }
 
   NSError? get streamError {
@@ -58811,7 +59005,7 @@ class NSStream extends NSObject {
       int port,
       ffi.Pointer<ffi.Pointer<ObjCObject>> inputStream,
       ffi.Pointer<ffi.Pointer<ObjCObject>> outputStream) {
-    _lib._objc_msgSend_788(
+    _lib._objc_msgSend_792(
         _lib._class_NSStream1,
         _lib._sel_getStreamsToHostWithName_port_inputStream_outputStream_1,
         hostname?._id ?? ffi.nullptr,
@@ -58826,7 +59020,7 @@ class NSStream extends NSObject {
       int port,
       ffi.Pointer<ffi.Pointer<ObjCObject>> inputStream,
       ffi.Pointer<ffi.Pointer<ObjCObject>> outputStream) {
-    _lib._objc_msgSend_791(
+    _lib._objc_msgSend_795(
         _lib._class_NSStream1,
         _lib._sel_getStreamsToHost_port_inputStream_outputStream_1,
         host?._id ?? ffi.nullptr,
@@ -58840,7 +59034,7 @@ class NSStream extends NSObject {
       int bufferSize,
       ffi.Pointer<ffi.Pointer<ObjCObject>> inputStream,
       ffi.Pointer<ffi.Pointer<ObjCObject>> outputStream) {
-    _lib._objc_msgSend_792(
+    _lib._objc_msgSend_796(
         _lib._class_NSStream1,
         _lib._sel_getBoundStreamsWithBufferSize_inputStream_outputStream_1,
         bufferSize,
@@ -58973,7 +59167,7 @@ class NSOutputStream extends NSStream {
   }
 
   int write_maxLength_(ffi.Pointer<ffi.Uint8> buffer, int len) {
-    return _lib._objc_msgSend_786(
+    return _lib._objc_msgSend_790(
         _id, _lib._sel_write_maxLength_1, buffer, len);
   }
 
@@ -58988,7 +59182,7 @@ class NSOutputStream extends NSStream {
 
   NSOutputStream initToBuffer_capacity_(
       ffi.Pointer<ffi.Uint8> buffer, int capacity) {
-    final _ret = _lib._objc_msgSend_787(
+    final _ret = _lib._objc_msgSend_791(
         _id, _lib._sel_initToBuffer_capacity_1, buffer, capacity);
     return NSOutputStream._(_ret, _lib, retain: true, release: true);
   }
@@ -59013,7 +59207,7 @@ class NSOutputStream extends NSStream {
 
   static NSOutputStream outputStreamToBuffer_capacity_(
       SentryCocoa _lib, ffi.Pointer<ffi.Uint8> buffer, int capacity) {
-    final _ret = _lib._objc_msgSend_787(_lib._class_NSOutputStream1,
+    final _ret = _lib._objc_msgSend_791(_lib._class_NSOutputStream1,
         _lib._sel_outputStreamToBuffer_capacity_1, buffer, capacity);
     return NSOutputStream._(_ret, _lib, retain: true, release: true);
   }
@@ -59044,7 +59238,7 @@ class NSOutputStream extends NSStream {
       int port,
       ffi.Pointer<ffi.Pointer<ObjCObject>> inputStream,
       ffi.Pointer<ffi.Pointer<ObjCObject>> outputStream) {
-    _lib._objc_msgSend_788(
+    _lib._objc_msgSend_792(
         _lib._class_NSOutputStream1,
         _lib._sel_getStreamsToHostWithName_port_inputStream_outputStream_1,
         hostname?._id ?? ffi.nullptr,
@@ -59059,7 +59253,7 @@ class NSOutputStream extends NSStream {
       int port,
       ffi.Pointer<ffi.Pointer<ObjCObject>> inputStream,
       ffi.Pointer<ffi.Pointer<ObjCObject>> outputStream) {
-    _lib._objc_msgSend_791(
+    _lib._objc_msgSend_795(
         _lib._class_NSOutputStream1,
         _lib._sel_getStreamsToHost_port_inputStream_outputStream_1,
         host?._id ?? ffi.nullptr,
@@ -59073,7 +59267,7 @@ class NSOutputStream extends NSStream {
       int bufferSize,
       ffi.Pointer<ffi.Pointer<ObjCObject>> inputStream,
       ffi.Pointer<ffi.Pointer<ObjCObject>> outputStream) {
-    _lib._objc_msgSend_792(
+    _lib._objc_msgSend_796(
         _lib._class_NSOutputStream1,
         _lib._sel_getBoundStreamsWithBufferSize_inputStream_outputStream_1,
         bufferSize,
@@ -59215,7 +59409,7 @@ class NSHost extends NSObject {
   }
 
   bool isEqualToHost_(NSHost? aHost) {
-    return _lib._objc_msgSend_789(
+    return _lib._objc_msgSend_793(
         _id, _lib._sel_isEqualToHost_1, aHost?._id ?? ffi.nullptr);
   }
 
@@ -59255,7 +59449,7 @@ class NSHost extends NSObject {
   }
 
   static void setHostCacheEnabled_(SentryCocoa _lib, bool flag) {
-    _lib._objc_msgSend_790(
+    _lib._objc_msgSend_794(
         _lib._class_NSHost1, _lib._sel_setHostCacheEnabled_1, flag);
   }
 
@@ -59383,7 +59577,7 @@ class NSURLResponse extends NSObject {
 
   NSURLResponse initWithURL_MIMEType_expectedContentLength_textEncodingName_(
       NSURL? URL, NSString? MIMEType, int length, NSString? name) {
-    final _ret = _lib._objc_msgSend_796(
+    final _ret = _lib._objc_msgSend_800(
         _id,
         _lib._sel_initWithURL_MIMEType_expectedContentLength_textEncodingName_1,
         URL?._id ?? ffi.nullptr,
@@ -59625,14 +59819,14 @@ class NSIndexPath extends NSObject {
 
   static NSIndexPath indexPathWithIndexes_length_(
       SentryCocoa _lib, ffi.Pointer<ffi.UnsignedLong> indexes, int length) {
-    final _ret = _lib._objc_msgSend_802(_lib._class_NSIndexPath1,
+    final _ret = _lib._objc_msgSend_806(_lib._class_NSIndexPath1,
         _lib._sel_indexPathWithIndexes_length_1, indexes, length);
     return NSIndexPath._(_ret, _lib, retain: true, release: true);
   }
 
   NSIndexPath initWithIndexes_length_(
       ffi.Pointer<ffi.UnsignedLong> indexes, int length) {
-    final _ret = _lib._objc_msgSend_802(
+    final _ret = _lib._objc_msgSend_806(
         _id, _lib._sel_initWithIndexes_length_1, indexes, length);
     return NSIndexPath._(_ret, _lib, retain: true, release: true);
   }
@@ -59644,13 +59838,13 @@ class NSIndexPath extends NSObject {
 
   NSIndexPath indexPathByAddingIndex_(int index) {
     final _ret =
-        _lib._objc_msgSend_803(_id, _lib._sel_indexPathByAddingIndex_1, index);
+        _lib._objc_msgSend_807(_id, _lib._sel_indexPathByAddingIndex_1, index);
     return NSIndexPath._(_ret, _lib, retain: true, release: true);
   }
 
   NSIndexPath indexPathByRemovingLastIndex() {
     final _ret =
-        _lib._objc_msgSend_804(_id, _lib._sel_indexPathByRemovingLastIndex1);
+        _lib._objc_msgSend_808(_id, _lib._sel_indexPathByRemovingLastIndex1);
     return NSIndexPath._(_ret, _lib, retain: true, release: true);
   }
 
@@ -59664,17 +59858,17 @@ class NSIndexPath extends NSObject {
 
   void getIndexes_range_(
       ffi.Pointer<ffi.UnsignedLong> indexes, _NSRange positionRange) {
-    _lib._objc_msgSend_805(
+    _lib._objc_msgSend_809(
         _id, _lib._sel_getIndexes_range_1, indexes, positionRange);
   }
 
   int compare_(NSIndexPath? otherObject) {
-    return _lib._objc_msgSend_806(
+    return _lib._objc_msgSend_810(
         _id, _lib._sel_compare_1, otherObject?._id ?? ffi.nullptr);
   }
 
   void getIndexes_(ffi.Pointer<ffi.UnsignedLong> indexes) {
-    _lib._objc_msgSend_807(_id, _lib._sel_getIndexes_1, indexes);
+    _lib._objc_msgSend_811(_id, _lib._sel_getIndexes_1, indexes);
   }
 
   @override
@@ -59800,7 +59994,7 @@ class NSInflectionRule extends NSObject {
   }
 
   static NSInflectionRule? getAutomaticRule(SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_808(
+    final _ret = _lib._objc_msgSend_812(
         _lib._class_NSInflectionRule1, _lib._sel_automaticRule1);
     return _ret.address == 0
         ? null
@@ -59928,38 +60122,78 @@ class NSMorphology extends NSObject {
   }
 
   int get grammaticalGender {
-    return _lib._objc_msgSend_809(_id, _lib._sel_grammaticalGender1);
+    return _lib._objc_msgSend_813(_id, _lib._sel_grammaticalGender1);
   }
 
   set grammaticalGender(int value) {
-    return _lib._objc_msgSend_810(_id, _lib._sel_setGrammaticalGender_1, value);
+    return _lib._objc_msgSend_814(_id, _lib._sel_setGrammaticalGender_1, value);
   }
 
   int get partOfSpeech {
-    return _lib._objc_msgSend_811(_id, _lib._sel_partOfSpeech1);
+    return _lib._objc_msgSend_815(_id, _lib._sel_partOfSpeech1);
   }
 
   set partOfSpeech(int value) {
-    return _lib._objc_msgSend_812(_id, _lib._sel_setPartOfSpeech_1, value);
+    return _lib._objc_msgSend_816(_id, _lib._sel_setPartOfSpeech_1, value);
   }
 
   int get number {
-    return _lib._objc_msgSend_813(_id, _lib._sel_number1);
+    return _lib._objc_msgSend_817(_id, _lib._sel_number1);
   }
 
   set number(int value) {
-    return _lib._objc_msgSend_814(_id, _lib._sel_setNumber_1, value);
+    return _lib._objc_msgSend_818(_id, _lib._sel_setNumber_1, value);
+  }
+
+  int get grammaticalCase {
+    return _lib._objc_msgSend_819(_id, _lib._sel_grammaticalCase1);
+  }
+
+  set grammaticalCase(int value) {
+    return _lib._objc_msgSend_820(_id, _lib._sel_setGrammaticalCase_1, value);
+  }
+
+  int get determination {
+    return _lib._objc_msgSend_821(_id, _lib._sel_determination1);
+  }
+
+  set determination(int value) {
+    return _lib._objc_msgSend_822(_id, _lib._sel_setDetermination_1, value);
+  }
+
+  int get grammaticalPerson {
+    return _lib._objc_msgSend_823(_id, _lib._sel_grammaticalPerson1);
+  }
+
+  set grammaticalPerson(int value) {
+    return _lib._objc_msgSend_824(_id, _lib._sel_setGrammaticalPerson_1, value);
+  }
+
+  int get pronounType {
+    return _lib._objc_msgSend_825(_id, _lib._sel_pronounType1);
+  }
+
+  set pronounType(int value) {
+    return _lib._objc_msgSend_826(_id, _lib._sel_setPronounType_1, value);
+  }
+
+  int get definiteness {
+    return _lib._objc_msgSend_827(_id, _lib._sel_definiteness1);
+  }
+
+  set definiteness(int value) {
+    return _lib._objc_msgSend_828(_id, _lib._sel_setDefiniteness_1, value);
   }
 
   NSMorphologyCustomPronoun customPronounForLanguage_(NSString? language) {
-    final _ret = _lib._objc_msgSend_815(_id,
+    final _ret = _lib._objc_msgSend_829(_id,
         _lib._sel_customPronounForLanguage_1, language?._id ?? ffi.nullptr);
     return NSMorphologyCustomPronoun._(_ret, _lib, retain: true, release: true);
   }
 
   bool setCustomPronoun_forLanguage_error_(NSMorphologyCustomPronoun? features,
       NSString? language, ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    return _lib._objc_msgSend_816(
+    return _lib._objc_msgSend_830(
         _id,
         _lib._sel_setCustomPronoun_forLanguage_error_1,
         features?._id ?? ffi.nullptr,
@@ -59972,7 +60206,7 @@ class NSMorphology extends NSObject {
   }
 
   static NSMorphology? getUserMorphology(SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_817(
+    final _ret = _lib._objc_msgSend_831(
         _lib._class_NSMorphology1, _lib._sel_userMorphology1);
     return _ret.address == 0
         ? null
@@ -60105,6 +60339,50 @@ abstract class NSGrammaticalNumber {
   static const int NSGrammaticalNumberPluralTwo = 4;
   static const int NSGrammaticalNumberPluralFew = 5;
   static const int NSGrammaticalNumberPluralMany = 6;
+}
+
+abstract class NSGrammaticalCase {
+  static const int NSGrammaticalCaseNotSet = 0;
+  static const int NSGrammaticalCaseNominative = 1;
+  static const int NSGrammaticalCaseAccusative = 2;
+  static const int NSGrammaticalCaseDative = 3;
+  static const int NSGrammaticalCaseGenitive = 4;
+  static const int NSGrammaticalCasePrepositional = 5;
+  static const int NSGrammaticalCaseAblative = 6;
+  static const int NSGrammaticalCaseAdessive = 7;
+  static const int NSGrammaticalCaseAllative = 8;
+  static const int NSGrammaticalCaseElative = 9;
+  static const int NSGrammaticalCaseIllative = 10;
+  static const int NSGrammaticalCaseEssive = 11;
+  static const int NSGrammaticalCaseInessive = 12;
+  static const int NSGrammaticalCaseLocative = 13;
+  static const int NSGrammaticalCaseTranslative = 14;
+}
+
+abstract class NSGrammaticalDetermination {
+  static const int NSGrammaticalDeterminationNotSet = 0;
+  static const int NSGrammaticalDeterminationIndependent = 1;
+  static const int NSGrammaticalDeterminationDependent = 2;
+}
+
+abstract class NSGrammaticalPerson {
+  static const int NSGrammaticalPersonNotSet = 0;
+  static const int NSGrammaticalPersonFirst = 1;
+  static const int NSGrammaticalPersonSecond = 2;
+  static const int NSGrammaticalPersonThird = 3;
+}
+
+abstract class NSGrammaticalPronounType {
+  static const int NSGrammaticalPronounTypeNotSet = 0;
+  static const int NSGrammaticalPronounTypePersonal = 1;
+  static const int NSGrammaticalPronounTypeReflexive = 2;
+  static const int NSGrammaticalPronounTypePossessive = 3;
+}
+
+abstract class NSGrammaticalDefiniteness {
+  static const int NSGrammaticalDefinitenessNotSet = 0;
+  static const int NSGrammaticalDefinitenessIndefinite = 1;
+  static const int NSGrammaticalDefinitenessDefinite = 2;
 }
 
 class NSMorphologyCustomPronoun extends NSObject {
@@ -60332,12 +60610,12 @@ class NSOperationQueue extends NSObject {
   }
 
   void addOperation_(NSOperation? op) {
-    _lib._objc_msgSend_818(
+    _lib._objc_msgSend_832(
         _id, _lib._sel_addOperation_1, op?._id ?? ffi.nullptr);
   }
 
   void addOperations_waitUntilFinished_(NSArray? ops, bool wait) {
-    _lib._objc_msgSend_821(_id, _lib._sel_addOperations_waitUntilFinished_1,
+    _lib._objc_msgSend_835(_id, _lib._sel_addOperations_waitUntilFinished_1,
         ops?._id ?? ffi.nullptr, wait);
   }
 
@@ -60387,12 +60665,12 @@ class NSOperationQueue extends NSObject {
   }
 
   NSObject get underlyingQueue {
-    final _ret = _lib._objc_msgSend_822(_id, _lib._sel_underlyingQueue1);
+    final _ret = _lib._objc_msgSend_836(_id, _lib._sel_underlyingQueue1);
     return NSObject._(_ret, _lib, retain: true, release: true);
   }
 
   set underlyingQueue(NSObject value) {
-    return _lib._objc_msgSend_823(
+    return _lib._objc_msgSend_837(
         _id, _lib._sel_setUnderlyingQueue_1, value._id);
   }
 
@@ -60405,7 +60683,7 @@ class NSOperationQueue extends NSObject {
   }
 
   static NSOperationQueue? getCurrentQueue(SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_824(
+    final _ret = _lib._objc_msgSend_838(
         _lib._class_NSOperationQueue1, _lib._sel_currentQueue1);
     return _ret.address == 0
         ? null
@@ -60413,7 +60691,7 @@ class NSOperationQueue extends NSObject {
   }
 
   static NSOperationQueue? getMainQueue(SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_824(
+    final _ret = _lib._objc_msgSend_838(
         _lib._class_NSOperationQueue1, _lib._sel_mainQueue1);
     return _ret.address == 0
         ? null
@@ -60584,12 +60862,12 @@ class NSOperation extends NSObject {
   }
 
   void addDependency_(NSOperation? op) {
-    _lib._objc_msgSend_818(
+    _lib._objc_msgSend_832(
         _id, _lib._sel_addDependency_1, op?._id ?? ffi.nullptr);
   }
 
   void removeDependency_(NSOperation? op) {
-    _lib._objc_msgSend_818(
+    _lib._objc_msgSend_832(
         _id, _lib._sel_removeDependency_1, op?._id ?? ffi.nullptr);
   }
 
@@ -60601,11 +60879,11 @@ class NSOperation extends NSObject {
   }
 
   int get queuePriority {
-    return _lib._objc_msgSend_819(_id, _lib._sel_queuePriority1);
+    return _lib._objc_msgSend_833(_id, _lib._sel_queuePriority1);
   }
 
   set queuePriority(int value) {
-    return _lib._objc_msgSend_820(_id, _lib._sel_setQueuePriority_1, value);
+    return _lib._objc_msgSend_834(_id, _lib._sel_setQueuePriority_1, value);
   }
 
   ObjCBlock_ffiVoid get completionBlock {
@@ -60775,26 +61053,26 @@ class NSPointerArray extends NSObject {
 
   NSPointerArray initWithOptions_(int options) {
     final _ret =
-        _lib._objc_msgSend_825(_id, _lib._sel_initWithOptions_1, options);
+        _lib._objc_msgSend_839(_id, _lib._sel_initWithOptions_1, options);
     return NSPointerArray._(_ret, _lib, retain: true, release: true);
   }
 
   NSPointerArray initWithPointerFunctions_(NSPointerFunctions? functions) {
-    final _ret = _lib._objc_msgSend_839(_id,
+    final _ret = _lib._objc_msgSend_853(_id,
         _lib._sel_initWithPointerFunctions_1, functions?._id ?? ffi.nullptr);
     return NSPointerArray._(_ret, _lib, retain: true, release: true);
   }
 
   static NSPointerArray pointerArrayWithOptions_(
       SentryCocoa _lib, int options) {
-    final _ret = _lib._objc_msgSend_840(_lib._class_NSPointerArray1,
+    final _ret = _lib._objc_msgSend_854(_lib._class_NSPointerArray1,
         _lib._sel_pointerArrayWithOptions_1, options);
     return NSPointerArray._(_ret, _lib, retain: true, release: true);
   }
 
   static NSPointerArray pointerArrayWithPointerFunctions_(
       SentryCocoa _lib, NSPointerFunctions? functions) {
-    final _ret = _lib._objc_msgSend_841(
+    final _ret = _lib._objc_msgSend_855(
         _lib._class_NSPointerArray1,
         _lib._sel_pointerArrayWithPointerFunctions_1,
         functions?._id ?? ffi.nullptr);
@@ -60802,14 +61080,14 @@ class NSPointerArray extends NSObject {
   }
 
   NSPointerFunctions? get pointerFunctions {
-    final _ret = _lib._objc_msgSend_842(_id, _lib._sel_pointerFunctions1);
+    final _ret = _lib._objc_msgSend_856(_id, _lib._sel_pointerFunctions1);
     return _ret.address == 0
         ? null
         : NSPointerFunctions._(_ret, _lib, retain: true, release: true);
   }
 
   ffi.Pointer<ffi.Void> pointerAtIndex_(int index) {
-    return _lib._objc_msgSend_843(_id, _lib._sel_pointerAtIndex_1, index);
+    return _lib._objc_msgSend_857(_id, _lib._sel_pointerAtIndex_1, index);
   }
 
   void addPointer_(ffi.Pointer<ffi.Void> pointer) {
@@ -60826,7 +61104,7 @@ class NSPointerArray extends NSObject {
 
   void replacePointerAtIndex_withPointer_(
       int index, ffi.Pointer<ffi.Void> item) {
-    _lib._objc_msgSend_844(
+    _lib._objc_msgSend_858(
         _id, _lib._sel_replacePointerAtIndex_withPointer_1, index, item);
   }
 
@@ -60855,13 +61133,13 @@ class NSPointerArray extends NSObject {
   }
 
   static NSPointerArray strongObjectsPointerArray(SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_845(
+    final _ret = _lib._objc_msgSend_859(
         _lib._class_NSPointerArray1, _lib._sel_strongObjectsPointerArray1);
     return NSPointerArray._(_ret, _lib, retain: true, release: true);
   }
 
   static NSPointerArray weakObjectsPointerArray(SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_845(
+    final _ret = _lib._objc_msgSend_859(
         _lib._class_NSPointerArray1, _lib._sel_weakObjectsPointerArray1);
     return NSPointerArray._(_ret, _lib, retain: true, release: true);
   }
@@ -61008,13 +61286,13 @@ class NSPointerFunctions extends NSObject {
 
   NSPointerFunctions initWithOptions_(int options) {
     final _ret =
-        _lib._objc_msgSend_825(_id, _lib._sel_initWithOptions_1, options);
+        _lib._objc_msgSend_839(_id, _lib._sel_initWithOptions_1, options);
     return NSPointerFunctions._(_ret, _lib, retain: true, release: true);
   }
 
   static NSPointerFunctions pointerFunctionsWithOptions_(
       SentryCocoa _lib, int options) {
-    final _ret = _lib._objc_msgSend_826(_lib._class_NSPointerFunctions1,
+    final _ret = _lib._objc_msgSend_840(_lib._class_NSPointerFunctions1,
         _lib._sel_pointerFunctionsWithOptions_1, options);
     return NSPointerFunctions._(_ret, _lib, retain: true, release: true);
   }
@@ -61027,7 +61305,7 @@ class NSPointerFunctions extends NSObject {
                       ffi.NativeFunction<
                           ffi.UnsignedLong Function(ffi.Pointer<ffi.Void>)>>)>>
       get hashFunction {
-    return _lib._objc_msgSend_827(_id, _lib._sel_hashFunction1);
+    return _lib._objc_msgSend_841(_id, _lib._sel_hashFunction1);
   }
 
   set hashFunction(
@@ -61040,7 +61318,7 @@ class NSPointerFunctions extends NSObject {
                               ffi.UnsignedLong Function(
                                   ffi.Pointer<ffi.Void>)>>)>>
           value) {
-    return _lib._objc_msgSend_828(_id, _lib._sel_setHashFunction_1, value);
+    return _lib._objc_msgSend_842(_id, _lib._sel_setHashFunction_1, value);
   }
 
   ffi.Pointer<
@@ -61052,7 +61330,7 @@ class NSPointerFunctions extends NSObject {
                       ffi.NativeFunction<
                           ffi.UnsignedLong Function(ffi.Pointer<ffi.Void>)>>)>>
       get isEqualFunction {
-    return _lib._objc_msgSend_829(_id, _lib._sel_isEqualFunction1);
+    return _lib._objc_msgSend_843(_id, _lib._sel_isEqualFunction1);
   }
 
   set isEqualFunction(
@@ -61066,13 +61344,13 @@ class NSPointerFunctions extends NSObject {
                               ffi.UnsignedLong Function(
                                   ffi.Pointer<ffi.Void>)>>)>>
           value) {
-    return _lib._objc_msgSend_830(_id, _lib._sel_setIsEqualFunction_1, value);
+    return _lib._objc_msgSend_844(_id, _lib._sel_setIsEqualFunction_1, value);
   }
 
   ffi.Pointer<
           ffi.NativeFunction<ffi.UnsignedLong Function(ffi.Pointer<ffi.Void>)>>
       get sizeFunction {
-    return _lib._objc_msgSend_831(_id, _lib._sel_sizeFunction1);
+    return _lib._objc_msgSend_845(_id, _lib._sel_sizeFunction1);
   }
 
   set sizeFunction(
@@ -61080,14 +61358,14 @@ class NSPointerFunctions extends NSObject {
               ffi
               .NativeFunction<ffi.UnsignedLong Function(ffi.Pointer<ffi.Void>)>>
           value) {
-    return _lib._objc_msgSend_832(_id, _lib._sel_setSizeFunction_1, value);
+    return _lib._objc_msgSend_846(_id, _lib._sel_setSizeFunction_1, value);
   }
 
   ffi.Pointer<
           ffi.NativeFunction<
               ffi.Pointer<ObjCObject> Function(ffi.Pointer<ffi.Void>)>>
       get descriptionFunction {
-    return _lib._objc_msgSend_833(_id, _lib._sel_descriptionFunction1);
+    return _lib._objc_msgSend_847(_id, _lib._sel_descriptionFunction1);
   }
 
   set descriptionFunction(
@@ -61095,7 +61373,7 @@ class NSPointerFunctions extends NSObject {
               ffi.NativeFunction<
                   ffi.Pointer<ObjCObject> Function(ffi.Pointer<ffi.Void>)>>
           value) {
-    return _lib._objc_msgSend_834(
+    return _lib._objc_msgSend_848(
         _id, _lib._sel_setDescriptionFunction_1, value);
   }
 
@@ -61107,7 +61385,7 @@ class NSPointerFunctions extends NSObject {
                       ffi.NativeFunction<
                           ffi.UnsignedLong Function(ffi.Pointer<ffi.Void>)>>)>>
       get relinquishFunction {
-    return _lib._objc_msgSend_835(_id, _lib._sel_relinquishFunction1);
+    return _lib._objc_msgSend_849(_id, _lib._sel_relinquishFunction1);
   }
 
   set relinquishFunction(
@@ -61120,7 +61398,7 @@ class NSPointerFunctions extends NSObject {
                               ffi.UnsignedLong Function(
                                   ffi.Pointer<ffi.Void>)>>)>>
           value) {
-    return _lib._objc_msgSend_836(
+    return _lib._objc_msgSend_850(
         _id, _lib._sel_setRelinquishFunction_1, value);
   }
 
@@ -61132,7 +61410,7 @@ class NSPointerFunctions extends NSObject {
                   ffi.NativeFunction<
                       ffi.UnsignedLong Function(ffi.Pointer<ffi.Void>)>>,
               ffi.Bool)>> get acquireFunction {
-    return _lib._objc_msgSend_837(_id, _lib._sel_acquireFunction1);
+    return _lib._objc_msgSend_851(_id, _lib._sel_acquireFunction1);
   }
 
   set acquireFunction(
@@ -61146,7 +61424,7 @@ class NSPointerFunctions extends NSObject {
                                   ffi.Pointer<ffi.Void>)>>,
                       ffi.Bool)>>
           value) {
-    return _lib._objc_msgSend_838(_id, _lib._sel_setAcquireFunction_1, value);
+    return _lib._objc_msgSend_852(_id, _lib._sel_setAcquireFunction_1, value);
   }
 
   bool get usesStrongWriteBarrier {
@@ -61284,7 +61562,7 @@ class NSProcessInfo extends NSObject {
   }
 
   static NSProcessInfo? getProcessInfo(SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_846(
+    final _ret = _lib._objc_msgSend_860(
         _lib._class_NSProcessInfo1, _lib._sel_processInfo1);
     return _ret.address == 0
         ? null
@@ -61353,7 +61631,7 @@ class NSProcessInfo extends NSObject {
   }
 
   void getOperatingSystemVersion(ffi.Pointer<NSOperatingSystemVersion> stret) {
-    _lib._objc_msgSend_847(stret, _id, _lib._sel_operatingSystemVersion1);
+    _lib._objc_msgSend_861(stret, _id, _lib._sel_operatingSystemVersion1);
   }
 
   int get processorCount {
@@ -61369,7 +61647,7 @@ class NSProcessInfo extends NSObject {
   }
 
   bool isOperatingSystemAtLeastVersion_(NSOperatingSystemVersion version) {
-    return _lib._objc_msgSend_848(
+    return _lib._objc_msgSend_862(
         _id, _lib._sel_isOperatingSystemAtLeastVersion_1, version);
   }
 
@@ -61406,7 +61684,7 @@ class NSProcessInfo extends NSObject {
   }
 
   NSObject beginActivityWithOptions_reason_(int options, NSString? reason) {
-    final _ret = _lib._objc_msgSend_849(
+    final _ret = _lib._objc_msgSend_863(
         _id,
         _lib._sel_beginActivityWithOptions_reason_1,
         options,
@@ -61421,7 +61699,7 @@ class NSProcessInfo extends NSObject {
 
   void performActivityWithOptions_reason_usingBlock_(
       int options, NSString? reason, ObjCBlock_ffiVoid block) {
-    _lib._objc_msgSend_850(
+    _lib._objc_msgSend_864(
         _id,
         _lib._sel_performActivityWithOptions_reason_usingBlock_1,
         options,
@@ -61431,7 +61709,7 @@ class NSProcessInfo extends NSObject {
 
   void performExpiringActivityWithReason_usingBlock_(
       NSString? reason, ObjCBlock_ffiVoid_bool block) {
-    _lib._objc_msgSend_851(
+    _lib._objc_msgSend_865(
         _id,
         _lib._sel_performExpiringActivityWithReason_usingBlock_1,
         reason?._id ?? ffi.nullptr,
@@ -61453,7 +61731,7 @@ class NSProcessInfo extends NSObject {
   }
 
   int get thermalState {
-    return _lib._objc_msgSend_852(_id, _lib._sel_thermalState1);
+    return _lib._objc_msgSend_866(_id, _lib._sel_thermalState1);
   }
 
   bool get lowPowerModeEnabled {
@@ -61682,7 +61960,7 @@ class NSTextCheckingResult extends NSObject {
   }
 
   int get resultType {
-    return _lib._objc_msgSend_853(_id, _lib._sel_resultType1);
+    return _lib._objc_msgSend_867(_id, _lib._sel_resultType1);
   }
 
   void getRange(ffi.Pointer<_NSRange> stret) {
@@ -61690,7 +61968,7 @@ class NSTextCheckingResult extends NSObject {
   }
 
   NSOrthography? get orthography {
-    final _ret = _lib._objc_msgSend_854(_id, _lib._sel_orthography1);
+    final _ret = _lib._objc_msgSend_868(_id, _lib._sel_orthography1);
     return _ret.address == 0
         ? null
         : NSOrthography._(_ret, _lib, retain: true, release: true);
@@ -61750,7 +62028,7 @@ class NSTextCheckingResult extends NSObject {
   }
 
   NSRegularExpression? get regularExpression {
-    final _ret = _lib._objc_msgSend_866(_id, _lib._sel_regularExpression1);
+    final _ret = _lib._objc_msgSend_880(_id, _lib._sel_regularExpression1);
     return _ret.address == 0
         ? null
         : NSRegularExpression._(_ret, _lib, retain: true, release: true);
@@ -61777,7 +62055,7 @@ class NSTextCheckingResult extends NSObject {
   }
 
   NSTextCheckingResult resultByAdjustingRangesWithOffset_(int offset) {
-    final _ret = _lib._objc_msgSend_867(
+    final _ret = _lib._objc_msgSend_881(
         _id, _lib._sel_resultByAdjustingRangesWithOffset_1, offset);
     return NSTextCheckingResult._(_ret, _lib, retain: true, release: true);
   }
@@ -61791,7 +62069,7 @@ class NSTextCheckingResult extends NSObject {
 
   static NSTextCheckingResult orthographyCheckingResultWithRange_orthography_(
       SentryCocoa _lib, _NSRange range, NSOrthography? orthography) {
-    final _ret = _lib._objc_msgSend_868(
+    final _ret = _lib._objc_msgSend_882(
         _lib._class_NSTextCheckingResult1,
         _lib._sel_orthographyCheckingResultWithRange_orthography_1,
         range,
@@ -61801,14 +62079,14 @@ class NSTextCheckingResult extends NSObject {
 
   static NSTextCheckingResult spellCheckingResultWithRange_(
       SentryCocoa _lib, _NSRange range) {
-    final _ret = _lib._objc_msgSend_869(_lib._class_NSTextCheckingResult1,
+    final _ret = _lib._objc_msgSend_883(_lib._class_NSTextCheckingResult1,
         _lib._sel_spellCheckingResultWithRange_1, range);
     return NSTextCheckingResult._(_ret, _lib, retain: true, release: true);
   }
 
   static NSTextCheckingResult grammarCheckingResultWithRange_details_(
       SentryCocoa _lib, _NSRange range, NSArray? details) {
-    final _ret = _lib._objc_msgSend_870(
+    final _ret = _lib._objc_msgSend_884(
         _lib._class_NSTextCheckingResult1,
         _lib._sel_grammarCheckingResultWithRange_details_1,
         range,
@@ -61818,7 +62096,7 @@ class NSTextCheckingResult extends NSObject {
 
   static NSTextCheckingResult dateCheckingResultWithRange_date_(
       SentryCocoa _lib, _NSRange range, NSDate? date) {
-    final _ret = _lib._objc_msgSend_871(
+    final _ret = _lib._objc_msgSend_885(
         _lib._class_NSTextCheckingResult1,
         _lib._sel_dateCheckingResultWithRange_date_1,
         range,
@@ -61829,7 +62107,7 @@ class NSTextCheckingResult extends NSObject {
   static NSTextCheckingResult
       dateCheckingResultWithRange_date_timeZone_duration_(SentryCocoa _lib,
           _NSRange range, NSDate? date, NSTimeZone? timeZone, double duration) {
-    final _ret = _lib._objc_msgSend_872(
+    final _ret = _lib._objc_msgSend_886(
         _lib._class_NSTextCheckingResult1,
         _lib._sel_dateCheckingResultWithRange_date_timeZone_duration_1,
         range,
@@ -61841,7 +62119,7 @@ class NSTextCheckingResult extends NSObject {
 
   static NSTextCheckingResult addressCheckingResultWithRange_components_(
       SentryCocoa _lib, _NSRange range, NSDictionary? components) {
-    final _ret = _lib._objc_msgSend_873(
+    final _ret = _lib._objc_msgSend_887(
         _lib._class_NSTextCheckingResult1,
         _lib._sel_addressCheckingResultWithRange_components_1,
         range,
@@ -61851,7 +62129,7 @@ class NSTextCheckingResult extends NSObject {
 
   static NSTextCheckingResult linkCheckingResultWithRange_URL_(
       SentryCocoa _lib, _NSRange range, NSURL? url) {
-    final _ret = _lib._objc_msgSend_874(
+    final _ret = _lib._objc_msgSend_888(
         _lib._class_NSTextCheckingResult1,
         _lib._sel_linkCheckingResultWithRange_URL_1,
         range,
@@ -61861,7 +62139,7 @@ class NSTextCheckingResult extends NSObject {
 
   static NSTextCheckingResult quoteCheckingResultWithRange_replacementString_(
       SentryCocoa _lib, _NSRange range, NSString? replacementString) {
-    final _ret = _lib._objc_msgSend_875(
+    final _ret = _lib._objc_msgSend_889(
         _lib._class_NSTextCheckingResult1,
         _lib._sel_quoteCheckingResultWithRange_replacementString_1,
         range,
@@ -61871,7 +62149,7 @@ class NSTextCheckingResult extends NSObject {
 
   static NSTextCheckingResult dashCheckingResultWithRange_replacementString_(
       SentryCocoa _lib, _NSRange range, NSString? replacementString) {
-    final _ret = _lib._objc_msgSend_875(
+    final _ret = _lib._objc_msgSend_889(
         _lib._class_NSTextCheckingResult1,
         _lib._sel_dashCheckingResultWithRange_replacementString_1,
         range,
@@ -61882,7 +62160,7 @@ class NSTextCheckingResult extends NSObject {
   static NSTextCheckingResult
       replacementCheckingResultWithRange_replacementString_(
           SentryCocoa _lib, _NSRange range, NSString? replacementString) {
-    final _ret = _lib._objc_msgSend_875(
+    final _ret = _lib._objc_msgSend_889(
         _lib._class_NSTextCheckingResult1,
         _lib._sel_replacementCheckingResultWithRange_replacementString_1,
         range,
@@ -61893,7 +62171,7 @@ class NSTextCheckingResult extends NSObject {
   static NSTextCheckingResult
       correctionCheckingResultWithRange_replacementString_(
           SentryCocoa _lib, _NSRange range, NSString? replacementString) {
-    final _ret = _lib._objc_msgSend_875(
+    final _ret = _lib._objc_msgSend_889(
         _lib._class_NSTextCheckingResult1,
         _lib._sel_correctionCheckingResultWithRange_replacementString_1,
         range,
@@ -61907,7 +62185,7 @@ class NSTextCheckingResult extends NSObject {
           _NSRange range,
           NSString? replacementString,
           NSArray? alternativeStrings) {
-    final _ret = _lib._objc_msgSend_876(
+    final _ret = _lib._objc_msgSend_890(
         _lib._class_NSTextCheckingResult1,
         _lib._sel_correctionCheckingResultWithRange_replacementString_alternativeStrings_1,
         range,
@@ -61922,7 +62200,7 @@ class NSTextCheckingResult extends NSObject {
           ffi.Pointer<_NSRange> ranges,
           int count,
           NSRegularExpression? regularExpression) {
-    final _ret = _lib._objc_msgSend_877(
+    final _ret = _lib._objc_msgSend_891(
         _lib._class_NSTextCheckingResult1,
         _lib._sel_regularExpressionCheckingResultWithRanges_count_regularExpression_1,
         ranges,
@@ -61933,7 +62211,7 @@ class NSTextCheckingResult extends NSObject {
 
   static NSTextCheckingResult phoneNumberCheckingResultWithRange_phoneNumber_(
       SentryCocoa _lib, _NSRange range, NSString? phoneNumber) {
-    final _ret = _lib._objc_msgSend_875(
+    final _ret = _lib._objc_msgSend_889(
         _lib._class_NSTextCheckingResult1,
         _lib._sel_phoneNumberCheckingResultWithRange_phoneNumber_1,
         range,
@@ -61944,7 +62222,7 @@ class NSTextCheckingResult extends NSObject {
   static NSTextCheckingResult
       transitInformationCheckingResultWithRange_components_(
           SentryCocoa _lib, _NSRange range, NSDictionary? components) {
-    final _ret = _lib._objc_msgSend_873(
+    final _ret = _lib._objc_msgSend_887(
         _lib._class_NSTextCheckingResult1,
         _lib._sel_transitInformationCheckingResultWithRange_components_1,
         range,
@@ -62090,7 +62368,7 @@ class NSRegularExpression extends NSObject {
       NSString? pattern,
       int options,
       ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    final _ret = _lib._objc_msgSend_855(
+    final _ret = _lib._objc_msgSend_869(
         _lib._class_NSRegularExpression1,
         _lib._sel_regularExpressionWithPattern_options_error_1,
         pattern?._id ?? ffi.nullptr,
@@ -62101,7 +62379,7 @@ class NSRegularExpression extends NSObject {
 
   NSRegularExpression initWithPattern_options_error_(NSString? pattern,
       int options, ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    final _ret = _lib._objc_msgSend_856(
+    final _ret = _lib._objc_msgSend_870(
         _id,
         _lib._sel_initWithPattern_options_error_1,
         pattern?._id ?? ffi.nullptr,
@@ -62118,7 +62396,7 @@ class NSRegularExpression extends NSObject {
   }
 
   int get options {
-    return _lib._objc_msgSend_857(_id, _lib._sel_options1);
+    return _lib._objc_msgSend_871(_id, _lib._sel_options1);
   }
 
   int get numberOfCaptureGroups {
@@ -62136,7 +62414,7 @@ class NSRegularExpression extends NSObject {
       int options,
       _NSRange range,
       ObjCBlock_ffiVoid_NSTextCheckingResult_NSMatchingFlags_bool block) {
-    _lib._objc_msgSend_858(
+    _lib._objc_msgSend_872(
         _id,
         _lib._sel_enumerateMatchesInString_options_range_usingBlock_1,
         string?._id ?? ffi.nullptr,
@@ -62147,7 +62425,7 @@ class NSRegularExpression extends NSObject {
 
   NSArray matchesInString_options_range_(
       NSString? string, int options, _NSRange range) {
-    final _ret = _lib._objc_msgSend_859(
+    final _ret = _lib._objc_msgSend_873(
         _id,
         _lib._sel_matchesInString_options_range_1,
         string?._id ?? ffi.nullptr,
@@ -62158,7 +62436,7 @@ class NSRegularExpression extends NSObject {
 
   int numberOfMatchesInString_options_range_(
       NSString? string, int options, _NSRange range) {
-    return _lib._objc_msgSend_860(
+    return _lib._objc_msgSend_874(
         _id,
         _lib._sel_numberOfMatchesInString_options_range_1,
         string?._id ?? ffi.nullptr,
@@ -62168,7 +62446,7 @@ class NSRegularExpression extends NSObject {
 
   NSTextCheckingResult firstMatchInString_options_range_(
       NSString? string, int options, _NSRange range) {
-    final _ret = _lib._objc_msgSend_861(
+    final _ret = _lib._objc_msgSend_875(
         _id,
         _lib._sel_firstMatchInString_options_range_1,
         string?._id ?? ffi.nullptr,
@@ -62179,7 +62457,7 @@ class NSRegularExpression extends NSObject {
 
   void rangeOfFirstMatchInString_options_range_(ffi.Pointer<_NSRange> stret,
       NSString? string, int options, _NSRange range) {
-    _lib._objc_msgSend_862(
+    _lib._objc_msgSend_876(
         stret,
         _id,
         _lib._sel_rangeOfFirstMatchInString_options_range_1,
@@ -62190,7 +62468,7 @@ class NSRegularExpression extends NSObject {
 
   NSString stringByReplacingMatchesInString_options_range_withTemplate_(
       NSString? string, int options, _NSRange range, NSString? templ) {
-    final _ret = _lib._objc_msgSend_863(
+    final _ret = _lib._objc_msgSend_877(
         _id,
         _lib._sel_stringByReplacingMatchesInString_options_range_withTemplate_1,
         string?._id ?? ffi.nullptr,
@@ -62202,7 +62480,7 @@ class NSRegularExpression extends NSObject {
 
   int replaceMatchesInString_options_range_withTemplate_(
       NSMutableString? string, int options, _NSRange range, NSString? templ) {
-    return _lib._objc_msgSend_864(
+    return _lib._objc_msgSend_878(
         _id,
         _lib._sel_replaceMatchesInString_options_range_withTemplate_1,
         string?._id ?? ffi.nullptr,
@@ -62216,7 +62494,7 @@ class NSRegularExpression extends NSObject {
       NSString? string,
       int offset,
       NSString? templ) {
-    final _ret = _lib._objc_msgSend_865(
+    final _ret = _lib._objc_msgSend_879(
         _id,
         _lib._sel_replacementStringForResult_inString_offset_template_1,
         result?._id ?? ffi.nullptr,
@@ -62485,7 +62763,7 @@ class NSURLCache extends NSObject {
   }
 
   static NSURLCache? getSharedURLCache(SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_878(
+    final _ret = _lib._objc_msgSend_892(
         _lib._class_NSURLCache1, _lib._sel_sharedURLCache1);
     return _ret.address == 0
         ? null
@@ -62493,13 +62771,13 @@ class NSURLCache extends NSObject {
   }
 
   static void setSharedURLCache(SentryCocoa _lib, NSURLCache? value) {
-    return _lib._objc_msgSend_879(_lib._class_NSURLCache1,
+    return _lib._objc_msgSend_893(_lib._class_NSURLCache1,
         _lib._sel_setSharedURLCache_1, value?._id ?? ffi.nullptr);
   }
 
   NSURLCache initWithMemoryCapacity_diskCapacity_diskPath_(
       int memoryCapacity, int diskCapacity, NSString? path) {
-    final _ret = _lib._objc_msgSend_880(
+    final _ret = _lib._objc_msgSend_894(
         _id,
         _lib._sel_initWithMemoryCapacity_diskCapacity_diskPath_1,
         memoryCapacity,
@@ -62510,7 +62788,7 @@ class NSURLCache extends NSObject {
 
   NSURLCache initWithMemoryCapacity_diskCapacity_directoryURL_(
       int memoryCapacity, int diskCapacity, NSURL? directoryURL) {
-    final _ret = _lib._objc_msgSend_881(
+    final _ret = _lib._objc_msgSend_895(
         _id,
         _lib._sel_initWithMemoryCapacity_diskCapacity_directoryURL_1,
         memoryCapacity,
@@ -62520,19 +62798,19 @@ class NSURLCache extends NSObject {
   }
 
   NSCachedURLResponse cachedResponseForRequest_(NSURLRequest? request) {
-    final _ret = _lib._objc_msgSend_885(
+    final _ret = _lib._objc_msgSend_899(
         _id, _lib._sel_cachedResponseForRequest_1, request?._id ?? ffi.nullptr);
     return NSCachedURLResponse._(_ret, _lib, retain: true, release: true);
   }
 
   void storeCachedResponse_forRequest_(
       NSCachedURLResponse? cachedResponse, NSURLRequest? request) {
-    _lib._objc_msgSend_886(_id, _lib._sel_storeCachedResponse_forRequest_1,
+    _lib._objc_msgSend_900(_id, _lib._sel_storeCachedResponse_forRequest_1,
         cachedResponse?._id ?? ffi.nullptr, request?._id ?? ffi.nullptr);
   }
 
   void removeCachedResponseForRequest_(NSURLRequest? request) {
-    _lib._objc_msgSend_887(_id, _lib._sel_removeCachedResponseForRequest_1,
+    _lib._objc_msgSend_901(_id, _lib._sel_removeCachedResponseForRequest_1,
         request?._id ?? ffi.nullptr);
   }
 
@@ -62571,14 +62849,14 @@ class NSURLCache extends NSObject {
 
   void storeCachedResponse_forDataTask_(
       NSCachedURLResponse? cachedResponse, NSURLSessionDataTask? dataTask) {
-    _lib._objc_msgSend_888(_id, _lib._sel_storeCachedResponse_forDataTask_1,
+    _lib._objc_msgSend_902(_id, _lib._sel_storeCachedResponse_forDataTask_1,
         cachedResponse?._id ?? ffi.nullptr, dataTask?._id ?? ffi.nullptr);
   }
 
   void getCachedResponseForDataTask_completionHandler_(
       NSURLSessionDataTask? dataTask,
       ObjCBlock_ffiVoid_NSCachedURLResponse completionHandler) {
-    _lib._objc_msgSend_889(
+    _lib._objc_msgSend_903(
         _id,
         _lib._sel_getCachedResponseForDataTask_completionHandler_1,
         dataTask?._id ?? ffi.nullptr,
@@ -62586,7 +62864,7 @@ class NSURLCache extends NSObject {
   }
 
   void removeCachedResponseForDataTask_(NSURLSessionDataTask? dataTask) {
-    _lib._objc_msgSend_890(_id, _lib._sel_removeCachedResponseForDataTask_1,
+    _lib._objc_msgSend_904(_id, _lib._sel_removeCachedResponseForDataTask_1,
         dataTask?._id ?? ffi.nullptr);
   }
 
@@ -62708,7 +62986,7 @@ class NSCachedURLResponse extends NSObject {
 
   NSCachedURLResponse initWithResponse_data_(
       NSURLResponse? response, NSData? data) {
-    final _ret = _lib._objc_msgSend_882(_id, _lib._sel_initWithResponse_data_1,
+    final _ret = _lib._objc_msgSend_896(_id, _lib._sel_initWithResponse_data_1,
         response?._id ?? ffi.nullptr, data?._id ?? ffi.nullptr);
     return NSCachedURLResponse._(_ret, _lib, retain: true, release: true);
   }
@@ -62718,7 +62996,7 @@ class NSCachedURLResponse extends NSObject {
       NSData? data,
       NSDictionary? userInfo,
       int storagePolicy) {
-    final _ret = _lib._objc_msgSend_883(
+    final _ret = _lib._objc_msgSend_897(
         _id,
         _lib._sel_initWithResponse_data_userInfo_storagePolicy_1,
         response?._id ?? ffi.nullptr,
@@ -62729,7 +63007,7 @@ class NSCachedURLResponse extends NSObject {
   }
 
   NSURLResponse? get response {
-    final _ret = _lib._objc_msgSend_797(_id, _lib._sel_response1);
+    final _ret = _lib._objc_msgSend_801(_id, _lib._sel_response1);
     return _ret.address == 0
         ? null
         : NSURLResponse._(_ret, _lib, retain: true, release: true);
@@ -62750,7 +63028,7 @@ class NSCachedURLResponse extends NSObject {
   }
 
   int get storagePolicy {
-    return _lib._objc_msgSend_884(_id, _lib._sel_storagePolicy1);
+    return _lib._objc_msgSend_898(_id, _lib._sel_storagePolicy1);
   }
 
   @override
@@ -63067,7 +63345,7 @@ class NSURLConnection extends NSObject {
 
   NSURLConnection initWithRequest_delegate_startImmediately_(
       NSURLRequest? request, NSObject delegate, bool startImmediately) {
-    final _ret = _lib._objc_msgSend_891(
+    final _ret = _lib._objc_msgSend_905(
         _id,
         _lib._sel_initWithRequest_delegate_startImmediately_1,
         request?._id ?? ffi.nullptr,
@@ -63078,7 +63356,7 @@ class NSURLConnection extends NSObject {
 
   NSURLConnection initWithRequest_delegate_(
       NSURLRequest? request, NSObject delegate) {
-    final _ret = _lib._objc_msgSend_892(
+    final _ret = _lib._objc_msgSend_906(
         _id,
         _lib._sel_initWithRequest_delegate_1,
         request?._id ?? ffi.nullptr,
@@ -63088,7 +63366,7 @@ class NSURLConnection extends NSObject {
 
   static NSURLConnection connectionWithRequest_delegate_(
       SentryCocoa _lib, NSURLRequest? request, NSObject delegate) {
-    final _ret = _lib._objc_msgSend_893(
+    final _ret = _lib._objc_msgSend_907(
         _lib._class_NSURLConnection1,
         _lib._sel_connectionWithRequest_delegate_1,
         request?._id ?? ffi.nullptr,
@@ -63097,14 +63375,14 @@ class NSURLConnection extends NSObject {
   }
 
   NSURLRequest? get originalRequest {
-    final _ret = _lib._objc_msgSend_795(_id, _lib._sel_originalRequest1);
+    final _ret = _lib._objc_msgSend_799(_id, _lib._sel_originalRequest1);
     return _ret.address == 0
         ? null
         : NSURLRequest._(_ret, _lib, retain: true, release: true);
   }
 
   NSURLRequest? get currentRequest {
-    final _ret = _lib._objc_msgSend_795(_id, _lib._sel_currentRequest1);
+    final _ret = _lib._objc_msgSend_799(_id, _lib._sel_currentRequest1);
     return _ret.address == 0
         ? null
         : NSURLRequest._(_ret, _lib, retain: true, release: true);
@@ -63129,12 +63407,12 @@ class NSURLConnection extends NSObject {
   }
 
   void setDelegateQueue_(NSOperationQueue? queue) {
-    _lib._objc_msgSend_894(
+    _lib._objc_msgSend_908(
         _id, _lib._sel_setDelegateQueue_1, queue?._id ?? ffi.nullptr);
   }
 
   static bool canHandleRequest_(SentryCocoa _lib, NSURLRequest? request) {
-    return _lib._objc_msgSend_895(_lib._class_NSURLConnection1,
+    return _lib._objc_msgSend_909(_lib._class_NSURLConnection1,
         _lib._sel_canHandleRequest_1, request?._id ?? ffi.nullptr);
   }
 
@@ -63143,7 +63421,7 @@ class NSURLConnection extends NSObject {
       NSURLRequest? request,
       ffi.Pointer<ffi.Pointer<ObjCObject>> response,
       ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    final _ret = _lib._objc_msgSend_896(
+    final _ret = _lib._objc_msgSend_910(
         _lib._class_NSURLConnection1,
         _lib._sel_sendSynchronousRequest_returningResponse_error_1,
         request?._id ?? ffi.nullptr,
@@ -63157,7 +63435,7 @@ class NSURLConnection extends NSObject {
       NSURLRequest? request,
       NSOperationQueue? queue,
       ObjCBlock_ffiVoid_NSURLResponse_NSData_NSError handler) {
-    _lib._objc_msgSend_897(
+    _lib._objc_msgSend_911(
         _lib._class_NSURLConnection1,
         _lib._sel_sendAsynchronousRequest_queue_completionHandler_1,
         request?._id ?? ffi.nullptr,
@@ -63393,12 +63671,12 @@ class NSURLCredential extends NSObject {
   }
 
   int get persistence {
-    return _lib._objc_msgSend_898(_id, _lib._sel_persistence1);
+    return _lib._objc_msgSend_912(_id, _lib._sel_persistence1);
   }
 
   NSURLCredential initWithUser_password_persistence_(
       NSString? user, NSString? password, int persistence) {
-    final _ret = _lib._objc_msgSend_899(
+    final _ret = _lib._objc_msgSend_913(
         _id,
         _lib._sel_initWithUser_password_persistence_1,
         user?._id ?? ffi.nullptr,
@@ -63409,7 +63687,7 @@ class NSURLCredential extends NSObject {
 
   static NSURLCredential credentialWithUser_password_persistence_(
       SentryCocoa _lib, NSString? user, NSString? password, int persistence) {
-    final _ret = _lib._objc_msgSend_900(
+    final _ret = _lib._objc_msgSend_914(
         _lib._class_NSURLCredential1,
         _lib._sel_credentialWithUser_password_persistence_1,
         user?._id ?? ffi.nullptr,
@@ -63440,7 +63718,7 @@ class NSURLCredential extends NSObject {
       ffi.Pointer<__SecIdentity> identity,
       NSArray? certArray,
       int persistence) {
-    final _ret = _lib._objc_msgSend_901(
+    final _ret = _lib._objc_msgSend_915(
         _id,
         _lib._sel_initWithIdentity_certificates_persistence_1,
         identity,
@@ -63454,7 +63732,7 @@ class NSURLCredential extends NSObject {
       ffi.Pointer<__SecIdentity> identity,
       NSArray? certArray,
       int persistence) {
-    final _ret = _lib._objc_msgSend_902(
+    final _ret = _lib._objc_msgSend_916(
         _lib._class_NSURLCredential1,
         _lib._sel_credentialWithIdentity_certificates_persistence_1,
         identity,
@@ -63464,7 +63742,7 @@ class NSURLCredential extends NSObject {
   }
 
   ffi.Pointer<__SecIdentity> get identity {
-    return _lib._objc_msgSend_903(_id, _lib._sel_identity1);
+    return _lib._objc_msgSend_917(_id, _lib._sel_identity1);
   }
 
   NSArray? get certificates {
@@ -63475,13 +63753,13 @@ class NSURLCredential extends NSObject {
   }
 
   NSURLCredential initWithTrust_(ffi.Pointer<__SecTrust> trust) {
-    final _ret = _lib._objc_msgSend_904(_id, _lib._sel_initWithTrust_1, trust);
+    final _ret = _lib._objc_msgSend_918(_id, _lib._sel_initWithTrust_1, trust);
     return NSURLCredential._(_ret, _lib, retain: true, release: true);
   }
 
   static NSURLCredential credentialForTrust_(
       SentryCocoa _lib, ffi.Pointer<__SecTrust> trust) {
-    final _ret = _lib._objc_msgSend_905(
+    final _ret = _lib._objc_msgSend_919(
         _lib._class_NSURLCredential1, _lib._sel_credentialForTrust_1, trust);
     return NSURLCredential._(_ret, _lib, retain: true, release: true);
   }
@@ -63620,7 +63898,7 @@ class NSURLProtectionSpace extends NSObject {
       NSString? protocol,
       NSString? realm,
       NSString? authenticationMethod) {
-    final _ret = _lib._objc_msgSend_906(
+    final _ret = _lib._objc_msgSend_920(
         _id,
         _lib._sel_initWithHost_port_protocol_realm_authenticationMethod_1,
         host?._id ?? ffi.nullptr,
@@ -63637,7 +63915,7 @@ class NSURLProtectionSpace extends NSObject {
       NSString? type,
       NSString? realm,
       NSString? authenticationMethod) {
-    final _ret = _lib._objc_msgSend_906(
+    final _ret = _lib._objc_msgSend_920(
         _id,
         _lib._sel_initWithProxyHost_port_type_realm_authenticationMethod_1,
         host?._id ?? ffi.nullptr,
@@ -63703,7 +63981,7 @@ class NSURLProtectionSpace extends NSObject {
   }
 
   ffi.Pointer<__SecTrust> get serverTrust {
-    return _lib._objc_msgSend_907(_id, _lib._sel_serverTrust1);
+    return _lib._objc_msgSend_921(_id, _lib._sel_serverTrust1);
   }
 
   @override
@@ -63825,7 +64103,7 @@ class NSURLCredentialStorage extends NSObject {
   }
 
   static NSURLCredentialStorage? getSharedCredentialStorage(SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_908(_lib._class_NSURLCredentialStorage1,
+    final _ret = _lib._objc_msgSend_922(_lib._class_NSURLCredentialStorage1,
         _lib._sel_sharedCredentialStorage1);
     return _ret.address == 0
         ? null
@@ -63833,7 +64111,7 @@ class NSURLCredentialStorage extends NSObject {
   }
 
   NSDictionary credentialsForProtectionSpace_(NSURLProtectionSpace? space) {
-    final _ret = _lib._objc_msgSend_909(_id,
+    final _ret = _lib._objc_msgSend_923(_id,
         _lib._sel_credentialsForProtectionSpace_1, space?._id ?? ffi.nullptr);
     return NSDictionary._(_ret, _lib, retain: true, release: true);
   }
@@ -63847,19 +64125,19 @@ class NSURLCredentialStorage extends NSObject {
 
   void setCredential_forProtectionSpace_(
       NSURLCredential? credential, NSURLProtectionSpace? space) {
-    _lib._objc_msgSend_910(_id, _lib._sel_setCredential_forProtectionSpace_1,
+    _lib._objc_msgSend_924(_id, _lib._sel_setCredential_forProtectionSpace_1,
         credential?._id ?? ffi.nullptr, space?._id ?? ffi.nullptr);
   }
 
   void removeCredential_forProtectionSpace_(
       NSURLCredential? credential, NSURLProtectionSpace? space) {
-    _lib._objc_msgSend_910(_id, _lib._sel_removeCredential_forProtectionSpace_1,
+    _lib._objc_msgSend_924(_id, _lib._sel_removeCredential_forProtectionSpace_1,
         credential?._id ?? ffi.nullptr, space?._id ?? ffi.nullptr);
   }
 
   void removeCredential_forProtectionSpace_options_(NSURLCredential? credential,
       NSURLProtectionSpace? space, NSDictionary? options) {
-    _lib._objc_msgSend_911(
+    _lib._objc_msgSend_925(
         _id,
         _lib._sel_removeCredential_forProtectionSpace_options_1,
         credential?._id ?? ffi.nullptr,
@@ -63869,7 +64147,7 @@ class NSURLCredentialStorage extends NSObject {
 
   NSURLCredential defaultCredentialForProtectionSpace_(
       NSURLProtectionSpace? space) {
-    final _ret = _lib._objc_msgSend_912(
+    final _ret = _lib._objc_msgSend_926(
         _id,
         _lib._sel_defaultCredentialForProtectionSpace_1,
         space?._id ?? ffi.nullptr);
@@ -63878,7 +64156,7 @@ class NSURLCredentialStorage extends NSObject {
 
   void setDefaultCredential_forProtectionSpace_(
       NSURLCredential? credential, NSURLProtectionSpace? space) {
-    _lib._objc_msgSend_910(
+    _lib._objc_msgSend_924(
         _id,
         _lib._sel_setDefaultCredential_forProtectionSpace_1,
         credential?._id ?? ffi.nullptr,
@@ -63889,7 +64167,7 @@ class NSURLCredentialStorage extends NSObject {
       NSURLProtectionSpace? protectionSpace,
       NSURLSessionTask? task,
       ObjCBlock_ffiVoid_NSDictionary completionHandler) {
-    _lib._objc_msgSend_913(
+    _lib._objc_msgSend_927(
         _id,
         _lib._sel_getCredentialsForProtectionSpace_task_completionHandler_1,
         protectionSpace?._id ?? ffi.nullptr,
@@ -63899,7 +64177,7 @@ class NSURLCredentialStorage extends NSObject {
 
   void setCredential_forProtectionSpace_task_(NSURLCredential? credential,
       NSURLProtectionSpace? protectionSpace, NSURLSessionTask? task) {
-    _lib._objc_msgSend_914(
+    _lib._objc_msgSend_928(
         _id,
         _lib._sel_setCredential_forProtectionSpace_task_1,
         credential?._id ?? ffi.nullptr,
@@ -63912,7 +64190,7 @@ class NSURLCredentialStorage extends NSObject {
       NSURLProtectionSpace? protectionSpace,
       NSDictionary? options,
       NSURLSessionTask? task) {
-    _lib._objc_msgSend_915(
+    _lib._objc_msgSend_929(
         _id,
         _lib._sel_removeCredential_forProtectionSpace_options_task_1,
         credential?._id ?? ffi.nullptr,
@@ -63925,7 +64203,7 @@ class NSURLCredentialStorage extends NSObject {
       NSURLProtectionSpace? space,
       NSURLSessionTask? task,
       ObjCBlock_ffiVoid_NSURLCredential completionHandler) {
-    _lib._objc_msgSend_916(
+    _lib._objc_msgSend_930(
         _id,
         _lib._sel_getDefaultCredentialForProtectionSpace_task_completionHandler_1,
         space?._id ?? ffi.nullptr,
@@ -63937,7 +64215,7 @@ class NSURLCredentialStorage extends NSObject {
       NSURLCredential? credential,
       NSURLProtectionSpace? protectionSpace,
       NSURLSessionTask? task) {
-    _lib._objc_msgSend_914(
+    _lib._objc_msgSend_928(
         _id,
         _lib._sel_setDefaultCredential_forProtectionSpace_task_1,
         credential?._id ?? ffi.nullptr,
@@ -64204,7 +64482,7 @@ class NSURLProtocol extends NSObject {
 
   NSURLProtocol initWithRequest_cachedResponse_client_(NSURLRequest? request,
       NSCachedURLResponse? cachedResponse, NSObject? client) {
-    final _ret = _lib._objc_msgSend_917(
+    final _ret = _lib._objc_msgSend_931(
         _id,
         _lib._sel_initWithRequest_cachedResponse_client_1,
         request?._id ?? ffi.nullptr,
@@ -64221,34 +64499,34 @@ class NSURLProtocol extends NSObject {
   }
 
   NSURLRequest? get request {
-    final _ret = _lib._objc_msgSend_795(_id, _lib._sel_request1);
+    final _ret = _lib._objc_msgSend_799(_id, _lib._sel_request1);
     return _ret.address == 0
         ? null
         : NSURLRequest._(_ret, _lib, retain: true, release: true);
   }
 
   NSCachedURLResponse? get cachedResponse {
-    final _ret = _lib._objc_msgSend_918(_id, _lib._sel_cachedResponse1);
+    final _ret = _lib._objc_msgSend_932(_id, _lib._sel_cachedResponse1);
     return _ret.address == 0
         ? null
         : NSCachedURLResponse._(_ret, _lib, retain: true, release: true);
   }
 
   static bool canInitWithRequest_(SentryCocoa _lib, NSURLRequest? request) {
-    return _lib._objc_msgSend_895(_lib._class_NSURLProtocol1,
+    return _lib._objc_msgSend_909(_lib._class_NSURLProtocol1,
         _lib._sel_canInitWithRequest_1, request?._id ?? ffi.nullptr);
   }
 
   static NSURLRequest canonicalRequestForRequest_(
       SentryCocoa _lib, NSURLRequest? request) {
-    final _ret = _lib._objc_msgSend_919(_lib._class_NSURLProtocol1,
+    final _ret = _lib._objc_msgSend_933(_lib._class_NSURLProtocol1,
         _lib._sel_canonicalRequestForRequest_1, request?._id ?? ffi.nullptr);
     return NSURLRequest._(_ret, _lib, retain: true, release: true);
   }
 
   static bool requestIsCacheEquivalent_toRequest_(
       SentryCocoa _lib, NSURLRequest? a, NSURLRequest? b) {
-    return _lib._objc_msgSend_920(
+    return _lib._objc_msgSend_934(
         _lib._class_NSURLProtocol1,
         _lib._sel_requestIsCacheEquivalent_toRequest_1,
         a?._id ?? ffi.nullptr,
@@ -64265,7 +64543,7 @@ class NSURLProtocol extends NSObject {
 
   static NSObject propertyForKey_inRequest_(
       SentryCocoa _lib, NSString? key, NSURLRequest? request) {
-    final _ret = _lib._objc_msgSend_921(
+    final _ret = _lib._objc_msgSend_935(
         _lib._class_NSURLProtocol1,
         _lib._sel_propertyForKey_inRequest_1,
         key?._id ?? ffi.nullptr,
@@ -64275,7 +64553,7 @@ class NSURLProtocol extends NSObject {
 
   static void setProperty_forKey_inRequest_(SentryCocoa _lib, NSObject value,
       NSString? key, NSMutableURLRequest? request) {
-    _lib._objc_msgSend_927(
+    _lib._objc_msgSend_941(
         _lib._class_NSURLProtocol1,
         _lib._sel_setProperty_forKey_inRequest_1,
         value._id,
@@ -64285,7 +64563,7 @@ class NSURLProtocol extends NSObject {
 
   static void removePropertyForKey_inRequest_(
       SentryCocoa _lib, NSString? key, NSMutableURLRequest? request) {
-    _lib._objc_msgSend_928(
+    _lib._objc_msgSend_942(
         _lib._class_NSURLProtocol1,
         _lib._sel_removePropertyForKey_inRequest_1,
         key?._id ?? ffi.nullptr,
@@ -64303,13 +64581,13 @@ class NSURLProtocol extends NSObject {
   }
 
   static bool canInitWithTask_(SentryCocoa _lib, NSURLSessionTask? task) {
-    return _lib._objc_msgSend_929(_lib._class_NSURLProtocol1,
+    return _lib._objc_msgSend_943(_lib._class_NSURLProtocol1,
         _lib._sel_canInitWithTask_1, task?._id ?? ffi.nullptr);
   }
 
   NSURLProtocol initWithTask_cachedResponse_client_(NSURLSessionTask? task,
       NSCachedURLResponse? cachedResponse, NSObject? client) {
-    final _ret = _lib._objc_msgSend_930(
+    final _ret = _lib._objc_msgSend_944(
         _id,
         _lib._sel_initWithTask_cachedResponse_client_1,
         task?._id ?? ffi.nullptr,
@@ -64319,7 +64597,7 @@ class NSURLProtocol extends NSObject {
   }
 
   NSURLSessionTask? get task {
-    final _ret = _lib._objc_msgSend_931(_id, _lib._sel_task1);
+    final _ret = _lib._objc_msgSend_945(_id, _lib._sel_task1);
     return _ret.address == 0
         ? null
         : NSURLSessionTask._(_ret, _lib, retain: true, release: true);
@@ -64457,11 +64735,11 @@ class NSMutableURLRequest extends NSURLRequest {
 
   @override
   int get cachePolicy {
-    return _lib._objc_msgSend_782(_id, _lib._sel_cachePolicy1);
+    return _lib._objc_msgSend_786(_id, _lib._sel_cachePolicy1);
   }
 
   set cachePolicy(int value) {
-    return _lib._objc_msgSend_922(_id, _lib._sel_setCachePolicy_1, value);
+    return _lib._objc_msgSend_936(_id, _lib._sel_setCachePolicy_1, value);
   }
 
   @override
@@ -64488,11 +64766,11 @@ class NSMutableURLRequest extends NSURLRequest {
 
   @override
   int get networkServiceType {
-    return _lib._objc_msgSend_783(_id, _lib._sel_networkServiceType1);
+    return _lib._objc_msgSend_787(_id, _lib._sel_networkServiceType1);
   }
 
   set networkServiceType(int value) {
-    return _lib._objc_msgSend_923(
+    return _lib._objc_msgSend_937(
         _id, _lib._sel_setNetworkServiceType_1, value);
   }
 
@@ -64539,11 +64817,11 @@ class NSMutableURLRequest extends NSURLRequest {
 
   @override
   int get attribution {
-    return _lib._objc_msgSend_784(_id, _lib._sel_attribution1);
+    return _lib._objc_msgSend_788(_id, _lib._sel_attribution1);
   }
 
   set attribution(int value) {
-    return _lib._objc_msgSend_924(_id, _lib._sel_setAttribution_1, value);
+    return _lib._objc_msgSend_938(_id, _lib._sel_setAttribution_1, value);
   }
 
   @override
@@ -64601,20 +64879,20 @@ class NSMutableURLRequest extends NSURLRequest {
   }
 
   set HTTPBody(NSData? value) {
-    return _lib._objc_msgSend_925(
+    return _lib._objc_msgSend_939(
         _id, _lib._sel_setHTTPBody_1, value?._id ?? ffi.nullptr);
   }
 
   @override
   NSInputStream? get HTTPBodyStream {
-    final _ret = _lib._objc_msgSend_794(_id, _lib._sel_HTTPBodyStream1);
+    final _ret = _lib._objc_msgSend_798(_id, _lib._sel_HTTPBodyStream1);
     return _ret.address == 0
         ? null
         : NSInputStream._(_ret, _lib, retain: true, release: true);
   }
 
   set HTTPBodyStream(NSInputStream? value) {
-    return _lib._objc_msgSend_926(
+    return _lib._objc_msgSend_940(
         _id, _lib._sel_setHTTPBodyStream_1, value?._id ?? ffi.nullptr);
   }
 
@@ -64651,7 +64929,7 @@ class NSMutableURLRequest extends NSURLRequest {
 
   static NSMutableURLRequest requestWithURL_cachePolicy_timeoutInterval_(
       SentryCocoa _lib, NSURL? URL, int cachePolicy, double timeoutInterval) {
-    final _ret = _lib._objc_msgSend_781(
+    final _ret = _lib._objc_msgSend_785(
         _lib._class_NSMutableURLRequest1,
         _lib._sel_requestWithURL_cachePolicy_timeoutInterval_1,
         URL?._id ?? ffi.nullptr,
@@ -64670,7 +64948,7 @@ class NSMutableURLRequest extends NSURLRequest {
   @override
   NSMutableURLRequest initWithURL_cachePolicy_timeoutInterval_(
       NSURL? URL, int cachePolicy, double timeoutInterval) {
-    final _ret = _lib._objc_msgSend_781(
+    final _ret = _lib._objc_msgSend_785(
         _id,
         _lib._sel_initWithURL_cachePolicy_timeoutInterval_1,
         URL?._id ?? ffi.nullptr,
@@ -64808,7 +65086,7 @@ class NSXMLParser extends NSObject {
   }
 
   NSXMLParser initWithStream_(NSInputStream? stream) {
-    final _ret = _lib._objc_msgSend_932(
+    final _ret = _lib._objc_msgSend_946(
         _id, _lib._sel_initWithStream_1, stream?._id ?? ffi.nullptr);
     return NSXMLParser._(_ret, _lib, retain: true, release: true);
   }
@@ -64844,12 +65122,12 @@ class NSXMLParser extends NSObject {
   }
 
   int get externalEntityResolvingPolicy {
-    return _lib._objc_msgSend_933(
+    return _lib._objc_msgSend_947(
         _id, _lib._sel_externalEntityResolvingPolicy1);
   }
 
   set externalEntityResolvingPolicy(int value) {
-    return _lib._objc_msgSend_934(
+    return _lib._objc_msgSend_948(
         _id, _lib._sel_setExternalEntityResolvingPolicy_1, value);
   }
 
@@ -64862,7 +65140,7 @@ class NSXMLParser extends NSObject {
   }
 
   set allowedExternalEntityURLs(NSSet? value) {
-    return _lib._objc_msgSend_935(_id, _lib._sel_setAllowedExternalEntityURLs_1,
+    return _lib._objc_msgSend_949(_id, _lib._sel_setAllowedExternalEntityURLs_1,
         value?._id ?? ffi.nullptr);
   }
 
@@ -65036,7 +65314,7 @@ class NSFileWrapper extends NSObject {
 
   NSFileWrapper initWithURL_options_error_(
       NSURL? url, int options, ffi.Pointer<ffi.Pointer<ObjCObject>> outError) {
-    final _ret = _lib._objc_msgSend_936(
+    final _ret = _lib._objc_msgSend_950(
         _id,
         _lib._sel_initWithURL_options_error_1,
         url?._id ?? ffi.nullptr,
@@ -65138,7 +65416,7 @@ class NSFileWrapper extends NSObject {
 
   bool readFromURL_options_error_(
       NSURL? url, int options, ffi.Pointer<ffi.Pointer<ObjCObject>> outError) {
-    return _lib._objc_msgSend_937(_id, _lib._sel_readFromURL_options_error_1,
+    return _lib._objc_msgSend_951(_id, _lib._sel_readFromURL_options_error_1,
         url?._id ?? ffi.nullptr, options, outError);
   }
 
@@ -65147,7 +65425,7 @@ class NSFileWrapper extends NSObject {
       int options,
       NSURL? originalContentsURL,
       ffi.Pointer<ffi.Pointer<ObjCObject>> outError) {
-    return _lib._objc_msgSend_938(
+    return _lib._objc_msgSend_952(
         _id,
         _lib._sel_writeToURL_options_originalContentsURL_error_1,
         url?._id ?? ffi.nullptr,
@@ -65165,14 +65443,14 @@ class NSFileWrapper extends NSObject {
   }
 
   NSString addFileWrapper_(NSFileWrapper? child) {
-    final _ret = _lib._objc_msgSend_939(
+    final _ret = _lib._objc_msgSend_953(
         _id, _lib._sel_addFileWrapper_1, child?._id ?? ffi.nullptr);
     return NSString._(_ret, _lib, retain: true, release: true);
   }
 
   NSString addRegularFileWithContents_preferredFilename_(
       NSData? data, NSString? fileName) {
-    final _ret = _lib._objc_msgSend_940(
+    final _ret = _lib._objc_msgSend_954(
         _id,
         _lib._sel_addRegularFileWithContents_preferredFilename_1,
         data?._id ?? ffi.nullptr,
@@ -65181,7 +65459,7 @@ class NSFileWrapper extends NSObject {
   }
 
   void removeFileWrapper_(NSFileWrapper? child) {
-    _lib._objc_msgSend_941(
+    _lib._objc_msgSend_955(
         _id, _lib._sel_removeFileWrapper_1, child?._id ?? ffi.nullptr);
   }
 
@@ -65193,7 +65471,7 @@ class NSFileWrapper extends NSObject {
   }
 
   NSString keyForFileWrapper_(NSFileWrapper? child) {
-    final _ret = _lib._objc_msgSend_939(
+    final _ret = _lib._objc_msgSend_953(
         _id, _lib._sel_keyForFileWrapper_1, child?._id ?? ffi.nullptr);
     return NSString._(_ret, _lib, retain: true, release: true);
   }
@@ -65237,7 +65515,7 @@ class NSFileWrapper extends NSObject {
 
   bool writeToFile_atomically_updateFilenames_(
       NSString? path, bool atomicFlag, bool updateFilenamesFlag) {
-    return _lib._objc_msgSend_942(
+    return _lib._objc_msgSend_956(
         _id,
         _lib._sel_writeToFile_atomically_updateFilenames_1,
         path?._id ?? ffi.nullptr,
@@ -65393,7 +65671,7 @@ class NSURLSession extends NSObject {
   }
 
   static NSURLSession? getSharedSession(SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_943(
+    final _ret = _lib._objc_msgSend_957(
         _lib._class_NSURLSession1, _lib._sel_sharedSession1);
     return _ret.address == 0
         ? null
@@ -65402,7 +65680,7 @@ class NSURLSession extends NSObject {
 
   static NSURLSession sessionWithConfiguration_(
       SentryCocoa _lib, NSURLSessionConfiguration? configuration) {
-    final _ret = _lib._objc_msgSend_954(
+    final _ret = _lib._objc_msgSend_968(
         _lib._class_NSURLSession1,
         _lib._sel_sessionWithConfiguration_1,
         configuration?._id ?? ffi.nullptr);
@@ -65414,7 +65692,7 @@ class NSURLSession extends NSObject {
       NSURLSessionConfiguration? configuration,
       NSObject? delegate,
       NSOperationQueue? queue) {
-    final _ret = _lib._objc_msgSend_955(
+    final _ret = _lib._objc_msgSend_969(
         _lib._class_NSURLSession1,
         _lib._sel_sessionWithConfiguration_delegate_delegateQueue_1,
         configuration?._id ?? ffi.nullptr,
@@ -65424,7 +65702,7 @@ class NSURLSession extends NSObject {
   }
 
   NSOperationQueue? get delegateQueue {
-    final _ret = _lib._objc_msgSend_824(_id, _lib._sel_delegateQueue1);
+    final _ret = _lib._objc_msgSend_838(_id, _lib._sel_delegateQueue1);
     return _ret.address == 0
         ? null
         : NSOperationQueue._(_ret, _lib, retain: true, release: true);
@@ -65438,7 +65716,7 @@ class NSURLSession extends NSObject {
   }
 
   NSURLSessionConfiguration? get configuration {
-    final _ret = _lib._objc_msgSend_944(_id, _lib._sel_configuration1);
+    final _ret = _lib._objc_msgSend_958(_id, _lib._sel_configuration1);
     return _ret.address == 0
         ? null
         : NSURLSessionConfiguration._(_ret, _lib, retain: true, release: true);
@@ -65476,31 +65754,31 @@ class NSURLSession extends NSObject {
 
   void getTasksWithCompletionHandler_(
       ObjCBlock_ffiVoid_NSArray_NSArray_NSArray completionHandler) {
-    _lib._objc_msgSend_956(
+    _lib._objc_msgSend_970(
         _id, _lib._sel_getTasksWithCompletionHandler_1, completionHandler._id);
   }
 
   void getAllTasksWithCompletionHandler_(
       ObjCBlock_ffiVoid_NSArray completionHandler) {
-    _lib._objc_msgSend_957(_id, _lib._sel_getAllTasksWithCompletionHandler_1,
+    _lib._objc_msgSend_971(_id, _lib._sel_getAllTasksWithCompletionHandler_1,
         completionHandler._id);
   }
 
   NSURLSessionDataTask dataTaskWithRequest_(NSURLRequest? request) {
-    final _ret = _lib._objc_msgSend_958(
+    final _ret = _lib._objc_msgSend_972(
         _id, _lib._sel_dataTaskWithRequest_1, request?._id ?? ffi.nullptr);
     return NSURLSessionDataTask._(_ret, _lib, retain: true, release: true);
   }
 
   NSURLSessionDataTask dataTaskWithURL_(NSURL? url) {
-    final _ret = _lib._objc_msgSend_959(
+    final _ret = _lib._objc_msgSend_973(
         _id, _lib._sel_dataTaskWithURL_1, url?._id ?? ffi.nullptr);
     return NSURLSessionDataTask._(_ret, _lib, retain: true, release: true);
   }
 
   NSURLSessionUploadTask uploadTaskWithRequest_fromFile_(
       NSURLRequest? request, NSURL? fileURL) {
-    final _ret = _lib._objc_msgSend_960(
+    final _ret = _lib._objc_msgSend_975(
         _id,
         _lib._sel_uploadTaskWithRequest_fromFile_1,
         request?._id ?? ffi.nullptr,
@@ -65510,7 +65788,7 @@ class NSURLSession extends NSObject {
 
   NSURLSessionUploadTask uploadTaskWithRequest_fromData_(
       NSURLRequest? request, NSData? bodyData) {
-    final _ret = _lib._objc_msgSend_961(
+    final _ret = _lib._objc_msgSend_976(
         _id,
         _lib._sel_uploadTaskWithRequest_fromData_1,
         request?._id ?? ffi.nullptr,
@@ -65518,33 +65796,39 @@ class NSURLSession extends NSObject {
     return NSURLSessionUploadTask._(_ret, _lib, retain: true, release: true);
   }
 
+  NSURLSessionUploadTask uploadTaskWithResumeData_(NSData? resumeData) {
+    final _ret = _lib._objc_msgSend_977(_id,
+        _lib._sel_uploadTaskWithResumeData_1, resumeData?._id ?? ffi.nullptr);
+    return NSURLSessionUploadTask._(_ret, _lib, retain: true, release: true);
+  }
+
   NSURLSessionUploadTask uploadTaskWithStreamedRequest_(NSURLRequest? request) {
-    final _ret = _lib._objc_msgSend_962(_id,
+    final _ret = _lib._objc_msgSend_978(_id,
         _lib._sel_uploadTaskWithStreamedRequest_1, request?._id ?? ffi.nullptr);
     return NSURLSessionUploadTask._(_ret, _lib, retain: true, release: true);
   }
 
   NSURLSessionDownloadTask downloadTaskWithRequest_(NSURLRequest? request) {
-    final _ret = _lib._objc_msgSend_964(
+    final _ret = _lib._objc_msgSend_979(
         _id, _lib._sel_downloadTaskWithRequest_1, request?._id ?? ffi.nullptr);
     return NSURLSessionDownloadTask._(_ret, _lib, retain: true, release: true);
   }
 
   NSURLSessionDownloadTask downloadTaskWithURL_(NSURL? url) {
-    final _ret = _lib._objc_msgSend_965(
+    final _ret = _lib._objc_msgSend_980(
         _id, _lib._sel_downloadTaskWithURL_1, url?._id ?? ffi.nullptr);
     return NSURLSessionDownloadTask._(_ret, _lib, retain: true, release: true);
   }
 
   NSURLSessionDownloadTask downloadTaskWithResumeData_(NSData? resumeData) {
-    final _ret = _lib._objc_msgSend_966(_id,
+    final _ret = _lib._objc_msgSend_981(_id,
         _lib._sel_downloadTaskWithResumeData_1, resumeData?._id ?? ffi.nullptr);
     return NSURLSessionDownloadTask._(_ret, _lib, retain: true, release: true);
   }
 
   NSURLSessionStreamTask streamTaskWithHostName_port_(
       NSString? hostname, int port) {
-    final _ret = _lib._objc_msgSend_969(
+    final _ret = _lib._objc_msgSend_984(
         _id,
         _lib._sel_streamTaskWithHostName_port_1,
         hostname?._id ?? ffi.nullptr,
@@ -65553,20 +65837,20 @@ class NSURLSession extends NSObject {
   }
 
   NSURLSessionStreamTask streamTaskWithNetService_(NSNetService? service) {
-    final _ret = _lib._objc_msgSend_975(
+    final _ret = _lib._objc_msgSend_990(
         _id, _lib._sel_streamTaskWithNetService_1, service?._id ?? ffi.nullptr);
     return NSURLSessionStreamTask._(_ret, _lib, retain: true, release: true);
   }
 
   NSURLSessionWebSocketTask webSocketTaskWithURL_(NSURL? url) {
-    final _ret = _lib._objc_msgSend_982(
+    final _ret = _lib._objc_msgSend_997(
         _id, _lib._sel_webSocketTaskWithURL_1, url?._id ?? ffi.nullptr);
     return NSURLSessionWebSocketTask._(_ret, _lib, retain: true, release: true);
   }
 
   NSURLSessionWebSocketTask webSocketTaskWithURL_protocols_(
       NSURL? url, NSArray? protocols) {
-    final _ret = _lib._objc_msgSend_983(
+    final _ret = _lib._objc_msgSend_998(
         _id,
         _lib._sel_webSocketTaskWithURL_protocols_1,
         url?._id ?? ffi.nullptr,
@@ -65575,7 +65859,7 @@ class NSURLSession extends NSObject {
   }
 
   NSURLSessionWebSocketTask webSocketTaskWithRequest_(NSURLRequest? request) {
-    final _ret = _lib._objc_msgSend_984(
+    final _ret = _lib._objc_msgSend_999(
         _id, _lib._sel_webSocketTaskWithRequest_1, request?._id ?? ffi.nullptr);
     return NSURLSessionWebSocketTask._(_ret, _lib, retain: true, release: true);
   }
@@ -65595,7 +65879,7 @@ class NSURLSession extends NSObject {
   NSURLSessionDataTask dataTaskWithRequest_completionHandler_(
       NSURLRequest? request,
       ObjCBlock_ffiVoid_NSData_NSURLResponse_NSError completionHandler) {
-    final _ret = _lib._objc_msgSend_985(
+    final _ret = _lib._objc_msgSend_1000(
         _id,
         _lib._sel_dataTaskWithRequest_completionHandler_1,
         request?._id ?? ffi.nullptr,
@@ -65605,7 +65889,7 @@ class NSURLSession extends NSObject {
 
   NSURLSessionDataTask dataTaskWithURL_completionHandler_(NSURL? url,
       ObjCBlock_ffiVoid_NSData_NSURLResponse_NSError completionHandler) {
-    final _ret = _lib._objc_msgSend_986(
+    final _ret = _lib._objc_msgSend_1001(
         _id,
         _lib._sel_dataTaskWithURL_completionHandler_1,
         url?._id ?? ffi.nullptr,
@@ -65617,7 +65901,7 @@ class NSURLSession extends NSObject {
       NSURLRequest? request,
       NSURL? fileURL,
       ObjCBlock_ffiVoid_NSData_NSURLResponse_NSError completionHandler) {
-    final _ret = _lib._objc_msgSend_987(
+    final _ret = _lib._objc_msgSend_1002(
         _id,
         _lib._sel_uploadTaskWithRequest_fromFile_completionHandler_1,
         request?._id ?? ffi.nullptr,
@@ -65630,7 +65914,7 @@ class NSURLSession extends NSObject {
       NSURLRequest? request,
       NSData? bodyData,
       ObjCBlock_ffiVoid_NSData_NSURLResponse_NSError completionHandler) {
-    final _ret = _lib._objc_msgSend_988(
+    final _ret = _lib._objc_msgSend_1003(
         _id,
         _lib._sel_uploadTaskWithRequest_fromData_completionHandler_1,
         request?._id ?? ffi.nullptr,
@@ -65639,10 +65923,21 @@ class NSURLSession extends NSObject {
     return NSURLSessionUploadTask._(_ret, _lib, retain: true, release: true);
   }
 
+  NSURLSessionUploadTask uploadTaskWithResumeData_completionHandler_(
+      NSData? resumeData,
+      ObjCBlock_ffiVoid_NSData_NSURLResponse_NSError completionHandler) {
+    final _ret = _lib._objc_msgSend_1004(
+        _id,
+        _lib._sel_uploadTaskWithResumeData_completionHandler_1,
+        resumeData?._id ?? ffi.nullptr,
+        completionHandler._id);
+    return NSURLSessionUploadTask._(_ret, _lib, retain: true, release: true);
+  }
+
   NSURLSessionDownloadTask downloadTaskWithRequest_completionHandler_(
       NSURLRequest? request,
       ObjCBlock_ffiVoid_NSURL_NSURLResponse_NSError completionHandler) {
-    final _ret = _lib._objc_msgSend_989(
+    final _ret = _lib._objc_msgSend_1005(
         _id,
         _lib._sel_downloadTaskWithRequest_completionHandler_1,
         request?._id ?? ffi.nullptr,
@@ -65652,7 +65947,7 @@ class NSURLSession extends NSObject {
 
   NSURLSessionDownloadTask downloadTaskWithURL_completionHandler_(NSURL? url,
       ObjCBlock_ffiVoid_NSURL_NSURLResponse_NSError completionHandler) {
-    final _ret = _lib._objc_msgSend_990(
+    final _ret = _lib._objc_msgSend_1006(
         _id,
         _lib._sel_downloadTaskWithURL_completionHandler_1,
         url?._id ?? ffi.nullptr,
@@ -65663,7 +65958,7 @@ class NSURLSession extends NSObject {
   NSURLSessionDownloadTask downloadTaskWithResumeData_completionHandler_(
       NSData? resumeData,
       ObjCBlock_ffiVoid_NSURL_NSURLResponse_NSError completionHandler) {
-    final _ret = _lib._objc_msgSend_991(
+    final _ret = _lib._objc_msgSend_1007(
         _id,
         _lib._sel_downloadTaskWithResumeData_completionHandler_1,
         resumeData?._id ?? ffi.nullptr,
@@ -65779,7 +66074,7 @@ class NSURLSessionConfiguration extends NSObject {
 
   static NSURLSessionConfiguration? getDefaultSessionConfiguration(
       SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_944(_lib._class_NSURLSessionConfiguration1,
+    final _ret = _lib._objc_msgSend_958(_lib._class_NSURLSessionConfiguration1,
         _lib._sel_defaultSessionConfiguration1);
     return _ret.address == 0
         ? null
@@ -65788,7 +66083,7 @@ class NSURLSessionConfiguration extends NSObject {
 
   static NSURLSessionConfiguration? getEphemeralSessionConfiguration(
       SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_944(_lib._class_NSURLSessionConfiguration1,
+    final _ret = _lib._objc_msgSend_958(_lib._class_NSURLSessionConfiguration1,
         _lib._sel_ephemeralSessionConfiguration1);
     return _ret.address == 0
         ? null
@@ -65798,7 +66093,7 @@ class NSURLSessionConfiguration extends NSObject {
   static NSURLSessionConfiguration
       backgroundSessionConfigurationWithIdentifier_(
           SentryCocoa _lib, NSString? identifier) {
-    final _ret = _lib._objc_msgSend_945(
+    final _ret = _lib._objc_msgSend_959(
         _lib._class_NSURLSessionConfiguration1,
         _lib._sel_backgroundSessionConfigurationWithIdentifier_1,
         identifier?._id ?? ffi.nullptr);
@@ -65813,11 +66108,11 @@ class NSURLSessionConfiguration extends NSObject {
   }
 
   int get requestCachePolicy {
-    return _lib._objc_msgSend_782(_id, _lib._sel_requestCachePolicy1);
+    return _lib._objc_msgSend_786(_id, _lib._sel_requestCachePolicy1);
   }
 
   set requestCachePolicy(int value) {
-    return _lib._objc_msgSend_922(
+    return _lib._objc_msgSend_936(
         _id, _lib._sel_setRequestCachePolicy_1, value);
   }
 
@@ -65840,11 +66135,11 @@ class NSURLSessionConfiguration extends NSObject {
   }
 
   int get networkServiceType {
-    return _lib._objc_msgSend_783(_id, _lib._sel_networkServiceType1);
+    return _lib._objc_msgSend_787(_id, _lib._sel_networkServiceType1);
   }
 
   set networkServiceType(int value) {
-    return _lib._objc_msgSend_923(
+    return _lib._objc_msgSend_937(
         _id, _lib._sel_setNetworkServiceType_1, value);
   }
 
@@ -65938,40 +66233,40 @@ class NSURLSessionConfiguration extends NSObject {
   }
 
   int get TLSMinimumSupportedProtocol {
-    return _lib._objc_msgSend_946(_id, _lib._sel_TLSMinimumSupportedProtocol1);
+    return _lib._objc_msgSend_960(_id, _lib._sel_TLSMinimumSupportedProtocol1);
   }
 
   set TLSMinimumSupportedProtocol(int value) {
-    return _lib._objc_msgSend_947(
+    return _lib._objc_msgSend_961(
         _id, _lib._sel_setTLSMinimumSupportedProtocol_1, value);
   }
 
   int get TLSMaximumSupportedProtocol {
-    return _lib._objc_msgSend_946(_id, _lib._sel_TLSMaximumSupportedProtocol1);
+    return _lib._objc_msgSend_960(_id, _lib._sel_TLSMaximumSupportedProtocol1);
   }
 
   set TLSMaximumSupportedProtocol(int value) {
-    return _lib._objc_msgSend_947(
+    return _lib._objc_msgSend_961(
         _id, _lib._sel_setTLSMaximumSupportedProtocol_1, value);
   }
 
   int get TLSMinimumSupportedProtocolVersion {
-    return _lib._objc_msgSend_948(
+    return _lib._objc_msgSend_962(
         _id, _lib._sel_TLSMinimumSupportedProtocolVersion1);
   }
 
   set TLSMinimumSupportedProtocolVersion(int value) {
-    return _lib._objc_msgSend_949(
+    return _lib._objc_msgSend_963(
         _id, _lib._sel_setTLSMinimumSupportedProtocolVersion_1, value);
   }
 
   int get TLSMaximumSupportedProtocolVersion {
-    return _lib._objc_msgSend_948(
+    return _lib._objc_msgSend_962(
         _id, _lib._sel_TLSMaximumSupportedProtocolVersion1);
   }
 
   set TLSMaximumSupportedProtocolVersion(int value) {
-    return _lib._objc_msgSend_949(
+    return _lib._objc_msgSend_963(
         _id, _lib._sel_setTLSMaximumSupportedProtocolVersion_1, value);
   }
 
@@ -65994,11 +66289,11 @@ class NSURLSessionConfiguration extends NSObject {
   }
 
   int get HTTPCookieAcceptPolicy {
-    return _lib._objc_msgSend_779(_id, _lib._sel_HTTPCookieAcceptPolicy1);
+    return _lib._objc_msgSend_783(_id, _lib._sel_HTTPCookieAcceptPolicy1);
   }
 
   set HTTPCookieAcceptPolicy(int value) {
-    return _lib._objc_msgSend_780(
+    return _lib._objc_msgSend_784(
         _id, _lib._sel_setHTTPCookieAcceptPolicy_1, value);
   }
 
@@ -66024,38 +66319,38 @@ class NSURLSessionConfiguration extends NSObject {
   }
 
   NSHTTPCookieStorage? get HTTPCookieStorage {
-    final _ret = _lib._objc_msgSend_773(_id, _lib._sel_HTTPCookieStorage1);
+    final _ret = _lib._objc_msgSend_777(_id, _lib._sel_HTTPCookieStorage1);
     return _ret.address == 0
         ? null
         : NSHTTPCookieStorage._(_ret, _lib, retain: true, release: true);
   }
 
   set HTTPCookieStorage(NSHTTPCookieStorage? value) {
-    return _lib._objc_msgSend_950(
+    return _lib._objc_msgSend_964(
         _id, _lib._sel_setHTTPCookieStorage_1, value?._id ?? ffi.nullptr);
   }
 
   NSURLCredentialStorage? get URLCredentialStorage {
-    final _ret = _lib._objc_msgSend_908(_id, _lib._sel_URLCredentialStorage1);
+    final _ret = _lib._objc_msgSend_922(_id, _lib._sel_URLCredentialStorage1);
     return _ret.address == 0
         ? null
         : NSURLCredentialStorage._(_ret, _lib, retain: true, release: true);
   }
 
   set URLCredentialStorage(NSURLCredentialStorage? value) {
-    return _lib._objc_msgSend_951(
+    return _lib._objc_msgSend_965(
         _id, _lib._sel_setURLCredentialStorage_1, value?._id ?? ffi.nullptr);
   }
 
   NSURLCache? get URLCache {
-    final _ret = _lib._objc_msgSend_878(_id, _lib._sel_URLCache1);
+    final _ret = _lib._objc_msgSend_892(_id, _lib._sel_URLCache1);
     return _ret.address == 0
         ? null
         : NSURLCache._(_ret, _lib, retain: true, release: true);
   }
 
   set URLCache(NSURLCache? value) {
-    return _lib._objc_msgSend_879(
+    return _lib._objc_msgSend_893(
         _id, _lib._sel_setURLCache_1, value?._id ?? ffi.nullptr);
   }
 
@@ -66077,16 +66372,16 @@ class NSURLSessionConfiguration extends NSObject {
   }
 
   set protocolClasses(NSArray? value) {
-    return _lib._objc_msgSend_731(
+    return _lib._objc_msgSend_735(
         _id, _lib._sel_setProtocolClasses_1, value?._id ?? ffi.nullptr);
   }
 
   int get multipathServiceType {
-    return _lib._objc_msgSend_952(_id, _lib._sel_multipathServiceType1);
+    return _lib._objc_msgSend_966(_id, _lib._sel_multipathServiceType1);
   }
 
   set multipathServiceType(int value) {
-    return _lib._objc_msgSend_953(
+    return _lib._objc_msgSend_967(
         _id, _lib._sel_setMultipathServiceType_1, value);
   }
 
@@ -66105,7 +66400,7 @@ class NSURLSessionConfiguration extends NSObject {
 
   static NSURLSessionConfiguration backgroundSessionConfiguration_(
       SentryCocoa _lib, NSString? identifier) {
-    final _ret = _lib._objc_msgSend_945(
+    final _ret = _lib._objc_msgSend_959(
         _lib._class_NSURLSessionConfiguration1,
         _lib._sel_backgroundSessionConfiguration_1,
         identifier?._id ?? ffi.nullptr);
@@ -66371,6 +66666,12 @@ class NSURLSessionUploadTask extends NSURLSessionDataTask {
     return NSURLSessionUploadTask._(_ret, _lib, retain: false, release: true);
   }
 
+  void cancelByProducingResumeData_(
+      ObjCBlock_ffiVoid_NSData completionHandler) {
+    _lib._objc_msgSend_974(
+        _id, _lib._sel_cancelByProducingResumeData_1, completionHandler._id);
+  }
+
   static NSURLSessionUploadTask allocWithZone_(
       SentryCocoa _lib, ffi.Pointer<_NSZone> zone) {
     final _ret = _lib._objc_msgSend_3(
@@ -66452,6 +66753,75 @@ class NSURLSessionUploadTask extends NSURLSessionDataTask {
   }
 }
 
+void _ObjCBlock_ffiVoid_NSData_fnPtrTrampoline(
+    ffi.Pointer<_ObjCBlock> block, ffi.Pointer<ObjCObject> arg0) {
+  return block.ref.target
+      .cast<
+          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ObjCObject> arg0)>>()
+      .asFunction<void Function(ffi.Pointer<ObjCObject> arg0)>()(arg0);
+}
+
+final _ObjCBlock_ffiVoid_NSData_closureRegistry = <int, Function>{};
+int _ObjCBlock_ffiVoid_NSData_closureRegistryIndex = 0;
+ffi.Pointer<ffi.Void> _ObjCBlock_ffiVoid_NSData_registerClosure(Function fn) {
+  final id = ++_ObjCBlock_ffiVoid_NSData_closureRegistryIndex;
+  _ObjCBlock_ffiVoid_NSData_closureRegistry[id] = fn;
+  return ffi.Pointer<ffi.Void>.fromAddress(id);
+}
+
+void _ObjCBlock_ffiVoid_NSData_closureTrampoline(
+    ffi.Pointer<_ObjCBlock> block, ffi.Pointer<ObjCObject> arg0) {
+  return (_ObjCBlock_ffiVoid_NSData_closureRegistry[block.ref.target.address]
+      as void Function(ffi.Pointer<ObjCObject>))(arg0);
+}
+
+class ObjCBlock_ffiVoid_NSData extends _ObjCBlockBase {
+  ObjCBlock_ffiVoid_NSData._(ffi.Pointer<_ObjCBlock> id, SentryCocoa lib)
+      : super._(id, lib, retain: false, release: true);
+
+  /// Creates a block from a C function pointer.
+  ObjCBlock_ffiVoid_NSData.fromFunctionPointer(
+      SentryCocoa lib,
+      ffi.Pointer<
+              ffi
+              .NativeFunction<ffi.Void Function(ffi.Pointer<ObjCObject> arg0)>>
+          ptr)
+      : this._(
+            lib._newBlock1(
+                _cFuncTrampoline ??= ffi.Pointer.fromFunction<
+                            ffi.Void Function(ffi.Pointer<_ObjCBlock> block,
+                                ffi.Pointer<ObjCObject> arg0)>(
+                        _ObjCBlock_ffiVoid_NSData_fnPtrTrampoline)
+                    .cast(),
+                ptr.cast()),
+            lib);
+  static ffi.Pointer<ffi.Void>? _cFuncTrampoline;
+
+  /// Creates a block from a Dart function.
+  ObjCBlock_ffiVoid_NSData.fromFunction(
+      SentryCocoa lib, void Function(ffi.Pointer<ObjCObject> arg0) fn)
+      : this._(
+            lib._newBlock1(
+                _dartFuncTrampoline ??= ffi.Pointer.fromFunction<
+                            ffi.Void Function(ffi.Pointer<_ObjCBlock> block,
+                                ffi.Pointer<ObjCObject> arg0)>(
+                        _ObjCBlock_ffiVoid_NSData_closureTrampoline)
+                    .cast(),
+                _ObjCBlock_ffiVoid_NSData_registerClosure(fn)),
+            lib);
+  static ffi.Pointer<ffi.Void>? _dartFuncTrampoline;
+  void call(ffi.Pointer<ObjCObject> arg0) {
+    return _id.ref.invoke
+        .cast<
+            ffi.NativeFunction<
+                ffi.Void Function(ffi.Pointer<_ObjCBlock> block,
+                    ffi.Pointer<ObjCObject> arg0)>>()
+        .asFunction<
+            void Function(ffi.Pointer<_ObjCBlock> block,
+                ffi.Pointer<ObjCObject> arg0)>()(_id, arg0);
+  }
+}
+
 class NSURLSessionDownloadTask extends NSURLSessionTask {
   NSURLSessionDownloadTask._(ffi.Pointer<ObjCObject> id, SentryCocoa lib,
       {bool retain = false, bool release = false})
@@ -66479,7 +66849,7 @@ class NSURLSessionDownloadTask extends NSURLSessionTask {
 
   void cancelByProducingResumeData_(
       ObjCBlock_ffiVoid_NSData completionHandler) {
-    _lib._objc_msgSend_963(
+    _lib._objc_msgSend_974(
         _id, _lib._sel_cancelByProducingResumeData_1, completionHandler._id);
   }
 
@@ -66576,75 +66946,6 @@ class NSURLSessionDownloadTask extends NSURLSessionTask {
   }
 }
 
-void _ObjCBlock_ffiVoid_NSData_fnPtrTrampoline(
-    ffi.Pointer<_ObjCBlock> block, ffi.Pointer<ObjCObject> arg0) {
-  return block.ref.target
-      .cast<
-          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ObjCObject> arg0)>>()
-      .asFunction<void Function(ffi.Pointer<ObjCObject> arg0)>()(arg0);
-}
-
-final _ObjCBlock_ffiVoid_NSData_closureRegistry = <int, Function>{};
-int _ObjCBlock_ffiVoid_NSData_closureRegistryIndex = 0;
-ffi.Pointer<ffi.Void> _ObjCBlock_ffiVoid_NSData_registerClosure(Function fn) {
-  final id = ++_ObjCBlock_ffiVoid_NSData_closureRegistryIndex;
-  _ObjCBlock_ffiVoid_NSData_closureRegistry[id] = fn;
-  return ffi.Pointer<ffi.Void>.fromAddress(id);
-}
-
-void _ObjCBlock_ffiVoid_NSData_closureTrampoline(
-    ffi.Pointer<_ObjCBlock> block, ffi.Pointer<ObjCObject> arg0) {
-  return (_ObjCBlock_ffiVoid_NSData_closureRegistry[block.ref.target.address]
-      as void Function(ffi.Pointer<ObjCObject>))(arg0);
-}
-
-class ObjCBlock_ffiVoid_NSData extends _ObjCBlockBase {
-  ObjCBlock_ffiVoid_NSData._(ffi.Pointer<_ObjCBlock> id, SentryCocoa lib)
-      : super._(id, lib, retain: false, release: true);
-
-  /// Creates a block from a C function pointer.
-  ObjCBlock_ffiVoid_NSData.fromFunctionPointer(
-      SentryCocoa lib,
-      ffi.Pointer<
-              ffi
-              .NativeFunction<ffi.Void Function(ffi.Pointer<ObjCObject> arg0)>>
-          ptr)
-      : this._(
-            lib._newBlock1(
-                _cFuncTrampoline ??= ffi.Pointer.fromFunction<
-                            ffi.Void Function(ffi.Pointer<_ObjCBlock> block,
-                                ffi.Pointer<ObjCObject> arg0)>(
-                        _ObjCBlock_ffiVoid_NSData_fnPtrTrampoline)
-                    .cast(),
-                ptr.cast()),
-            lib);
-  static ffi.Pointer<ffi.Void>? _cFuncTrampoline;
-
-  /// Creates a block from a Dart function.
-  ObjCBlock_ffiVoid_NSData.fromFunction(
-      SentryCocoa lib, void Function(ffi.Pointer<ObjCObject> arg0) fn)
-      : this._(
-            lib._newBlock1(
-                _dartFuncTrampoline ??= ffi.Pointer.fromFunction<
-                            ffi.Void Function(ffi.Pointer<_ObjCBlock> block,
-                                ffi.Pointer<ObjCObject> arg0)>(
-                        _ObjCBlock_ffiVoid_NSData_closureTrampoline)
-                    .cast(),
-                _ObjCBlock_ffiVoid_NSData_registerClosure(fn)),
-            lib);
-  static ffi.Pointer<ffi.Void>? _dartFuncTrampoline;
-  void call(ffi.Pointer<ObjCObject> arg0) {
-    return _id.ref.invoke
-        .cast<
-            ffi.NativeFunction<
-                ffi.Void Function(ffi.Pointer<_ObjCBlock> block,
-                    ffi.Pointer<ObjCObject> arg0)>>()
-        .asFunction<
-            void Function(ffi.Pointer<_ObjCBlock> block,
-                ffi.Pointer<ObjCObject> arg0)>()(_id, arg0);
-  }
-}
-
 class NSURLSessionStreamTask extends NSURLSessionTask {
   NSURLSessionStreamTask._(ffi.Pointer<ObjCObject> id, SentryCocoa lib,
       {bool retain = false, bool release = false})
@@ -66675,7 +66976,7 @@ class NSURLSessionStreamTask extends NSURLSessionTask {
       int maxBytes,
       double timeout,
       ObjCBlock_ffiVoid_NSData_bool_NSError completionHandler) {
-    _lib._objc_msgSend_967(
+    _lib._objc_msgSend_982(
         _id,
         _lib._sel_readDataOfMinLength_maxLength_timeout_completionHandler_1,
         minBytes,
@@ -66686,7 +66987,7 @@ class NSURLSessionStreamTask extends NSURLSessionTask {
 
   void writeData_timeout_completionHandler_(NSData? data, double timeout,
       ObjCBlock_ffiVoid_NSError completionHandler) {
-    _lib._objc_msgSend_968(_id, _lib._sel_writeData_timeout_completionHandler_1,
+    _lib._objc_msgSend_983(_id, _lib._sel_writeData_timeout_completionHandler_1,
         data?._id ?? ffi.nullptr, timeout, completionHandler._id);
   }
 
@@ -66929,7 +67230,7 @@ class NSNetService extends NSObject {
 
   NSNetService initWithDomain_type_name_port_(
       NSString? domain, NSString? type, NSString? name, int port) {
-    final _ret = _lib._objc_msgSend_970(
+    final _ret = _lib._objc_msgSend_985(
         _id,
         _lib._sel_initWithDomain_type_name_port_1,
         domain?._id ?? ffi.nullptr,
@@ -67025,7 +67326,7 @@ class NSNetService extends NSObject {
   }
 
   void publishWithOptions_(int options) {
-    _lib._objc_msgSend_971(_id, _lib._sel_publishWithOptions_1, options);
+    _lib._objc_msgSend_986(_id, _lib._sel_publishWithOptions_1, options);
   }
 
   void resolve() {
@@ -67038,14 +67339,14 @@ class NSNetService extends NSObject {
 
   static NSDictionary dictionaryFromTXTRecordData_(
       SentryCocoa _lib, NSData? txtData) {
-    final _ret = _lib._objc_msgSend_972(_lib._class_NSNetService1,
+    final _ret = _lib._objc_msgSend_987(_lib._class_NSNetService1,
         _lib._sel_dictionaryFromTXTRecordData_1, txtData?._id ?? ffi.nullptr);
     return NSDictionary._(_ret, _lib, retain: true, release: true);
   }
 
   static NSData dataFromTXTRecordDictionary_(
       SentryCocoa _lib, NSDictionary? txtDictionary) {
-    final _ret = _lib._objc_msgSend_973(
+    final _ret = _lib._objc_msgSend_988(
         _lib._class_NSNetService1,
         _lib._sel_dataFromTXTRecordDictionary_1,
         txtDictionary?._id ?? ffi.nullptr);
@@ -67059,7 +67360,7 @@ class NSNetService extends NSObject {
   bool getInputStream_outputStream_(
       ffi.Pointer<ffi.Pointer<ObjCObject>> inputStream,
       ffi.Pointer<ffi.Pointer<ObjCObject>> outputStream) {
-    return _lib._objc_msgSend_974(_id, _lib._sel_getInputStream_outputStream_1,
+    return _lib._objc_msgSend_989(_id, _lib._sel_getInputStream_outputStream_1,
         inputStream, outputStream);
   }
 
@@ -67206,25 +67507,25 @@ class NSURLSessionWebSocketTask extends NSURLSessionTask {
 
   void sendMessage_completionHandler_(NSURLSessionWebSocketMessage? message,
       ObjCBlock_ffiVoid_NSError completionHandler) {
-    _lib._objc_msgSend_977(_id, _lib._sel_sendMessage_completionHandler_1,
+    _lib._objc_msgSend_992(_id, _lib._sel_sendMessage_completionHandler_1,
         message?._id ?? ffi.nullptr, completionHandler._id);
   }
 
   void receiveMessageWithCompletionHandler_(
       ObjCBlock_ffiVoid_NSURLSessionWebSocketMessage_NSError
           completionHandler) {
-    _lib._objc_msgSend_978(_id, _lib._sel_receiveMessageWithCompletionHandler_1,
+    _lib._objc_msgSend_993(_id, _lib._sel_receiveMessageWithCompletionHandler_1,
         completionHandler._id);
   }
 
   void sendPingWithPongReceiveHandler_(
       ObjCBlock_ffiVoid_NSError pongReceiveHandler) {
-    _lib._objc_msgSend_979(_id, _lib._sel_sendPingWithPongReceiveHandler_1,
+    _lib._objc_msgSend_994(_id, _lib._sel_sendPingWithPongReceiveHandler_1,
         pongReceiveHandler._id);
   }
 
   void cancelWithCloseCode_reason_(int closeCode, NSData? reason) {
-    _lib._objc_msgSend_980(_id, _lib._sel_cancelWithCloseCode_reason_1,
+    _lib._objc_msgSend_995(_id, _lib._sel_cancelWithCloseCode_reason_1,
         closeCode, reason?._id ?? ffi.nullptr);
   }
 
@@ -67238,7 +67539,7 @@ class NSURLSessionWebSocketTask extends NSURLSessionTask {
   }
 
   int get closeCode {
-    return _lib._objc_msgSend_981(_id, _lib._sel_closeCode1);
+    return _lib._objc_msgSend_996(_id, _lib._sel_closeCode1);
   }
 
   NSData? get closeReason {
@@ -67385,7 +67686,7 @@ class NSURLSessionWebSocketMessage extends NSObject {
   }
 
   int get type {
-    return _lib._objc_msgSend_976(_id, _lib._sel_type1);
+    return _lib._objc_msgSend_991(_id, _lib._sel_type1);
   }
 
   NSData? get data {
@@ -67866,14 +68167,14 @@ class NSProtocolChecker extends NSProxy {
   }
 
   Protocol? get protocol {
-    final _ret = _lib._objc_msgSend_992(_id, _lib._sel_protocol1);
+    final _ret = _lib._objc_msgSend_1008(_id, _lib._sel_protocol1);
     return _ret.address == 0
         ? null
         : Protocol._(_ret, _lib, retain: true, release: true);
   }
 
   NSObject? get target {
-    final _ret = _lib._objc_msgSend_822(_id, _lib._sel_target1);
+    final _ret = _lib._objc_msgSend_836(_id, _lib._sel_target1);
     return _ret.address == 0
         ? null
         : NSObject._(_ret, _lib, retain: true, release: true);
@@ -67881,7 +68182,7 @@ class NSProtocolChecker extends NSProxy {
 
   static NSProtocolChecker protocolCheckerWithTarget_protocol_(
       SentryCocoa _lib, NSObject? anObject, Protocol? aProtocol) {
-    final _ret = _lib._objc_msgSend_993(
+    final _ret = _lib._objc_msgSend_1009(
         _lib._class_NSProtocolChecker1,
         _lib._sel_protocolCheckerWithTarget_protocol_1,
         anObject?._id ?? ffi.nullptr,
@@ -67891,7 +68192,7 @@ class NSProtocolChecker extends NSProxy {
 
   NSProtocolChecker initWithTarget_protocol_(
       NSObject? anObject, Protocol? aProtocol) {
-    final _ret = _lib._objc_msgSend_993(
+    final _ret = _lib._objc_msgSend_1009(
         _id,
         _lib._sel_initWithTarget_protocol_1,
         anObject?._id ?? ffi.nullptr,
@@ -67960,7 +68261,7 @@ class NSTask extends NSObject {
   }
 
   set arguments(NSArray? value) {
-    return _lib._objc_msgSend_731(
+    return _lib._objc_msgSend_735(
         _id, _lib._sel_setArguments_1, value?._id ?? ffi.nullptr);
   }
 
@@ -67986,6 +68287,18 @@ class NSTask extends NSObject {
   set currentDirectoryURL(NSURL? value) {
     return _lib._objc_msgSend_621(
         _id, _lib._sel_setCurrentDirectoryURL_1, value?._id ?? ffi.nullptr);
+  }
+
+  NSData? get launchRequirementData {
+    final _ret = _lib._objc_msgSend_39(_id, _lib._sel_launchRequirementData1);
+    return _ret.address == 0
+        ? null
+        : NSData._(_ret, _lib, retain: true, release: true);
+  }
+
+  set launchRequirementData(NSData? value) {
+    return _lib._objc_msgSend_939(
+        _id, _lib._sel_setLaunchRequirementData_1, value?._id ?? ffi.nullptr);
   }
 
   NSObject get standardInput {
@@ -68017,7 +68330,7 @@ class NSTask extends NSObject {
   }
 
   bool launchAndReturnError_(ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    return _lib._objc_msgSend_225(_id, _lib._sel_launchAndReturnError_1, error);
+    return _lib._objc_msgSend_236(_id, _lib._sel_launchAndReturnError_1, error);
   }
 
   void interrupt() {
@@ -68049,16 +68362,16 @@ class NSTask extends NSObject {
   }
 
   int get terminationReason {
-    return _lib._objc_msgSend_994(_id, _lib._sel_terminationReason1);
+    return _lib._objc_msgSend_1010(_id, _lib._sel_terminationReason1);
   }
 
   ObjCBlock_ffiVoid_NSTask get terminationHandler {
-    final _ret = _lib._objc_msgSend_995(_id, _lib._sel_terminationHandler1);
+    final _ret = _lib._objc_msgSend_1011(_id, _lib._sel_terminationHandler1);
     return ObjCBlock_ffiVoid_NSTask._(_ret, _lib);
   }
 
   set terminationHandler(ObjCBlock_ffiVoid_NSTask value) {
-    return _lib._objc_msgSend_996(
+    return _lib._objc_msgSend_1012(
         _id, _lib._sel_setTerminationHandler_1, value._id);
   }
 
@@ -68077,7 +68390,7 @@ class NSTask extends NSObject {
           NSArray? arguments,
           ffi.Pointer<ffi.Pointer<ObjCObject>> error,
           ObjCBlock_ffiVoid_NSTask terminationHandler) {
-    final _ret = _lib._objc_msgSend_997(
+    final _ret = _lib._objc_msgSend_1013(
         _lib._class_NSTask1,
         _lib._sel_launchedTaskWithExecutableURL_arguments_error_terminationHandler_1,
         url?._id ?? ffi.nullptr,
@@ -68121,7 +68434,7 @@ class NSTask extends NSObject {
 
   static NSTask launchedTaskWithLaunchPath_arguments_(
       SentryCocoa _lib, NSString? path, NSArray? arguments) {
-    final _ret = _lib._objc_msgSend_998(
+    final _ret = _lib._objc_msgSend_1014(
         _lib._class_NSTask1,
         _lib._sel_launchedTaskWithLaunchPath_arguments_1,
         path?._id ?? ffi.nullptr,
@@ -68340,7 +68653,7 @@ class NSXMLElement extends NSXMLNode {
 
   @override
   NSXMLElement initWithKind_options_(int kind, int options) {
-    final _ret = _lib._objc_msgSend_1000(
+    final _ret = _lib._objc_msgSend_1016(
         _id, _lib._sel_initWithKind_options_1, kind, options);
     return NSXMLElement._(_ret, _lib, retain: true, release: true);
   }
@@ -68361,7 +68674,7 @@ class NSXMLElement extends NSXMLNode {
   }
 
   void addAttribute_(NSXMLNode? attribute) {
-    _lib._objc_msgSend_1012(
+    _lib._objc_msgSend_1028(
         _id, _lib._sel_addAttribute_1, attribute?._id ?? ffi.nullptr);
   }
 
@@ -68378,7 +68691,7 @@ class NSXMLElement extends NSXMLNode {
   }
 
   set attributes(NSArray? value) {
-    return _lib._objc_msgSend_731(
+    return _lib._objc_msgSend_735(
         _id, _lib._sel_setAttributes_1, value?._id ?? ffi.nullptr);
   }
 
@@ -68388,13 +68701,13 @@ class NSXMLElement extends NSXMLNode {
   }
 
   NSXMLNode attributeForName_(NSString? name) {
-    final _ret = _lib._objc_msgSend_1016(
+    final _ret = _lib._objc_msgSend_1032(
         _id, _lib._sel_attributeForName_1, name?._id ?? ffi.nullptr);
     return NSXMLNode._(_ret, _lib, retain: true, release: true);
   }
 
   NSXMLNode attributeForLocalName_URI_(NSString? localName, NSString? URI) {
-    final _ret = _lib._objc_msgSend_1033(
+    final _ret = _lib._objc_msgSend_1049(
         _id,
         _lib._sel_attributeForLocalName_URI_1,
         localName?._id ?? ffi.nullptr,
@@ -68403,7 +68716,7 @@ class NSXMLElement extends NSXMLNode {
   }
 
   void addNamespace_(NSXMLNode? aNamespace) {
-    _lib._objc_msgSend_1012(
+    _lib._objc_msgSend_1028(
         _id, _lib._sel_addNamespace_1, aNamespace?._id ?? ffi.nullptr);
   }
 
@@ -68420,18 +68733,18 @@ class NSXMLElement extends NSXMLNode {
   }
 
   set namespaces(NSArray? value) {
-    return _lib._objc_msgSend_731(
+    return _lib._objc_msgSend_735(
         _id, _lib._sel_setNamespaces_1, value?._id ?? ffi.nullptr);
   }
 
   NSXMLNode namespaceForPrefix_(NSString? name) {
-    final _ret = _lib._objc_msgSend_1016(
+    final _ret = _lib._objc_msgSend_1032(
         _id, _lib._sel_namespaceForPrefix_1, name?._id ?? ffi.nullptr);
     return NSXMLNode._(_ret, _lib, retain: true, release: true);
   }
 
   NSXMLNode resolveNamespaceForName_(NSString? name) {
-    final _ret = _lib._objc_msgSend_1016(
+    final _ret = _lib._objc_msgSend_1032(
         _id, _lib._sel_resolveNamespaceForName_1, name?._id ?? ffi.nullptr);
     return NSXMLNode._(_ret, _lib, retain: true, release: true);
   }
@@ -68445,12 +68758,12 @@ class NSXMLElement extends NSXMLNode {
   }
 
   void insertChild_atIndex_(NSXMLNode? child, int index) {
-    _lib._objc_msgSend_1010(
+    _lib._objc_msgSend_1026(
         _id, _lib._sel_insertChild_atIndex_1, child?._id ?? ffi.nullptr, index);
   }
 
   void insertChildren_atIndex_(NSArray? children, int index) {
-    _lib._objc_msgSend_1011(_id, _lib._sel_insertChildren_atIndex_1,
+    _lib._objc_msgSend_1027(_id, _lib._sel_insertChildren_atIndex_1,
         children?._id ?? ffi.nullptr, index);
   }
 
@@ -68464,17 +68777,17 @@ class NSXMLElement extends NSXMLNode {
   }
 
   void addChild_(NSXMLNode? child) {
-    _lib._objc_msgSend_1012(
+    _lib._objc_msgSend_1028(
         _id, _lib._sel_addChild_1, child?._id ?? ffi.nullptr);
   }
 
   void replaceChildAtIndex_withNode_(int index, NSXMLNode? node) {
-    _lib._objc_msgSend_1013(_id, _lib._sel_replaceChildAtIndex_withNode_1,
+    _lib._objc_msgSend_1029(_id, _lib._sel_replaceChildAtIndex_withNode_1,
         index, node?._id ?? ffi.nullptr);
   }
 
   void normalizeAdjacentTextNodesPreservingCDATA_(bool preserve) {
-    _lib._objc_msgSend_790(
+    _lib._objc_msgSend_794(
         _id, _lib._sel_normalizeAdjacentTextNodesPreservingCDATA_1, preserve);
   }
 
@@ -68491,7 +68804,7 @@ class NSXMLElement extends NSXMLNode {
 
   @override
   NSXMLElement initWithKind_(int kind) {
-    final _ret = _lib._objc_msgSend_999(_id, _lib._sel_initWithKind_1, kind);
+    final _ret = _lib._objc_msgSend_1015(_id, _lib._sel_initWithKind_1, kind);
     return NSXMLElement._(_ret, _lib, retain: true, release: true);
   }
 
@@ -68503,7 +68816,7 @@ class NSXMLElement extends NSXMLNode {
 
   static NSObject documentWithRootElement_(
       SentryCocoa _lib, NSXMLElement? element) {
-    final _ret = _lib._objc_msgSend_1001(_lib._class_NSXMLElement1,
+    final _ret = _lib._objc_msgSend_1017(_lib._class_NSXMLElement1,
         _lib._sel_documentWithRootElement_1, element?._id ?? ffi.nullptr);
     return NSObject._(_ret, _lib, retain: true, release: true);
   }
@@ -68536,7 +68849,7 @@ class NSXMLElement extends NSXMLNode {
 
   static NSObject elementWithName_children_attributes_(SentryCocoa _lib,
       NSString? name, NSArray? children, NSArray? attributes) {
-    final _ret = _lib._objc_msgSend_1002(
+    final _ret = _lib._objc_msgSend_1018(
         _lib._class_NSXMLElement1,
         _lib._sel_elementWithName_children_attributes_1,
         name?._id ?? ffi.nullptr,
@@ -68620,7 +68933,7 @@ class NSXMLElement extends NSXMLNode {
 
   static NSXMLNode predefinedNamespaceForPrefix_(
       SentryCocoa _lib, NSString? name) {
-    final _ret = _lib._objc_msgSend_1016(_lib._class_NSXMLElement1,
+    final _ret = _lib._objc_msgSend_1032(_lib._class_NSXMLElement1,
         _lib._sel_predefinedNamespaceForPrefix_1, name?._id ?? ffi.nullptr);
     return NSXMLNode._(_ret, _lib, retain: true, release: true);
   }
@@ -68742,12 +69055,12 @@ class NSXMLNode extends NSObject {
   }
 
   NSXMLNode initWithKind_(int kind) {
-    final _ret = _lib._objc_msgSend_999(_id, _lib._sel_initWithKind_1, kind);
+    final _ret = _lib._objc_msgSend_1015(_id, _lib._sel_initWithKind_1, kind);
     return NSXMLNode._(_ret, _lib, retain: true, release: true);
   }
 
   NSXMLNode initWithKind_options_(int kind, int options) {
-    final _ret = _lib._objc_msgSend_1000(
+    final _ret = _lib._objc_msgSend_1016(
         _id, _lib._sel_initWithKind_options_1, kind, options);
     return NSXMLNode._(_ret, _lib, retain: true, release: true);
   }
@@ -68760,7 +69073,7 @@ class NSXMLNode extends NSObject {
 
   static NSObject documentWithRootElement_(
       SentryCocoa _lib, NSXMLElement? element) {
-    final _ret = _lib._objc_msgSend_1001(_lib._class_NSXMLNode1,
+    final _ret = _lib._objc_msgSend_1017(_lib._class_NSXMLNode1,
         _lib._sel_documentWithRootElement_1, element?._id ?? ffi.nullptr);
     return NSObject._(_ret, _lib, retain: true, release: true);
   }
@@ -68793,7 +69106,7 @@ class NSXMLNode extends NSObject {
 
   static NSObject elementWithName_children_attributes_(SentryCocoa _lib,
       NSString? name, NSArray? children, NSArray? attributes) {
-    final _ret = _lib._objc_msgSend_1002(
+    final _ret = _lib._objc_msgSend_1018(
         _lib._class_NSXMLNode1,
         _lib._sel_elementWithName_children_attributes_1,
         name?._id ?? ffi.nullptr,
@@ -68864,7 +69177,7 @@ class NSXMLNode extends NSObject {
   }
 
   int get kind {
-    return _lib._objc_msgSend_1003(_id, _lib._sel_kind1);
+    return _lib._objc_msgSend_1019(_id, _lib._sel_kind1);
   }
 
   NSString? get name {
@@ -68901,7 +69214,7 @@ class NSXMLNode extends NSObject {
   }
 
   void setStringValue_resolvingEntities_(NSString? string, bool resolve) {
-    _lib._objc_msgSend_1004(_id, _lib._sel_setStringValue_resolvingEntities_1,
+    _lib._objc_msgSend_1020(_id, _lib._sel_setStringValue_resolvingEntities_1,
         string?._id ?? ffi.nullptr, resolve);
   }
 
@@ -68914,14 +69227,14 @@ class NSXMLNode extends NSObject {
   }
 
   NSXMLDocument? get rootDocument {
-    final _ret = _lib._objc_msgSend_1027(_id, _lib._sel_rootDocument1);
+    final _ret = _lib._objc_msgSend_1043(_id, _lib._sel_rootDocument1);
     return _ret.address == 0
         ? null
         : NSXMLDocument._(_ret, _lib, retain: true, release: true);
   }
 
   NSXMLNode? get parent {
-    final _ret = _lib._objc_msgSend_1028(_id, _lib._sel_parent1);
+    final _ret = _lib._objc_msgSend_1044(_id, _lib._sel_parent1);
     return _ret.address == 0
         ? null
         : NSXMLNode._(_ret, _lib, retain: true, release: true);
@@ -68939,33 +69252,33 @@ class NSXMLNode extends NSObject {
   }
 
   NSXMLNode childAtIndex_(int index) {
-    final _ret = _lib._objc_msgSend_1029(_id, _lib._sel_childAtIndex_1, index);
+    final _ret = _lib._objc_msgSend_1045(_id, _lib._sel_childAtIndex_1, index);
     return NSXMLNode._(_ret, _lib, retain: true, release: true);
   }
 
   NSXMLNode? get previousSibling {
-    final _ret = _lib._objc_msgSend_1028(_id, _lib._sel_previousSibling1);
+    final _ret = _lib._objc_msgSend_1044(_id, _lib._sel_previousSibling1);
     return _ret.address == 0
         ? null
         : NSXMLNode._(_ret, _lib, retain: true, release: true);
   }
 
   NSXMLNode? get nextSibling {
-    final _ret = _lib._objc_msgSend_1028(_id, _lib._sel_nextSibling1);
+    final _ret = _lib._objc_msgSend_1044(_id, _lib._sel_nextSibling1);
     return _ret.address == 0
         ? null
         : NSXMLNode._(_ret, _lib, retain: true, release: true);
   }
 
   NSXMLNode? get previousNode {
-    final _ret = _lib._objc_msgSend_1028(_id, _lib._sel_previousNode1);
+    final _ret = _lib._objc_msgSend_1044(_id, _lib._sel_previousNode1);
     return _ret.address == 0
         ? null
         : NSXMLNode._(_ret, _lib, retain: true, release: true);
   }
 
   NSXMLNode? get nextNode {
-    final _ret = _lib._objc_msgSend_1028(_id, _lib._sel_nextNode1);
+    final _ret = _lib._objc_msgSend_1044(_id, _lib._sel_nextNode1);
     return _ret.address == 0
         ? null
         : NSXMLNode._(_ret, _lib, retain: true, release: true);
@@ -69022,7 +69335,7 @@ class NSXMLNode extends NSObject {
 
   static NSXMLNode predefinedNamespaceForPrefix_(
       SentryCocoa _lib, NSString? name) {
-    final _ret = _lib._objc_msgSend_1016(_lib._class_NSXMLNode1,
+    final _ret = _lib._objc_msgSend_1032(_lib._class_NSXMLNode1,
         _lib._sel_predefinedNamespaceForPrefix_1, name?._id ?? ffi.nullptr);
     return NSXMLNode._(_ret, _lib, retain: true, release: true);
   }
@@ -69043,12 +69356,12 @@ class NSXMLNode extends NSObject {
 
   NSString XMLStringWithOptions_(int options) {
     final _ret =
-        _lib._objc_msgSend_1030(_id, _lib._sel_XMLStringWithOptions_1, options);
+        _lib._objc_msgSend_1046(_id, _lib._sel_XMLStringWithOptions_1, options);
     return NSString._(_ret, _lib, retain: true, release: true);
   }
 
   NSString canonicalXMLStringPreservingComments_(bool comments) {
-    final _ret = _lib._objc_msgSend_1031(
+    final _ret = _lib._objc_msgSend_1047(
         _id, _lib._sel_canonicalXMLStringPreservingComments_1, comments);
     return NSString._(_ret, _lib, retain: true, release: true);
   }
@@ -69062,7 +69375,7 @@ class NSXMLNode extends NSObject {
 
   NSArray objectsForXQuery_constants_error_(NSString? xquery,
       NSDictionary? constants, ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    final _ret = _lib._objc_msgSend_1032(
+    final _ret = _lib._objc_msgSend_1048(
         _id,
         _lib._sel_objectsForXQuery_constants_error_1,
         xquery?._id ?? ffi.nullptr,
@@ -69240,7 +69553,7 @@ class NSXMLDocument extends NSXMLNode {
 
   NSXMLDocument initWithXMLString_options_error_(
       NSString? string, int mask, ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    final _ret = _lib._objc_msgSend_1005(
+    final _ret = _lib._objc_msgSend_1021(
         _id,
         _lib._sel_initWithXMLString_options_error_1,
         string?._id ?? ffi.nullptr,
@@ -69251,7 +69564,7 @@ class NSXMLDocument extends NSXMLNode {
 
   NSXMLDocument initWithContentsOfURL_options_error_(
       NSURL? url, int mask, ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    final _ret = _lib._objc_msgSend_1006(
+    final _ret = _lib._objc_msgSend_1022(
         _id,
         _lib._sel_initWithContentsOfURL_options_error_1,
         url?._id ?? ffi.nullptr,
@@ -69262,7 +69575,7 @@ class NSXMLDocument extends NSXMLNode {
 
   NSXMLDocument initWithData_options_error_(
       NSData? data, int mask, ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    final _ret = _lib._objc_msgSend_1007(
+    final _ret = _lib._objc_msgSend_1023(
         _id,
         _lib._sel_initWithData_options_error_1,
         data?._id ?? ffi.nullptr,
@@ -69272,7 +69585,7 @@ class NSXMLDocument extends NSXMLNode {
   }
 
   NSXMLDocument initWithRootElement_(NSXMLElement? element) {
-    final _ret = _lib._objc_msgSend_1001(
+    final _ret = _lib._objc_msgSend_1017(
         _id, _lib._sel_initWithRootElement_1, element?._id ?? ffi.nullptr);
     return NSXMLDocument._(_ret, _lib, retain: true, release: true);
   }
@@ -69316,11 +69629,11 @@ class NSXMLDocument extends NSXMLNode {
   }
 
   int get documentContentKind {
-    return _lib._objc_msgSend_1008(_id, _lib._sel_documentContentKind1);
+    return _lib._objc_msgSend_1024(_id, _lib._sel_documentContentKind1);
   }
 
   set documentContentKind(int value) {
-    return _lib._objc_msgSend_1009(
+    return _lib._objc_msgSend_1025(
         _id, _lib._sel_setDocumentContentKind_1, value);
   }
 
@@ -69337,34 +69650,34 @@ class NSXMLDocument extends NSXMLNode {
   }
 
   NSXMLDTD? get DTD {
-    final _ret = _lib._objc_msgSend_1019(_id, _lib._sel_DTD1);
+    final _ret = _lib._objc_msgSend_1035(_id, _lib._sel_DTD1);
     return _ret.address == 0
         ? null
         : NSXMLDTD._(_ret, _lib, retain: true, release: true);
   }
 
   set DTD(NSXMLDTD? value) {
-    return _lib._objc_msgSend_1020(
+    return _lib._objc_msgSend_1036(
         _id, _lib._sel_setDTD_1, value?._id ?? ffi.nullptr);
   }
 
   void setRootElement_(NSXMLElement? root) {
-    _lib._objc_msgSend_1021(
+    _lib._objc_msgSend_1037(
         _id, _lib._sel_setRootElement_1, root?._id ?? ffi.nullptr);
   }
 
   NSXMLElement rootElement() {
-    final _ret = _lib._objc_msgSend_1022(_id, _lib._sel_rootElement1);
+    final _ret = _lib._objc_msgSend_1038(_id, _lib._sel_rootElement1);
     return NSXMLElement._(_ret, _lib, retain: true, release: true);
   }
 
   void insertChild_atIndex_(NSXMLNode? child, int index) {
-    _lib._objc_msgSend_1010(
+    _lib._objc_msgSend_1026(
         _id, _lib._sel_insertChild_atIndex_1, child?._id ?? ffi.nullptr, index);
   }
 
   void insertChildren_atIndex_(NSArray? children, int index) {
-    _lib._objc_msgSend_1011(_id, _lib._sel_insertChildren_atIndex_1,
+    _lib._objc_msgSend_1027(_id, _lib._sel_insertChildren_atIndex_1,
         children?._id ?? ffi.nullptr, index);
   }
 
@@ -69378,12 +69691,12 @@ class NSXMLDocument extends NSXMLNode {
   }
 
   void addChild_(NSXMLNode? child) {
-    _lib._objc_msgSend_1012(
+    _lib._objc_msgSend_1028(
         _id, _lib._sel_addChild_1, child?._id ?? ffi.nullptr);
   }
 
   void replaceChildAtIndex_withNode_(int index, NSXMLNode? node) {
-    _lib._objc_msgSend_1013(_id, _lib._sel_replaceChildAtIndex_withNode_1,
+    _lib._objc_msgSend_1029(_id, _lib._sel_replaceChildAtIndex_withNode_1,
         index, node?._id ?? ffi.nullptr);
   }
 
@@ -69396,13 +69709,13 @@ class NSXMLDocument extends NSXMLNode {
 
   NSData XMLDataWithOptions_(int options) {
     final _ret =
-        _lib._objc_msgSend_1023(_id, _lib._sel_XMLDataWithOptions_1, options);
+        _lib._objc_msgSend_1039(_id, _lib._sel_XMLDataWithOptions_1, options);
     return NSData._(_ret, _lib, retain: true, release: true);
   }
 
   NSObject objectByApplyingXSLT_arguments_error_(NSData? xslt,
       NSDictionary? arguments, ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    final _ret = _lib._objc_msgSend_1024(
+    final _ret = _lib._objc_msgSend_1040(
         _id,
         _lib._sel_objectByApplyingXSLT_arguments_error_1,
         xslt?._id ?? ffi.nullptr,
@@ -69413,7 +69726,7 @@ class NSXMLDocument extends NSXMLNode {
 
   NSObject objectByApplyingXSLTString_arguments_error_(NSString? xslt,
       NSDictionary? arguments, ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    final _ret = _lib._objc_msgSend_1025(
+    final _ret = _lib._objc_msgSend_1041(
         _id,
         _lib._sel_objectByApplyingXSLTString_arguments_error_1,
         xslt?._id ?? ffi.nullptr,
@@ -69424,7 +69737,7 @@ class NSXMLDocument extends NSXMLNode {
 
   NSObject objectByApplyingXSLTAtURL_arguments_error_(NSURL? xsltURL,
       NSDictionary? argument, ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    final _ret = _lib._objc_msgSend_1026(
+    final _ret = _lib._objc_msgSend_1042(
         _id,
         _lib._sel_objectByApplyingXSLTAtURL_arguments_error_1,
         xsltURL?._id ?? ffi.nullptr,
@@ -69434,19 +69747,19 @@ class NSXMLDocument extends NSXMLNode {
   }
 
   bool validateAndReturnError_(ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    return _lib._objc_msgSend_225(
+    return _lib._objc_msgSend_236(
         _id, _lib._sel_validateAndReturnError_1, error);
   }
 
   @override
   NSXMLDocument initWithKind_(int kind) {
-    final _ret = _lib._objc_msgSend_999(_id, _lib._sel_initWithKind_1, kind);
+    final _ret = _lib._objc_msgSend_1015(_id, _lib._sel_initWithKind_1, kind);
     return NSXMLDocument._(_ret, _lib, retain: true, release: true);
   }
 
   @override
   NSXMLDocument initWithKind_options_(int kind, int options) {
-    final _ret = _lib._objc_msgSend_1000(
+    final _ret = _lib._objc_msgSend_1016(
         _id, _lib._sel_initWithKind_options_1, kind, options);
     return NSXMLDocument._(_ret, _lib, retain: true, release: true);
   }
@@ -69459,7 +69772,7 @@ class NSXMLDocument extends NSXMLNode {
 
   static NSObject documentWithRootElement_(
       SentryCocoa _lib, NSXMLElement? element) {
-    final _ret = _lib._objc_msgSend_1001(_lib._class_NSXMLDocument1,
+    final _ret = _lib._objc_msgSend_1017(_lib._class_NSXMLDocument1,
         _lib._sel_documentWithRootElement_1, element?._id ?? ffi.nullptr);
     return NSObject._(_ret, _lib, retain: true, release: true);
   }
@@ -69492,7 +69805,7 @@ class NSXMLDocument extends NSXMLNode {
 
   static NSObject elementWithName_children_attributes_(SentryCocoa _lib,
       NSString? name, NSArray? children, NSArray? attributes) {
-    final _ret = _lib._objc_msgSend_1002(
+    final _ret = _lib._objc_msgSend_1018(
         _lib._class_NSXMLDocument1,
         _lib._sel_elementWithName_children_attributes_1,
         name?._id ?? ffi.nullptr,
@@ -69576,7 +69889,7 @@ class NSXMLDocument extends NSXMLNode {
 
   static NSXMLNode predefinedNamespaceForPrefix_(
       SentryCocoa _lib, NSString? name) {
-    final _ret = _lib._objc_msgSend_1016(_lib._class_NSXMLDocument1,
+    final _ret = _lib._objc_msgSend_1032(_lib._class_NSXMLDocument1,
         _lib._sel_predefinedNamespaceForPrefix_1, name?._id ?? ffi.nullptr);
     return NSXMLNode._(_ret, _lib, retain: true, release: true);
   }
@@ -69706,14 +70019,14 @@ class NSXMLDTD extends NSXMLNode {
 
   @override
   NSXMLDTD initWithKind_options_(int kind, int options) {
-    final _ret = _lib._objc_msgSend_1000(
+    final _ret = _lib._objc_msgSend_1016(
         _id, _lib._sel_initWithKind_options_1, kind, options);
     return NSXMLDTD._(_ret, _lib, retain: true, release: true);
   }
 
   NSXMLDTD initWithContentsOfURL_options_error_(
       NSURL? url, int mask, ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    final _ret = _lib._objc_msgSend_1006(
+    final _ret = _lib._objc_msgSend_1022(
         _id,
         _lib._sel_initWithContentsOfURL_options_error_1,
         url?._id ?? ffi.nullptr,
@@ -69724,7 +70037,7 @@ class NSXMLDTD extends NSXMLNode {
 
   NSXMLDTD initWithData_options_error_(
       NSData? data, int mask, ffi.Pointer<ffi.Pointer<ObjCObject>> error) {
-    final _ret = _lib._objc_msgSend_1007(
+    final _ret = _lib._objc_msgSend_1023(
         _id,
         _lib._sel_initWithData_options_error_1,
         data?._id ?? ffi.nullptr,
@@ -69758,12 +70071,12 @@ class NSXMLDTD extends NSXMLNode {
   }
 
   void insertChild_atIndex_(NSXMLNode? child, int index) {
-    _lib._objc_msgSend_1010(
+    _lib._objc_msgSend_1026(
         _id, _lib._sel_insertChild_atIndex_1, child?._id ?? ffi.nullptr, index);
   }
 
   void insertChildren_atIndex_(NSArray? children, int index) {
-    _lib._objc_msgSend_1011(_id, _lib._sel_insertChildren_atIndex_1,
+    _lib._objc_msgSend_1027(_id, _lib._sel_insertChildren_atIndex_1,
         children?._id ?? ffi.nullptr, index);
   }
 
@@ -69777,36 +70090,36 @@ class NSXMLDTD extends NSXMLNode {
   }
 
   void addChild_(NSXMLNode? child) {
-    _lib._objc_msgSend_1012(
+    _lib._objc_msgSend_1028(
         _id, _lib._sel_addChild_1, child?._id ?? ffi.nullptr);
   }
 
   void replaceChildAtIndex_withNode_(int index, NSXMLNode? node) {
-    _lib._objc_msgSend_1013(_id, _lib._sel_replaceChildAtIndex_withNode_1,
+    _lib._objc_msgSend_1029(_id, _lib._sel_replaceChildAtIndex_withNode_1,
         index, node?._id ?? ffi.nullptr);
   }
 
   NSXMLDTDNode entityDeclarationForName_(NSString? name) {
-    final _ret = _lib._objc_msgSend_1017(
+    final _ret = _lib._objc_msgSend_1033(
         _id, _lib._sel_entityDeclarationForName_1, name?._id ?? ffi.nullptr);
     return NSXMLDTDNode._(_ret, _lib, retain: true, release: true);
   }
 
   NSXMLDTDNode notationDeclarationForName_(NSString? name) {
-    final _ret = _lib._objc_msgSend_1017(
+    final _ret = _lib._objc_msgSend_1033(
         _id, _lib._sel_notationDeclarationForName_1, name?._id ?? ffi.nullptr);
     return NSXMLDTDNode._(_ret, _lib, retain: true, release: true);
   }
 
   NSXMLDTDNode elementDeclarationForName_(NSString? name) {
-    final _ret = _lib._objc_msgSend_1017(
+    final _ret = _lib._objc_msgSend_1033(
         _id, _lib._sel_elementDeclarationForName_1, name?._id ?? ffi.nullptr);
     return NSXMLDTDNode._(_ret, _lib, retain: true, release: true);
   }
 
   NSXMLDTDNode attributeDeclarationForName_elementName_(
       NSString? name, NSString? elementName) {
-    final _ret = _lib._objc_msgSend_1018(
+    final _ret = _lib._objc_msgSend_1034(
         _id,
         _lib._sel_attributeDeclarationForName_elementName_1,
         name?._id ?? ffi.nullptr,
@@ -69816,7 +70129,7 @@ class NSXMLDTD extends NSXMLNode {
 
   static NSXMLDTDNode predefinedEntityDeclarationForName_(
       SentryCocoa _lib, NSString? name) {
-    final _ret = _lib._objc_msgSend_1017(
+    final _ret = _lib._objc_msgSend_1033(
         _lib._class_NSXMLDTD1,
         _lib._sel_predefinedEntityDeclarationForName_1,
         name?._id ?? ffi.nullptr);
@@ -69825,7 +70138,7 @@ class NSXMLDTD extends NSXMLNode {
 
   @override
   NSXMLDTD initWithKind_(int kind) {
-    final _ret = _lib._objc_msgSend_999(_id, _lib._sel_initWithKind_1, kind);
+    final _ret = _lib._objc_msgSend_1015(_id, _lib._sel_initWithKind_1, kind);
     return NSXMLDTD._(_ret, _lib, retain: true, release: true);
   }
 
@@ -69837,7 +70150,7 @@ class NSXMLDTD extends NSXMLNode {
 
   static NSObject documentWithRootElement_(
       SentryCocoa _lib, NSXMLElement? element) {
-    final _ret = _lib._objc_msgSend_1001(_lib._class_NSXMLDTD1,
+    final _ret = _lib._objc_msgSend_1017(_lib._class_NSXMLDTD1,
         _lib._sel_documentWithRootElement_1, element?._id ?? ffi.nullptr);
     return NSObject._(_ret, _lib, retain: true, release: true);
   }
@@ -69870,7 +70183,7 @@ class NSXMLDTD extends NSXMLNode {
 
   static NSObject elementWithName_children_attributes_(SentryCocoa _lib,
       NSString? name, NSArray? children, NSArray? attributes) {
-    final _ret = _lib._objc_msgSend_1002(
+    final _ret = _lib._objc_msgSend_1018(
         _lib._class_NSXMLDTD1,
         _lib._sel_elementWithName_children_attributes_1,
         name?._id ?? ffi.nullptr,
@@ -69954,7 +70267,7 @@ class NSXMLDTD extends NSXMLNode {
 
   static NSXMLNode predefinedNamespaceForPrefix_(
       SentryCocoa _lib, NSString? name) {
-    final _ret = _lib._objc_msgSend_1016(_lib._class_NSXMLDTD1,
+    final _ret = _lib._objc_msgSend_1032(_lib._class_NSXMLDTD1,
         _lib._sel_predefinedNamespaceForPrefix_1, name?._id ?? ffi.nullptr);
     return NSXMLNode._(_ret, _lib, retain: true, release: true);
   }
@@ -70074,7 +70387,7 @@ class NSXMLDTDNode extends NSXMLNode {
 
   @override
   NSXMLDTDNode initWithKind_options_(int kind, int options) {
-    final _ret = _lib._objc_msgSend_1000(
+    final _ret = _lib._objc_msgSend_1016(
         _id, _lib._sel_initWithKind_options_1, kind, options);
     return NSXMLDTDNode._(_ret, _lib, retain: true, release: true);
   }
@@ -70086,11 +70399,11 @@ class NSXMLDTDNode extends NSXMLNode {
   }
 
   int get DTDKind {
-    return _lib._objc_msgSend_1014(_id, _lib._sel_DTDKind1);
+    return _lib._objc_msgSend_1030(_id, _lib._sel_DTDKind1);
   }
 
   set DTDKind(int value) {
-    return _lib._objc_msgSend_1015(_id, _lib._sel_setDTDKind_1, value);
+    return _lib._objc_msgSend_1031(_id, _lib._sel_setDTDKind_1, value);
   }
 
   bool get external1 {
@@ -70135,7 +70448,7 @@ class NSXMLDTDNode extends NSXMLNode {
 
   @override
   NSXMLDTDNode initWithKind_(int kind) {
-    final _ret = _lib._objc_msgSend_999(_id, _lib._sel_initWithKind_1, kind);
+    final _ret = _lib._objc_msgSend_1015(_id, _lib._sel_initWithKind_1, kind);
     return NSXMLDTDNode._(_ret, _lib, retain: true, release: true);
   }
 
@@ -70147,7 +70460,7 @@ class NSXMLDTDNode extends NSXMLNode {
 
   static NSObject documentWithRootElement_(
       SentryCocoa _lib, NSXMLElement? element) {
-    final _ret = _lib._objc_msgSend_1001(_lib._class_NSXMLDTDNode1,
+    final _ret = _lib._objc_msgSend_1017(_lib._class_NSXMLDTDNode1,
         _lib._sel_documentWithRootElement_1, element?._id ?? ffi.nullptr);
     return NSObject._(_ret, _lib, retain: true, release: true);
   }
@@ -70180,7 +70493,7 @@ class NSXMLDTDNode extends NSXMLNode {
 
   static NSObject elementWithName_children_attributes_(SentryCocoa _lib,
       NSString? name, NSArray? children, NSArray? attributes) {
-    final _ret = _lib._objc_msgSend_1002(
+    final _ret = _lib._objc_msgSend_1018(
         _lib._class_NSXMLDTDNode1,
         _lib._sel_elementWithName_children_attributes_1,
         name?._id ?? ffi.nullptr,
@@ -70264,7 +70577,7 @@ class NSXMLDTDNode extends NSXMLNode {
 
   static NSXMLNode predefinedNamespaceForPrefix_(
       SentryCocoa _lib, NSString? name) {
-    final _ret = _lib._objc_msgSend_1016(_lib._class_NSXMLDTDNode1,
+    final _ret = _lib._objc_msgSend_1032(_lib._class_NSXMLDTDNode1,
         _lib._sel_predefinedNamespaceForPrefix_1, name?._id ?? ffi.nullptr);
     return NSXMLNode._(_ret, _lib, retain: true, release: true);
   }
@@ -70411,18 +70724,18 @@ class PrivateSentrySDKOnly extends NSObject {
 
   /// For storing an envelope synchronously to disk.
   static void storeEnvelope_(SentryCocoa _lib, SentryEnvelope? envelope) {
-    _lib._objc_msgSend_1055(_lib._class_PrivateSentrySDKOnly1,
+    _lib._objc_msgSend_1050(_lib._class_PrivateSentrySDKOnly1,
         _lib._sel_storeEnvelope_1, envelope?._id ?? ffi.nullptr);
   }
 
   static void captureEnvelope_(SentryCocoa _lib, SentryEnvelope? envelope) {
-    _lib._objc_msgSend_1055(_lib._class_PrivateSentrySDKOnly1,
+    _lib._objc_msgSend_1050(_lib._class_PrivateSentrySDKOnly1,
         _lib._sel_captureEnvelope_1, envelope?._id ?? ffi.nullptr);
   }
 
   /// Create an envelope from @c NSData. Needed for example by Flutter.
   static SentryEnvelope envelopeWithData_(SentryCocoa _lib, NSData? data) {
-    final _ret = _lib._objc_msgSend_1056(_lib._class_PrivateSentrySDKOnly1,
+    final _ret = _lib._objc_msgSend_1051(_lib._class_PrivateSentrySDKOnly1,
         _lib._sel_envelopeWithData_1, data?._id ?? ffi.nullptr);
     return SentryEnvelope._(_ret, _lib, retain: true, release: true);
   }
@@ -70444,7 +70757,7 @@ class PrivateSentrySDKOnly extends NSObject {
   /// gathering them for other backtrace information, like a performance transaction. If this is for a
   /// crash, each image's data section crash info is also included.
   static NSArray getDebugImagesCrashed_(SentryCocoa _lib, bool isCrash) {
-    final _ret = _lib._objc_msgSend_1057(_lib._class_PrivateSentrySDKOnly1,
+    final _ret = _lib._objc_msgSend_1052(_lib._class_PrivateSentrySDKOnly1,
         _lib._sel_getDebugImagesCrashed_1, isCrash);
     return NSArray._(_ret, _lib, retain: true, release: true);
   }
@@ -70488,8 +70801,8 @@ class PrivateSentrySDKOnly extends NSObject {
 
   /// Start a profiler session associated with the given @c SentryId.
   /// @return The system time when the profiler session started.
-  static int startProfilerForTrace_(SentryCocoa _lib, SentryId? traceId) {
-    return _lib._objc_msgSend_1058(_lib._class_PrivateSentrySDKOnly1,
+  static int startProfilerForTrace_(SentryCocoa _lib, SentryId1? traceId) {
+    return _lib._objc_msgSend_1053(_lib._class_PrivateSentrySDKOnly1,
         _lib._sel_startProfilerForTrace_1, traceId?._id ?? ffi.nullptr);
   }
 
@@ -70500,7 +70813,7 @@ class PrivateSentrySDKOnly extends NSObject {
       int startSystemTime,
       int endSystemTime,
       SentryId? traceId) {
-    final _ret = _lib._objc_msgSend_1059(
+    final _ret = _lib._objc_msgSend_1054(
         _lib._class_PrivateSentrySDKOnly1,
         _lib._sel_collectProfileBetween_and_forTrace_1,
         startSystemTime,
@@ -70512,25 +70825,25 @@ class PrivateSentrySDKOnly extends NSObject {
   /// Discard profiler session data associated with the given @c SentryId.
   /// This only needs to be called in case you haven't collected the profile (and don't intend to).
   static void discardProfilerForTrace_(SentryCocoa _lib, SentryId? traceId) {
-    _lib._objc_msgSend_1060(_lib._class_PrivateSentrySDKOnly1,
+    _lib._objc_msgSend_1055(_lib._class_PrivateSentrySDKOnly1,
         _lib._sel_discardProfilerForTrace_1, traceId?._id ?? ffi.nullptr);
   }
 
   static ObjCBlock_ffiVoid_SentryAppStartMeasurement
       getOnAppStartMeasurementAvailable(SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_1061(_lib._class_PrivateSentrySDKOnly1,
+    final _ret = _lib._objc_msgSend_1056(_lib._class_PrivateSentrySDKOnly1,
         _lib._sel_onAppStartMeasurementAvailable1);
     return ObjCBlock_ffiVoid_SentryAppStartMeasurement._(_ret, _lib);
   }
 
   static void setOnAppStartMeasurementAvailable(
       SentryCocoa _lib, ObjCBlock_ffiVoid_SentryAppStartMeasurement value) {
-    return _lib._objc_msgSend_1062(_lib._class_PrivateSentrySDKOnly1,
+    return _lib._objc_msgSend_1057(_lib._class_PrivateSentrySDKOnly1,
         _lib._sel_setOnAppStartMeasurementAvailable_1, value._id);
   }
 
   static SentryAppStartMeasurement? getAppStartMeasurement(SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_1063(
+    final _ret = _lib._objc_msgSend_1058(
         _lib._class_PrivateSentrySDKOnly1, _lib._sel_appStartMeasurement1);
     return _ret.address == 0
         ? null
@@ -70546,7 +70859,7 @@ class PrivateSentrySDKOnly extends NSObject {
   }
 
   static SentryOptions? getOptions(SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_1064(
+    final _ret = _lib._objc_msgSend_1059(
         _lib._class_PrivateSentrySDKOnly1, _lib._sel_options1);
     return _ret.address == 0
         ? null
@@ -70580,16 +70893,37 @@ class PrivateSentrySDKOnly extends NSObject {
 
   static SentryUser userWithDictionary_(
       SentryCocoa _lib, NSDictionary? dictionary) {
-    final _ret = _lib._objc_msgSend_1065(_lib._class_PrivateSentrySDKOnly1,
+    final _ret = _lib._objc_msgSend_1060(_lib._class_PrivateSentrySDKOnly1,
         _lib._sel_userWithDictionary_1, dictionary?._id ?? ffi.nullptr);
     return SentryUser._(_ret, _lib, retain: true, release: true);
   }
 
   static SentryBreadcrumb breadcrumbWithDictionary_(
       SentryCocoa _lib, NSDictionary? dictionary) {
-    final _ret = _lib._objc_msgSend_1066(_lib._class_PrivateSentrySDKOnly1,
+    final _ret = _lib._objc_msgSend_1061(_lib._class_PrivateSentrySDKOnly1,
         _lib._sel_breadcrumbWithDictionary_1, dictionary?._id ?? ffi.nullptr);
     return SentryBreadcrumb._(_ret, _lib, retain: true, release: true);
+  }
+
+  static void captureReplay(SentryCocoa _lib) {
+    _lib._objc_msgSend_1(
+        _lib._class_PrivateSentrySDKOnly1, _lib._sel_captureReplay1);
+  }
+
+  static NSString getReplayId(SentryCocoa _lib) {
+    final _ret = _lib._objc_msgSend_20(
+        _lib._class_PrivateSentrySDKOnly1, _lib._sel_getReplayId1);
+    return NSString._(_ret, _lib, retain: true, release: true);
+  }
+
+  static void addReplayIgnoreClasses_(SentryCocoa _lib, NSArray? classes) {
+    _lib._objc_msgSend_441(_lib._class_PrivateSentrySDKOnly1,
+        _lib._sel_addReplayIgnoreClasses_1, classes?._id ?? ffi.nullptr);
+  }
+
+  static void addReplayRedactClasses_(SentryCocoa _lib, NSArray? classes) {
+    _lib._objc_msgSend_441(_lib._class_PrivateSentrySDKOnly1,
+        _lib._sel_addReplayRedactClasses_1, classes?._id ?? ffi.nullptr);
   }
 
   @override
@@ -70685,7 +71019,7 @@ class PrivateSentrySDKOnly extends NSObject {
   }
 }
 
-class SentryEnvelope extends NSObject {
+class SentryEnvelope extends _ObjCWrapper {
   SentryEnvelope._(ffi.Pointer<ObjCObject> id, SentryCocoa lib,
       {bool retain = false, bool release = false})
       : super._(id, lib, retain: retain, release: release);
@@ -70707,177 +71041,9 @@ class SentryEnvelope extends NSObject {
     return obj._lib._objc_msgSend_0(obj._id, obj._lib._sel_isKindOfClass_1,
         obj._lib._class_SentryEnvelope1);
   }
-
-  @override
-  SentryEnvelope init() {
-    final _ret = _lib._objc_msgSend_2(_id, _lib._sel_init1);
-    return SentryEnvelope._(_ret, _lib, retain: true, release: true);
-  }
-
-  static SentryEnvelope new1(SentryCocoa _lib) {
-    final _ret =
-        _lib._objc_msgSend_2(_lib._class_SentryEnvelope1, _lib._sel_new1);
-    return SentryEnvelope._(_ret, _lib, retain: false, release: true);
-  }
-
-  SentryEnvelope initWithId_singleItem_(
-      SentryId? id, SentryEnvelopeItem? item) {
-    final _ret = _lib._objc_msgSend_1045(_id, _lib._sel_initWithId_singleItem_1,
-        id?._id ?? ffi.nullptr, item?._id ?? ffi.nullptr);
-    return SentryEnvelope._(_ret, _lib, retain: true, release: true);
-  }
-
-  SentryEnvelope initWithHeader_singleItem_(
-      SentryEnvelopeHeader? header, SentryEnvelopeItem? item) {
-    final _ret = _lib._objc_msgSend_1051(
-        _id,
-        _lib._sel_initWithHeader_singleItem_1,
-        header?._id ?? ffi.nullptr,
-        item?._id ?? ffi.nullptr);
-    return SentryEnvelope._(_ret, _lib, retain: true, release: true);
-  }
-
-  SentryEnvelope initWithId_items_(SentryId? id, NSArray? items) {
-    final _ret = _lib._objc_msgSend_1052(_id, _lib._sel_initWithId_items_1,
-        id?._id ?? ffi.nullptr, items?._id ?? ffi.nullptr);
-    return SentryEnvelope._(_ret, _lib, retain: true, release: true);
-  }
-
-  /// Initializes a @c SentryEnvelope with a single session.
-  /// @param session to init the envelope with.
-  SentryEnvelope initWithSession_(SentrySession? session) {
-    final _ret = _lib._objc_msgSend_1040(
-        _id, _lib._sel_initWithSession_1, session?._id ?? ffi.nullptr);
-    return SentryEnvelope._(_ret, _lib, retain: true, release: true);
-  }
-
-  /// Initializes a @c SentryEnvelope with a list of sessions.
-  /// Can be used when an operation that starts a session closes an ongoing session.
-  /// @param sessions to init the envelope with.
-  SentryEnvelope initWithSessions_(NSArray? sessions) {
-    final _ret = _lib._objc_msgSend_67(
-        _id, _lib._sel_initWithSessions_1, sessions?._id ?? ffi.nullptr);
-    return SentryEnvelope._(_ret, _lib, retain: true, release: true);
-  }
-
-  SentryEnvelope initWithHeader_items_(
-      SentryEnvelopeHeader? header, NSArray? items) {
-    final _ret = _lib._objc_msgSend_1053(_id, _lib._sel_initWithHeader_items_1,
-        header?._id ?? ffi.nullptr, items?._id ?? ffi.nullptr);
-    return SentryEnvelope._(_ret, _lib, retain: true, release: true);
-  }
-
-  /// Convenience init for a single event.
-  SentryEnvelope initWithEvent_(SentryEvent? event) {
-    final _ret = _lib._objc_msgSend_1039(
-        _id, _lib._sel_initWithEvent_1, event?._id ?? ffi.nullptr);
-    return SentryEnvelope._(_ret, _lib, retain: true, release: true);
-  }
-
-  SentryEnvelope initWithUserFeedback_(SentryUserFeedback? userFeedback) {
-    final _ret = _lib._objc_msgSend_1041(_id, _lib._sel_initWithUserFeedback_1,
-        userFeedback?._id ?? ffi.nullptr);
-    return SentryEnvelope._(_ret, _lib, retain: true, release: true);
-  }
-
-  /// The envelope header.
-  SentryEnvelopeHeader? get header {
-    final _ret = _lib._objc_msgSend_1054(_id, _lib._sel_header1);
-    return _ret.address == 0
-        ? null
-        : SentryEnvelopeHeader._(_ret, _lib, retain: true, release: true);
-  }
-
-  /// The envelope items.
-  NSArray? get items {
-    final _ret = _lib._objc_msgSend_79(_id, _lib._sel_items1);
-    return _ret.address == 0
-        ? null
-        : NSArray._(_ret, _lib, retain: true, release: true);
-  }
-
-  static SentryEnvelope allocWithZone_(
-      SentryCocoa _lib, ffi.Pointer<_NSZone> zone) {
-    final _ret = _lib._objc_msgSend_3(
-        _lib._class_SentryEnvelope1, _lib._sel_allocWithZone_1, zone);
-    return SentryEnvelope._(_ret, _lib, retain: false, release: true);
-  }
-
-  static SentryEnvelope alloc(SentryCocoa _lib) {
-    final _ret =
-        _lib._objc_msgSend_2(_lib._class_SentryEnvelope1, _lib._sel_alloc1);
-    return SentryEnvelope._(_ret, _lib, retain: false, release: true);
-  }
-
-  static void cancelPreviousPerformRequestsWithTarget_selector_object_(
-      SentryCocoa _lib,
-      NSObject aTarget,
-      ffi.Pointer<ObjCSel> aSelector,
-      NSObject anArgument) {
-    _lib._objc_msgSend_14(
-        _lib._class_SentryEnvelope1,
-        _lib._sel_cancelPreviousPerformRequestsWithTarget_selector_object_1,
-        aTarget._id,
-        aSelector,
-        anArgument._id);
-  }
-
-  static void cancelPreviousPerformRequestsWithTarget_(
-      SentryCocoa _lib, NSObject aTarget) {
-    _lib._objc_msgSend_15(_lib._class_SentryEnvelope1,
-        _lib._sel_cancelPreviousPerformRequestsWithTarget_1, aTarget._id);
-  }
-
-  static bool getAccessInstanceVariablesDirectly(SentryCocoa _lib) {
-    return _lib._objc_msgSend_12(_lib._class_SentryEnvelope1,
-        _lib._sel_accessInstanceVariablesDirectly1);
-  }
-
-  static bool useStoredAccessor(SentryCocoa _lib) {
-    return _lib._objc_msgSend_12(
-        _lib._class_SentryEnvelope1, _lib._sel_useStoredAccessor1);
-  }
-
-  static NSSet keyPathsForValuesAffectingValueForKey_(
-      SentryCocoa _lib, NSString? key) {
-    final _ret = _lib._objc_msgSend_58(
-        _lib._class_SentryEnvelope1,
-        _lib._sel_keyPathsForValuesAffectingValueForKey_1,
-        key?._id ?? ffi.nullptr);
-    return NSSet._(_ret, _lib, retain: true, release: true);
-  }
-
-  static bool automaticallyNotifiesObserversForKey_(
-      SentryCocoa _lib, NSString? key) {
-    return _lib._objc_msgSend_59(
-        _lib._class_SentryEnvelope1,
-        _lib._sel_automaticallyNotifiesObserversForKey_1,
-        key?._id ?? ffi.nullptr);
-  }
-
-  static void setKeys_triggerChangeNotificationsForDependentKey_(
-      SentryCocoa _lib, NSArray? keys, NSString? dependentKey) {
-    _lib._objc_msgSend_82(
-        _lib._class_SentryEnvelope1,
-        _lib._sel_setKeys_triggerChangeNotificationsForDependentKey_1,
-        keys?._id ?? ffi.nullptr,
-        dependentKey?._id ?? ffi.nullptr);
-  }
-
-  static NSArray classFallbacksForKeyedArchiver(SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_79(
-        _lib._class_SentryEnvelope1, _lib._sel_classFallbacksForKeyedArchiver1);
-    return NSArray._(_ret, _lib, retain: true, release: true);
-  }
-
-  static NSObject classForKeyedUnarchiver(SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_2(
-        _lib._class_SentryEnvelope1, _lib._sel_classForKeyedUnarchiver1);
-    return NSObject._(_ret, _lib, retain: true, release: true);
-  }
 }
 
-class SentryId extends NSObject {
+class SentryId extends _ObjCWrapper {
   SentryId._(ffi.Pointer<ObjCObject> id, SentryCocoa lib,
       {bool retain = false, bool release = false})
       : super._(id, lib, retain: retain, release: release);
@@ -70897,826 +71063,7 @@ class SentryId extends NSObject {
   /// Returns whether [obj] is an instance of [SentryId].
   static bool isInstance(_ObjCWrapper obj) {
     return obj._lib._objc_msgSend_0(
-        obj._id, obj._lib._sel_isKindOfClass_1, obj._lib._class_SentryId1);
-  }
-
-  /// Creates a @c SentryId with a random UUID.
-  @override
-  SentryId init() {
-    final _ret = _lib._objc_msgSend_2(_id, _lib._sel_init1);
-    return SentryId._(_ret, _lib, retain: true, release: true);
-  }
-
-  /// Creates a SentryId with the given UUID.
-  SentryId initWithUUID_(NSUUID? uuid) {
-    final _ret = _lib._objc_msgSend_1037(
-        _id, _lib._sel_initWithUUID_1, uuid?._id ?? ffi.nullptr);
-    return SentryId._(_ret, _lib, retain: true, release: true);
-  }
-
-  /// Creates a @c SentryId from a 32 character hexadecimal string without dashes such as
-  /// "12c2d058d58442709aa2eca08bf20986" or a 36 character hexadecimal string such as such as
-  /// "12c2d058-d584-4270-9aa2-eca08bf20986".
-  /// @return SentryId.empty for invalid strings.
-  SentryId initWithUUIDString_(NSString? string) {
-    final _ret = _lib._objc_msgSend_30(
-        _id, _lib._sel_initWithUUIDString_1, string?._id ?? ffi.nullptr);
-    return SentryId._(_ret, _lib, retain: true, release: true);
-  }
-
-  /// Returns a 32 lowercase character hexadecimal string description of the @c SentryId, such as
-  /// "12c2d058d58442709aa2eca08bf20986".
-  NSString? get sentryIdString {
-    final _ret = _lib._objc_msgSend_20(_id, _lib._sel_sentryIdString1);
-    return _ret.address == 0
-        ? null
-        : NSString._(_ret, _lib, retain: true, release: true);
-  }
-
-  /// A @c SentryId with an empty UUID "00000000000000000000000000000000".
-  static SentryId? getEmpty(SentryCocoa _lib) {
-    final _ret =
-        _lib._objc_msgSend_1038(_lib._class_SentryId1, _lib._sel_empty1);
-    return _ret.address == 0
-        ? null
-        : SentryId._(_ret, _lib, retain: true, release: true);
-  }
-
-  static SentryId new1(SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_2(_lib._class_SentryId1, _lib._sel_new1);
-    return SentryId._(_ret, _lib, retain: false, release: true);
-  }
-
-  static SentryId allocWithZone_(SentryCocoa _lib, ffi.Pointer<_NSZone> zone) {
-    final _ret = _lib._objc_msgSend_3(
-        _lib._class_SentryId1, _lib._sel_allocWithZone_1, zone);
-    return SentryId._(_ret, _lib, retain: false, release: true);
-  }
-
-  static SentryId alloc(SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_2(_lib._class_SentryId1, _lib._sel_alloc1);
-    return SentryId._(_ret, _lib, retain: false, release: true);
-  }
-
-  static void cancelPreviousPerformRequestsWithTarget_selector_object_(
-      SentryCocoa _lib,
-      NSObject aTarget,
-      ffi.Pointer<ObjCSel> aSelector,
-      NSObject anArgument) {
-    _lib._objc_msgSend_14(
-        _lib._class_SentryId1,
-        _lib._sel_cancelPreviousPerformRequestsWithTarget_selector_object_1,
-        aTarget._id,
-        aSelector,
-        anArgument._id);
-  }
-
-  static void cancelPreviousPerformRequestsWithTarget_(
-      SentryCocoa _lib, NSObject aTarget) {
-    _lib._objc_msgSend_15(_lib._class_SentryId1,
-        _lib._sel_cancelPreviousPerformRequestsWithTarget_1, aTarget._id);
-  }
-
-  static bool getAccessInstanceVariablesDirectly(SentryCocoa _lib) {
-    return _lib._objc_msgSend_12(
-        _lib._class_SentryId1, _lib._sel_accessInstanceVariablesDirectly1);
-  }
-
-  static bool useStoredAccessor(SentryCocoa _lib) {
-    return _lib._objc_msgSend_12(
-        _lib._class_SentryId1, _lib._sel_useStoredAccessor1);
-  }
-
-  static NSSet keyPathsForValuesAffectingValueForKey_(
-      SentryCocoa _lib, NSString? key) {
-    final _ret = _lib._objc_msgSend_58(
-        _lib._class_SentryId1,
-        _lib._sel_keyPathsForValuesAffectingValueForKey_1,
-        key?._id ?? ffi.nullptr);
-    return NSSet._(_ret, _lib, retain: true, release: true);
-  }
-
-  static bool automaticallyNotifiesObserversForKey_(
-      SentryCocoa _lib, NSString? key) {
-    return _lib._objc_msgSend_59(
-        _lib._class_SentryId1,
-        _lib._sel_automaticallyNotifiesObserversForKey_1,
-        key?._id ?? ffi.nullptr);
-  }
-
-  static void setKeys_triggerChangeNotificationsForDependentKey_(
-      SentryCocoa _lib, NSArray? keys, NSString? dependentKey) {
-    _lib._objc_msgSend_82(
-        _lib._class_SentryId1,
-        _lib._sel_setKeys_triggerChangeNotificationsForDependentKey_1,
-        keys?._id ?? ffi.nullptr,
-        dependentKey?._id ?? ffi.nullptr);
-  }
-
-  static NSArray classFallbacksForKeyedArchiver(SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_79(
-        _lib._class_SentryId1, _lib._sel_classFallbacksForKeyedArchiver1);
-    return NSArray._(_ret, _lib, retain: true, release: true);
-  }
-
-  static NSObject classForKeyedUnarchiver(SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_2(
-        _lib._class_SentryId1, _lib._sel_classForKeyedUnarchiver1);
-    return NSObject._(_ret, _lib, retain: true, release: true);
-  }
-}
-
-class NSUUID extends NSObject {
-  NSUUID._(ffi.Pointer<ObjCObject> id, SentryCocoa lib,
-      {bool retain = false, bool release = false})
-      : super._(id, lib, retain: retain, release: release);
-
-  /// Returns a [NSUUID] that points to the same underlying object as [other].
-  static NSUUID castFrom<T extends _ObjCWrapper>(T other) {
-    return NSUUID._(other._id, other._lib, retain: true, release: true);
-  }
-
-  /// Returns a [NSUUID] that wraps the given raw object pointer.
-  static NSUUID castFromPointer(SentryCocoa lib, ffi.Pointer<ObjCObject> other,
-      {bool retain = false, bool release = false}) {
-    return NSUUID._(other, lib, retain: retain, release: release);
-  }
-
-  /// Returns whether [obj] is an instance of [NSUUID].
-  static bool isInstance(_ObjCWrapper obj) {
-    return obj._lib._objc_msgSend_0(
-        obj._id, obj._lib._sel_isKindOfClass_1, obj._lib._class_NSUUID1);
-  }
-
-  static NSUUID UUID(SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_2(_lib._class_NSUUID1, _lib._sel_UUID1);
-    return NSUUID._(_ret, _lib, retain: true, release: true);
-  }
-
-  @override
-  NSUUID init() {
-    final _ret = _lib._objc_msgSend_2(_id, _lib._sel_init1);
-    return NSUUID._(_ret, _lib, retain: true, release: true);
-  }
-
-  NSUUID initWithUUIDString_(NSString? string) {
-    final _ret = _lib._objc_msgSend_30(
-        _id, _lib._sel_initWithUUIDString_1, string?._id ?? ffi.nullptr);
-    return NSUUID._(_ret, _lib, retain: true, release: true);
-  }
-
-  NSUUID initWithUUIDBytes_(ffi.Pointer<ffi.UnsignedChar> bytes) {
-    final _ret =
-        _lib._objc_msgSend_1034(_id, _lib._sel_initWithUUIDBytes_1, bytes);
-    return NSUUID._(_ret, _lib, retain: true, release: true);
-  }
-
-  void getUUIDBytes_(ffi.Pointer<ffi.UnsignedChar> uuid) {
-    _lib._objc_msgSend_1035(_id, _lib._sel_getUUIDBytes_1, uuid);
-  }
-
-  int compare_(NSUUID? otherUUID) {
-    return _lib._objc_msgSend_1036(
-        _id, _lib._sel_compare_1, otherUUID?._id ?? ffi.nullptr);
-  }
-
-  NSString? get UUIDString {
-    final _ret = _lib._objc_msgSend_20(_id, _lib._sel_UUIDString1);
-    return _ret.address == 0
-        ? null
-        : NSString._(_ret, _lib, retain: true, release: true);
-  }
-
-  static NSUUID new1(SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_2(_lib._class_NSUUID1, _lib._sel_new1);
-    return NSUUID._(_ret, _lib, retain: false, release: true);
-  }
-
-  static NSUUID allocWithZone_(SentryCocoa _lib, ffi.Pointer<_NSZone> zone) {
-    final _ret = _lib._objc_msgSend_3(
-        _lib._class_NSUUID1, _lib._sel_allocWithZone_1, zone);
-    return NSUUID._(_ret, _lib, retain: false, release: true);
-  }
-
-  static NSUUID alloc(SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_2(_lib._class_NSUUID1, _lib._sel_alloc1);
-    return NSUUID._(_ret, _lib, retain: false, release: true);
-  }
-
-  static void cancelPreviousPerformRequestsWithTarget_selector_object_(
-      SentryCocoa _lib,
-      NSObject aTarget,
-      ffi.Pointer<ObjCSel> aSelector,
-      NSObject anArgument) {
-    _lib._objc_msgSend_14(
-        _lib._class_NSUUID1,
-        _lib._sel_cancelPreviousPerformRequestsWithTarget_selector_object_1,
-        aTarget._id,
-        aSelector,
-        anArgument._id);
-  }
-
-  static void cancelPreviousPerformRequestsWithTarget_(
-      SentryCocoa _lib, NSObject aTarget) {
-    _lib._objc_msgSend_15(_lib._class_NSUUID1,
-        _lib._sel_cancelPreviousPerformRequestsWithTarget_1, aTarget._id);
-  }
-
-  static bool getAccessInstanceVariablesDirectly(SentryCocoa _lib) {
-    return _lib._objc_msgSend_12(
-        _lib._class_NSUUID1, _lib._sel_accessInstanceVariablesDirectly1);
-  }
-
-  static bool useStoredAccessor(SentryCocoa _lib) {
-    return _lib._objc_msgSend_12(
-        _lib._class_NSUUID1, _lib._sel_useStoredAccessor1);
-  }
-
-  static NSSet keyPathsForValuesAffectingValueForKey_(
-      SentryCocoa _lib, NSString? key) {
-    final _ret = _lib._objc_msgSend_58(
-        _lib._class_NSUUID1,
-        _lib._sel_keyPathsForValuesAffectingValueForKey_1,
-        key?._id ?? ffi.nullptr);
-    return NSSet._(_ret, _lib, retain: true, release: true);
-  }
-
-  static bool automaticallyNotifiesObserversForKey_(
-      SentryCocoa _lib, NSString? key) {
-    return _lib._objc_msgSend_59(
-        _lib._class_NSUUID1,
-        _lib._sel_automaticallyNotifiesObserversForKey_1,
-        key?._id ?? ffi.nullptr);
-  }
-
-  static void setKeys_triggerChangeNotificationsForDependentKey_(
-      SentryCocoa _lib, NSArray? keys, NSString? dependentKey) {
-    _lib._objc_msgSend_82(
-        _lib._class_NSUUID1,
-        _lib._sel_setKeys_triggerChangeNotificationsForDependentKey_1,
-        keys?._id ?? ffi.nullptr,
-        dependentKey?._id ?? ffi.nullptr);
-  }
-
-  static NSArray classFallbacksForKeyedArchiver(SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_79(
-        _lib._class_NSUUID1, _lib._sel_classFallbacksForKeyedArchiver1);
-    return NSArray._(_ret, _lib, retain: true, release: true);
-  }
-
-  static NSObject classForKeyedUnarchiver(SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_2(
-        _lib._class_NSUUID1, _lib._sel_classForKeyedUnarchiver1);
-    return NSObject._(_ret, _lib, retain: true, release: true);
-  }
-}
-
-class SentryEnvelopeItem extends NSObject {
-  SentryEnvelopeItem._(ffi.Pointer<ObjCObject> id, SentryCocoa lib,
-      {bool retain = false, bool release = false})
-      : super._(id, lib, retain: retain, release: release);
-
-  /// Returns a [SentryEnvelopeItem] that points to the same underlying object as [other].
-  static SentryEnvelopeItem castFrom<T extends _ObjCWrapper>(T other) {
-    return SentryEnvelopeItem._(other._id, other._lib,
-        retain: true, release: true);
-  }
-
-  /// Returns a [SentryEnvelopeItem] that wraps the given raw object pointer.
-  static SentryEnvelopeItem castFromPointer(
-      SentryCocoa lib, ffi.Pointer<ObjCObject> other,
-      {bool retain = false, bool release = false}) {
-    return SentryEnvelopeItem._(other, lib, retain: retain, release: release);
-  }
-
-  /// Returns whether [obj] is an instance of [SentryEnvelopeItem].
-  static bool isInstance(_ObjCWrapper obj) {
-    return obj._lib._objc_msgSend_0(obj._id, obj._lib._sel_isKindOfClass_1,
-        obj._lib._class_SentryEnvelopeItem1);
-  }
-
-  @override
-  SentryEnvelopeItem init() {
-    final _ret = _lib._objc_msgSend_2(_id, _lib._sel_init1);
-    return SentryEnvelopeItem._(_ret, _lib, retain: true, release: true);
-  }
-
-  static SentryEnvelopeItem new1(SentryCocoa _lib) {
-    final _ret =
-        _lib._objc_msgSend_2(_lib._class_SentryEnvelopeItem1, _lib._sel_new1);
-    return SentryEnvelopeItem._(_ret, _lib, retain: false, release: true);
-  }
-
-  SentryEnvelopeItem initWithEvent_(SentryEvent? event) {
-    final _ret = _lib._objc_msgSend_1039(
-        _id, _lib._sel_initWithEvent_1, event?._id ?? ffi.nullptr);
-    return SentryEnvelopeItem._(_ret, _lib, retain: true, release: true);
-  }
-
-  SentryEnvelopeItem initWithSession_(SentrySession? session) {
-    final _ret = _lib._objc_msgSend_1040(
-        _id, _lib._sel_initWithSession_1, session?._id ?? ffi.nullptr);
-    return SentryEnvelopeItem._(_ret, _lib, retain: true, release: true);
-  }
-
-  SentryEnvelopeItem initWithUserFeedback_(SentryUserFeedback? userFeedback) {
-    final _ret = _lib._objc_msgSend_1041(_id, _lib._sel_initWithUserFeedback_1,
-        userFeedback?._id ?? ffi.nullptr);
-    return SentryEnvelopeItem._(_ret, _lib, retain: true, release: true);
-  }
-
-  SentryEnvelopeItem initWithAttachment_maxAttachmentSize_(
-      SentryAttachment? attachment, int maxAttachmentSize) {
-    final _ret = _lib._objc_msgSend_1042(
-        _id,
-        _lib._sel_initWithAttachment_maxAttachmentSize_1,
-        attachment?._id ?? ffi.nullptr,
-        maxAttachmentSize);
-    return SentryEnvelopeItem._(_ret, _lib, retain: true, release: true);
-  }
-
-  SentryEnvelopeItem initWithHeader_data_(
-      SentryEnvelopeItemHeader? header, NSData? data) {
-    final _ret = _lib._objc_msgSend_1043(_id, _lib._sel_initWithHeader_data_1,
-        header?._id ?? ffi.nullptr, data?._id ?? ffi.nullptr);
-    return SentryEnvelopeItem._(_ret, _lib, retain: true, release: true);
-  }
-
-  /// The envelope item header.
-  SentryEnvelopeItemHeader? get header {
-    final _ret = _lib._objc_msgSend_1044(_id, _lib._sel_header1);
-    return _ret.address == 0
-        ? null
-        : SentryEnvelopeItemHeader._(_ret, _lib, retain: true, release: true);
-  }
-
-  /// The envelope payload.
-  NSData? get data {
-    final _ret = _lib._objc_msgSend_39(_id, _lib._sel_data1);
-    return _ret.address == 0
-        ? null
-        : NSData._(_ret, _lib, retain: true, release: true);
-  }
-
-  static SentryEnvelopeItem allocWithZone_(
-      SentryCocoa _lib, ffi.Pointer<_NSZone> zone) {
-    final _ret = _lib._objc_msgSend_3(
-        _lib._class_SentryEnvelopeItem1, _lib._sel_allocWithZone_1, zone);
-    return SentryEnvelopeItem._(_ret, _lib, retain: false, release: true);
-  }
-
-  static SentryEnvelopeItem alloc(SentryCocoa _lib) {
-    final _ret =
-        _lib._objc_msgSend_2(_lib._class_SentryEnvelopeItem1, _lib._sel_alloc1);
-    return SentryEnvelopeItem._(_ret, _lib, retain: false, release: true);
-  }
-
-  static void cancelPreviousPerformRequestsWithTarget_selector_object_(
-      SentryCocoa _lib,
-      NSObject aTarget,
-      ffi.Pointer<ObjCSel> aSelector,
-      NSObject anArgument) {
-    _lib._objc_msgSend_14(
-        _lib._class_SentryEnvelopeItem1,
-        _lib._sel_cancelPreviousPerformRequestsWithTarget_selector_object_1,
-        aTarget._id,
-        aSelector,
-        anArgument._id);
-  }
-
-  static void cancelPreviousPerformRequestsWithTarget_(
-      SentryCocoa _lib, NSObject aTarget) {
-    _lib._objc_msgSend_15(_lib._class_SentryEnvelopeItem1,
-        _lib._sel_cancelPreviousPerformRequestsWithTarget_1, aTarget._id);
-  }
-
-  static bool getAccessInstanceVariablesDirectly(SentryCocoa _lib) {
-    return _lib._objc_msgSend_12(_lib._class_SentryEnvelopeItem1,
-        _lib._sel_accessInstanceVariablesDirectly1);
-  }
-
-  static bool useStoredAccessor(SentryCocoa _lib) {
-    return _lib._objc_msgSend_12(
-        _lib._class_SentryEnvelopeItem1, _lib._sel_useStoredAccessor1);
-  }
-
-  static NSSet keyPathsForValuesAffectingValueForKey_(
-      SentryCocoa _lib, NSString? key) {
-    final _ret = _lib._objc_msgSend_58(
-        _lib._class_SentryEnvelopeItem1,
-        _lib._sel_keyPathsForValuesAffectingValueForKey_1,
-        key?._id ?? ffi.nullptr);
-    return NSSet._(_ret, _lib, retain: true, release: true);
-  }
-
-  static bool automaticallyNotifiesObserversForKey_(
-      SentryCocoa _lib, NSString? key) {
-    return _lib._objc_msgSend_59(
-        _lib._class_SentryEnvelopeItem1,
-        _lib._sel_automaticallyNotifiesObserversForKey_1,
-        key?._id ?? ffi.nullptr);
-  }
-
-  static void setKeys_triggerChangeNotificationsForDependentKey_(
-      SentryCocoa _lib, NSArray? keys, NSString? dependentKey) {
-    _lib._objc_msgSend_82(
-        _lib._class_SentryEnvelopeItem1,
-        _lib._sel_setKeys_triggerChangeNotificationsForDependentKey_1,
-        keys?._id ?? ffi.nullptr,
-        dependentKey?._id ?? ffi.nullptr);
-  }
-
-  static NSArray classFallbacksForKeyedArchiver(SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_79(_lib._class_SentryEnvelopeItem1,
-        _lib._sel_classFallbacksForKeyedArchiver1);
-    return NSArray._(_ret, _lib, retain: true, release: true);
-  }
-
-  static NSObject classForKeyedUnarchiver(SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_2(
-        _lib._class_SentryEnvelopeItem1, _lib._sel_classForKeyedUnarchiver1);
-    return NSObject._(_ret, _lib, retain: true, release: true);
-  }
-}
-
-class SentryEvent extends _ObjCWrapper {
-  SentryEvent._(ffi.Pointer<ObjCObject> id, SentryCocoa lib,
-      {bool retain = false, bool release = false})
-      : super._(id, lib, retain: retain, release: release);
-
-  /// Returns a [SentryEvent] that points to the same underlying object as [other].
-  static SentryEvent castFrom<T extends _ObjCWrapper>(T other) {
-    return SentryEvent._(other._id, other._lib, retain: true, release: true);
-  }
-
-  /// Returns a [SentryEvent] that wraps the given raw object pointer.
-  static SentryEvent castFromPointer(
-      SentryCocoa lib, ffi.Pointer<ObjCObject> other,
-      {bool retain = false, bool release = false}) {
-    return SentryEvent._(other, lib, retain: retain, release: release);
-  }
-
-  /// Returns whether [obj] is an instance of [SentryEvent].
-  static bool isInstance(_ObjCWrapper obj) {
-    return obj._lib._objc_msgSend_0(
-        obj._id, obj._lib._sel_isKindOfClass_1, obj._lib._class_SentryEvent1);
-  }
-}
-
-class SentrySession extends _ObjCWrapper {
-  SentrySession._(ffi.Pointer<ObjCObject> id, SentryCocoa lib,
-      {bool retain = false, bool release = false})
-      : super._(id, lib, retain: retain, release: release);
-
-  /// Returns a [SentrySession] that points to the same underlying object as [other].
-  static SentrySession castFrom<T extends _ObjCWrapper>(T other) {
-    return SentrySession._(other._id, other._lib, retain: true, release: true);
-  }
-
-  /// Returns a [SentrySession] that wraps the given raw object pointer.
-  static SentrySession castFromPointer(
-      SentryCocoa lib, ffi.Pointer<ObjCObject> other,
-      {bool retain = false, bool release = false}) {
-    return SentrySession._(other, lib, retain: retain, release: release);
-  }
-
-  /// Returns whether [obj] is an instance of [SentrySession].
-  static bool isInstance(_ObjCWrapper obj) {
-    return obj._lib._objc_msgSend_0(
-        obj._id, obj._lib._sel_isKindOfClass_1, obj._lib._class_SentrySession1);
-  }
-}
-
-class SentryUserFeedback extends _ObjCWrapper {
-  SentryUserFeedback._(ffi.Pointer<ObjCObject> id, SentryCocoa lib,
-      {bool retain = false, bool release = false})
-      : super._(id, lib, retain: retain, release: release);
-
-  /// Returns a [SentryUserFeedback] that points to the same underlying object as [other].
-  static SentryUserFeedback castFrom<T extends _ObjCWrapper>(T other) {
-    return SentryUserFeedback._(other._id, other._lib,
-        retain: true, release: true);
-  }
-
-  /// Returns a [SentryUserFeedback] that wraps the given raw object pointer.
-  static SentryUserFeedback castFromPointer(
-      SentryCocoa lib, ffi.Pointer<ObjCObject> other,
-      {bool retain = false, bool release = false}) {
-    return SentryUserFeedback._(other, lib, retain: retain, release: release);
-  }
-
-  /// Returns whether [obj] is an instance of [SentryUserFeedback].
-  static bool isInstance(_ObjCWrapper obj) {
-    return obj._lib._objc_msgSend_0(obj._id, obj._lib._sel_isKindOfClass_1,
-        obj._lib._class_SentryUserFeedback1);
-  }
-}
-
-class SentryAttachment extends _ObjCWrapper {
-  SentryAttachment._(ffi.Pointer<ObjCObject> id, SentryCocoa lib,
-      {bool retain = false, bool release = false})
-      : super._(id, lib, retain: retain, release: release);
-
-  /// Returns a [SentryAttachment] that points to the same underlying object as [other].
-  static SentryAttachment castFrom<T extends _ObjCWrapper>(T other) {
-    return SentryAttachment._(other._id, other._lib,
-        retain: true, release: true);
-  }
-
-  /// Returns a [SentryAttachment] that wraps the given raw object pointer.
-  static SentryAttachment castFromPointer(
-      SentryCocoa lib, ffi.Pointer<ObjCObject> other,
-      {bool retain = false, bool release = false}) {
-    return SentryAttachment._(other, lib, retain: retain, release: release);
-  }
-
-  /// Returns whether [obj] is an instance of [SentryAttachment].
-  static bool isInstance(_ObjCWrapper obj) {
-    return obj._lib._objc_msgSend_0(obj._id, obj._lib._sel_isKindOfClass_1,
-        obj._lib._class_SentryAttachment1);
-  }
-}
-
-class SentryEnvelopeItemHeader extends _ObjCWrapper {
-  SentryEnvelopeItemHeader._(ffi.Pointer<ObjCObject> id, SentryCocoa lib,
-      {bool retain = false, bool release = false})
-      : super._(id, lib, retain: retain, release: release);
-
-  /// Returns a [SentryEnvelopeItemHeader] that points to the same underlying object as [other].
-  static SentryEnvelopeItemHeader castFrom<T extends _ObjCWrapper>(T other) {
-    return SentryEnvelopeItemHeader._(other._id, other._lib,
-        retain: true, release: true);
-  }
-
-  /// Returns a [SentryEnvelopeItemHeader] that wraps the given raw object pointer.
-  static SentryEnvelopeItemHeader castFromPointer(
-      SentryCocoa lib, ffi.Pointer<ObjCObject> other,
-      {bool retain = false, bool release = false}) {
-    return SentryEnvelopeItemHeader._(other, lib,
-        retain: retain, release: release);
-  }
-
-  /// Returns whether [obj] is an instance of [SentryEnvelopeItemHeader].
-  static bool isInstance(_ObjCWrapper obj) {
-    return obj._lib._objc_msgSend_0(obj._id, obj._lib._sel_isKindOfClass_1,
-        obj._lib._class_SentryEnvelopeItemHeader1);
-  }
-}
-
-class SentryEnvelopeHeader extends NSObject {
-  SentryEnvelopeHeader._(ffi.Pointer<ObjCObject> id, SentryCocoa lib,
-      {bool retain = false, bool release = false})
-      : super._(id, lib, retain: retain, release: release);
-
-  /// Returns a [SentryEnvelopeHeader] that points to the same underlying object as [other].
-  static SentryEnvelopeHeader castFrom<T extends _ObjCWrapper>(T other) {
-    return SentryEnvelopeHeader._(other._id, other._lib,
-        retain: true, release: true);
-  }
-
-  /// Returns a [SentryEnvelopeHeader] that wraps the given raw object pointer.
-  static SentryEnvelopeHeader castFromPointer(
-      SentryCocoa lib, ffi.Pointer<ObjCObject> other,
-      {bool retain = false, bool release = false}) {
-    return SentryEnvelopeHeader._(other, lib, retain: retain, release: release);
-  }
-
-  /// Returns whether [obj] is an instance of [SentryEnvelopeHeader].
-  static bool isInstance(_ObjCWrapper obj) {
-    return obj._lib._objc_msgSend_0(obj._id, obj._lib._sel_isKindOfClass_1,
-        obj._lib._class_SentryEnvelopeHeader1);
-  }
-
-  @override
-  SentryEnvelopeHeader init() {
-    final _ret = _lib._objc_msgSend_2(_id, _lib._sel_init1);
-    return SentryEnvelopeHeader._(_ret, _lib, retain: true, release: true);
-  }
-
-  static SentryEnvelopeHeader new1(SentryCocoa _lib) {
-    final _ret =
-        _lib._objc_msgSend_2(_lib._class_SentryEnvelopeHeader1, _lib._sel_new1);
-    return SentryEnvelopeHeader._(_ret, _lib, retain: false, release: true);
-  }
-
-  /// Initializes an @c SentryEnvelopeHeader object with the specified eventId.
-  /// @note Sets the @c sdkInfo from @c SentryMeta.
-  /// @param eventId The identifier of the event. Can be nil if no event in the envelope or attachment
-  /// related to event.
-  SentryEnvelopeHeader initWithId_(SentryId? eventId) {
-    final _ret = _lib._objc_msgSend_1046(
-        _id, _lib._sel_initWithId_1, eventId?._id ?? ffi.nullptr);
-    return SentryEnvelopeHeader._(_ret, _lib, retain: true, release: true);
-  }
-
-  /// Initializes a @c SentryEnvelopeHeader object with the specified @c eventId and @c traceContext.
-  /// @param eventId The identifier of the event. Can be @c nil if no event in the envelope or
-  /// attachment related to event.
-  /// @param traceContext Current trace state.
-  SentryEnvelopeHeader initWithId_traceContext_(
-      SentryId? eventId, SentryTraceContext? traceContext) {
-    final _ret = _lib._objc_msgSend_1047(
-        _id,
-        _lib._sel_initWithId_traceContext_1,
-        eventId?._id ?? ffi.nullptr,
-        traceContext?._id ?? ffi.nullptr);
-    return SentryEnvelopeHeader._(_ret, _lib, retain: true, release: true);
-  }
-
-  /// Initializes a @c SentryEnvelopeHeader object with the specified @c eventId, @c skdInfo and
-  /// @c traceContext. It is recommended to use @c initWithId:traceContext: because it sets the
-  /// @c sdkInfo for you.
-  /// @param eventId The identifier of the event. Can be @c nil if no event in the envelope or
-  /// attachment related to event.
-  /// @param sdkInfo Describes the Sentry SDK. Can be @c nil for backwards compatibility. New
-  /// instances should always provide a version.
-  /// @param traceContext Current trace state.
-  SentryEnvelopeHeader initWithId_sdkInfo_traceContext_(SentryId? eventId,
-      SentrySdkInfo? sdkInfo, SentryTraceContext? traceContext) {
-    final _ret = _lib._objc_msgSend_1048(
-        _id,
-        _lib._sel_initWithId_sdkInfo_traceContext_1,
-        eventId?._id ?? ffi.nullptr,
-        sdkInfo?._id ?? ffi.nullptr,
-        traceContext?._id ?? ffi.nullptr);
-    return SentryEnvelopeHeader._(_ret, _lib, retain: true, release: true);
-  }
-
-  /// The event identifier, if available.
-  /// An event id exist if the envelope contains an event of items within it are related. i.e
-  /// Attachments
-  SentryId? get eventId {
-    final _ret = _lib._objc_msgSend_1038(_id, _lib._sel_eventId1);
-    return _ret.address == 0
-        ? null
-        : SentryId._(_ret, _lib, retain: true, release: true);
-  }
-
-  SentrySdkInfo? get sdkInfo {
-    final _ret = _lib._objc_msgSend_1049(_id, _lib._sel_sdkInfo1);
-    return _ret.address == 0
-        ? null
-        : SentrySdkInfo._(_ret, _lib, retain: true, release: true);
-  }
-
-  SentryTraceContext? get traceContext {
-    final _ret = _lib._objc_msgSend_1050(_id, _lib._sel_traceContext1);
-    return _ret.address == 0
-        ? null
-        : SentryTraceContext._(_ret, _lib, retain: true, release: true);
-  }
-
-  /// The timestamp when the event was sent from the SDK as string in RFC 3339 format. Used
-  /// for clock drift correction of the event timestamp. The time zone must be UTC.
-  ///
-  /// The timestamp should be generated as close as possible to the transmision of the event,
-  /// so that the delay between sending the envelope and receiving it on the server-side is
-  /// minimized.
-  NSDate? get sentAt {
-    final _ret = _lib._objc_msgSend_162(_id, _lib._sel_sentAt1);
-    return _ret.address == 0
-        ? null
-        : NSDate._(_ret, _lib, retain: true, release: true);
-  }
-
-  /// The timestamp when the event was sent from the SDK as string in RFC 3339 format. Used
-  /// for clock drift correction of the event timestamp. The time zone must be UTC.
-  ///
-  /// The timestamp should be generated as close as possible to the transmision of the event,
-  /// so that the delay between sending the envelope and receiving it on the server-side is
-  /// minimized.
-  set sentAt(NSDate? value) {
-    return _lib._objc_msgSend_525(
-        _id, _lib._sel_setSentAt_1, value?._id ?? ffi.nullptr);
-  }
-
-  static SentryEnvelopeHeader allocWithZone_(
-      SentryCocoa _lib, ffi.Pointer<_NSZone> zone) {
-    final _ret = _lib._objc_msgSend_3(
-        _lib._class_SentryEnvelopeHeader1, _lib._sel_allocWithZone_1, zone);
-    return SentryEnvelopeHeader._(_ret, _lib, retain: false, release: true);
-  }
-
-  static SentryEnvelopeHeader alloc(SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_2(
-        _lib._class_SentryEnvelopeHeader1, _lib._sel_alloc1);
-    return SentryEnvelopeHeader._(_ret, _lib, retain: false, release: true);
-  }
-
-  static void cancelPreviousPerformRequestsWithTarget_selector_object_(
-      SentryCocoa _lib,
-      NSObject aTarget,
-      ffi.Pointer<ObjCSel> aSelector,
-      NSObject anArgument) {
-    _lib._objc_msgSend_14(
-        _lib._class_SentryEnvelopeHeader1,
-        _lib._sel_cancelPreviousPerformRequestsWithTarget_selector_object_1,
-        aTarget._id,
-        aSelector,
-        anArgument._id);
-  }
-
-  static void cancelPreviousPerformRequestsWithTarget_(
-      SentryCocoa _lib, NSObject aTarget) {
-    _lib._objc_msgSend_15(_lib._class_SentryEnvelopeHeader1,
-        _lib._sel_cancelPreviousPerformRequestsWithTarget_1, aTarget._id);
-  }
-
-  static bool getAccessInstanceVariablesDirectly(SentryCocoa _lib) {
-    return _lib._objc_msgSend_12(_lib._class_SentryEnvelopeHeader1,
-        _lib._sel_accessInstanceVariablesDirectly1);
-  }
-
-  static bool useStoredAccessor(SentryCocoa _lib) {
-    return _lib._objc_msgSend_12(
-        _lib._class_SentryEnvelopeHeader1, _lib._sel_useStoredAccessor1);
-  }
-
-  static NSSet keyPathsForValuesAffectingValueForKey_(
-      SentryCocoa _lib, NSString? key) {
-    final _ret = _lib._objc_msgSend_58(
-        _lib._class_SentryEnvelopeHeader1,
-        _lib._sel_keyPathsForValuesAffectingValueForKey_1,
-        key?._id ?? ffi.nullptr);
-    return NSSet._(_ret, _lib, retain: true, release: true);
-  }
-
-  static bool automaticallyNotifiesObserversForKey_(
-      SentryCocoa _lib, NSString? key) {
-    return _lib._objc_msgSend_59(
-        _lib._class_SentryEnvelopeHeader1,
-        _lib._sel_automaticallyNotifiesObserversForKey_1,
-        key?._id ?? ffi.nullptr);
-  }
-
-  static void setKeys_triggerChangeNotificationsForDependentKey_(
-      SentryCocoa _lib, NSArray? keys, NSString? dependentKey) {
-    _lib._objc_msgSend_82(
-        _lib._class_SentryEnvelopeHeader1,
-        _lib._sel_setKeys_triggerChangeNotificationsForDependentKey_1,
-        keys?._id ?? ffi.nullptr,
-        dependentKey?._id ?? ffi.nullptr);
-  }
-
-  static NSArray classFallbacksForKeyedArchiver(SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_79(_lib._class_SentryEnvelopeHeader1,
-        _lib._sel_classFallbacksForKeyedArchiver1);
-    return NSArray._(_ret, _lib, retain: true, release: true);
-  }
-
-  static NSObject classForKeyedUnarchiver(SentryCocoa _lib) {
-    final _ret = _lib._objc_msgSend_2(
-        _lib._class_SentryEnvelopeHeader1, _lib._sel_classForKeyedUnarchiver1);
-    return NSObject._(_ret, _lib, retain: true, release: true);
-  }
-}
-
-class SentryTraceContext extends _ObjCWrapper {
-  SentryTraceContext._(ffi.Pointer<ObjCObject> id, SentryCocoa lib,
-      {bool retain = false, bool release = false})
-      : super._(id, lib, retain: retain, release: release);
-
-  /// Returns a [SentryTraceContext] that points to the same underlying object as [other].
-  static SentryTraceContext castFrom<T extends _ObjCWrapper>(T other) {
-    return SentryTraceContext._(other._id, other._lib,
-        retain: true, release: true);
-  }
-
-  /// Returns a [SentryTraceContext] that wraps the given raw object pointer.
-  static SentryTraceContext castFromPointer(
-      SentryCocoa lib, ffi.Pointer<ObjCObject> other,
-      {bool retain = false, bool release = false}) {
-    return SentryTraceContext._(other, lib, retain: retain, release: release);
-  }
-
-  /// Returns whether [obj] is an instance of [SentryTraceContext].
-  static bool isInstance(_ObjCWrapper obj) {
-    return obj._lib._objc_msgSend_0(obj._id, obj._lib._sel_isKindOfClass_1,
-        obj._lib._class_SentryTraceContext1);
-  }
-}
-
-class SentrySdkInfo extends _ObjCWrapper {
-  SentrySdkInfo._(ffi.Pointer<ObjCObject> id, SentryCocoa lib,
-      {bool retain = false, bool release = false})
-      : super._(id, lib, retain: retain, release: release);
-
-  /// Returns a [SentrySdkInfo] that points to the same underlying object as [other].
-  static SentrySdkInfo castFrom<T extends _ObjCWrapper>(T other) {
-    return SentrySdkInfo._(other._id, other._lib, retain: true, release: true);
-  }
-
-  /// Returns a [SentrySdkInfo] that wraps the given raw object pointer.
-  static SentrySdkInfo castFromPointer(
-      SentryCocoa lib, ffi.Pointer<ObjCObject> other,
-      {bool retain = false, bool release = false}) {
-    return SentrySdkInfo._(other, lib, retain: retain, release: release);
-  }
-
-  /// Returns whether [obj] is an instance of [SentrySdkInfo].
-  static bool isInstance(_ObjCWrapper obj) {
-    return obj._lib._objc_msgSend_0(
-        obj._id, obj._lib._sel_isKindOfClass_1, obj._lib._class_SentrySdkInfo1);
+        obj._id, obj._lib._sel_isKindOfClass_1, obj._lib._class_SentryId2);
   }
 }
 
@@ -71890,5 +71237,456 @@ class SentryBreadcrumb extends _ObjCWrapper {
   static bool isInstance(_ObjCWrapper obj) {
     return obj._lib._objc_msgSend_0(obj._id, obj._lib._sel_isKindOfClass_1,
         obj._lib._class_SentryBreadcrumb1);
+  }
+}
+
+class SentryCurrentDateProvider extends NSObject {
+  SentryCurrentDateProvider._(ffi.Pointer<ObjCObject> id, SentryCocoa lib,
+      {bool retain = false, bool release = false})
+      : super._(id, lib, retain: retain, release: release);
+
+  /// Returns a [SentryCurrentDateProvider] that points to the same underlying object as [other].
+  static SentryCurrentDateProvider castFrom<T extends _ObjCWrapper>(T other) {
+    return SentryCurrentDateProvider._(other._id, other._lib,
+        retain: true, release: true);
+  }
+
+  /// Returns a [SentryCurrentDateProvider] that wraps the given raw object pointer.
+  static SentryCurrentDateProvider castFromPointer(
+      SentryCocoa lib, ffi.Pointer<ObjCObject> other,
+      {bool retain = false, bool release = false}) {
+    return SentryCurrentDateProvider._(other, lib,
+        retain: retain, release: release);
+  }
+
+  /// Returns whether [obj] is an instance of [SentryCurrentDateProvider].
+  static bool isInstance(_ObjCWrapper obj) {
+    return obj._lib._objc_msgSend_0(obj._id, obj._lib._sel_isKindOfClass_1,
+        obj._lib._class_SentryCurrentDateProvider1);
+  }
+
+  NSDate date() {
+    final _ret = _lib._objc_msgSend_162(_id, _lib._sel_date1);
+    return NSDate._(_ret, _lib, retain: true, release: true);
+  }
+
+  int timezoneOffset() {
+    return _lib._objc_msgSend_78(_id, _lib._sel_timezoneOffset1);
+  }
+
+  int systemTime() {
+    return _lib._objc_msgSend_1062(_id, _lib._sel_systemTime1);
+  }
+
+  @override
+  SentryCurrentDateProvider init() {
+    final _ret = _lib._objc_msgSend_2(_id, _lib._sel_init1);
+    return SentryCurrentDateProvider._(_ret, _lib, retain: true, release: true);
+  }
+
+  int get bucketTimestamp {
+    return _lib._objc_msgSend_1062(_id, _lib._sel_bucketTimestamp1);
+  }
+
+  static SentryCurrentDateProvider new1(SentryCocoa _lib) {
+    final _ret = _lib._objc_msgSend_2(
+        _lib._class_SentryCurrentDateProvider1, _lib._sel_new1);
+    return SentryCurrentDateProvider._(_ret, _lib,
+        retain: false, release: true);
+  }
+
+  static SentryCurrentDateProvider allocWithZone_(
+      SentryCocoa _lib, ffi.Pointer<_NSZone> zone) {
+    final _ret = _lib._objc_msgSend_3(_lib._class_SentryCurrentDateProvider1,
+        _lib._sel_allocWithZone_1, zone);
+    return SentryCurrentDateProvider._(_ret, _lib,
+        retain: false, release: true);
+  }
+
+  static SentryCurrentDateProvider alloc(SentryCocoa _lib) {
+    final _ret = _lib._objc_msgSend_2(
+        _lib._class_SentryCurrentDateProvider1, _lib._sel_alloc1);
+    return SentryCurrentDateProvider._(_ret, _lib,
+        retain: false, release: true);
+  }
+
+  static void cancelPreviousPerformRequestsWithTarget_selector_object_(
+      SentryCocoa _lib,
+      NSObject aTarget,
+      ffi.Pointer<ObjCSel> aSelector,
+      NSObject anArgument) {
+    _lib._objc_msgSend_14(
+        _lib._class_SentryCurrentDateProvider1,
+        _lib._sel_cancelPreviousPerformRequestsWithTarget_selector_object_1,
+        aTarget._id,
+        aSelector,
+        anArgument._id);
+  }
+
+  static void cancelPreviousPerformRequestsWithTarget_(
+      SentryCocoa _lib, NSObject aTarget) {
+    _lib._objc_msgSend_15(_lib._class_SentryCurrentDateProvider1,
+        _lib._sel_cancelPreviousPerformRequestsWithTarget_1, aTarget._id);
+  }
+
+  static bool getAccessInstanceVariablesDirectly(SentryCocoa _lib) {
+    return _lib._objc_msgSend_12(_lib._class_SentryCurrentDateProvider1,
+        _lib._sel_accessInstanceVariablesDirectly1);
+  }
+
+  static bool useStoredAccessor(SentryCocoa _lib) {
+    return _lib._objc_msgSend_12(
+        _lib._class_SentryCurrentDateProvider1, _lib._sel_useStoredAccessor1);
+  }
+
+  static NSSet keyPathsForValuesAffectingValueForKey_(
+      SentryCocoa _lib, NSString? key) {
+    final _ret = _lib._objc_msgSend_58(
+        _lib._class_SentryCurrentDateProvider1,
+        _lib._sel_keyPathsForValuesAffectingValueForKey_1,
+        key?._id ?? ffi.nullptr);
+    return NSSet._(_ret, _lib, retain: true, release: true);
+  }
+
+  static bool automaticallyNotifiesObserversForKey_(
+      SentryCocoa _lib, NSString? key) {
+    return _lib._objc_msgSend_59(
+        _lib._class_SentryCurrentDateProvider1,
+        _lib._sel_automaticallyNotifiesObserversForKey_1,
+        key?._id ?? ffi.nullptr);
+  }
+
+  static void setKeys_triggerChangeNotificationsForDependentKey_(
+      SentryCocoa _lib, NSArray? keys, NSString? dependentKey) {
+    _lib._objc_msgSend_82(
+        _lib._class_SentryCurrentDateProvider1,
+        _lib._sel_setKeys_triggerChangeNotificationsForDependentKey_1,
+        keys?._id ?? ffi.nullptr,
+        dependentKey?._id ?? ffi.nullptr);
+  }
+
+  static NSArray classFallbacksForKeyedArchiver(SentryCocoa _lib) {
+    final _ret = _lib._objc_msgSend_79(_lib._class_SentryCurrentDateProvider1,
+        _lib._sel_classFallbacksForKeyedArchiver1);
+    return NSArray._(_ret, _lib, retain: true, release: true);
+  }
+
+  static NSObject classForKeyedUnarchiver(SentryCocoa _lib) {
+    final _ret = _lib._objc_msgSend_2(_lib._class_SentryCurrentDateProvider1,
+        _lib._sel_classForKeyedUnarchiver1);
+    return NSObject._(_ret, _lib, retain: true, release: true);
+  }
+}
+
+class SentryId1 extends NSObject {
+  SentryId1._(ffi.Pointer<ObjCObject> id, SentryCocoa lib,
+      {bool retain = false, bool release = false})
+      : super._(id, lib, retain: retain, release: release);
+
+  /// Returns a [SentryId1] that points to the same underlying object as [other].
+  static SentryId1 castFrom<T extends _ObjCWrapper>(T other) {
+    return SentryId1._(other._id, other._lib, retain: true, release: true);
+  }
+
+  /// Returns a [SentryId1] that wraps the given raw object pointer.
+  static SentryId1 castFromPointer(
+      SentryCocoa lib, ffi.Pointer<ObjCObject> other,
+      {bool retain = false, bool release = false}) {
+    return SentryId1._(other, lib, retain: retain, release: release);
+  }
+
+  /// Returns whether [obj] is an instance of [SentryId1].
+  static bool isInstance(_ObjCWrapper obj) {
+    return obj._lib._objc_msgSend_0(
+        obj._id, obj._lib._sel_isKindOfClass_1, obj._lib._class_SentryId11);
+  }
+
+  static SentryId1? getEmpty(SentryCocoa _lib) {
+    final _ret =
+        _lib._objc_msgSend_1063(_lib._class_SentryId11, _lib._sel_empty1);
+    return _ret.address == 0
+        ? null
+        : SentryId1._(_ret, _lib, retain: true, release: true);
+  }
+
+  static void setEmpty(SentryCocoa _lib, SentryId1? value) {
+    return _lib._objc_msgSend_1064(_lib._class_SentryId11, _lib._sel_setEmpty_1,
+        value?._id ?? ffi.nullptr);
+  }
+
+  /// Returns a 32 lowercase character hexadecimal string description of the @c SentryId, such as
+  /// “12c2d058d58442709aa2eca08bf20986”.
+  NSString? get sentryIdString {
+    final _ret = _lib._objc_msgSend_20(_id, _lib._sel_sentryIdString1);
+    return _ret.address == 0
+        ? null
+        : NSString._(_ret, _lib, retain: true, release: true);
+  }
+
+  /// Creates a @c SentryId with a random UUID.
+  @override
+  SentryId1 init() {
+    final _ret = _lib._objc_msgSend_2(_id, _lib._sel_init1);
+    return SentryId1._(_ret, _lib, retain: true, release: true);
+  }
+
+  /// Creates a SentryId with the given UUID.
+  SentryId1 initWithUuid_(NSUUID? uuid) {
+    final _ret = _lib._objc_msgSend_1068(
+        _id, _lib._sel_initWithUuid_1, uuid?._id ?? ffi.nullptr);
+    return SentryId1._(_ret, _lib, retain: true, release: true);
+  }
+
+  /// Creates a @c SentryId from a 32 character hexadecimal string without dashes such as
+  /// “12c2d058d58442709aa2eca08bf20986” or a 36 character hexadecimal string such as such as
+  /// “12c2d058-d584-4270-9aa2-eca08bf20986”.
+  /// @return SentryId.empty for invalid strings.
+  SentryId1 initWithUUIDString_(NSString? uuidString) {
+    final _ret = _lib._objc_msgSend_30(
+        _id, _lib._sel_initWithUUIDString_1, uuidString?._id ?? ffi.nullptr);
+    return SentryId1._(_ret, _lib, retain: true, release: true);
+  }
+
+  bool isEqual_(NSObject object) {
+    return _lib._objc_msgSend_0(_id, _lib._sel_isEqual_1, object._id);
+  }
+
+  NSString? get description {
+    final _ret = _lib._objc_msgSend_20(_id, _lib._sel_description1);
+    return _ret.address == 0
+        ? null
+        : NSString._(_ret, _lib, retain: true, release: true);
+  }
+
+  int get hash {
+    return _lib._objc_msgSend_10(_id, _lib._sel_hash1);
+  }
+
+  static SentryId1 new1(SentryCocoa _lib) {
+    final _ret = _lib._objc_msgSend_2(_lib._class_SentryId11, _lib._sel_new1);
+    return SentryId1._(_ret, _lib, retain: false, release: true);
+  }
+
+  static SentryId1 allocWithZone_(SentryCocoa _lib, ffi.Pointer<_NSZone> zone) {
+    final _ret = _lib._objc_msgSend_3(
+        _lib._class_SentryId11, _lib._sel_allocWithZone_1, zone);
+    return SentryId1._(_ret, _lib, retain: false, release: true);
+  }
+
+  static SentryId1 alloc(SentryCocoa _lib) {
+    final _ret = _lib._objc_msgSend_2(_lib._class_SentryId11, _lib._sel_alloc1);
+    return SentryId1._(_ret, _lib, retain: false, release: true);
+  }
+
+  static void cancelPreviousPerformRequestsWithTarget_selector_object_(
+      SentryCocoa _lib,
+      NSObject aTarget,
+      ffi.Pointer<ObjCSel> aSelector,
+      NSObject anArgument) {
+    _lib._objc_msgSend_14(
+        _lib._class_SentryId11,
+        _lib._sel_cancelPreviousPerformRequestsWithTarget_selector_object_1,
+        aTarget._id,
+        aSelector,
+        anArgument._id);
+  }
+
+  static void cancelPreviousPerformRequestsWithTarget_(
+      SentryCocoa _lib, NSObject aTarget) {
+    _lib._objc_msgSend_15(_lib._class_SentryId11,
+        _lib._sel_cancelPreviousPerformRequestsWithTarget_1, aTarget._id);
+  }
+
+  static bool getAccessInstanceVariablesDirectly(SentryCocoa _lib) {
+    return _lib._objc_msgSend_12(
+        _lib._class_SentryId11, _lib._sel_accessInstanceVariablesDirectly1);
+  }
+
+  static bool useStoredAccessor(SentryCocoa _lib) {
+    return _lib._objc_msgSend_12(
+        _lib._class_SentryId11, _lib._sel_useStoredAccessor1);
+  }
+
+  static NSSet keyPathsForValuesAffectingValueForKey_(
+      SentryCocoa _lib, NSString? key) {
+    final _ret = _lib._objc_msgSend_58(
+        _lib._class_SentryId11,
+        _lib._sel_keyPathsForValuesAffectingValueForKey_1,
+        key?._id ?? ffi.nullptr);
+    return NSSet._(_ret, _lib, retain: true, release: true);
+  }
+
+  static bool automaticallyNotifiesObserversForKey_(
+      SentryCocoa _lib, NSString? key) {
+    return _lib._objc_msgSend_59(
+        _lib._class_SentryId11,
+        _lib._sel_automaticallyNotifiesObserversForKey_1,
+        key?._id ?? ffi.nullptr);
+  }
+
+  static void setKeys_triggerChangeNotificationsForDependentKey_(
+      SentryCocoa _lib, NSArray? keys, NSString? dependentKey) {
+    _lib._objc_msgSend_82(
+        _lib._class_SentryId11,
+        _lib._sel_setKeys_triggerChangeNotificationsForDependentKey_1,
+        keys?._id ?? ffi.nullptr,
+        dependentKey?._id ?? ffi.nullptr);
+  }
+
+  static NSArray classFallbacksForKeyedArchiver(SentryCocoa _lib) {
+    final _ret = _lib._objc_msgSend_79(
+        _lib._class_SentryId11, _lib._sel_classFallbacksForKeyedArchiver1);
+    return NSArray._(_ret, _lib, retain: true, release: true);
+  }
+
+  static NSObject classForKeyedUnarchiver(SentryCocoa _lib) {
+    final _ret = _lib._objc_msgSend_2(
+        _lib._class_SentryId11, _lib._sel_classForKeyedUnarchiver1);
+    return NSObject._(_ret, _lib, retain: true, release: true);
+  }
+}
+
+class NSUUID extends NSObject {
+  NSUUID._(ffi.Pointer<ObjCObject> id, SentryCocoa lib,
+      {bool retain = false, bool release = false})
+      : super._(id, lib, retain: retain, release: release);
+
+  /// Returns a [NSUUID] that points to the same underlying object as [other].
+  static NSUUID castFrom<T extends _ObjCWrapper>(T other) {
+    return NSUUID._(other._id, other._lib, retain: true, release: true);
+  }
+
+  /// Returns a [NSUUID] that wraps the given raw object pointer.
+  static NSUUID castFromPointer(SentryCocoa lib, ffi.Pointer<ObjCObject> other,
+      {bool retain = false, bool release = false}) {
+    return NSUUID._(other, lib, retain: retain, release: release);
+  }
+
+  /// Returns whether [obj] is an instance of [NSUUID].
+  static bool isInstance(_ObjCWrapper obj) {
+    return obj._lib._objc_msgSend_0(
+        obj._id, obj._lib._sel_isKindOfClass_1, obj._lib._class_NSUUID1);
+  }
+
+  static NSUUID UUID(SentryCocoa _lib) {
+    final _ret = _lib._objc_msgSend_2(_lib._class_NSUUID1, _lib._sel_UUID1);
+    return NSUUID._(_ret, _lib, retain: true, release: true);
+  }
+
+  @override
+  NSUUID init() {
+    final _ret = _lib._objc_msgSend_2(_id, _lib._sel_init1);
+    return NSUUID._(_ret, _lib, retain: true, release: true);
+  }
+
+  NSUUID initWithUUIDString_(NSString? string) {
+    final _ret = _lib._objc_msgSend_30(
+        _id, _lib._sel_initWithUUIDString_1, string?._id ?? ffi.nullptr);
+    return NSUUID._(_ret, _lib, retain: true, release: true);
+  }
+
+  NSUUID initWithUUIDBytes_(ffi.Pointer<ffi.UnsignedChar> bytes) {
+    final _ret =
+        _lib._objc_msgSend_1065(_id, _lib._sel_initWithUUIDBytes_1, bytes);
+    return NSUUID._(_ret, _lib, retain: true, release: true);
+  }
+
+  void getUUIDBytes_(ffi.Pointer<ffi.UnsignedChar> uuid) {
+    _lib._objc_msgSend_1066(_id, _lib._sel_getUUIDBytes_1, uuid);
+  }
+
+  int compare_(NSUUID? otherUUID) {
+    return _lib._objc_msgSend_1067(
+        _id, _lib._sel_compare_1, otherUUID?._id ?? ffi.nullptr);
+  }
+
+  NSString? get UUIDString {
+    final _ret = _lib._objc_msgSend_20(_id, _lib._sel_UUIDString1);
+    return _ret.address == 0
+        ? null
+        : NSString._(_ret, _lib, retain: true, release: true);
+  }
+
+  static NSUUID new1(SentryCocoa _lib) {
+    final _ret = _lib._objc_msgSend_2(_lib._class_NSUUID1, _lib._sel_new1);
+    return NSUUID._(_ret, _lib, retain: false, release: true);
+  }
+
+  static NSUUID allocWithZone_(SentryCocoa _lib, ffi.Pointer<_NSZone> zone) {
+    final _ret = _lib._objc_msgSend_3(
+        _lib._class_NSUUID1, _lib._sel_allocWithZone_1, zone);
+    return NSUUID._(_ret, _lib, retain: false, release: true);
+  }
+
+  static NSUUID alloc(SentryCocoa _lib) {
+    final _ret = _lib._objc_msgSend_2(_lib._class_NSUUID1, _lib._sel_alloc1);
+    return NSUUID._(_ret, _lib, retain: false, release: true);
+  }
+
+  static void cancelPreviousPerformRequestsWithTarget_selector_object_(
+      SentryCocoa _lib,
+      NSObject aTarget,
+      ffi.Pointer<ObjCSel> aSelector,
+      NSObject anArgument) {
+    _lib._objc_msgSend_14(
+        _lib._class_NSUUID1,
+        _lib._sel_cancelPreviousPerformRequestsWithTarget_selector_object_1,
+        aTarget._id,
+        aSelector,
+        anArgument._id);
+  }
+
+  static void cancelPreviousPerformRequestsWithTarget_(
+      SentryCocoa _lib, NSObject aTarget) {
+    _lib._objc_msgSend_15(_lib._class_NSUUID1,
+        _lib._sel_cancelPreviousPerformRequestsWithTarget_1, aTarget._id);
+  }
+
+  static bool getAccessInstanceVariablesDirectly(SentryCocoa _lib) {
+    return _lib._objc_msgSend_12(
+        _lib._class_NSUUID1, _lib._sel_accessInstanceVariablesDirectly1);
+  }
+
+  static bool useStoredAccessor(SentryCocoa _lib) {
+    return _lib._objc_msgSend_12(
+        _lib._class_NSUUID1, _lib._sel_useStoredAccessor1);
+  }
+
+  static NSSet keyPathsForValuesAffectingValueForKey_(
+      SentryCocoa _lib, NSString? key) {
+    final _ret = _lib._objc_msgSend_58(
+        _lib._class_NSUUID1,
+        _lib._sel_keyPathsForValuesAffectingValueForKey_1,
+        key?._id ?? ffi.nullptr);
+    return NSSet._(_ret, _lib, retain: true, release: true);
+  }
+
+  static bool automaticallyNotifiesObserversForKey_(
+      SentryCocoa _lib, NSString? key) {
+    return _lib._objc_msgSend_59(
+        _lib._class_NSUUID1,
+        _lib._sel_automaticallyNotifiesObserversForKey_1,
+        key?._id ?? ffi.nullptr);
+  }
+
+  static void setKeys_triggerChangeNotificationsForDependentKey_(
+      SentryCocoa _lib, NSArray? keys, NSString? dependentKey) {
+    _lib._objc_msgSend_82(
+        _lib._class_NSUUID1,
+        _lib._sel_setKeys_triggerChangeNotificationsForDependentKey_1,
+        keys?._id ?? ffi.nullptr,
+        dependentKey?._id ?? ffi.nullptr);
+  }
+
+  static NSArray classFallbacksForKeyedArchiver(SentryCocoa _lib) {
+    final _ret = _lib._objc_msgSend_79(
+        _lib._class_NSUUID1, _lib._sel_classFallbacksForKeyedArchiver1);
+    return NSArray._(_ret, _lib, retain: true, release: true);
+  }
+
+  static NSObject classForKeyedUnarchiver(SentryCocoa _lib) {
+    final _ret = _lib._objc_msgSend_2(
+        _lib._class_NSUUID1, _lib._sel_classForKeyedUnarchiver1);
+    return NSObject._(_ret, _lib, retain: true, release: true);
   }
 }

--- a/flutter/lib/src/native/cocoa/sentry_native_cocoa.dart
+++ b/flutter/lib/src/native/cocoa/sentry_native_cocoa.dart
@@ -14,7 +14,7 @@ class SentryNativeCocoa extends SentryNativeChannel {
 
   @override
   int? startProfiler(SentryId traceId) {
-    final cSentryId = cocoa.SentryId.alloc(_lib)
+    final cSentryId = cocoa.SentryId1.alloc(_lib)
       ..initWithUUIDString_(cocoa.NSString(_lib, traceId.toString()));
     final startTime =
         cocoa.PrivateSentrySDKOnly.startProfilerForTrace_(_lib, cSentryId);

--- a/flutter/scripts/generate-cocoa-bindings.sh
+++ b/flutter/scripts/generate-cocoa-bindings.sh
@@ -28,11 +28,12 @@ dart pub add 'dev:ffigen:{"git":{"url":"https://github.com/getsentry/ffigen","re
 temp="cocoa_bindings_temp"
 rm -rf $temp
 mkdir -p $temp
-curl -Lv https://github.com/getsentry/sentry-cocoa/releases/download/$cocoa_version/Sentry.xcframework.zip -o $temp/Sentry.xcframework.zip
+curl -Lv --fail-with-body https://github.com/getsentry/sentry-cocoa/releases/download/$cocoa_version/Sentry.xcframework.zip -o $temp/Sentry.xcframework.zip
 subdir="Sentry.xcframework/macos-arm64_x86_64/Sentry.framework"
 unzip -q $temp/Sentry.xcframework.zip "$subdir/*" -d $temp
 mv "$temp/$subdir" $temp/Sentry.framework
 
 dart run ffigen --config ffi-cocoa.yaml
 sed -i.bak 's|final class|class|g' lib/src/native/cocoa/binding.dart
+sed -i.bak 's|static int startProfilerForTrace_(SentryCocoa _lib, SentryId? traceId)|static int startProfilerForTrace_(SentryCocoa _lib, SentryId1? traceId)|g' lib/src/native/cocoa/binding.dart
 rm lib/src/native/cocoa/binding.dart.bak


### PR DESCRIPTION
Updates cooca  sdk to `8.25.0` on v7 branch.

`8.25.0` contains the final fix for the new apple privacy 

#skip-changelog