### PR TITLE
v7 fix: event processor blocking transactions if `autoAppStart` is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## Unreleased
 
+### Fixes
+
+- Event processor blocking transactions from being sent if `autoAppStart` is false ([#2028](https://github.com/getsentry/sentry-dart/pull/2028))
+
+### Features
+
+- Adds app start spans to first transaction ([#2009](https://github.com/getsentry/sentry-dart/pull/2009))
+
+### Fixes
+
+- Fix `PlatformException` title parsing ([#2033](https://github.com/getsentry/sentry-dart/pull/2033))
+
+## 8.1.0
+
+### Features
+
+- Set snapshot to `true` if stacktrace is not provided ([#2000](https://github.com/getsentry/sentry-dart/pull/2000))
+  - If the stacktrace is not provided, the Sentry SDK will fetch the current stacktrace via `StackTrace.current` and the snapshot will be set to `true` - **this may change the grouping behavior**
+  - `snapshot = true` means it's a synthetic exception, reflecting the current state of the thread rather than the stack trace of a real exception
+
+### Fixes
+
+- Timing metric aggregates metrics in the created span ([#1994](https://github.com/getsentry/sentry-dart/pull/1994))
+
 ### Dependencies
 
 - Bump Cocoa SDK from v8.21.0 to v8.25.0 ([#2018](https://github.com/getsentry/sentry-dart/pull/2018))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,25 +6,7 @@
 
 - Event processor blocking transactions from being sent if `autoAppStart` is false ([#2028](https://github.com/getsentry/sentry-dart/pull/2028))
 
-### Features
-
-- Adds app start spans to first transaction ([#2009](https://github.com/getsentry/sentry-dart/pull/2009))
-
-### Fixes
-
-- Fix `PlatformException` title parsing ([#2033](https://github.com/getsentry/sentry-dart/pull/2033))
-
-## 8.1.0
-
-### Features
-
-- Set snapshot to `true` if stacktrace is not provided ([#2000](https://github.com/getsentry/sentry-dart/pull/2000))
-  - If the stacktrace is not provided, the Sentry SDK will fetch the current stacktrace via `StackTrace.current` and the snapshot will be set to `true` - **this may change the grouping behavior**
-  - `snapshot = true` means it's a synthetic exception, reflecting the current state of the thread rather than the stack trace of a real exception
-
-### Fixes
-
-- Timing metric aggregates metrics in the created span ([#1994](https://github.com/getsentry/sentry-dart/pull/1994))
+## 7.20.1
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 7.20.1
+## Unreleased
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Event processor blocking transactions from being sent if `autoAppStart` is false ([#2028](https://github.com/getsentry/sentry-dart/pull/2028))
+- Event processor blocking transactions from being sent if `autoAppStart` is false ([#2045](https://github.com/getsentry/sentry-dart/pull/2045))
 
 ## 7.20.1
 

--- a/flutter/test/navigation/sentry_display_widget_test.dart
+++ b/flutter/test/navigation/sentry_display_widget_test.dart
@@ -92,7 +92,7 @@ void main() {
     expect(tracer.measurements, hasLength(1));
     final measurement = tracer.measurements['time_to_initial_display'];
     expect(measurement, isNotNull);
-    expect(measurement?.value, appStartInfo.duration.inMilliseconds);
+    expect(measurement?.value, appStartInfo.duration?.inMilliseconds);
     expect(measurement?.value, ttidSpanDuration.inMilliseconds);
     expect(measurement?.unit, DurationSentryMeasurementUnit.milliSecond);
   });


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Applies the same fix https://github.com/getsentry/sentry-dart/pull/2028 to v7


## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
