### PR TITLE
Fix compatibility with Drift 2.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixes
 
+- Fix sentry_drift compatibility with Drift 2.19.0 ([#2162](https://github.com/getsentry/sentry-dart/pull/2162))
 - App starts hanging for 30s ([#2140](https://github.com/getsentry/sentry-dart/pull/2140))
   - Time out for app start info retrieval has been reduced to 10s
   - If `autoAppStarts` is `false` and `setAppStartEnd` has not been called, the app start event processor will now return early instead of waiting for `getAppStartInfo` to finish

--- a/drift/lib/src/sentry_query_executor.dart
+++ b/drift/lib/src/sentry_query_executor.dart
@@ -168,6 +168,16 @@ class SentryQueryExecutor extends QueryExecutor {
   }
 
   @override
+  QueryExecutor beginExclusive() {
+    final dynamic exec = _executor;
+    try {
+      return exec.beginExclusive() as QueryExecutor;
+    } catch (e) {
+      throw Exception('This method is not supported in Drift versions <2.19.0');
+    }
+  }
+
+  @override
   Future<void> close() {
     return _spanHelper.asyncWrapInSpan(
       'Close DB: $_dbName',

--- a/drift/lib/src/sentry_query_executor.dart
+++ b/drift/lib/src/sentry_query_executor.dart
@@ -169,6 +169,7 @@ class SentryQueryExecutor extends QueryExecutor {
   }
 
   @override
+  // ignore: override_on_non_overriding_member, public_member_api_docs
   QueryExecutor beginExclusive() {
     final dynamic uncheckedExecutor = _executor;
     try {

--- a/drift/lib/src/sentry_query_executor.dart
+++ b/drift/lib/src/sentry_query_executor.dart
@@ -3,9 +3,10 @@ import 'dart:async';
 import 'package:drift/drift.dart';
 import 'package:meta/meta.dart';
 import 'package:sentry/sentry.dart';
-import 'version.dart';
+
 import 'sentry_span_helper.dart';
 import 'sentry_transaction_executor.dart';
+import 'version.dart';
 
 /// Signature of a function that opens a database connection when instructed to.
 typedef DatabaseOpener = FutureOr<QueryExecutor> Function();
@@ -169,10 +170,10 @@ class SentryQueryExecutor extends QueryExecutor {
 
   @override
   QueryExecutor beginExclusive() {
-    final dynamic exec = _executor;
+    final dynamic uncheckedExecutor = _executor;
     try {
-      return exec.beginExclusive() as QueryExecutor;
-    } catch (e) {
+      return uncheckedExecutor.beginExclusive() as QueryExecutor;
+    } on NoSuchMethodError catch (_) {
       throw Exception('This method is not supported in Drift versions <2.19.0');
     }
   }

--- a/drift/lib/src/sentry_transaction_executor.dart
+++ b/drift/lib/src/sentry_transaction_executor.dart
@@ -1,6 +1,7 @@
 import 'package:drift/backends.dart';
 import 'package:meta/meta.dart';
 import 'package:sentry/sentry.dart';
+
 import 'sentry_span_helper.dart';
 
 /// @nodoc
@@ -135,6 +136,7 @@ class SentryTransactionExecutor extends TransactionExecutor {
   }
 
   @override
+  // ignore: override_on_non_overriding_member, public_member_api_docs
   QueryExecutor beginExclusive() {
     final dynamic uncheckedExecutor = _executor;
     try {

--- a/drift/lib/src/sentry_transaction_executor.dart
+++ b/drift/lib/src/sentry_transaction_executor.dart
@@ -135,6 +135,16 @@ class SentryTransactionExecutor extends TransactionExecutor {
   }
 
   @override
+  QueryExecutor beginExclusive() {
+    final dynamic exec = _executor;
+    try {
+      return exec.beginExclusive() as QueryExecutor;
+    } catch (e) {
+      throw Exception('This method is not supported in Drift versions <2.19.0');
+    }
+  }
+
+  @override
   Future<int> runUpdate(String statement, List<Object?> args) {
     return _spanHelper.asyncWrapInSpan(
       _spanDescriptionForOperations(statement),

--- a/drift/lib/src/sentry_transaction_executor.dart
+++ b/drift/lib/src/sentry_transaction_executor.dart
@@ -136,10 +136,10 @@ class SentryTransactionExecutor extends TransactionExecutor {
 
   @override
   QueryExecutor beginExclusive() {
-    final dynamic exec = _executor;
+    final dynamic uncheckedExecutor = _executor;
     try {
-      return exec.beginExclusive() as QueryExecutor;
-    } catch (e) {
+      return uncheckedExecutor.beginExclusive() as QueryExecutor;
+    } on NoSuchMethodError catch (_) {
       throw Exception('This method is not supported in Drift versions <2.19.0');
     }
   }

--- a/drift/test/sentry_database_test.dart
+++ b/drift/test/sentry_database_test.dart
@@ -324,9 +324,14 @@ void main() {
         });
       } catch (_) {}
 
+      final spans = fixture.tracer.children
+          .where((child) => child.status == SpanStatus.aborted());
+      expect(spans.length, 1);
+      final abortedSpan = spans.first;
+
       verifySpan(
         expectedTransactionStatement,
-        fixture.getCreatedSpan(),
+        abortedSpan,
         origin: SentryTraceOrigins.autoDbDriftTransactionExecutor,
         status: SpanStatus.aborted(),
       );


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Drift recently published `2.19.0` which adds another method to the `QueryExecutor` interface

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Backwards compatibility

## :green_heart: How did you test it?
CI, if it compiles we're good

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
