### PR TITLE
feat: associate dart errors with replays

### DIFF
--- a/dart/lib/src/protocol/sentry_trace_context.dart
+++ b/dart/lib/src/protocol/sentry_trace_context.dart
@@ -17,6 +17,9 @@ class SentryTraceContext {
   /// Id of a parent span
   final SpanId? parentSpanId;
 
+  /// Replay associated with this trace.
+  final SentryId? replayId;
+
   /// Whether the span is sampled or not
   final bool? sampled;
 
@@ -45,6 +48,9 @@ class SentryTraceContext {
           ? null
           : SpanId.fromId(json['parent_span_id'] as String),
       traceId: SentryId.fromId(json['trace_id'] as String),
+      replayId: json['replay_id'] == null
+          ? null
+          : SentryId.fromId(json['replay_id'] as String),
       description: json['description'] as String?,
       status: json['status'] == null
           ? null
@@ -61,6 +67,7 @@ class SentryTraceContext {
       'trace_id': traceId.toString(),
       'op': operation,
       if (parentSpanId != null) 'parent_span_id': parentSpanId!.toString(),
+      if (replayId != null) 'replay_id': replayId!.toString(),
       if (description != null) 'description': description,
       if (status != null) 'status': status!.toString(),
       if (origin != null) 'origin': origin,
@@ -76,6 +83,7 @@ class SentryTraceContext {
         parentSpanId: parentSpanId,
         sampled: sampled,
         origin: origin,
+        replayId: replayId,
       );
 
   SentryTraceContext({
@@ -87,6 +95,7 @@ class SentryTraceContext {
     this.description,
     this.status,
     this.origin,
+    this.replayId,
   })  : traceId = traceId ?? SentryId.newId(),
         spanId = spanId ?? SpanId.newId();
 
@@ -94,9 +103,9 @@ class SentryTraceContext {
   factory SentryTraceContext.fromPropagationContext(
       PropagationContext propagationContext) {
     return SentryTraceContext(
-      traceId: propagationContext.traceId,
-      spanId: propagationContext.spanId,
-      operation: 'default',
-    );
+        traceId: propagationContext.traceId,
+        spanId: propagationContext.spanId,
+        operation: 'default',
+        replayId: propagationContext.baggage?.getReplayId());
   }
 }

--- a/dart/lib/src/scope.dart
+++ b/dart/lib/src/scope.dart
@@ -97,6 +97,16 @@ class Scope {
   /// they must be JSON-serializable.
   Map<String, dynamic> get extra => Map.unmodifiable(_extra);
 
+  SentryId? _replayId;
+
+  /// Get the active replay recording.
+  @internal
+  SentryId? get replayId => _replayId;
+
+  /// Set the active replay recording id.
+  @internal
+  set replayId(SentryId? value) => _replayId = value;
+
   final Contexts _contexts = Contexts();
 
   /// Unmodifiable map of the scope contexts key/value
@@ -237,6 +247,7 @@ class Scope {
     _tags.clear();
     _extra.clear();
     _eventProcessors.clear();
+    _replayId = null;
 
     _clearBreadcrumbsSync();
     _setUserSync(null);
@@ -425,7 +436,8 @@ class Scope {
       ..fingerprint = List.from(fingerprint)
       .._transaction = _transaction
       ..span = span
-      .._enableScopeSync = false;
+      .._enableScopeSync = false
+      .._replayId = _replayId;
 
     clone._setUserSync(user);
 

--- a/dart/lib/src/scope.dart
+++ b/dart/lib/src/scope.dart
@@ -97,15 +97,12 @@ class Scope {
   /// they must be JSON-serializable.
   Map<String, dynamic> get extra => Map.unmodifiable(_extra);
 
-  SentryId? _replayId;
-
-  /// Get the active replay recording.
+  /// Active replay recording.
   @internal
   SentryId? get replayId => _replayId;
-
-  /// Set the active replay recording id.
   @internal
   set replayId(SentryId? value) => _replayId = value;
+  SentryId? _replayId;
 
   final Contexts _contexts = Contexts();
 

--- a/dart/lib/src/sentry_baggage.dart
+++ b/dart/lib/src/sentry_baggage.dart
@@ -109,6 +109,9 @@ class SentryBaggage {
     if (scope.user?.segment != null) {
       setUserSegment(scope.user!.segment!);
     }
+    if (scope.replayId != null && scope.replayId != SentryId.empty()) {
+      setReplayId(scope.replayId.toString());
+    }
   }
 
   static Map<String, String> _extractKeyValuesFromBaggageString(
@@ -199,6 +202,13 @@ class SentryBaggage {
     }
 
     return double.tryParse(sampleRate);
+  }
+
+  void setReplayId(String value) => set('sentry-replay_id', value);
+
+  SentryId? getReplayId() {
+    final replayId = get('sentry-replay_id');
+    return replayId == null ? null : SentryId.fromId(replayId);
   }
 
   Map<String, String> get keyValues => Map.unmodifiable(_keyValues);

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -143,15 +143,15 @@ class SentryClient {
 
     var traceContext = scope?.span?.traceContext();
     if (traceContext == null) {
-      if (scope?.propagationContext.baggage == null) {
-        scope?.propagationContext.baggage =
-            SentryBaggage({}, logger: _options.logger);
-        scope?.propagationContext.baggage?.setValuesFromScope(scope, _options);
-      }
       if (scope != null) {
+        scope.propagationContext.baggage ??=
+            SentryBaggage({}, logger: _options.logger)
+              ..setValuesFromScope(scope, _options);
         traceContext = SentryTraceContextHeader.fromBaggage(
             scope.propagationContext.baggage!);
       }
+    } else {
+      traceContext.replayId = scope?.replayId;
     }
 
     final envelope = SentryEnvelope.fromEvent(

--- a/dart/lib/src/sentry_trace_context_header.dart
+++ b/dart/lib/src/sentry_trace_context_header.dart
@@ -43,7 +43,8 @@ class SentryTraceContextHeader {
       transaction: json['transaction'],
       sampleRate: json['sample_rate'],
       sampled: json['sampled'],
-      replayId: json['replay_id'],
+      replayId:
+          json['replay_id'] == null ? null : SentryId.fromId(json['replay_id']),
     );
   }
 

--- a/dart/lib/src/sentry_trace_context_header.dart
+++ b/dart/lib/src/sentry_trace_context_header.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import 'protocol/sentry_id.dart';
 import 'sentry_baggage.dart';
 import 'sentry_options.dart';
@@ -13,6 +15,7 @@ class SentryTraceContextHeader {
     this.transaction,
     this.sampleRate,
     this.sampled,
+    this.replayId,
   });
 
   final SentryId traceId;
@@ -24,6 +27,9 @@ class SentryTraceContextHeader {
   final String? transaction;
   final String? sampleRate;
   final String? sampled;
+
+  @internal
+  SentryId? replayId;
 
   /// Deserializes a [SentryTraceContextHeader] from JSON [Map].
   factory SentryTraceContextHeader.fromJson(Map<String, dynamic> json) {
@@ -37,6 +43,7 @@ class SentryTraceContextHeader {
       transaction: json['transaction'],
       sampleRate: json['sample_rate'],
       sampled: json['sampled'],
+      replayId: json['replay_id'],
     );
   }
 
@@ -52,6 +59,7 @@ class SentryTraceContextHeader {
       if (transaction != null) 'transaction': transaction,
       if (sampleRate != null) 'sample_rate': sampleRate,
       if (sampled != null) 'sampled': sampled,
+      if (replayId != null) 'replay_id': replayId.toString(),
     };
   }
 
@@ -83,6 +91,9 @@ class SentryTraceContextHeader {
     if (sampled != null) {
       baggage.setSampled(sampled!);
     }
+    if (replayId != null) {
+      baggage.setReplayId(replayId.toString());
+    }
     return baggage;
   }
 
@@ -92,6 +103,7 @@ class SentryTraceContextHeader {
       baggage.get('sentry-public_key').toString(),
       release: baggage.get('sentry-release'),
       environment: baggage.get('sentry-environment'),
+      replayId: baggage.getReplayId(),
     );
   }
 }

--- a/dart/test/protocol/sentry_baggage_header_test.dart
+++ b/dart/test/protocol/sentry_baggage_header_test.dart
@@ -21,11 +21,23 @@ void main() {
       baggage.setTransaction('transaction');
       baggage.setSampleRate('1.0');
       baggage.setSampled('false');
+      final replayId = SentryId.newId().toString();
+      baggage.setReplayId(replayId);
 
       final baggageHeader = SentryBaggageHeader.fromBaggage(baggage);
 
-      expect(baggageHeader.value,
-          'sentry-trace_id=$id,sentry-public_key=publicKey,sentry-release=release,sentry-environment=environment,sentry-user_id=userId,sentry-user_segment=userSegment,sentry-transaction=transaction,sentry-sample_rate=1.0,sentry-sampled=false');
+      expect(
+          baggageHeader.value,
+          'sentry-trace_id=$id,'
+          'sentry-public_key=publicKey,'
+          'sentry-release=release,'
+          'sentry-environment=environment,'
+          'sentry-user_id=userId,'
+          'sentry-user_segment=userSegment,'
+          'sentry-transaction=transaction,'
+          'sentry-sample_rate=1.0,'
+          'sentry-sampled=false,'
+          'sentry-replay_id=$replayId');
     });
   });
 }

--- a/dart/test/scope_test.dart
+++ b/dart/test/scope_test.dart
@@ -86,6 +86,14 @@ void main() {
     expect(sut.fingerprint, fingerprints);
   });
 
