### PR TITLE
fix: event processor blocking transactions from being sent if `autoAppStart` is false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Event processor blocking transactions from being sent if `autoAppStart` is false ([#2028](https://github.com/getsentry/sentry-dart/pull/2028))
+
 ### Features
 
 - Adds app start spans to first transaction ([#2009](https://github.com/getsentry/sentry-dart/pull/2009))

--- a/flutter/lib/src/event_processor/native_app_start_event_processor.dart
+++ b/flutter/lib/src/event_processor/native_app_start_event_processor.dart
@@ -34,7 +34,7 @@ class NativeAppStartEventProcessor implements EventProcessor {
     final appStartEnd = _native.appStartEnd;
     if (!options.autoAppStart) {
       if (appStartEnd != null) {
-        appStartInfo?.setEnd(appStartEnd);
+        appStartInfo?.end = appStartEnd;
       } else {
         // If autoAppStart is disabled and appStartEnd is not set, we can't add app starts
         return event;

--- a/flutter/lib/src/integrations/native_app_start_integration.dart
+++ b/flutter/lib/src/integrations/native_app_start_integration.dart
@@ -15,7 +15,7 @@ class NativeAppStartIntegration extends Integration<SentryFlutterOptions> {
   final SentryNative _native;
   final FrameCallbackHandler _frameCallbackHandler;
 
-  /// Duration to wait for the app start info to be fetched.
+  /// Timeout duration to wait for the app start info to be fetched.
   static const _timeoutDuration = Duration(seconds: 30);
 
   /// We filter out App starts more than 60s

--- a/flutter/lib/src/navigation/sentry_navigator_observer.dart
+++ b/flutter/lib/src/navigation/sentry_navigator_observer.dart
@@ -105,6 +105,10 @@ class SentryNavigatorObserver extends RouteObserver<PageRoute<dynamic>> {
   }
 
   final Hub _hub;
+
+  SentryFlutterOptions? get _options => _hub.options is SentryFlutterOptions
+      ? _hub.options as SentryFlutterOptions
+      : null;
   final bool _enableAutoTransactions;
   final Duration _autoFinishAfter;
   final bool _setRouteNameAsTransaction;
@@ -143,10 +147,12 @@ class SentryNavigatorObserver extends RouteObserver<PageRoute<dynamic>> {
       to: route.settings,
     );
 
-    // Clearing the display tracker here is safe since didPush happens before the Widget is built
-    _timeToDisplayTracker?.clear();
-    _finishTimeToDisplayTracking();
-    _startTimeToDisplayTracking(route);
+    if (_options?.autoAppStart == true) {
+      // Clearing the display tracker here is safe since didPush happens before the Widget is built
+      _timeToDisplayTracker?.clear();
+      _finishTimeToDisplayTracking();
+      _startTimeToDisplayTracking(route);
+    }
   }
 
   @override
@@ -176,7 +182,9 @@ class SentryNavigatorObserver extends RouteObserver<PageRoute<dynamic>> {
       to: previousRoute?.settings,
     );
 
-    _finishTimeToDisplayTracking(clearAfter: true);
+    if (_options?.autoAppStart == true) {
+      _finishTimeToDisplayTracking(clearAfter: true);
+    }
   }
 
   void _addBreadcrumb({

--- a/flutter/lib/src/navigation/sentry_navigator_observer.dart
+++ b/flutter/lib/src/navigation/sentry_navigator_observer.dart
@@ -105,10 +105,6 @@ class SentryNavigatorObserver extends RouteObserver<PageRoute<dynamic>> {
   }
 
   final Hub _hub;
-
-  SentryFlutterOptions? get _options => _hub.options is SentryFlutterOptions
-      ? _hub.options as SentryFlutterOptions
-      : null;
   final bool _enableAutoTransactions;
   final Duration _autoFinishAfter;
   final bool _setRouteNameAsTransaction;

--- a/flutter/lib/src/navigation/sentry_navigator_observer.dart
+++ b/flutter/lib/src/navigation/sentry_navigator_observer.dart
@@ -147,12 +147,10 @@ class SentryNavigatorObserver extends RouteObserver<PageRoute<dynamic>> {
       to: route.settings,
     );
 
-    if (_options?.autoAppStart == true) {
-      // Clearing the display tracker here is safe since didPush happens before the Widget is built
-      _timeToDisplayTracker?.clear();
-      _finishTimeToDisplayTracking();
-      _startTimeToDisplayTracking(route);
-    }
+    // Clearing the display tracker here is safe since didPush happens before the Widget is built
+    _timeToDisplayTracker?.clear();
+    _finishTimeToDisplayTracking();
+    _startTimeToDisplayTracking(route);
   }
 
   @override
@@ -182,9 +180,7 @@ class SentryNavigatorObserver extends RouteObserver<PageRoute<dynamic>> {
       to: previousRoute?.settings,
     );
 
-    if (_options?.autoAppStart == true) {
-      _finishTimeToDisplayTracking(clearAfter: true);
-    }
+    _finishTimeToDisplayTracking(clearAfter: true);
   }
 
   void _addBreadcrumb({

--- a/flutter/test/integrations/native_app_start_integration_test.dart
+++ b/flutter/test/integrations/native_app_start_integration_test.dart
@@ -27,9 +27,7 @@ void main() {
       fixture.binding.nativeAppStart = NativeAppStart(
           appStartTime: 0, pluginRegistrationTime: 10, isColdStart: true);
 
-      await fixture
-          .getNativeAppStartIntegration()
-          .call(fixture.hub, fixture.options);
+      fixture.getNativeAppStartIntegration().call(fixture.hub, fixture.options);
 
       final tracer = fixture.createTracer();
       final transaction = SentryTransaction(tracer);
@@ -49,9 +47,7 @@ void main() {
       fixture.binding.nativeAppStart = NativeAppStart(
           appStartTime: 0, pluginRegistrationTime: 10, isColdStart: true);
 
-      await fixture
-          .getNativeAppStartIntegration()
-          .call(fixture.hub, fixture.options);
+      fixture.getNativeAppStartIntegration().call(fixture.hub, fixture.options);
 
       final tracer = fixture.createTracer();
       final transaction = SentryTransaction(tracer);
@@ -72,9 +68,7 @@ void main() {
           appStartTime: 0, pluginRegistrationTime: 10, isColdStart: true);
       final measurement = SentryMeasurement.warmAppStart(Duration(seconds: 1));
 
-      await fixture
-          .getNativeAppStartIntegration()
-          .call(fixture.hub, fixture.options);
+      fixture.getNativeAppStartIntegration().call(fixture.hub, fixture.options);
 
       final tracer = fixture.createTracer();
       final transaction = SentryTransaction(tracer).copyWith();
@@ -96,9 +90,7 @@ void main() {
       fixture.binding.nativeAppStart = NativeAppStart(
           appStartTime: 0, pluginRegistrationTime: 10, isColdStart: true);
 
-      await fixture
-          .getNativeAppStartIntegration()
-          .call(fixture.hub, fixture.options);
+      fixture.getNativeAppStartIntegration().call(fixture.hub, fixture.options);
 
       final tracer = fixture.createTracer();
       final transaction = SentryTransaction(tracer);
@@ -116,9 +108,7 @@ void main() {
       fixture.binding.nativeAppStart = NativeAppStart(
           appStartTime: 0, pluginRegistrationTime: 10, isColdStart: true);
 
-      await fixture
-          .getNativeAppStartIntegration()
-          .call(fixture.hub, fixture.options);
+      fixture.getNativeAppStartIntegration().call(fixture.hub, fixture.options);
 
       final appStartInfo = await NativeAppStartIntegration.getAppStartInfo();
       expect(appStartInfo?.start, DateTime.fromMillisecondsSinceEpoch(0));
@@ -132,9 +122,7 @@ void main() {
       fixture.binding.nativeAppStart = NativeAppStart(
           appStartTime: 0, pluginRegistrationTime: 10, isColdStart: true);
 
-      await fixture
-          .getNativeAppStartIntegration()
-          .call(fixture.hub, fixture.options);
+      fixture.getNativeAppStartIntegration().call(fixture.hub, fixture.options);
 
       final tracer = fixture.createTracer();
       final transaction = SentryTransaction(tracer);
@@ -155,9 +143,7 @@ void main() {
           appStartTime: 0, pluginRegistrationTime: 10, isColdStart: true);
       SentryFlutter.native = fixture.native;
 
-      await fixture
-          .getNativeAppStartIntegration()
-          .call(fixture.hub, fixture.options);
+      fixture.getNativeAppStartIntegration().call(fixture.hub, fixture.options);
 
       SentryFlutter.setAppStartEnd(DateTime.fromMillisecondsSinceEpoch(10));
 
@@ -216,9 +202,7 @@ void main() {
       SentryFlutter.mainIsolateStartTime =
           DateTime.fromMillisecondsSinceEpoch(15);
 
-      await fixture
-          .getNativeAppStartIntegration()
-          .call(fixture.hub, fixture.options);
+      fixture.getNativeAppStartIntegration().call(fixture.hub, fixture.options);
 
       final processor = fixture.options.eventProcessors.first;
       tracer = fixture.createTracer();

--- a/flutter/test/navigation/sentry_display_widget_test.dart
+++ b/flutter/test/navigation/sentry_display_widget_test.dart
@@ -94,7 +94,7 @@ void main() {
     expect(tracer.measurements, hasLength(1));
     final measurement = tracer.measurements['time_to_initial_display'];
     expect(measurement, isNotNull);
-    expect(measurement?.value, appStartInfo.duration.inMilliseconds);
+    expect(measurement?.value, appStartInfo.duration?.inMilliseconds);
     expect(measurement?.value, ttidSpanDuration.inMilliseconds);
     expect(measurement?.unit, DurationSentryMeasurementUnit.milliSecond);
   });


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
if `autoAppStart` is false then the Future wats for `AppStartInfo` forever

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #2007 

## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
