### PR TITLE
fix: sqflite min version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Dependencies
 
+- Bump `sqflite_common` minimum version from `^2.0.0` to `^2.3.0` and `sqflite` from `^2.0.0` to `^2.1.0`
+  - This is not a breaking change since the minimum version should have been set like this in the first place.
+  - The API that is being used internally is only available starting from these new minimum versions.
 - Bump Cocoa SDK from v8.25.2 to v8.26.0 ([#2060](https://github.com/getsentry/sentry-dart/pull/2060))
   - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8260)
   - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.25.2...8.26.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Dependencies
 
-- Bump `sqflite_common` minimum version from `^2.0.0` to `^2.3.0` and `sqflite` from `^2.0.0` to `^2.1.0`
+- Bump `sqflite_common` minimum version from `^2.0.0` to `^2.3.0` and `sqflite` from `^2.0.0` to `^2.1.0` ([#2075](https://github.com/getsentry/sentry-dart/pull/2075))
   - This is not a breaking change since the minimum version should have been set like this in the first place.
   - The API that is being used internally is only available starting from these new minimum versions.
 - Bump Cocoa SDK from v8.25.2 to v8.26.0 ([#2060](https://github.com/getsentry/sentry-dart/pull/2060))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,8 @@
 
 ### Dependencies
 
-- Bump `sqflite_common` minimum version from `^2.0.0` to `^2.3.0` and `sqflite` from `^2.0.0` to `^2.1.0` ([#2075](https://github.com/getsentry/sentry-dart/pull/2075))
-  - This is not a breaking change since the minimum version should have been set like this in the first place.
-  - The API that is being used internally is only available starting from these new minimum versions.
+- Bump `sqflite` minimum version from `^2.0.0` to `^2.2.8` ([#2075](https://github.com/getsentry/sentry-dart/pull/2075))
+  - This is not a breaking change since we are using api internally that is only valid from that version.
 - Bump Cocoa SDK from v8.25.2 to v8.26.0 ([#2060](https://github.com/getsentry/sentry-dart/pull/2060))
   - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8260)
   - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.25.2...8.26.0)

--- a/sqflite/pubspec.yaml
+++ b/sqflite/pubspec.yaml
@@ -16,8 +16,8 @@ platforms:
 
 dependencies:
   sentry: 8.2.0
-  sqflite: ^2.0.0
-  sqflite_common: ^2.0.0
+  sqflite: ^2.1.0
+  sqflite_common: ^2.3.0
   meta: ^1.3.0
   path: ^1.8.3
 
@@ -29,4 +29,4 @@ dev_dependencies:
   mockito: ^5.1.0
   build_runner: ^2.4.2
   yaml: ^3.1.0 # needed for version match (code and pubspec)
-  sqflite_common_ffi: ^2.0.0
+  sqflite_common_ffi: ^2.3.0

--- a/sqflite/pubspec.yaml
+++ b/sqflite/pubspec.yaml
@@ -16,8 +16,8 @@ platforms:
 
 dependencies:
   sentry: 8.2.0
-  sqflite: ^2.3.3+1
-  sqflite_common: ^2.5.4
+  sqflite: ^2.2.2
+  sqflite_common: ^2.4.1
   meta: ^1.3.0
   path: ^1.8.3
 

--- a/sqflite/pubspec.yaml
+++ b/sqflite/pubspec.yaml
@@ -18,15 +18,15 @@ dependencies:
   sentry: 8.2.0
   sqflite: ^2.2.8
   sqflite_common: ^2.0.0
-  meta: ^1.12.0
-  path: ^1.9.0
+  meta: ^1.3.0
+  path: ^1.8.3
 
 dev_dependencies:
   lints: ^3.0.0
   flutter_test:
     sdk: flutter
-  coverage: ^1.8.0
-  mockito: ^5.4.4
-  build_runner: ^2.4.11
-  yaml: ^3.1.2 # needed for version match (code and pubspec)
+  coverage: ^1.3.0
+  mockito: ^5.1.0
+  build_runner: ^2.4.2
+  yaml: ^3.1.0 # needed for version match (code and pubspec)
   sqflite_common_ffi: ^2.0.0

--- a/sqflite/pubspec.yaml
+++ b/sqflite/pubspec.yaml
@@ -16,8 +16,8 @@ platforms:
 
 dependencies:
   sentry: 8.2.0
-  sqflite: ^2.2.2
-  sqflite_common: ^2.4.0+2
+  sqflite: ^2.3.3+1
+  sqflite_common: ^2.5.4
   meta: ^1.3.0
   path: ^1.8.3
 

--- a/sqflite/pubspec.yaml
+++ b/sqflite/pubspec.yaml
@@ -16,8 +16,8 @@ platforms:
 
 dependencies:
   sentry: 8.2.0
-  sqflite: ^2.1.0
-  sqflite_common: ^2.3.0
+  sqflite: ^2.2.2
+  sqflite_common: ^2.4.0+2
   meta: ^1.3.0
   path: ^1.8.3
 
@@ -29,4 +29,4 @@ dev_dependencies:
   mockito: ^5.1.0
   build_runner: ^2.4.2
   yaml: ^3.1.0 # needed for version match (code and pubspec)
-  sqflite_common_ffi: ^2.3.0
+  sqflite_common_ffi: ^2.2.0+1

--- a/sqflite/pubspec.yaml
+++ b/sqflite/pubspec.yaml
@@ -16,17 +16,17 @@ platforms:
 
 dependencies:
   sentry: 8.2.0
-  sqflite: ^2.2.2
-  sqflite_common: ^2.4.1
-  meta: ^1.3.0
-  path: ^1.8.3
+  sqflite: ^2.2.8
+  sqflite_common: ^2.0.0
+  meta: ^1.12.0
+  path: ^1.9.0
 
 dev_dependencies:
   lints: ^3.0.0
   flutter_test:
     sdk: flutter
-  coverage: ^1.3.0
-  mockito: ^5.1.0
-  build_runner: ^2.4.2
-  yaml: ^3.1.0 # needed for version match (code and pubspec)
-  sqflite_common_ffi: ^2.2.0+1
+  coverage: ^1.8.0
+  mockito: ^5.4.4
+  build_runner: ^2.4.11
+  yaml: ^3.1.2 # needed for version match (code and pubspec)
+  sqflite_common_ffi: ^2.0.0


### PR DESCRIPTION
Fix min_version.

Pana analyzer is now also running flutter pub downgrade which we didn't test before