+  test('sets replay ID', () {
+    final sut = fixture.getSut();
+
+    sut.replayId = SentryId.fromId('1');
+
+    expect(sut.replayId, SentryId.fromId('1'));
+  });
+
   test('adds $Breadcrumb', () {
     final sut = fixture.getSut();
 
@@ -305,6 +313,7 @@ void main() {
     sut.level = SentryLevel.debug;
     sut.transaction = 'test';
     sut.span = null;
+    sut.replayId = SentryId.newId();
 
     final user = SentryUser(id: 'test');
     sut.setUser(user);
@@ -320,21 +329,15 @@ void main() {
     sut.clear();
 
     expect(sut.breadcrumbs.length, 0);
-
     expect(sut.level, null);
-
     expect(sut.transaction, null);
     expect(sut.span, null);
-
     expect(sut.user, null);
-
     expect(sut.fingerprint.length, 0);
-
     expect(sut.tags.length, 0);
-
     expect(sut.extra.length, 0);
-
     expect(sut.eventProcessors.length, 0);
+    expect(sut.replayId, isNull);
   });
 
   test('clones', () async {
@@ -347,6 +350,7 @@ void main() {
     sut.addAttachment(SentryAttachment.fromIntList([0, 0, 0, 0], 'test.txt'));
     sut.span = NoOpSentrySpan();
     sut.level = SentryLevel.warning;
+    sut.replayId = SentryId.newId();
     await sut.setUser(SentryUser(id: 'id'));
     await sut.setTag('key', 'vakye');
     await sut.setExtra('key', 'vakye');
@@ -367,6 +371,7 @@ void main() {
       true,
     );
     expect(sut.span, clone.span);
+    expect(sut.replayId, clone.replayId);
   });
 
   test('clone does not additionally call observers', () async {

--- a/dart/test/sentry_trace_context_header_test.dart
+++ b/dart/test/sentry_trace_context_header_test.dart
@@ -14,7 +14,8 @@ void main() {
       'user_segment': 'user_segment',
       'transaction': 'transaction',
       'sample_rate': '1.0',
-      'sampled': 'false'
+      'sampled': 'false',
+      'replay_id': '456',
     };
     final context = SentryTraceContextHeader.fromJson(mapJson);
 
@@ -28,6 +29,7 @@ void main() {
       expect(context.transaction, 'transaction');
       expect(context.sampleRate, '1.0');
       expect(context.sampled, 'false');
+      expect(context.replayId, SentryId.fromId('456'));
     });
 
     test('toJson', () {
@@ -39,8 +41,19 @@ void main() {
     test('to baggage', () {
       final baggage = context.toBaggage();
 
-      expect(baggage.toHeaderString(),
-          'sentry-trace_id=${id.toString()},sentry-public_key=123,sentry-release=release,sentry-environment=environment,sentry-user_id=user_id,sentry-user_segment=user_segment,sentry-transaction=transaction,sentry-sample_rate=1.0,sentry-sampled=false');
+      expect(
+        baggage.toHeaderString(),
+        'sentry-trace_id=${id.toString()},'
+        'sentry-public_key=123,'
+        'sentry-release=release,'
+        'sentry-environment=environment,'
+        'sentry-user_id=user_id,'
+        'sentry-user_segment=user_segment,'
+        'sentry-transaction=transaction,'
+        'sentry-sample_rate=1.0,'
+        'sentry-sampled=false,'
+        'sentry-replay_id=456',
+      );
     });
   });
 }

--- a/dart/test/sentry_trace_context_test.dart
+++ b/dart/test/sentry_trace_context_test.dart
@@ -16,27 +16,31 @@ void main() {
     expect(map['description'], 'desc');
     expect(map['status'], 'aborted');
     expect(map['origin'], 'auto.ui');
+    expect(map['replay_id'], isNotNull);
   });
 
   test('fromJson deserializes', () {
     final map = {
       'op': 'op',
-      'span_id': '0000000000000000',
-      'trace_id': '00000000000000000000000000000000',
-      'parent_span_id': '0000000000000000',
+      'span_id': '0000000000000001',
+      'trace_id': '00000000000000000000000000000002',
+      'parent_span_id': '0000000000000003',
       'description': 'desc',
       'status': 'aborted',
-      'origin': 'auto.ui'
+      'origin': 'auto.ui',
+      'replay_id': '00000000000000000000000000000004'
     };
     final traceContext = SentryTraceContext.fromJson(map);
 
     expect(traceContext.description, 'desc');
     expect(traceContext.operation, 'op');
-    expect(traceContext.spanId.toString(), '0000000000000000');
-    expect(traceContext.traceId.toString(), '00000000000000000000000000000000');
-    expect(traceContext.parentSpanId.toString(), '0000000000000000');
+    expect(traceContext.spanId.toString(), '0000000000000001');
+    expect(traceContext.traceId.toString(), '00000000000000000000000000000002');
+    expect(traceContext.parentSpanId.toString(), '0000000000000003');
     expect(traceContext.status.toString(), 'aborted');
     expect(traceContext.sampled, true);
+    expect(
+        traceContext.replayId.toString(), '00000000000000000000000000000004');
   });
 }
 
@@ -48,6 +52,7 @@ class Fixture {
         description: 'desc',
         sampled: true,
         status: SpanStatus.aborted(),
-        origin: 'auto.ui');
+        origin: 'auto.ui',
+        replayId: SentryId.newId());
   }
 }

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterReplayRecorder.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterReplayRecorder.kt
@@ -27,6 +27,7 @@ internal class SentryFlutterReplayRecorder(
             "width" to config.recordingWidth,
             "height" to config.recordingHeight,
             "frameRate" to config.frameRate,
+            "replayId" to integration.getReplayId().toString()
           ),
         )
       } catch (ignored: Exception) {

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterReplayRecorder.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterReplayRecorder.kt
@@ -27,7 +27,7 @@ internal class SentryFlutterReplayRecorder(
             "width" to config.recordingWidth,
             "height" to config.recordingHeight,
             "frameRate" to config.frameRate,
-            "replayId" to integration.getReplayId().toString()
+            "replayId" to integration.getReplayId().toString(),
           ),
         )
       } catch (ignored: Exception) {

--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -91,6 +91,7 @@ Future<void> setupSentry(
       options.navigatorKey = navigatorKey;
 
       options.experimental.replay.sessionSampleRate = 1.0;
+      options.experimental.replay.errorSampleRate = 1.0;
 
       _isIntegrationTest = isIntegrationTest;
       if (_isIntegrationTest) {

--- a/flutter/lib/src/event_processor/replay_event_processor.dart
+++ b/flutter/lib/src/event_processor/replay_event_processor.dart
@@ -13,11 +13,9 @@ class ReplayEventProcessor implements EventProcessor {
   Future<SentryEvent?> apply(SentryEvent event, Hint hint) async {
     if (event.eventId != SentryId.empty() &&
         event.exceptions?.isNotEmpty == true) {
-      final isCrash = event.exceptions!
-          .any((element) => element.mechanism?.handled == false);
-      // ignore: unused_local_variable
-      final replayId =
-          await _binding.sendReplayForEvent(event.eventId, isCrash);
+      final isCrash =
+          event.exceptions!.any((e) => e.mechanism?.handled == false);
+      await _binding.sendReplayForEvent(event.eventId, isCrash);
     }
     return event;
   }

--- a/flutter/lib/src/native/java/sentry_native_java.dart
+++ b/flutter/lib/src/native/java/sentry_native_java.dart
@@ -33,6 +33,9 @@ class SentryNativeJava extends SentryNativeChannel {
       channel.setMethodCallHandler((call) async {
         switch (call.method) {
           case 'ReplayRecorder.start':
+            final replayId =
+                SentryId.fromId(call.arguments['replayId'] as String);
+
             _startRecorder(
               call.arguments['directory'] as String,
               ScreenshotRecorderConfig(
@@ -41,10 +44,22 @@ class SentryNativeJava extends SentryNativeChannel {
                 frameRate: call.arguments['frameRate'] as int,
               ),
             );
+
+            Sentry.configureScope((s) {
+              // ignore: invalid_use_of_internal_member
+              s.replayId = replayId;
+            });
+
             break;
           case 'ReplayRecorder.stop':
             await _replayRecorder?.stop();
             _replayRecorder = null;
+
+            Sentry.configureScope((s) {
+              // ignore: invalid_use_of_internal_member
+              s.replayId = null;
+            });
+
             break;
           case 'ReplayRecorder.pause':
             await _replayRecorder?.stop();


### PR DESCRIPTION
part of #2032 so #skip-changelog

Result after this PR
* an error shows a replay - https://sentry-sdks.sentry.io/issues/4722238716/?project=5428562&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=24h&stream_index=0
* a replay shows an error - https://sentry-sdks.sentry.io/replays/46dbc60356204548bf96cb662d14b978/?project=5428561&project=5428562&query=&referrer=%2Freplays%2F&statsPeriod=24h&yAxis=count%28%29

## TODO
* [x] update tests of affected classes, if there are any

