### PR TITLE
ci: temporarily pin Dio in tests to a version that works with WASM 

### DIFF
--- a/dio/pubspec_overrides.yaml
+++ b/dio/pubspec_overrides.yaml
@@ -1,3 +1,5 @@
 dependency_overrides:
   sentry:
     path: ../dart
+  # Temporary, see https://github.com/cfug/dio/issues/2266
+  dio: 5.4.3+1


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The CI is currently broken because of Dio making a breaking change regarding WASM compatibility without a major version bump (See https://github.com/cfug/dio/issues/2266 for some details.) 

Currently, we cannot make a release because tests started to fail after the latest version was picked up in CI.  We don't want to change the dependency constraint because most users aren't using WASM compilation so we don't want to prevent them from updating Dio. Pinning in tests to a lower version works fine.


## :green_heart: How did you test it?
CI passes

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
