### PR TITLE
Add flag to disable reporting of view hierarchy identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Features
 
-- Add flag to disable reporting of view hierarchy identifiers which may contain sensitive information ([#2158](https://github.com/getsentry/sentry-dart/pull/2158))
+- Add flag to disable reporting of view hierarchy identifiers ([#2158](https://github.com/getsentry/sentry-dart/pull/2158))
+  - Use `reportViewHierarchyIdentifiers` to enable or disable the option
 - Record dropped spans in client reports ([#2154](https://github.com/getsentry/sentry-dart/pull/2154))
 - Add memory usage to contexts ([#2133](https://github.com/getsentry/sentry-dart/pull/2133))
   - Only for Linux/Windows applications, as iOS/Android/macOS use native SDKs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Add flag to disable reporting of view hierarchy identifiers which may contain sensitive information ([#2158](https://github.com/getsentry/sentry-dart/pull/2158))
 - Add memory usage to contexts ([#2133](https://github.com/getsentry/sentry-dart/pull/2133))
   - Only for Linux/Windows applications, as iOS/Android/macOS use native SDKs
 

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -213,6 +213,10 @@ class SentryFlutterOptions extends SentryOptions {
   @experimental
   bool attachViewHierarchy = false;
 
+  /// Enables reporting information of identifiers of the view hierarchy.
+  /// This might contain sensitive information.
+  bool reportViewHierarchyIdentifiers = true;
+
   /// When enabled, the SDK tracks when the application stops responding for a
   /// specific amount of time, See [appHangTimeoutInterval].
   /// Only available on iOS and macOS.

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -213,8 +213,12 @@ class SentryFlutterOptions extends SentryOptions {
   @experimental
   bool attachViewHierarchy = false;
 
-  /// Enables reporting information of identifiers of the view hierarchy.
-  /// This might contain sensitive information.
+  /// Enables collection of view hierarchy element identifiers.
+  ///
+  /// Identifiers are extracted from widget keys.
+  /// Disable this flag if your widget keys contain sensitive data.
+  ///
+  /// Default: `true`
   bool reportViewHierarchyIdentifiers = true;
 
   /// When enabled, the SDK tracks when the application stops responding for a

--- a/flutter/lib/src/view_hierarchy/sentry_tree_walker.dart
+++ b/flutter/lib/src/view_hierarchy/sentry_tree_walker.dart
@@ -209,9 +209,10 @@ import '../widget_utils.dart';
 class _TreeWalker {
   static const _privateDelimiter = '_';
 
-  _TreeWalker(this.rootElement);
+  _TreeWalker(this.rootElement, this.options);
 
   final Element rootElement;
+  final SentryFlutterOptions options;
 
   ValueChanged<Element> _visitor(
       SentryViewHierarchyElement parentSentryElement) {
@@ -278,10 +279,15 @@ class _TreeWalker {
       alpha = widget.opacity;
     }
 
+    String? identifier;
+    if (options.reportViewHierarchyIdentifiers) {
+      identifier = WidgetUtils.toStringValue(widget.key);
+    }
+
     return SentryViewHierarchyElement(
       element.widget.runtimeType.toString(),
       depth: element.depth,
-      identifier: WidgetUtils.toStringValue(element.widget.key),
+      identifier: identifier,
       width: width,
       height: height,
       x: x,
@@ -292,7 +298,8 @@ class _TreeWalker {
   }
 }
 
-SentryViewHierarchy? walkWidgetTree(WidgetsBinding instance) {
+SentryViewHierarchy? walkWidgetTree(
+    WidgetsBinding instance, SentryFlutterOptions options) {
   // to keep compatibility with older versions
   // ignore: deprecated_member_use
   final rootElement = instance.renderViewElement;
@@ -300,7 +307,7 @@ SentryViewHierarchy? walkWidgetTree(WidgetsBinding instance) {
     return null;
   }
 
-  final walker = _TreeWalker(rootElement);
+  final walker = _TreeWalker(rootElement, options);
 
   return walker.toSentryViewHierarchy();
 }

--- a/flutter/lib/src/view_hierarchy/view_hierarchy_event_processor.dart
+++ b/flutter/lib/src/view_hierarchy/view_hierarchy_event_processor.dart
@@ -23,7 +23,7 @@ class SentryViewHierarchyEventProcessor implements EventProcessor {
     if (instance == null) {
       return event;
     }
-    final sentryViewHierarchy = walkWidgetTree(instance);
+    final sentryViewHierarchy = walkWidgetTree(instance, _options);
 
     if (sentryViewHierarchy == null) {
       return event;

--- a/flutter/test/view_hierarchy/sentry_tree_walker_test.dart
+++ b/flutter/test/view_hierarchy/sentry_tree_walker_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sentry/sentry.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:sentry_flutter/src/view_hierarchy/sentry_tree_walker.dart';
 
 void main() {
@@ -16,7 +16,7 @@ void main() {
       await tester.runAsync(() async {
         await tester.pumpWidget(MyApp());
 
-        final sentryViewHierarchy = walkWidgetTree(instance);
+        final sentryViewHierarchy = walkWidgetTree(instance, SentryFlutterOptions());
 
         expect(sentryViewHierarchy!.renderingSystem, 'flutter');
       });
@@ -147,7 +147,8 @@ void main() {
 
 SentryViewHierarchyElement _getFirstSentryViewHierarchy(
     WidgetsBinding instance) {
-  final sentryViewHierarchy = walkWidgetTree(instance);
+  final options = SentryFlutterOptions();
+  final sentryViewHierarchy = walkWidgetTree(instance, options);
 
   return sentryViewHierarchy!.windows.first;
 }

--- a/flutter/test/view_hierarchy/sentry_tree_walker_test.dart
+++ b/flutter/test/view_hierarchy/sentry_tree_walker_test.dart
@@ -16,7 +16,8 @@ void main() {
       await tester.runAsync(() async {
         await tester.pumpWidget(MyApp());
 
-        final sentryViewHierarchy = walkWidgetTree(instance, SentryFlutterOptions());
+        final sentryViewHierarchy =
+            walkWidgetTree(instance, SentryFlutterOptions());
 
         expect(sentryViewHierarchy!.renderingSystem, 'flutter');
       });


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
It's very unusual but it's possible (maybe due to user error) that view hierarchy element identifier contain sensitive information since it's just extracted through the widget keys.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2086 

## :green_heart: How did you test it?
Unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
