### PR TITLE
fix: load contexts not setting the user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Load contexts integration not setting `SentryUser` ([#2089](https://github.com/getsentry/sentry-dart/pull/2089))
 - Change app start span description from `Cold start` to `Cold Start` and `Warm start` to `Warm Start` ([#2076](https://github.com/getsentry/sentry-dart/pull/2076))
 - Parse `PlatformException` from details instead of message ([#2052](https://github.com/getsentry/sentry-dart/pull/2052))
 

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -119,6 +119,8 @@ class SentryClient {
       return _sentryId;
     }
 
+    preparedEvent = _createUserOrSetDefaultIpAddress(preparedEvent);
+
     preparedEvent = await _runBeforeSend(
       preparedEvent,
       hint,
@@ -175,8 +177,6 @@ class SentryClient {
       sdk: event.sdk ?? _options.sdk,
       platform: event.platform ?? sdkPlatform(_options.platformChecker.isWeb),
     );
-
-    event = _createUserOrSetDefaultIpAddress(event);
 
     if (event is SentryTransaction) {
       return event;

--- a/dart/test/sentry_client_test.dart
+++ b/dart/test/sentry_client_test.dart
@@ -998,26 +998,6 @@ void main() {
       expect(capturedEvent.user?.id, fakeUser.id);
       expect(capturedEvent.user?.email, fakeUser.email);
     });
-
-    // This test is only valid if the LoadContextsIntegration does not override the user.
-    test('event preserves user ip address with default value after capture',
-        () async {
-      final client = fixture.getSut(sendDefaultPii: true);
-
-      final userWithIpAddress = SentryUser(ipAddress: '{{auto}}');
-      final event = fakeEvent.copyWith(user: userWithIpAddress);
-
-      await client.captureEvent(event);
-
-      final capturedEnvelope = fixture.transport.envelopes.first;
-      final capturedEvent = await eventFromEnvelope(capturedEnvelope);
-
-      expect(fixture.transport.envelopes.length, 1);
-      expect(capturedEvent.user, isNotNull);
-      expect(capturedEvent.user?.ipAddress, '{{auto}}');
-      expect(capturedEvent.user?.id, null);
-      expect(capturedEvent.user?.email, null);
-    });
   });
 
   group('SentryClient sampling', () {

--- a/dart/test/sentry_client_test.dart
+++ b/dart/test/sentry_client_test.dart
@@ -998,6 +998,26 @@ void main() {
       expect(capturedEvent.user?.id, fakeUser.id);
       expect(capturedEvent.user?.email, fakeUser.email);
     });
+
+    // This test is only valid if the LoadContextsIntegration does not override the user.
+    test('event preserves user ip address with default value after capture',
+        () async {
+      final client = fixture.getSut(sendDefaultPii: true);
+
+      final userWithIpAddress = SentryUser(ipAddress: '{{auto}}');
+      final event = fakeEvent.copyWith(user: userWithIpAddress);
+
+      await client.captureEvent(event);
+
+      final capturedEnvelope = fixture.transport.envelopes.first;
+      final capturedEvent = await eventFromEnvelope(capturedEnvelope);
+
+      expect(fixture.transport.envelopes.length, 1);
+      expect(capturedEvent.user, isNotNull);
+      expect(capturedEvent.user?.ipAddress, '{{auto}}');
+      expect(capturedEvent.user?.id, null);
+      expect(capturedEvent.user?.email, null);
+    });
   });
 
   group('SentryClient sampling', () {
@@ -1684,6 +1704,7 @@ class Fixture {
 
 class ExceptionWithCause {
   ExceptionWithCause(this.cause, this.stackTrace);
+
   final dynamic cause;
   final dynamic stackTrace;
 }
@@ -1698,6 +1719,7 @@ class ExceptionWithCauseExtractor
 
 class ExceptionWithStackTrace {
   ExceptionWithStackTrace(this.stackTrace);
+
   final StackTrace stackTrace;
 }
 

--- a/flutter/test/integrations/load_contexts_integration_test.dart
+++ b/flutter/test/integrations/load_contexts_integration_test.dart
@@ -129,7 +129,8 @@ void main() {
       expect(event.breadcrumbs!.first.message, 'native-mutated-applied');
     });
 
-    test('apply default IP to user during captureEvent after loading context', () async {
+    test('apply default IP to user during captureEvent after loading context',
+        () async {
       fixture.options.enableScopeSync = true;
 
       const expectedIp = '{{auto}}';
@@ -147,9 +148,7 @@ void main() {
       final options = fixture.options;
 
       final user = SentryUser(id: expectedId);
-      Map<String, dynamic> loadContexts = {
-        'user': user.toJson()
-      };
+      Map<String, dynamic> loadContexts = {'user': user.toJson()};
       final future = Future.value(loadContexts);
       when(fixture.methodChannel.invokeMethod<dynamic>('loadContexts'))
           .thenAnswer((_) => future);

--- a/flutter/test/integrations/load_contexts_integration_test.dart
+++ b/flutter/test/integrations/load_contexts_integration_test.dart
@@ -128,6 +128,46 @@ void main() {
       expect(event.breadcrumbs!.length, 1);
       expect(event.breadcrumbs!.first.message, 'native-mutated-applied');
     });
+
+    test('apply default IP to user during captureEvent after loading context', () async {
+      fixture.options.enableScopeSync = true;
+
+      const expectedIp = '{{auto}}';
+      String? actualIp;
+
+      const expectedId = '1';
+      String? actualId;
+
+      fixture.options.beforeSend = (event, hint) {
+        actualIp = event.user?.ipAddress;
+        actualId = event.user?.id;
+        return event;
+      };
+
+      final options = fixture.options;
+
+      final user = SentryUser(id: expectedId);
+      Map<String, dynamic> loadContexts = {
+        'user': user.toJson()
+      };
+      final future = Future.value(loadContexts);
+      when(fixture.methodChannel.invokeMethod<dynamic>('loadContexts'))
+          .thenAnswer((_) => future);
+      // ignore: deprecated_member_use
+      _channel.setMockMethodCallHandler((MethodCall methodCall) async {});
+
+      final integration = LoadContextsIntegration(fixture.methodChannel);
+      options.addIntegration(integration);
+      options.integrations.first.call(fixture.hub, options);
+
+      final client = SentryClient(options);
+      final event = SentryEvent();
+
+      await client.captureEvent(event);
+
+      expect(expectedIp, actualIp);
+      expect(expectedId, actualId);
+    });
   });
 }
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
By default the user's ip address is now `{{auto}}` so the user object is never null, however when loading the native context we check if `user == null` then we retrieve it. and by default we get the ID that way. but since the user is never null now by default, we don't retrieve it anymore.

https://github.com/getsentry/sentry-dart/blob/main/flutter/lib/src/integrations/load_contexts_integration.dart#L113

Solution: move setting the default ipAddress to after the event processors have run

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #2062 

## :green_heart: How did you test it?
Added another test + manual testing

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
