### PR TITLE
Fix truncated stacktraces in unhandled errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- Now captures meaningful stack traces when unhandled errors have empty or missing stack traces ([#2152](https://github.com/getsentry/sentry-dart/pull/2152))
+  - This will affect grouping for unhandled errors that have empty or missing stack traces.
 - App starts hanging for 30s ([#2140](https://github.com/getsentry/sentry-dart/pull/2140))
   - Time out for app start info retrieval has been reduced to 10s
   - If `autoAppStarts` is `false` and `setAppStartEnd` has not been called, the app start event processor will now return early instead of waiting for `getAppStartInfo` to finish

--- a/dart/lib/src/sentry_stack_trace_factory.dart
+++ b/dart/lib/src/sentry_stack_trace_factory.dart
@@ -4,7 +4,7 @@ import 'package:stack_trace/stack_trace.dart';
 import 'origin.dart';
 import 'protocol.dart';
 import 'sentry_options.dart';
-
+O
 /// converts [StackTrace] to [SentryStackFrame]s
 class SentryStackTraceFactory {
   final SentryOptions _options;

--- a/dart/lib/src/sentry_stack_trace_factory.dart
+++ b/dart/lib/src/sentry_stack_trace_factory.dart
@@ -4,7 +4,7 @@ import 'package:stack_trace/stack_trace.dart';
 import 'origin.dart';
 import 'protocol.dart';
 import 'sentry_options.dart';
-O
+
 /// converts [StackTrace] to [SentryStackFrame]s
 class SentryStackTraceFactory {
   final SentryOptions _options;

--- a/flutter/lib/src/integrations/flutter_error_integration.dart
+++ b/flutter/lib/src/integrations/flutter_error_integration.dart
@@ -2,6 +2,9 @@ import 'package:flutter/foundation.dart';
 import 'package:sentry/sentry.dart';
 import '../sentry_flutter_options.dart';
 
+// ignore: implementation_imports
+import 'package:sentry/src/utils/stacktrace_utils.dart';
+
 /// Integration that capture errors on the [FlutterError.onError] handler.
 ///
 /// Remarks:
@@ -77,7 +80,8 @@ class FlutterErrorIntegration implements Integration<SentryFlutterOptions> {
         );
 
         await hub.captureEvent(event,
-            stackTrace: errorDetails.stack,
+            // ignore: invalid_use_of_internal_member
+            stackTrace: errorDetails.stack ?? getCurrentStackTrace(),
             hint:
                 Hint.withMap({TypeCheckHint.syntheticException: errorDetails}));
         // we don't call Zone.current.handleUncaughtError because we'd like

--- a/flutter/lib/src/integrations/on_error_integration.dart
+++ b/flutter/lib/src/integrations/on_error_integration.dart
@@ -4,6 +4,9 @@ import 'package:flutter/widgets.dart';
 import 'package:sentry/sentry.dart';
 import '../sentry_flutter_options.dart';
 
+// ignore: implementation_imports
+import 'package:sentry/src/utils/stacktrace_utils.dart';
+
 typedef ErrorCallback = bool Function(Object exception, StackTrace stackTrace);
 
 /// Integration which captures `PlatformDispatcher.onError`
@@ -73,6 +76,11 @@ class OnErrorIntegration implements Integration<SentryFlutterOptions> {
       hub.configureScope(
         (scope) => scope.span?.status ??= const SpanStatus.internalError(),
       );
+
+      if (stackTrace == StackTrace.empty) {
+        // ignore: invalid_use_of_internal_member
+        stackTrace = getCurrentStackTrace();
+      }
 
       // unawaited future
       hub.captureEvent(event, stackTrace: stackTrace);

--- a/flutter/test/integrations/flutter_error_integration_test.dart
+++ b/flutter/test/integrations/flutter_error_integration_test.dart
@@ -211,6 +211,28 @@ void main() {
       expect(FlutterError.onError, afterIntegrationOnError);
     });
 
+    test(
+        'captureEvent never uses an empty or null stack trace',
+        () async {
+      final exception = StateError('error');
+      final details = FlutterErrorDetails(
+        exception: exception,
+        stack: null, // Explicitly set stack to null
+      );
+
+      _reportError(optionalDetails: details);
+
+      final captured = verify(
+        await fixture.hub.captureEvent(captureAny,
+            hint: anyNamed('hint'), stackTrace: captureAnyNamed('stackTrace')),
+      ).captured;
+
+      final stackTrace = captured[1] as StackTrace?;
+
+      expect(stackTrace, isNotNull);
+      expect(stackTrace.toString(), isNotEmpty);
+    });
+
     test('do not capture if silent error', () async {
       _reportError(silent: true);
 
@@ -222,7 +244,7 @@ void main() {
       _reportError(silent: true);
 
       verify(
-        await await fixture.hub.captureEvent(captureAny,
+        await fixture.hub.captureEvent(captureAny,
             hint: anyNamed('hint'), stackTrace: anyNamed('stackTrace')),
       );
     });

--- a/flutter/test/integrations/flutter_error_integration_test.dart
+++ b/flutter/test/integrations/flutter_error_integration_test.dart
@@ -211,9 +211,7 @@ void main() {
       expect(FlutterError.onError, afterIntegrationOnError);
     });
 
-    test(
-        'captureEvent never uses an empty or null stack trace',
-        () async {
+    test('captureEvent never uses an empty or null stack trace', () async {
       final exception = StateError('error');
       final details = FlutterErrorDetails(
         exception: exception,

--- a/flutter/test/integrations/flutter_error_integration_test.dart
+++ b/flutter/test/integrations/flutter_error_integration_test.dart
@@ -148,7 +148,7 @@ void main() {
       _reportError(handler: defaultError);
 
       verify(
-        await await fixture.hub.captureEvent(captureAny,
+        await fixture.hub.captureEvent(captureAny,
             hint: anyNamed('hint'), stackTrace: anyNamed('stackTrace')),
       );
 

--- a/flutter/test/integrations/flutter_error_integration_test.dart
+++ b/flutter/test/integrations/flutter_error_integration_test.dart
@@ -176,7 +176,7 @@ void main() {
       FlutterError.reportError(details);
 
       verify(
-        await await fixture.hub.captureEvent(captureAny,
+        await fixture.hub.captureEvent(captureAny,
             hint: anyNamed('hint'), stackTrace: anyNamed('stackTrace')),
       ).called(1);
 

--- a/flutter/test/integrations/flutter_error_integration_test.dart
+++ b/flutter/test/integrations/flutter_error_integration_test.dart
@@ -18,7 +18,8 @@ void main() {
     void _mockValues() {
       when(fixture.hub.configureScope(captureAny)).thenAnswer((_) {});
 
-      when(fixture.hub.captureEvent(captureAny, hint: anyNamed('hint')))
+      when(fixture.hub.captureEvent(captureAny,
+              hint: anyNamed('hint'), stackTrace: anyNamed('stackTrace')))
           .thenAnswer((_) => Future.value(SentryId.empty()));
 
       when(fixture.hub.options).thenReturn(fixture.options);
@@ -63,7 +64,11 @@ void main() {
       _reportError(exception: exception);
 
       final event = verify(
-        await fixture.hub.captureEvent(captureAny, hint: anyNamed('hint')),
+        await fixture.hub.captureEvent(
+          captureAny,
+          hint: anyNamed('hint'),
+          stackTrace: anyNamed('stackTrace'),
+        ),
       ).captured.first as SentryEvent;
 
       expect(event.level, SentryLevel.fatal);
@@ -95,7 +100,8 @@ void main() {
       _reportError(exception: StateError('error'), optionalDetails: details);
 
       final event = verify(
-        await fixture.hub.captureEvent(captureAny, hint: anyNamed('hint')),
+        await fixture.hub.captureEvent(captureAny,
+            hint: anyNamed('hint'), stackTrace: anyNamed('stackTrace')),
       ).captured.first as SentryEvent;
 
       expect(event.level, SentryLevel.fatal);
@@ -119,7 +125,8 @@ void main() {
       _reportError(exception: StateError('error'), optionalDetails: details);
 
       final event = verify(
-        await fixture.hub.captureEvent(captureAny, hint: anyNamed('hint')),
+        await fixture.hub.captureEvent(captureAny,
+            hint: anyNamed('hint'), stackTrace: anyNamed('stackTrace')),
       ).captured.first as SentryEvent;
 
       expect(event.level, SentryLevel.fatal);
@@ -141,7 +148,9 @@ void main() {
       _reportError(handler: defaultError);
 
       verify(
-          await fixture.hub.captureEvent(captureAny, hint: anyNamed('hint')));
+        await await fixture.hub.captureEvent(captureAny,
+            hint: anyNamed('hint'), stackTrace: anyNamed('stackTrace')),
+      );
 
       expect(called, true);
     });
@@ -166,8 +175,10 @@ void main() {
 
       FlutterError.reportError(details);
 
-      verify(await fixture.hub.captureEvent(captureAny, hint: anyNamed('hint')))
-          .called(1);
+      verify(
+        await await fixture.hub.captureEvent(captureAny,
+            hint: anyNamed('hint'), stackTrace: anyNamed('stackTrace')),
+      ).called(1);
 
       expect(numberOfDefaultCalls, 1);
     });
@@ -211,7 +222,9 @@ void main() {
       _reportError(silent: true);
 
       verify(
-          await fixture.hub.captureEvent(captureAny, hint: anyNamed('hint')));
+        await await fixture.hub.captureEvent(captureAny,
+            hint: anyNamed('hint'), stackTrace: anyNamed('stackTrace')),
+      );
     });
 
     test('adds integration', () {
@@ -255,7 +268,8 @@ void main() {
       _reportError(exception: exception);
 
       final event = verify(
-        await fixture.hub.captureEvent(captureAny, hint: anyNamed('hint')),
+        await fixture.hub.captureEvent(captureAny,
+            hint: anyNamed('hint'), stackTrace: anyNamed('stackTrace')),
       ).captured.first as SentryEvent;
 
       expect(event.level, SentryLevel.error);

--- a/flutter/test/integrations/on_error_integration_test.dart
+++ b/flutter/test/integrations/on_error_integration_test.dart
@@ -95,6 +95,25 @@ void main() {
       expect(throwableMechanism.mechanism.handled, false);
     });
 
+    test('captureEvent never uses an empty or null stack trace', () async {
+      final exception = StateError('error');
+      _reportError(
+        exception: exception,
+        stackTrace: StackTrace.current,
+        onErrorReturnValue: false,
+      );
+
+      final captured = verify(
+        await fixture.hub.captureEvent(captureAny,
+            hint: anyNamed('hint'), stackTrace: captureAnyNamed('stackTrace')),
+      ).captured;
+
+      final stackTrace = captured[1] as StackTrace?;
+
+      expect(stackTrace, isNotNull);
+      expect(stackTrace.toString(), isNotEmpty);
+    });
+
     test('calls default error', () async {
       var called = false;
       final defaultError = (_, __) {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
When the stacktrace we receive from an unhandled error is either empty or null we internally call `StackTrace.current` to grab it but it is truncated because the async nature of the error handling in the integration might be creating a new execution context, losing the original stack.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

What we currently have (doesn't help us debug the issue at all since we only see the frame up to a certain point): 
<img width="1124" alt="Screenshot 2024-07-09 at 12 46 05" src="https://github.com/getsentry/sentry-dart/assets/23364143/6324cf05-34e8-4262-8e26-fb898a7d1197">

What this fix improves on (now we can see the full context on where it happened):
<img width="1124" alt="Screenshot 2024-07-09 at 12 50 12" src="https://github.com/getsentry/sentry-dart/assets/23364143/2aa2d761-fc88-41ed-a159-a0f5dbff9a14">

This will most definitely change grouping for these (although I don't expect them to be the usual type of event)

## :green_heart: How did you test it?
Manual

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
