### PR TITLE
Record dropped spans in client reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Record dropped spans in client reports for Web, Linux and Windows ([#2154](https://github.com/getsentry/sentry-dart/pull/2154))
+- Record dropped spans in client reports ([#2154](https://github.com/getsentry/sentry-dart/pull/2154))
 - Add memory usage to contexts ([#2133](https://github.com/getsentry/sentry-dart/pull/2133))
   - Only for Linux/Windows applications, as iOS/Android/macOS use native SDKs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Record dropped spans in client reports for Web, Linux and Windows ([#2154](https://github.com/getsentry/sentry-dart/pull/2154))
 - Add memory usage to contexts ([#2133](https://github.com/getsentry/sentry-dart/pull/2133))
   - Only for Linux/Windows applications, as iOS/Android/macOS use native SDKs
 

--- a/dart/lib/src/client_reports/client_report_recorder.dart
+++ b/dart/lib/src/client_reports/client_report_recorder.dart
@@ -13,11 +13,11 @@ class ClientReportRecorder {
   final ClockProvider _clock;
   final Map<_QuantityKey, int> _quantities = {};
 
-  void recordLostEvent(
-      final DiscardReason reason, final DataCategory category) {
+  void recordLostEvent(final DiscardReason reason, final DataCategory category,
+      {int count = 1}) {
     final key = _QuantityKey(reason, category);
     var current = _quantities[key] ?? 0;
-    _quantities[key] = current + 1;
+    _quantities[key] = current + count;
   }
 
   ClientReport? flush() {

--- a/dart/lib/src/client_reports/discarded_event.dart
+++ b/dart/lib/src/client_reports/discarded_event.dart
@@ -54,6 +54,8 @@ extension _DataCategoryExtension on DataCategory {
         return 'session';
       case DataCategory.transaction:
         return 'transaction';
+      case DataCategory.span:
+        return 'span';
       case DataCategory.attachment:
         return 'attachment';
       case DataCategory.security:

--- a/dart/lib/src/client_reports/noop_client_report_recorder.dart
+++ b/dart/lib/src/client_reports/noop_client_report_recorder.dart
@@ -15,5 +15,6 @@ class NoOpClientReportRecorder implements ClientReportRecorder {
   }
 
   @override
-  void recordLostEvent(DiscardReason reason, DataCategory category) {}
+  void recordLostEvent(DiscardReason reason, DataCategory category,
+      {int count = 1}) {}
 }

--- a/dart/lib/src/hub.dart
+++ b/dart/lib/src/hub.dart
@@ -542,6 +542,11 @@ class Hub {
           DiscardReason.sampleRate,
           DataCategory.transaction,
         );
+        _options.recorder.recordLostEvent(
+          DiscardReason.sampleRate,
+          DataCategory.span,
+          count: transaction.spans.length + 1,
+        );
         _options.logger(
           SentryLevel.warning,
           'Transaction ${transaction.eventId} was dropped due to sampling decision.',

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -441,13 +441,12 @@ class SentryClient {
       }
     }
 
+    final discardReason = DiscardReason.beforeSend;
     if (processedEvent == null) {
-      _options.recorder
-          .recordLostEvent(DiscardReason.beforeSend, _getCategory(event));
+      _options.recorder.recordLostEvent(discardReason, _getCategory(event));
       if (event is SentryTransaction) {
         // We dropped the whole transaction, the dropped count includes all child spans + 1 root span
-        _options.recorder.recordLostEvent(
-            DiscardReason.beforeSend, DataCategory.span,
+        _options.recorder.recordLostEvent(discardReason, DataCategory.span,
             count: spanCountBeforeCallback + 1);
       }
       _options.logger(
@@ -460,8 +459,7 @@ class SentryClient {
       final spanCountAfterCallback = processedEvent.spans.length;
       final droppedSpanCount = spanCountBeforeCallback - spanCountAfterCallback;
       if (droppedSpanCount > 0) {
-        _options.recorder.recordLostEvent(
-            DiscardReason.beforeSend, DataCategory.span,
+        _options.recorder.recordLostEvent(discardReason, DataCategory.span,
             count: droppedSpanCount);
       }
     }
@@ -497,13 +495,13 @@ class SentryClient {
           rethrow;
         }
       }
+
+      final discardReason = DiscardReason.eventProcessor;
       if (processedEvent == null) {
-        _options.recorder
-            .recordLostEvent(DiscardReason.beforeSend, _getCategory(event));
+        _options.recorder.recordLostEvent(discardReason, _getCategory(event));
         if (event is SentryTransaction) {
           // We dropped the whole transaction, the dropped count includes all child spans + 1 root span
-          _options.recorder.recordLostEvent(
-              DiscardReason.beforeSend, DataCategory.span,
+          _options.recorder.recordLostEvent(discardReason, DataCategory.span,
               count: spanCountBeforeEventProcessors + 1);
         }
         _options.logger(SentryLevel.debug, 'Event was dropped by a processor');
@@ -514,8 +512,7 @@ class SentryClient {
         final droppedSpanCount =
             spanCountBeforeEventProcessors - spanCountAfterEventProcessors;
         if (droppedSpanCount > 0) {
-          _options.recorder.recordLostEvent(
-              DiscardReason.beforeSend, DataCategory.span,
+          _options.recorder.recordLostEvent(discardReason, DataCategory.span,
               count: droppedSpanCount);
         }
       }

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -517,6 +517,7 @@ class SentryClient {
         }
       }
     }
+
     return processedEvent;
   }
 

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -507,7 +507,7 @@ class SentryClient {
         _options.logger(SentryLevel.debug, 'Event was dropped by a processor');
       } else if (event is SentryTransaction &&
           processedEvent is SentryTransaction) {
-        // If beforeSend removed only some spans we still report them as dropped
+        // If event processor removed only some spans we still report them as dropped
         final spanCountAfterEventProcessors = processedEvent.spans.length;
         final droppedSpanCount =
             spanCountBeforeEventProcessors - spanCountAfterEventProcessors;

--- a/dart/lib/src/sentry_envelope_item.dart
+++ b/dart/lib/src/sentry_envelope_item.dart
@@ -1,8 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:meta/meta.dart';
-
 import 'client_reports/client_report.dart';
 import 'metrics/metric.dart';
 import 'protocol.dart';

--- a/dart/lib/src/transport/data_category.dart
+++ b/dart/lib/src/transport/data_category.dart
@@ -9,5 +9,24 @@ enum DataCategory {
   attachment,
   security,
   metricBucket,
-  unknown
+  unknown;
+
+  static DataCategory fromItemType(String itemType) {
+    switch (itemType) {
+      case 'event':
+        return DataCategory.error;
+      case 'session':
+        return DataCategory.session;
+      case 'attachment':
+        return DataCategory.attachment;
+      case 'transaction':
+        return DataCategory.transaction;
+      // The envelope item type used for metrics is statsd,
+      // whereas the client report category is metric_bucket
+      case 'statsd':
+        return DataCategory.metricBucket;
+      default:
+        return DataCategory.unknown;
+    }
+  }
 }

--- a/dart/lib/src/transport/data_category.dart
+++ b/dart/lib/src/transport/data_category.dart
@@ -5,6 +5,7 @@ enum DataCategory {
   error,
   session,
   transaction,
+  span,
   attachment,
   security,
   metricBucket,

--- a/dart/lib/src/transport/rate_limiter.dart
+++ b/dart/lib/src/transport/rate_limiter.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+
+import '../../sentry.dart';
 import '../transport/rate_limit_parser.dart';
 import '../sentry_options.dart';
 import '../sentry_envelope.dart';
@@ -25,8 +28,17 @@ class RateLimiter {
 
         _options.recorder.recordLostEvent(
           DiscardReason.rateLimitBackoff,
-          _categoryFromItemType(item.header.type),
+          DataCategory.fromItemType(item.header.type),
         );
+
+        final originalObject = item.originalObject;
+        if (originalObject is SentryTransaction) {
+          _options.recorder.recordLostEvent(
+            DiscardReason.rateLimitBackoff,
+            DataCategory.span,
+            count: originalObject.spans.length + 1,
+          );
+        }
       }
     }
 
@@ -80,7 +92,7 @@ class RateLimiter {
   // Private
 
   bool _isRetryAfter(String itemType) {
-    final dataCategory = _categoryFromItemType(itemType);
+    final dataCategory = DataCategory.fromItemType(itemType);
     final currentDate = DateTime.fromMillisecondsSinceEpoch(
         _options.clock().millisecondsSinceEpoch);
 
@@ -104,25 +116,6 @@ class RateLimiter {
     }
 
     return false;
-  }
-
-  DataCategory _categoryFromItemType(String itemType) {
-    switch (itemType) {
-      case 'event':
-        return DataCategory.error;
-      case 'session':
-        return DataCategory.session;
-      case 'attachment':
-        return DataCategory.attachment;
-      case 'transaction':
-        return DataCategory.transaction;
-      // The envelope item type used for metrics is statsd,
-      // whereas the client report category is metric_bucket
-      case 'statsd':
-        return DataCategory.metricBucket;
-      default:
-        return DataCategory.unknown;
-    }
   }
 
   void _applyRetryAfterOnlyIfLonger(DataCategory dataCategory, DateTime date) {

--- a/dart/lib/src/transport/rate_limiter.dart
+++ b/dart/lib/src/transport/rate_limiter.dart
@@ -1,10 +1,5 @@
-import 'dart:convert';
-
 import '../../sentry.dart';
 import '../transport/rate_limit_parser.dart';
-import '../sentry_options.dart';
-import '../sentry_envelope.dart';
-import '../sentry_envelope_item.dart';
 import 'rate_limit.dart';
 import 'data_category.dart';
 import '../client_reports/discard_reason.dart';

--- a/dart/lib/src/utils/transport_utils.dart
+++ b/dart/lib/src/utils/transport_utils.dart
@@ -19,6 +19,21 @@ class TransportUtils {
       }
 
       if (response.statusCode >= 400 && response.statusCode != 429) {
+        for (final item in envelope.items) {
+          options.recorder.recordLostEvent(
+            DiscardReason.networkError,
+            DataCategory.fromItemType(item.header.type),
+          );
+
+          final originalObject = item.originalObject;
+          if (originalObject is SentryTransaction) {
+            options.recorder.recordLostEvent(
+              DiscardReason.networkError,
+              DataCategory.span,
+              count: originalObject.spans.length + 1,
+            );
+          }
+        }
         options.recorder
             .recordLostEvent(DiscardReason.networkError, DataCategory.error);
       }

--- a/dart/lib/src/utils/transport_utils.dart
+++ b/dart/lib/src/utils/transport_utils.dart
@@ -34,8 +34,6 @@ class TransportUtils {
             );
           }
         }
-        options.recorder
-            .recordLostEvent(DiscardReason.networkError, DataCategory.error);
       }
     } else {
       options.logger(

--- a/dart/test/mocks.dart
+++ b/dart/test/mocks.dart
@@ -137,8 +137,8 @@ class DropAllEventProcessor implements EventProcessor {
   }
 }
 
-class DropNumberOfSpans implements EventProcessor {
-  DropNumberOfSpans(this.numberOfSpansToDrop);
+class DropSpansEventProcessor implements EventProcessor {
+  DropSpansEventProcessor(this.numberOfSpansToDrop);
 
   final int numberOfSpansToDrop;
 

--- a/dart/test/mocks.dart
+++ b/dart/test/mocks.dart
@@ -137,6 +137,25 @@ class DropAllEventProcessor implements EventProcessor {
   }
 }
 
+class DropNumberOfSpans implements EventProcessor {
+  DropNumberOfSpans(this.numberOfSpansToDrop);
+
+  final int numberOfSpansToDrop;
+
+  @override
+  SentryEvent? apply(SentryEvent event, Hint hint) {
+    if (event is SentryTransaction) {
+      if (numberOfSpansToDrop > event.spans.length) {
+        throw ArgumentError(
+            'numberOfSpansToDrop must be less than the number of spans in the transaction');
+      }
+      final droppedSpans = event.spans.take(numberOfSpansToDrop).toList();
+      event.spans.removeWhere((element) => droppedSpans.contains(element));
+    }
+    return event;
+  }
+}
+
 class FunctionEventProcessor implements EventProcessor {
   FunctionEventProcessor(this.applyFunction);
 

--- a/dart/test/mocks/mock_client_report_recorder.dart
+++ b/dart/test/mocks/mock_client_report_recorder.dart
@@ -7,9 +7,6 @@ import 'package:sentry/src/transport/data_category.dart';
 class MockClientReportRecorder implements ClientReportRecorder {
   List<DiscardedEvent> discardedEvents = [];
 
-  DiscardReason? reason;
-  DataCategory? category;
-
   ClientReport? clientReport;
 
   bool flushCalled = false;
@@ -23,8 +20,6 @@ class MockClientReportRecorder implements ClientReportRecorder {
   @override
   void recordLostEvent(DiscardReason reason, DataCategory category,
       {int count = 1}) {
-    this.reason = reason;
-    this.category = category;
     discardedEvents.add(DiscardedEvent(reason, category, count));
   }
 }

--- a/dart/test/mocks/mock_client_report_recorder.dart
+++ b/dart/test/mocks/mock_client_report_recorder.dart
@@ -1,9 +1,12 @@
 import 'package:sentry/src/client_reports/client_report_recorder.dart';
 import 'package:sentry/src/client_reports/discard_reason.dart';
 import 'package:sentry/src/client_reports/client_report.dart';
+import 'package:sentry/src/client_reports/discarded_event.dart';
 import 'package:sentry/src/transport/data_category.dart';
 
 class MockClientReportRecorder implements ClientReportRecorder {
+  List<DiscardedEvent> discardedEvents = [];
+
   DiscardReason? reason;
   DataCategory? category;
 
@@ -18,8 +21,10 @@ class MockClientReportRecorder implements ClientReportRecorder {
   }
 
   @override
-  void recordLostEvent(DiscardReason reason, DataCategory category) {
+  void recordLostEvent(DiscardReason reason, DataCategory category,
+      {int count = 1}) {
     this.reason = reason;
     this.category = category;
+    discardedEvents.add(DiscardedEvent(reason, category, count));
   }
 }

--- a/dart/test/protocol/rate_limiter_test.dart
+++ b/dart/test/protocol/rate_limiter_test.dart
@@ -1,5 +1,7 @@
+import 'package:collection/collection.dart';
 import 'package:sentry/sentry.dart';
 import 'package:sentry/src/client_reports/discard_reason.dart';
+import 'package:sentry/src/client_reports/discarded_event.dart';
 import 'package:sentry/src/transport/data_category.dart';
 import 'package:test/test.dart';
 
@@ -9,6 +11,7 @@ import 'package:sentry/src/sentry_envelope_header.dart';
 
 import '../mocks/mock_client_report_recorder.dart';
 import '../mocks/mock_hub.dart';
+import 'breadcrumb_test.dart';
 
 void main() {
   var fixture = Fixture();
@@ -205,14 +208,18 @@ void main() {
     final result = rateLimiter.filter(eventEnvelope);
     expect(result, isNull);
 
-    expect(fixture.mockRecorder.category, DataCategory.error);
-    expect(fixture.mockRecorder.reason, DiscardReason.rateLimitBackoff);
+    expect(fixture.mockRecorder.discardedEvents.first.category,
+        DataCategory.error);
+    expect(fixture.mockRecorder.discardedEvents.first.reason,
+        DiscardReason.rateLimitBackoff);
   });
 
   test('dropping of transaction recorded', () {
     final rateLimiter = fixture.getSut();
 
     final transaction = fixture.getTransaction();
+    transaction.tracer.startChild('child1');
+    transaction.tracer.startChild('child2');
     final eventItem = SentryEnvelopeItem.fromTransaction(transaction);
     final eventEnvelope = SentryEnvelope(
       SentryEnvelopeHeader.newEventId(),
@@ -225,8 +232,21 @@ void main() {
     final result = rateLimiter.filter(eventEnvelope);
     expect(result, isNull);
 
-    expect(fixture.mockRecorder.category, DataCategory.transaction);
-    expect(fixture.mockRecorder.reason, DiscardReason.rateLimitBackoff);
+    expect(fixture.mockRecorder.discardedEvents.length, 2);
+
+    final transactionDiscardedEvent = fixture.mockRecorder.discardedEvents
+        .firstWhereOrNull((element) =>
+            element.category == DataCategory.transaction &&
+            element.reason == DiscardReason.rateLimitBackoff);
+
+    final spanDiscardedEvent = fixture.mockRecorder.discardedEvents
+        .firstWhereOrNull((element) =>
+            element.category == DataCategory.span &&
+            element.reason == DiscardReason.rateLimitBackoff);
+
+    expect(transactionDiscardedEvent, isNotNull);
+    expect(spanDiscardedEvent, isNotNull);
+    expect(spanDiscardedEvent!.quantity, 3);
   });
 
   test('dropping of metrics recorded', () {
@@ -244,8 +264,10 @@ void main() {
     final result = rateLimiter.filter(eventEnvelope);
     expect(result, isNull);
 
-    expect(fixture.mockRecorder.category, DataCategory.metricBucket);
-    expect(fixture.mockRecorder.reason, DiscardReason.rateLimitBackoff);
+    expect(fixture.mockRecorder.discardedEvents.first.category,
+        DataCategory.metricBucket);
+    expect(fixture.mockRecorder.discardedEvents.first.reason,
+        DiscardReason.rateLimitBackoff);
   });
 
   group('apply rateLimit', () {

--- a/dart/test/protocol/rate_limiter_test.dart
+++ b/dart/test/protocol/rate_limiter_test.dart
@@ -1,7 +1,6 @@
 import 'package:collection/collection.dart';
 import 'package:sentry/sentry.dart';
 import 'package:sentry/src/client_reports/discard_reason.dart';
-import 'package:sentry/src/client_reports/discarded_event.dart';
 import 'package:sentry/src/transport/data_category.dart';
 import 'package:test/test.dart';
 
@@ -11,7 +10,6 @@ import 'package:sentry/src/sentry_envelope_header.dart';
 
 import '../mocks/mock_client_report_recorder.dart';
 import '../mocks/mock_hub.dart';
-import 'breadcrumb_test.dart';
 
 void main() {
   var fixture = Fixture();

--- a/dart/test/sentry_client_test.dart
+++ b/dart/test/sentry_client_test.dart
@@ -1446,7 +1446,8 @@ void main() {
           fixture.recorder.discardedEvents.first.category, DataCategory.error);
     });
 
-    test('transaction dropped by beforeSendTransaction is recorded', () async {
+    test('beforeSendTransaction correctly records dropped transaction',
+        () async {
       final sut = fixture.getSut();
       final transaction = SentryTransaction(fixture.tracer);
       fixture.tracer.startChild('child1');
@@ -1472,7 +1473,7 @@ void main() {
       expect(spanCount, 4);
     });
 
-    test('partially dropped spans by beforeSendTransaction is recorded',
+    test('beforeSendTransaction correctly records partially dropped spans',
         () async {
       final sut = fixture.getSut();
       final transaction = SentryTransaction(fixture.tracer);

--- a/dart/test/sentry_client_test.dart
+++ b/dart/test/sentry_client_test.dart
@@ -1462,11 +1462,8 @@ void main() {
 
       await sut.captureTransaction(transaction);
 
-      // 1 for the transaction and 1 for the spans
       expect(fixture.recorder.discardedEvents.length, 2);
 
-      // we dropped the whole tracer and it has 3 span children so the span count should be 4
-      // 3 children + 1 root span
       final spanCount = fixture.recorder.discardedEvents
           .firstWhere((element) =>
               element.category == DataCategory.span &&
@@ -1475,8 +1472,7 @@ void main() {
       expect(spanCount, 4);
     });
 
-    test(
-        'transaction dropped partial spans by beforeSendTransaction is recorded',
+    test('partially dropped spans by beforeSendTransaction is recorded',
         () async {
       final sut = fixture.getSut();
       final transaction = SentryTransaction(fixture.tracer);

--- a/dart/test/sentry_client_test.dart
+++ b/dart/test/sentry_client_test.dart
@@ -1460,7 +1460,7 @@ void main() {
       final spanCount = fixture.recorder.discardedEvents
           .firstWhere((element) =>
               element.category == DataCategory.span &&
-              element.reason == DiscardReason.beforeSend)
+              element.reason == DiscardReason.eventProcessor)
           .quantity;
       expect(spanCount, 4);
     });
@@ -1481,7 +1481,7 @@ void main() {
       final spanCount = fixture.recorder.discardedEvents
           .firstWhere((element) =>
               element.category == DataCategory.span &&
-              element.reason == DiscardReason.beforeSend)
+              element.reason == DiscardReason.eventProcessor)
           .quantity;
       expect(spanCount, numberOfSpansDropped);
     });

--- a/dart/test/sentry_client_test.dart
+++ b/dart/test/sentry_client_test.dart
@@ -1440,8 +1440,10 @@ void main() {
 
       await client.captureEvent(fakeEvent);
 
-      expect(fixture.recorder.reason, DiscardReason.eventProcessor);
-      expect(fixture.recorder.category, DataCategory.error);
+      expect(fixture.recorder.discardedEvents.first.reason,
+          DiscardReason.eventProcessor);
+      expect(
+          fixture.recorder.discardedEvents.first.category, DataCategory.error);
     });
 
     test('transaction dropped by beforeSendTransaction is recorded', () async {
@@ -1514,8 +1516,10 @@ void main() {
 
       await client.captureTransaction(transaction);
 
-      expect(fixture.recorder.reason, DiscardReason.eventProcessor);
-      expect(fixture.recorder.category, DataCategory.transaction);
+      expect(fixture.recorder.discardedEvents.first.reason,
+          DiscardReason.eventProcessor);
+      expect(fixture.recorder.discardedEvents.first.category,
+          DataCategory.transaction);
     });
 
     test('record beforeSend dropping event', () async {
@@ -1525,8 +1529,10 @@ void main() {
 
       await client.captureEvent(fakeEvent);
 
-      expect(fixture.recorder.reason, DiscardReason.beforeSend);
-      expect(fixture.recorder.category, DataCategory.error);
+      expect(fixture.recorder.discardedEvents.first.reason,
+          DiscardReason.beforeSend);
+      expect(
+          fixture.recorder.discardedEvents.first.category, DataCategory.error);
     });
 
     test('record sample rate dropping event', () async {
@@ -1536,8 +1542,10 @@ void main() {
 
       await client.captureEvent(fakeEvent);
 
-      expect(fixture.recorder.reason, DiscardReason.sampleRate);
-      expect(fixture.recorder.category, DataCategory.error);
+      expect(fixture.recorder.discardedEvents.first.reason,
+          DiscardReason.sampleRate);
+      expect(
+          fixture.recorder.discardedEvents.first.category, DataCategory.error);
     });
 
     test('user feedback envelope contains dsn', () async {

--- a/dart/test/sentry_client_test.dart
+++ b/dart/test/sentry_client_test.dart
@@ -1468,7 +1468,7 @@ void main() {
     test('record event processor dropping partially spans', () async {
       final numberOfSpansDropped = 2;
       final sut = fixture.getSut(
-          eventProcessor: DropNumberOfSpans(numberOfSpansDropped));
+          eventProcessor: DropSpansEventProcessor(numberOfSpansDropped));
       final transaction = SentryTransaction(fixture.tracer);
       fixture.tracer.startChild('child1');
       fixture.tracer.startChild('child2');

--- a/dart/test/transport/http_transport_test.dart
+++ b/dart/test/transport/http_transport_test.dart
@@ -260,8 +260,8 @@ void main() {
       );
       await sut.send(envelope);
 
-      expect(fixture.clientReportRecorder.discardedEvents.first.reason, null);
-      expect(fixture.clientReportRecorder.discardedEvents.first.category, null);
+      expect(fixture.clientReportRecorder.discardedEvents.isEmpty, isTrue);
+      expect(fixture.clientReportRecorder.discardedEvents.isEmpty, isTrue);
     });
 
     test('does record lost event for error >= 500', () async {

--- a/dart/test/transport/http_transport_test.dart
+++ b/dart/test/transport/http_transport_test.dart
@@ -261,7 +261,6 @@ void main() {
       await sut.send(envelope);
 
       expect(fixture.clientReportRecorder.discardedEvents.isEmpty, isTrue);
-      expect(fixture.clientReportRecorder.discardedEvents.isEmpty, isTrue);
     });
 
     test('does record lost event for error >= 500', () async {

--- a/dart/test/transport/http_transport_test.dart
+++ b/dart/test/transport/http_transport_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:collection/collection.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:sentry/sentry.dart';
@@ -7,6 +8,7 @@ import 'package:sentry/src/client_reports/discard_reason.dart';
 import 'package:sentry/src/sentry_envelope_header.dart';
 import 'package:sentry/src/sentry_envelope_item_header.dart';
 import 'package:sentry/src/sentry_item_type.dart';
+import 'package:sentry/src/sentry_tracer.dart';
 import 'package:sentry/src/transport/data_category.dart';
 import 'package:sentry/src/transport/http_transport.dart';
 import 'package:sentry/src/transport/rate_limiter.dart';
@@ -14,6 +16,7 @@ import 'package:test/test.dart';
 
 import '../mocks.dart';
 import '../mocks/mock_client_report_recorder.dart';
+import '../mocks/mock_hub.dart';
 
 void main() {
   SentryEnvelope givenEnvelope() {
@@ -205,8 +208,42 @@ void main() {
       );
       await sut.send(envelope);
 
-      expect(fixture.clientReportRecorder.reason, DiscardReason.networkError);
-      expect(fixture.clientReportRecorder.category, DataCategory.error);
+      expect(fixture.clientReportRecorder.discardedEvents.first.reason,
+          DiscardReason.networkError);
+      expect(fixture.clientReportRecorder.discardedEvents.first.category,
+          DataCategory.error);
+    });
+
+    test('does records lost transaction and span for error >= 400', () async {
+      final httpMock = MockClient((http.Request request) async {
+        return http.Response('{}', 400);
+      });
+      final sut = fixture.getSut(httpMock, MockRateLimiter());
+
+      final transaction = fixture.getTransaction();
+      transaction.tracer.startChild('child1');
+      transaction.tracer.startChild('child2');
+      final envelope = SentryEnvelope.fromTransaction(
+        transaction,
+        fixture.options.sdk,
+        dsn: fixture.options.dsn,
+      );
+      await sut.send(envelope);
+
+      final transactionDiscardedEvent = fixture
+          .clientReportRecorder.discardedEvents
+          .firstWhereOrNull((element) =>
+              element.category == DataCategory.transaction &&
+              element.reason == DiscardReason.networkError);
+
+      final spanDiscardedEvent = fixture.clientReportRecorder.discardedEvents
+          .firstWhereOrNull((element) =>
+              element.category == DataCategory.span &&
+              element.reason == DiscardReason.networkError);
+
+      expect(transactionDiscardedEvent, isNotNull);
+      expect(spanDiscardedEvent, isNotNull);
+      expect(spanDiscardedEvent!.quantity, 3);
     });
 
     test('does not record lost event for error 429', () async {
@@ -223,8 +260,8 @@ void main() {
       );
       await sut.send(envelope);
 
-      expect(fixture.clientReportRecorder.reason, null);
-      expect(fixture.clientReportRecorder.category, null);
+      expect(fixture.clientReportRecorder.discardedEvents.first.reason, null);
+      expect(fixture.clientReportRecorder.discardedEvents.first.category, null);
     });
 
     test('does record lost event for error >= 500', () async {
@@ -241,8 +278,10 @@ void main() {
       );
       await sut.send(envelope);
 
-      expect(fixture.clientReportRecorder.reason, DiscardReason.networkError);
-      expect(fixture.clientReportRecorder.category, DataCategory.error);
+      expect(fixture.clientReportRecorder.discardedEvents.first.reason,
+          DiscardReason.networkError);
+      expect(fixture.clientReportRecorder.discardedEvents.first.category,
+          DataCategory.error);
     });
   });
 }
@@ -261,5 +300,15 @@ class Fixture {
       return DateTime.utc(2019);
     };
     return HttpTransport(options, rateLimiter);
+  }
+
+  SentryTransaction getTransaction() {
+    final context = SentryTransactionContext(
+      'name',
+      'op',
+      samplingDecision: SentryTracesSamplingDecision(true),
+    );
+    final tracer = SentryTracer(context, MockHub());
+    return SentryTransaction(tracer);
   }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Reports the dropped spans as well in client reports, not only the transaction

For all platforms this change reports dropped spans through:
- sampling
- beforeSend/beforeSendTransaction -> either dropping the whole transaction or keeping the transaction but only dropping a few spans
- event processors with same report behaviour as beforeSend

For Web, Linux, Windows (through HttpTransport):
- rate limiter
- network errors

rate limit or network errors on ios, macos or android are handled by the native sdks

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related #2137 

## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
