### PR TITLE
Set dart runtime version with parsed `Platform.version`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
   - Time out for app start info retrieval has been reduced to 10s
   - If `autoAppStarts` is `false` and `setAppStartEnd` has not been called, the app start event processor will now return early instead of waiting for `getAppStartInfo` to finish
 
+### Improvements
+
+- Set dart runtime version with parsed `Platform.version` ([#2156](https://github.com/getsentry/sentry-dart/pull/2156))
+
 ## 8.4.0-beta.1
 
 ### Features

--- a/dart/lib/src/event_processor/enricher/io_enricher_event_processor.dart
+++ b/dart/lib/src/event_processor/enricher/io_enricher_event_processor.dart
@@ -12,12 +12,10 @@ EnricherEventProcessor enricherEventProcessor(SentryOptions options) {
 /// Uses Darts [Platform](https://api.dart.dev/stable/dart-io/Platform-class.html)
 /// class to read information.
 class IoEnricherEventProcessor implements EnricherEventProcessor {
-  IoEnricherEventProcessor(this._options) {
-    dartVersion = _extractDartVersion(Platform.version);
-  }
+  IoEnricherEventProcessor(this._options);
 
   final SentryOptions _options;
-  late final String dartVersion;
+  late final String _dartVersion = _extractDartVersion(Platform.version);
 
   /// Extracts the semantic version and channel from the full version string.
   ///
@@ -73,7 +71,7 @@ class IoEnricherEventProcessor implements EnricherEventProcessor {
     // like Flutter: https://flutter.dev/docs/testing/build-modes
     final dartRuntime = SentryRuntime(
       name: 'Dart',
-      version: dartVersion,
+      version: _dartVersion,
       rawDescription: Platform.version,
     );
     if (runtimes == null) {

--- a/dart/lib/src/event_processor/enricher/io_enricher_event_processor.dart
+++ b/dart/lib/src/event_processor/enricher/io_enricher_event_processor.dart
@@ -71,7 +71,6 @@ class IoEnricherEventProcessor implements EnricherEventProcessor {
   List<SentryRuntime> _getRuntimes(List<SentryRuntime>? runtimes) {
     // Pure Dart doesn't have specific runtimes per build mode
     // like Flutter: https://flutter.dev/docs/testing/build-modes
-
     final dartRuntime = SentryRuntime(
       name: 'Dart',
       version: dartVersion,

--- a/dart/lib/src/event_processor/enricher/io_enricher_event_processor.dart
+++ b/dart/lib/src/event_processor/enricher/io_enricher_event_processor.dart
@@ -26,7 +26,7 @@ class IoEnricherEventProcessor implements EnricherEventProcessor {
   /// Output: "3.5.0-180.3.beta (beta)"
   ///
   /// Falls back to the full version if the matching fails.
-  static String _extractDartVersion(String fullVersion) {
+  String _extractDartVersion(String fullVersion) {
     RegExp channelRegex = RegExp(r'\((stable|beta|dev)\)');
     Match? match = channelRegex.firstMatch(fullVersion);
     // if match is null this will return the full version

--- a/dart/lib/src/event_processor/enricher/io_enricher_event_processor.dart
+++ b/dart/lib/src/event_processor/enricher/io_enricher_event_processor.dart
@@ -72,7 +72,7 @@ class IoEnricherEventProcessor implements EnricherEventProcessor {
     // Pure Dart doesn't have specific runtimes per build mode
     // like Flutter: https://flutter.dev/docs/testing/build-modes
 
-    SentryRuntime dartRuntime = SentryRuntime(
+    final dartRuntime = SentryRuntime(
       name: 'Dart',
       version: dartVersion,
       rawDescription: Platform.version,

--- a/dart/lib/src/event_processor/enricher/io_enricher_event_processor.dart
+++ b/dart/lib/src/event_processor/enricher/io_enricher_event_processor.dart
@@ -54,8 +54,18 @@ class IoEnricherEventProcessor implements EnricherEventProcessor {
   List<SentryRuntime> _getRuntimes(List<SentryRuntime>? runtimes) {
     // Pure Dart doesn't have specific runtimes per build mode
     // like Flutter: https://flutter.dev/docs/testing/build-modes
-    final dartRuntime = SentryRuntime(
+
+    // Regex taken from semver package
+    final versionRegex = RegExp(r'^' // Start at beginning.
+        r'(\d+)\.(\d+)\.(\d+)' // Version number.
+        r'(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?' // Pre-release.
+        r'(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?' // Build.
+        r' \((beta|stable)\)'); // Channel.
+    final version = versionRegex.stringMatch(Platform.version);
+
+    SentryRuntime dartRuntime = SentryRuntime(
       name: 'Dart',
+      version: version ?? Platform.version,
       rawDescription: Platform.version,
     );
     if (runtimes == null) {

--- a/dart/lib/src/event_processor/enricher/io_enricher_event_processor.dart
+++ b/dart/lib/src/event_processor/enricher/io_enricher_event_processor.dart
@@ -51,18 +51,17 @@ class IoEnricherEventProcessor implements EnricherEventProcessor {
     );
   }
 
-  /// Extracts the version from the full version string.
-  /// Example of full version string:
+  /// Extracts the semantic version and channel from the full version string.
   /// 3.5.0-180.3.beta (beta) (Wed Jun 5 15:06:15 2024 +0000) on "android_arm64"
+  /// turns into 3.5.0-180.3.beta (beta)
   String _extractVersionWithChannel(String fullVersion) {
-    List<String> parts = fullVersion.split(') ');
+    RegExp channelRegex = RegExp(r'\((stable|beta|dev)\)');
+    Match? match = channelRegex.firstMatch(fullVersion);
 
-    // If there's at least one ')', return the first part plus ')'
-    if (parts.length > 1) {
-      return '${parts[0]})';
+    if (match != null) {
+      return fullVersion.substring(0, match.end);
     }
 
-    // If there's no ')', return the whole string (shouldn't happen with given format)
     return fullVersion;
   }
 

--- a/dart/lib/src/event_processor/enricher/io_enricher_event_processor.dart
+++ b/dart/lib/src/event_processor/enricher/io_enricher_event_processor.dart
@@ -51,21 +51,29 @@ class IoEnricherEventProcessor implements EnricherEventProcessor {
     );
   }
 
+  /// Extracts the version from the full version string.
+  /// Example of full version string:
+  /// 3.5.0-180.3.beta (beta) (Wed Jun 5 15:06:15 2024 +0000) on "android_arm64"
+  String _extractVersionWithChannel(String fullVersion) {
+    List<String> parts = fullVersion.split(') ');
+
+    // If there's at least one ')', return the first part plus ')'
+    if (parts.length > 1) {
+      return '${parts[0]})';
+    }
+
+    // If there's no ')', return the whole string (shouldn't happen with given format)
+    return fullVersion;
+  }
+
   List<SentryRuntime> _getRuntimes(List<SentryRuntime>? runtimes) {
     // Pure Dart doesn't have specific runtimes per build mode
     // like Flutter: https://flutter.dev/docs/testing/build-modes
 
-    // Regex taken from semver package
-    final versionRegex = RegExp(r'^' // Start at beginning.
-        r'(\d+)\.(\d+)\.(\d+)' // Version number.
-        r'(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?' // Pre-release.
-        r'(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?' // Build.
-        r' \((beta|stable)\)'); // Channel.
-    final version = versionRegex.stringMatch(Platform.version);
-
+    final version = _extractVersionWithChannel(Platform.version);
     SentryRuntime dartRuntime = SentryRuntime(
       name: 'Dart',
-      version: version ?? Platform.version,
+      version: version,
       rawDescription: Platform.version,
     );
     if (runtimes == null) {

--- a/dart/lib/src/event_processor/enricher/io_enricher_event_processor.dart
+++ b/dart/lib/src/event_processor/enricher/io_enricher_event_processor.dart
@@ -51,25 +51,21 @@ class IoEnricherEventProcessor implements EnricherEventProcessor {
     );
   }
 
-  /// Extracts the semantic version and channel from the full version string.
-  /// 3.5.0-180.3.beta (beta) (Wed Jun 5 15:06:15 2024 +0000) on "android_arm64"
-  /// turns into 3.5.0-180.3.beta (beta)
-  String _extractVersionWithChannel(String fullVersion) {
-    RegExp channelRegex = RegExp(r'\((stable|beta|dev)\)');
-    Match? match = channelRegex.firstMatch(fullVersion);
-
-    if (match != null) {
-      return fullVersion.substring(0, match.end);
-    }
-
-    return fullVersion;
-  }
-
   List<SentryRuntime> _getRuntimes(List<SentryRuntime>? runtimes) {
     // Pure Dart doesn't have specific runtimes per build mode
     // like Flutter: https://flutter.dev/docs/testing/build-modes
 
-    final version = _extractVersionWithChannel(Platform.version);
+    // Extracts the semantic version and channel from the full version string.
+    // 3.5.0-180.3.beta (beta) (Wed Jun 5 15:06:15 2024 +0000) on "android_arm64"
+    // turns into 3.5.0-180.3.beta (beta)
+    String version = Platform.version;
+    RegExp channelRegex = RegExp(r'\((stable|beta|dev)\)');
+    Match? match = channelRegex.firstMatch(version);
+
+    if (match != null) {
+      version = version.substring(0, match.end);
+    }
+
     SentryRuntime dartRuntime = SentryRuntime(
       name: 'Dart',
       version: version,

--- a/dart/test/event_processor/enricher/io_enricher_test.dart
+++ b/dart/test/event_processor/enricher/io_enricher_test.dart
@@ -27,8 +27,8 @@ void main() {
           .firstWhere((element) => element.name == 'Dart');
       expect(dartRuntime?.name, 'Dart');
       expect(dartRuntime?.rawDescription, isNotNull);
-      expect(dartRuntime!.version.toString() != Platform.version, true);
-      expect(Platform.version.contains(dartRuntime.version.toString()), true);
+      expect(dartRuntime!.version.toString(), isNot(Platform.version));
+      expect(Platform.version, contains(dartRuntime.version.toString()));
     });
 
     test('does add to existing runtimes', () {

--- a/dart/test/event_processor/enricher/io_enricher_test.dart
+++ b/dart/test/event_processor/enricher/io_enricher_test.dart
@@ -1,6 +1,8 @@
 @TestOn('vm')
 library dart_test;
 
+import 'dart:io';
+
 import 'package:sentry/sentry.dart';
 import 'package:sentry/src/event_processor/enricher/io_enricher_event_processor.dart';
 import 'package:test/test.dart';
@@ -25,6 +27,8 @@ void main() {
           .firstWhere((element) => element.name == 'Dart');
       expect(dartRuntime?.name, 'Dart');
       expect(dartRuntime?.rawDescription, isNotNull);
+      expect(dartRuntime!.version.toString() != Platform.version, true);
+      expect(Platform.version.contains(dartRuntime.version.toString()), true);
     });
 
     test('does add to existing runtimes', () {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Fills the additional version field of the runtime context with version + channel

This makes it possible internally to query data based on dart runtimes

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2141 

## :green_heart: How did you test it?
Unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
