### PR TITLE
v7: expand package info plus version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Dependencies
+
+- Expand dependency range of `package_info_plus` to allow an open range starting from version 1 ([#2024](https://github.com/getsentry/sentry-dart/pull/2024))
+
 ## 7.20.0
 
 ### Build

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   sentry: 7.20.0
-  package_info_plus: '>=1.0.0 <8.0.0'
+  package_info_plus: '>=1.0.0'
   meta: ^1.3.0
   ffi: ^2.0.0
 


### PR DESCRIPTION
Merges into v7 the version range fix since package info plus released multiple new majors