### PR TITLE
ref: Add getCurrentStackTrace

### DIFF
--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:math';
 import 'package:meta/meta.dart';
-import 'package:sentry/src/utils/stacktrace_utils.dart';
+import 'utils/stacktrace_utils.dart';
 import 'metrics/metric.dart';
 import 'metrics/metrics_aggregator.dart';
 import 'sentry_baggage.dart';

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:math';
 import 'package:meta/meta.dart';
+import 'package:sentry/src/utils/stacktrace_utils.dart';
 import 'metrics/metric.dart';
 import 'metrics/metrics_aggregator.dart';
 import 'sentry_baggage.dart';
@@ -235,7 +236,7 @@ class SentryClient {
     // therefore add it to the threads.
     // https://develop.sentry.dev/sdk/event-payloads/stacktrace/
     if (stackTrace != null || _options.attachStacktrace) {
-      stackTrace ??= StackTrace.current;
+      stackTrace ??= getCurrentStackTrace();
       final frames = _stackTraceFactory.getStackFrames(stackTrace);
 
       if (frames.isNotEmpty) {

--- a/dart/lib/src/sentry_exception_factory.dart
+++ b/dart/lib/src/sentry_exception_factory.dart
@@ -1,4 +1,4 @@
-import 'package:sentry/src/utils/stacktrace_utils.dart';
+import 'utils/stacktrace_utils.dart';
 
 import 'recursive_exception_cause_extractor.dart';
 import 'protocol.dart';

--- a/dart/lib/src/sentry_exception_factory.dart
+++ b/dart/lib/src/sentry_exception_factory.dart
@@ -1,3 +1,5 @@
+import 'package:sentry/src/utils/stacktrace_utils.dart';
+
 import 'recursive_exception_cause_extractor.dart';
 import 'protocol.dart';
 import 'sentry_options.dart';
@@ -40,7 +42,7 @@ class SentryExceptionFactory {
     if (_options.attachStacktrace) {
       if (stackTrace == null || stackTrace == StackTrace.empty) {
         snapshot = true;
-        stackTrace = StackTrace.current;
+        stackTrace = getCurrentStackTrace();
       }
     }
 

--- a/dart/lib/src/utils/stacktrace_utils.dart
+++ b/dart/lib/src/utils/stacktrace_utils.dart
@@ -1,0 +1,10 @@
+import 'package:meta/meta.dart';
+
+// A wrapper function around StackTrace.current so we can ignore it in the SDK
+// crash detection. Otherwise, the SDK crash detection would have to ignore the
+// method calling StackTrace.current, and it can't detect crashes in that
+// method.
+// You can read about the SDK crash detection here:
+// https://github.com/getsentry/sentry/blob/master/src/sentry/utils/sdk_crashes/README.rst
+@internal
+StackTrace getCurrentStackTrace() => StackTrace.current;


### PR DESCRIPTION


## :scroll: Description

Add the wrapper method getCurrentStackTrace so the SDK crash detection can ignore it.

#skip-changelog


## :bulb: Motivation and Context

For https://github.com/getsentry/sentry/pull/71545.


## :green_heart: How did you test it?
Unit tests are still green.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
