### PR TITLE
Add api for pausing/resuming cocoa app hang tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Features
 
+- Add API for pausing/resuming **iOS** and **macOS** app hang tracking ([#2134](https://github.com/getsentry/sentry-dart/pull/2134))
+  - This is useful if to prevent the Cocoa SDK from reporting wrongly detected app hangs when the OS shows a system dialog for asking specific permissions.
+  - Use `SentryFlutter.pauseAppHangTracking()` and `SentryFlutter.resumeAppHangTracking()`
 - Capture total frames, frames delay, slow & frozen frames and attach to spans ([#2106](https://github.com/getsentry/sentry-dart/pull/2106))
 - Support WebAssembly compilation (dart2wasm) ([#2113](https://github.com/getsentry/sentry-dart/pull/2113))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features
 
 - Add API for pausing/resuming **iOS** and **macOS** app hang tracking ([#2134](https://github.com/getsentry/sentry-dart/pull/2134))
-  - This is useful if to prevent the Cocoa SDK from reporting wrongly detected app hangs when the OS shows a system dialog for asking specific permissions.
+  - This is useful to prevent the Cocoa SDK from reporting wrongly detected app hangs when the OS shows a system dialog for asking specific permissions.
   - Use `SentryFlutter.pauseAppHangTracking()` and `SentryFlutter.resumeAppHangTracking()`
 - Capture total frames, frames delay, slow & frozen frames and attach to spans ([#2106](https://github.com/getsentry/sentry-dart/pull/2106))
 - Support WebAssembly compilation (dart2wasm) ([#2113](https://github.com/getsentry/sentry-dart/pull/2113))

--- a/flutter/ios/Classes/SentryFlutterPluginApple.swift
+++ b/flutter/ios/Classes/SentryFlutterPluginApple.swift
@@ -167,10 +167,10 @@ public class SentryFlutterPluginApple: NSObject, FlutterPlugin {
 
         case "displayRefreshRate":
             displayRefreshRate(result)
-            
+
         case "pauseAppHangTracking":
             pauseAppHangTracking(result)
-            
+
         case "resumeAppHangTracking":
             resumeAppHangTracking(result)
 
@@ -719,14 +719,14 @@ public class SentryFlutterPluginApple: NSObject, FlutterPlugin {
         result(Int(mode.refreshRate))
     }
     #endif
-    
+
     private func pauseAppHangTracking(_ result: @escaping FlutterResult) {
-        SentrySDK.pauseAppHangTracking();
+        SentrySDK.pauseAppHangTracking()
         result("")
     }
-    
+
     private func resumeAppHangTracking(_ result: @escaping FlutterResult) {
-        SentrySDK.resumeAppHangTracking();
+        SentrySDK.resumeAppHangTracking()
         result("")
     }
 }

--- a/flutter/ios/Classes/SentryFlutterPluginApple.swift
+++ b/flutter/ios/Classes/SentryFlutterPluginApple.swift
@@ -167,6 +167,12 @@ public class SentryFlutterPluginApple: NSObject, FlutterPlugin {
 
         case "displayRefreshRate":
             displayRefreshRate(result)
+            
+        case "pauseAppHangTracking":
+            pauseAppHangTracking(result)
+            
+        case "resumeAppHangTracking":
+            resumeAppHangTracking(result)
 
         default:
             result(FlutterMethodNotImplemented)
@@ -713,6 +719,16 @@ public class SentryFlutterPluginApple: NSObject, FlutterPlugin {
         result(Int(mode.refreshRate))
     }
     #endif
+    
+    private func pauseAppHangTracking(_ result: @escaping FlutterResult) {
+        SentrySDK.pauseAppHangTracking();
+        result("")
+    }
+    
+    private func resumeAppHangTracking(_ result: @escaping FlutterResult) {
+        SentrySDK.resumeAppHangTracking();
+        result("")
+    }
 }
 
 // swiftlint:enable function_body_length

--- a/flutter/lib/src/native/sentry_native_binding.dart
+++ b/flutter/lib/src/native/sentry_native_binding.dart
@@ -52,4 +52,8 @@ abstract class SentryNativeBinding {
       SentryId traceId, int startTimeNs, int endTimeNs);
 
   Future<List<DebugImage>?> loadDebugImages();
+
+  Future<void> pauseAppHangTracking();
+
+  Future<void> resumeAppHangTracking();
 }

--- a/flutter/lib/src/native/sentry_native_channel.dart
+++ b/flutter/lib/src/native/sentry_native_channel.dart
@@ -184,8 +184,10 @@ class SentryNativeChannel
       _channel.invokeMethod('displayRefreshRate');
 
   @override
-  Future<void> pauseAppHangTracking() => _channel.invokeMethod('pauseAppHangTracking');
+  Future<void> pauseAppHangTracking() =>
+      _channel.invokeMethod('pauseAppHangTracking');
 
   @override
-  Future<void> resumeAppHangTracking() => _channel.invokeMethod('resumeAppHangTracking');
+  Future<void> resumeAppHangTracking() =>
+      _channel.invokeMethod('resumeAppHangTracking');
 }

--- a/flutter/lib/src/native/sentry_native_channel.dart
+++ b/flutter/lib/src/native/sentry_native_channel.dart
@@ -182,4 +182,10 @@ class SentryNativeChannel
   @override
   Future<int?> displayRefreshRate() =>
       _channel.invokeMethod('displayRefreshRate');
+
+  @override
+  Future<void> pauseAppHangTracking() => _channel.invokeMethod('pauseAppHangTracking');
+
+  @override
+  Future<void> resumeAppHangTracking() => _channel.invokeMethod('resumeAppHangTracking');
 }

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -243,7 +243,7 @@ mixin SentryFlutter {
       // ignore: invalid_use_of_internal_member
       Sentry.currentHub.options.logger(
         SentryLevel.debug,
-        'Native integration is not available. Make sure SentryFlutter is initialized before accessing this API.',
+        'Native integration is not available. Make sure SentryFlutter is initialized before accessing the pauseAppHangTracking API.',
       );
       return Future<void>.value();
     }
@@ -257,7 +257,7 @@ mixin SentryFlutter {
       // ignore: invalid_use_of_internal_member
       Sentry.currentHub.options.logger(
         SentryLevel.debug,
-        'Native integration is not available. Make sure SentryFlutter is initialized before accessing this API.',
+        'Native integration is not available. Make sure SentryFlutter is initialized before accessing the resumeAppHangTracking API.',
       );
       return Future<void>.value();
     }

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -261,7 +261,7 @@ mixin SentryFlutter {
       );
       return Future<void>.value();
     }
-    return _native!.pauseAppHangTracking();
+    return _native!.resumeAppHangTracking();
   }
 
   @internal

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -236,6 +236,30 @@ mixin SentryFlutter {
     return SentryNavigatorObserver.timeToDisplayTracker?.reportFullyDisplayed();
   }
 
+  static Future<void> pauseAppHangTracking() {
+    if (_native == null) {
+      // ignore: invalid_use_of_internal_member
+      Sentry.currentHub.options.logger(
+        SentryLevel.debug,
+        'Native integration is not available. Make sure SentryFlutter is initialized before accessing this API.',
+      );
+      return Future<void>.value();
+    }
+    return native!.pauseAppHangTracking();
+  }
+
+  static Future<void> resumeAppHangTracking() {
+    if (_native == null) {
+      // ignore: invalid_use_of_internal_member
+      Sentry.currentHub.options.logger(
+        SentryLevel.debug,
+        'Native integration is not available. Make sure SentryFlutter is initialized before accessing this API.',
+      );
+      return Future<void>.value();
+    }
+    return native!.pauseAppHangTracking();
+  }
+
   @internal
   static SentryNativeBinding? get native => _native;
 

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -247,7 +247,7 @@ mixin SentryFlutter {
       );
       return Future<void>.value();
     }
-    return native!.pauseAppHangTracking();
+    return _native!.pauseAppHangTracking();
   }
 
   /// Resumes the app hang tracking.
@@ -261,7 +261,7 @@ mixin SentryFlutter {
       );
       return Future<void>.value();
     }
-    return native!.pauseAppHangTracking();
+    return _native!.pauseAppHangTracking();
   }
 
   @internal

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -236,6 +236,8 @@ mixin SentryFlutter {
     return SentryNavigatorObserver.timeToDisplayTracker?.reportFullyDisplayed();
   }
 
+  /// Pauses the app hang tracking.
+  /// Only for iOS and macOS.
   static Future<void> pauseAppHangTracking() {
     if (_native == null) {
       // ignore: invalid_use_of_internal_member
@@ -248,6 +250,8 @@ mixin SentryFlutter {
     return native!.pauseAppHangTracking();
   }
 
+  /// Resumes the app hang tracking.
+  /// Only for iOS and macOS
   static Future<void> resumeAppHangTracking() {
     if (_native == null) {
       // ignore: invalid_use_of_internal_member

--- a/flutter/test/mocks.mocks.dart
+++ b/flutter/test/mocks.mocks.dart
@@ -1320,6 +1320,26 @@ class MockSentryNativeBinding extends _i1.Mock
         ),
         returnValue: _i8.Future<List<_i3.DebugImage>?>.value(),
       ) as _i8.Future<List<_i3.DebugImage>?>);
+
+  @override
+  _i8.Future<void> pauseAppHangTracking() => (super.noSuchMethod(
+        Invocation.method(
+          #pauseAppHangTracking,
+          [],
+        ),
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
+
+  @override
+  _i8.Future<void> resumeAppHangTracking() => (super.noSuchMethod(
+        Invocation.method(
+          #resumeAppHangTracking,
+          [],
+        ),
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
 }
 
 /// A class which mocks [Hub].

--- a/flutter/test/sentry_flutter_test.dart
+++ b/flutter/test/sentry_flutter_test.dart
@@ -636,6 +636,13 @@ void main() {
     verify(SentryFlutter.native?.resumeAppHangTracking()).called(1);
   });
 
+  test('resumeAppHangTracking does nothing when native is null', () async {
+    SentryFlutter.native = null;
+
+    // This should complete without throwing an error
+    await expectLater(SentryFlutter.resumeAppHangTracking(), completes);
+  });
+
   test('pauseAppHangTracking calls native method when available', () async {
     SentryFlutter.native = MockSentryNativeBinding();
     when(SentryFlutter.native?.pauseAppHangTracking())
@@ -644,6 +651,13 @@ void main() {
     await SentryFlutter.pauseAppHangTracking();
 
     verify(SentryFlutter.native?.pauseAppHangTracking()).called(1);
+  });
+
+  test('pauseAppHangTracking does nothing when native is null', () async {
+    SentryFlutter.native = null;
+
+    // This should complete without throwing an error
+    await expectLater(SentryFlutter.pauseAppHangTracking(), completes);
   });
 }
 

--- a/flutter/test/sentry_flutter_test.dart
+++ b/flutter/test/sentry_flutter_test.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: invalid_use_of_internal_member
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:sentry/src/platform/platform.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
@@ -623,6 +624,26 @@ void main() {
 
       await Sentry.close();
     });
+  });
+
+  test('resumeAppHangTracking calls native method when available', () async {
+    SentryFlutter.native = MockSentryNativeBinding();
+    when(SentryFlutter.native?.resumeAppHangTracking())
+        .thenAnswer((_) => Future.value());
+
+    await SentryFlutter.resumeAppHangTracking();
+
+    verify(SentryFlutter.native?.resumeAppHangTracking()).called(1);
+  });
+
+  test('pauseAppHangTracking calls native method when available', () async {
+    SentryFlutter.native = MockSentryNativeBinding();
+    when(SentryFlutter.native?.pauseAppHangTracking())
+        .thenAnswer((_) => Future.value());
+
+    await SentryFlutter.pauseAppHangTracking();
+
+    verify(SentryFlutter.native?.pauseAppHangTracking()).called(1);
   });
 }
 

--- a/flutter/test/sentry_native_channel_test.dart
+++ b/flutter/test/sentry_native_channel_test.dart
@@ -284,6 +284,24 @@ void main() {
 
         expect(data?.map((v) => v.toJson()), json);
       });
+
+      test('pauseAppHangTracking', () async {
+        when(channel.invokeMethod('pauseAppHangTracking'))
+            .thenAnswer((_) => Future.value());
+
+        await sut.pauseAppHangTracking();
+
+        verify(channel.invokeMethod('pauseAppHangTracking'));
+      });
+
+      test('resumeAppHangTracking', () async {
+        when(channel.invokeMethod('resumeAppHangTracking'))
+            .thenAnswer((_) => Future.value());
+
+        await sut.resumeAppHangTracking();
+
+        verify(channel.invokeMethod('resumeAppHangTracking'));
+      });
     });
   }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Allows users to control the app hang tracking.

This might be important to prevent the Cocoa SDK from reporting wrongly detected app hangs when the OS shows a system dialog for asking specific permissions.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/getsentry/sentry-dart/issues/2116

## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps

```[tasklist]
### Tasks
- [ ] Add sentry-docs
``` 