### PR TITLE
Include sentry frames to enable crash detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+- Include sentry frames in stacktraces to enable SDK crash detection ([#2050](https://github.com/getsentry/sentry-dart/pull/2050))
+
 ### Fixes
 
 - Event processor blocking transactions from being sent if `autoAppStart` is false ([#2028](https://github.com/getsentry/sentry-dart/pull/2028))

--- a/dart/lib/src/sentry_stack_trace_factory.dart
+++ b/dart/lib/src/sentry_stack_trace_factory.dart
@@ -38,13 +38,9 @@ class SentryStackTraceFactory {
     for (var t = 0; t < chain.traces.length; t += 1) {
       final trace = chain.traces[t];
 
+      // NOTE: We want to keep the Sentry frames for crash detection
+      // this does not affect grouping since they're not marked as inApp
       for (final frame in trace.frames) {
-        // we don't want to add our own frames
-        if (frame.package != null &&
-            _sentryPackagesIdentifier.contains(frame.package)) {
-          continue;
-        }
-
         final stackTraceFrame = encodeStackTraceFrame(frame);
         if (stackTraceFrame != null) {
           frames.add(stackTraceFrame);

--- a/dart/lib/src/sentry_stack_trace_factory.dart
+++ b/dart/lib/src/sentry_stack_trace_factory.dart
@@ -15,18 +15,6 @@ class SentryStackTraceFactory {
   static final SentryStackFrame _asynchronousGapFrameJson =
       SentryStackFrame(absPath: '<asynchronous suspension>');
 
-  static const _sentryPackagesIdentifier = <String>[
-    'sentry',
-    'sentry_flutter',
-    'sentry_logging',
-    'sentry_dio',
-    'sentry_file',
-    'sentry_hive',
-    'sentry_isar',
-    'sentry_sqflite',
-    'sentry_drift',
-  ];
-
   SentryStackTraceFactory(this._options);
 
   /// returns the [SentryStackFrame] list from a stackTrace ([StackTrace] or [String])

--- a/dart/test/sentry_client_test.dart
+++ b/dart/test/sentry_client_test.dart
@@ -1684,7 +1684,6 @@ class Fixture {
 
 class ExceptionWithCause {
   ExceptionWithCause(this.cause, this.stackTrace);
-
   final dynamic cause;
   final dynamic stackTrace;
 }
@@ -1699,7 +1698,6 @@ class ExceptionWithCauseExtractor
 
 class ExceptionWithStackTrace {
   ExceptionWithStackTrace(this.stackTrace);
-
   final StackTrace stackTrace;
 }
 

--- a/dart/test/sentry_client_test.dart
+++ b/dart/test/sentry_client_test.dart
@@ -502,9 +502,9 @@ void main() {
       }
 
       final stackTrace = '''
-#0      init (package:sentry/sentry.dart:46:9)
-#1      bar (file:///pathto/test.dart:46:9)
+#0      baz (file:///pathto/test.dart:50:3)
 <asynchronous suspension>
+#1      bar (file:///pathto/test.dart:46:9)
 #2      capture (package:sentry/sentry.dart:46:9)
       ''';
 

--- a/dart/test/stack_trace_test.dart
+++ b/dart/test/stack_trace_test.dart
@@ -254,11 +254,6 @@ isolate_instructions: 10fa27070, vm_instructions: 10fa21e20
       final frames = Fixture()
           .getSut(considerInAppFramesByDefault: true)
           .getStackFrames(StackTrace.fromString('''
-#0      SentryClient._prepareEvent (package:sentry/src/sentry_client.dart:206:33)
-#1      SentryClient.captureEvent (package:sentry/src/sentry_client.dart:74:34)
-#2      Hub.captureEvent (package:sentry/src/hub.dart:97:38)
-<asynchronous suspension>
-#3      LoggingIntegration._onLog (package:sentry_logging/src/logging_integration.dart:58:7)
 <asynchronous suspension>
             '''))
           .map((frame) => frame.toJson());


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Adds sentry frames to stacktrace, this won't affect grouping

See https://sentry-sdks.sentry.io/issues/4722238716/events/d70d73150b2a401e9b56755f968cc1de/?project=5428562&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=next-event&statsPeriod=1h&stream_index=0

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
part of https://github.com/getsentry/sentry/issues/66762

## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
