### PR TITLE
ci: fix expected iOS binary size

### DIFF
--- a/metrics/metrics-ios.yml
+++ b/metrics/metrics-ios.yml
@@ -11,4 +11,4 @@ startupTimeTest:
 
 binarySizeTest:
   diffMin: 900 KiB
-  diffMax: 1200 KiB
+  diffMax: 1300 KiB


### PR DESCRIPTION
#skip-changelog

Recent PRs pushed the compiled binary diff over the edge we expect, so let's update it.
<img width="1306" alt="image" src="https://github.com/getsentry/sentry-dart/assets/6349682/1688bc39-b087-49d3-837a-a61b00160b33">
