### PR TITLE
fix: app starts hanging for 30s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Fixes
+
+- App starts hanging for 30s ([#2140](https://github.com/getsentry/sentry-dart/pull/2140))
+  - Time out for app start info retrieval has been reduced to 10s
+  - If `autoAppStarts` is `false` and `setAppStartEnd` has not been called, the app start event processor will now return early instead of waiting for `getAppStartInfo` to finish
+
 ### Features
 
 - Add API for pausing/resuming **iOS** and **macOS** app hang tracking ([#2134](https://github.com/getsentry/sentry-dart/pull/2134))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 # Changelog
 
-## 8.4.0-beta.1
+## Unreleased
 
 ### Fixes
 
 - App starts hanging for 30s ([#2140](https://github.com/getsentry/sentry-dart/pull/2140))
   - Time out for app start info retrieval has been reduced to 10s
   - If `autoAppStarts` is `false` and `setAppStartEnd` has not been called, the app start event processor will now return early instead of waiting for `getAppStartInfo` to finish
+
+## 8.4.0-beta.1
 
 ### Features
 

--- a/flutter/lib/src/event_processor/native_app_start_event_processor.dart
+++ b/flutter/lib/src/event_processor/native_app_start_event_processor.dart
@@ -24,16 +24,18 @@ class NativeAppStartEventProcessor implements EventProcessor {
       return event;
     }
 
-    final appStartInfo = await NativeAppStartIntegration.getAppStartInfo();
-
+    AppStartInfo? appStartInfo;
     if (!options.autoAppStart) {
       final appStartEnd = NativeAppStartIntegration.appStartEnd;
       if (appStartEnd != null) {
+        appStartInfo = await NativeAppStartIntegration.getAppStartInfo();
         appStartInfo?.end = appStartEnd;
       } else {
         // If autoAppStart is disabled and appStartEnd is not set, we can't add app starts
         return event;
       }
+    } else {
+      appStartInfo = await NativeAppStartIntegration.getAppStartInfo();
     }
 
     final measurement = appStartInfo?.toMeasurement();

--- a/flutter/lib/src/integrations/native_app_start_integration.dart
+++ b/flutter/lib/src/integrations/native_app_start_integration.dart
@@ -36,6 +36,9 @@ class NativeAppStartIntegration extends Integration<SentryFlutterOptions> {
   /// Timeout duration to wait for the app start info to be fetched.
   static const _timeoutDuration = Duration(seconds: 10);
 
+  @visibleForTesting
+  static Duration get timeoutDuration => _timeoutDuration;
+
   /// We filter out App starts more than 60s
   static const _maxAppStartMillis = 60000;
 

--- a/flutter/lib/src/integrations/native_app_start_integration.dart
+++ b/flutter/lib/src/integrations/native_app_start_integration.dart
@@ -34,7 +34,7 @@ class NativeAppStartIntegration extends Integration<SentryFlutterOptions> {
   static bool didAddAppStartMeasurement = false;
 
   /// Timeout duration to wait for the app start info to be fetched.
-  static const _timeoutDuration = Duration(seconds: 30);
+  static const _timeoutDuration = Duration(seconds: 10);
 
   /// We filter out App starts more than 60s
   static const _maxAppStartMillis = 60000;

--- a/flutter/test/integrations/native_app_start_integration_test.dart
+++ b/flutter/test/integrations/native_app_start_integration_test.dart
@@ -149,8 +149,10 @@ void main() {
     test(
         'does not trigger timeout if autoAppStart is false and setAppStartEnd is not called',
         () async {
-      // for testing purposes let's set a frame callback bigger timeout so our app start timeout is triggered
-      fixture = Fixture(frameCallbackTimeout: const Duration(seconds: 20));
+      // setting a frame callback with a bigger timeout than our app start timeout so the timeout would theoretically be triggered
+      fixture = Fixture(
+          frameCallbackTimeout: NativeAppStartIntegration.timeoutDuration +
+              const Duration(seconds: 5));
       fixture.options.autoAppStart = false;
 
       await fixture.registerIntegration();


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Fixes timeouts still happening with autoAppStarts disabled and setAppStartEnd not being called

Also timeout has been reduced to 10s as 30s is a bit aggressive, maybe it makes sense to lower it even more?

## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps

Let's discuss if `setAppStartEnd` is still needed.
