### PR TITLE
feat: replay breadcrumbs (android)

### DIFF
--- a/dart/lib/src/protocol/breadcrumb.dart
+++ b/dart/lib/src/protocol/breadcrumb.dart
@@ -50,6 +50,10 @@ class Breadcrumb {
     String? httpQuery,
     String? httpFragment,
   }) {
+    // The timestamp is used as the request-end time, so we need to set it right
+    // now and not rely on the default constructor.
+    timestamp ??= getUtcDateTime();
+
     return Breadcrumb(
       type: 'http',
       category: 'http',
@@ -65,6 +69,10 @@ class Breadcrumb {
         if (responseBodySize != null) 'response_body_size': responseBodySize,
         if (httpQuery != null) 'http.query': httpQuery,
         if (httpFragment != null) 'http.fragment': httpFragment,
+        if (requestDuration != null)
+          'start_timestamp':
+              timestamp.millisecondsSinceEpoch - requestDuration.inMilliseconds,
+        'end_timestamp': timestamp.millisecondsSinceEpoch,
       },
     );
   }

--- a/dart/lib/src/protocol/breadcrumb.dart
+++ b/dart/lib/src/protocol/breadcrumb.dart
@@ -104,11 +104,32 @@ class Breadcrumb {
     String? viewClass,
   }) {
     final newData = data ?? {};
+    var path = '';
+
     if (viewId != null) {
       newData['view.id'] = viewId;
+      path = viewId;
     }
+
+    if (newData.containsKey('label')) {
+      if (path.isEmpty) {
+        path = newData['label'];
+      } else {
+        path = "$path, label: ${newData['label']}";
+      }
+    }
+
     if (viewClass != null) {
       newData['view.class'] = viewClass;
+      if (path.isEmpty) {
+        path = viewClass;
+      } else {
+        path = "$viewClass($path)";
+      }
+    }
+
+    if (path.isNotEmpty && !newData.containsKey('path')) {
+      newData['path'] = path;
     }
 
     return Breadcrumb(

--- a/dart/lib/src/protocol/breadcrumb.dart
+++ b/dart/lib/src/protocol/breadcrumb.dart
@@ -72,7 +72,8 @@ class Breadcrumb {
         if (requestDuration != null)
           'start_timestamp':
               timestamp.millisecondsSinceEpoch - requestDuration.inMilliseconds,
-        'end_timestamp': timestamp.millisecondsSinceEpoch,
+        if (requestDuration != null)
+          'end_timestamp': timestamp.millisecondsSinceEpoch,
       },
     );
   }

--- a/dart/test/protocol/breadcrumb_test.dart
+++ b/dart/test/protocol/breadcrumb_test.dart
@@ -86,7 +86,7 @@ void main() {
           level: SentryLevel.fatal,
           reason: 'OK',
           statusCode: 200,
-          requestDuration: Duration.zero,
+          requestDuration: Duration(milliseconds: 55),
           timestamp: DateTime.now(),
           requestBodySize: 2,
           responseBodySize: 3,
@@ -103,13 +103,39 @@ void main() {
           'method': 'GET',
           'status_code': 200,
           'reason': 'OK',
-          'duration': '0:00:00.000000',
+          'duration': '0:00:00.055000',
           'request_body_size': 2,
           'response_body_size': 3,
           'http.query': 'foo=bar',
-          'http.fragment': 'baz'
+          'http.fragment': 'baz',
+          'start_timestamp': breadcrumb.timestamp.millisecondsSinceEpoch - 55,
+          'end_timestamp': breadcrumb.timestamp.millisecondsSinceEpoch
         },
         'level': 'fatal',
+        'type': 'http',
+      });
+    });
+
+    test('Breadcrumb http', () {
+      final breadcrumb = Breadcrumb.http(
+        url: Uri.parse('https://example.org'),
+        method: 'GET',
+        requestDuration: Duration(milliseconds: 10),
+      );
+      final json = breadcrumb.toJson();
+
+      expect(json, {
+        'timestamp':
+            formatDateAsIso8601WithMillisPrecision(breadcrumb.timestamp),
+        'category': 'http',
+        'data': {
+          'url': 'https://example.org',
+          'method': 'GET',
+          'duration': '0:00:00.010000',
+          'start_timestamp': breadcrumb.timestamp.millisecondsSinceEpoch - 10,
+          'end_timestamp': breadcrumb.timestamp.millisecondsSinceEpoch
+        },
+        'level': 'info',
         'type': 'http',
       });
     });

--- a/dart/test/protocol/breadcrumb_test.dart
+++ b/dart/test/protocol/breadcrumb_test.dart
@@ -218,6 +218,7 @@ void main() {
           'foo': 'bar',
           'view.id': 'foo',
           'view.class': 'bar',
+          'path': 'bar(foo)',
         },
       });
     });

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -151,7 +151,7 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
             recorderConfigProvider = null,
             replayCacheProvider = null,
           )
-
+        replay.breadcrumbConverter = SentryFlutterReplayBreadcrumbConverter()
         options.addIntegration(replay)
         options.setReplayController(replay)
       } else {
@@ -425,7 +425,7 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     if (args.isNotEmpty()) {
       val event = args.first() as ByteArray?
       val containsUnhandledException = args[1] as Boolean
-      if (event != null && event.isNotEmpty() && containsUnhandledException != null) {
+      if (event != null && event.isNotEmpty()) {
         val id = InternalSentrySdk.captureEnvelope(event, containsUnhandledException)
         if (id != null) {
           result.success("")

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterReplayBreadcrumbConverter.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterReplayBreadcrumbConverter.kt
@@ -32,7 +32,7 @@ class SentryFlutterReplayBreadcrumbConverter : DefaultReplayBreadcrumbConverter(
       "ui.click" ->
         newRRWebBreadcrumb(breadcrumb).apply {
           category = "ui.tap"
-          message = getTouchPathMessage(breadcrumb.data)
+          message = breadcrumb.data["path"] as String?
         }
 
       else -> {
@@ -63,24 +63,6 @@ class SentryFlutterReplayBreadcrumbConverter : DefaultReplayBreadcrumbConverter(
   private fun doubleTimestamp(date: Date) = doubleTimestamp(date.time)
 
   private fun doubleTimestamp(timestamp: Long) = timestamp / MILLIS_PER_SECOND
-
-  private fun getTouchPathMessage(data: Map<String, Any?>): String {
-    var message = data["view.id"] as String? ?: ""
-    if (data.containsKey("label")) {
-      message =
-        if (message.isNotEmpty()) {
-          "$message, label: ${data["label"]}"
-        } else {
-          data["label"] as String
-        }
-    }
-
-    if (data.containsKey("view.class")) {
-      message = "${data["view.class"]}($message)"
-    }
-
-    return message
-  }
 
   private fun convertNetworkBreadcrumb(breadcrumb: Breadcrumb): RRWebEvent? {
     var rrWebEvent = super.convert(breadcrumb)

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterReplayBreadcrumbConverter.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterReplayBreadcrumbConverter.kt
@@ -8,6 +8,8 @@ import io.sentry.rrweb.RRWebSpanEvent
 import java.util.Date
 import kotlin.LazyThreadSafetyMode.NONE
 
+private const val MILLIS_PER_SECOND = 1000.0
+
 class SentryFlutterReplayBreadcrumbConverter : DefaultReplayBreadcrumbConverter() {
   internal companion object {
     private val snakecasePattern by lazy(NONE) { "_[a-z]".toRegex() }
@@ -60,7 +62,7 @@ class SentryFlutterReplayBreadcrumbConverter : DefaultReplayBreadcrumbConverter(
 
   private fun doubleTimestamp(date: Date) = doubleTimestamp(date.time)
 
-  private fun doubleTimestamp(timestamp: Long) = timestamp / 1000.0
+  private fun doubleTimestamp(timestamp: Long) = timestamp / MILLIS_PER_SECOND
 
   private fun getTouchPathMessage(data: Map<String, Any?>): String {
     var message = data["view.id"] as String? ?: ""

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterReplayBreadcrumbConverter.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterReplayBreadcrumbConverter.kt
@@ -6,7 +6,6 @@ import io.sentry.rrweb.RRWebBreadcrumbEvent
 import io.sentry.rrweb.RRWebEvent
 import io.sentry.rrweb.RRWebSpanEvent
 import java.util.Date
-import kotlin.LazyThreadSafetyMode.NONE
 
 private const val MILLIS_PER_SECOND = 1000.0
 

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterReplayBreadcrumbConverter.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterReplayBreadcrumbConverter.kt
@@ -1,0 +1,102 @@
+package io.sentry.flutter
+
+import io.sentry.android.replay.DefaultReplayBreadcrumbConverter
+import io.sentry.Breadcrumb
+import io.sentry.rrweb.RRWebEvent
+import io.sentry.rrweb.RRWebBreadcrumbEvent
+import io.sentry.rrweb.RRWebSpanEvent
+import org.jetbrains.annotations.TestOnly
+import kotlin.LazyThreadSafetyMode.NONE
+
+class SentryFlutterReplayBreadcrumbConverter :
+  DefaultReplayBreadcrumbConverter() {
+
+  internal companion object {
+    private val snakecasePattern by lazy(NONE) { "_[a-z]".toRegex() }
+    private val supportedNetworkData = setOf(
+      "status_code",
+      "method",
+      "response_body_size",
+      "request_body_size",
+    )
+  }
+
+  override fun convert(breadcrumb: Breadcrumb): RRWebEvent? {
+    return when (breadcrumb.category) {
+      null -> null
+      "sentry.event" -> null
+      "sentry.transaction" -> null
+      "http" -> convertNetworkBreadcrumb(breadcrumb)
+      "ui.click" -> convertTouchBreadcrumb(breadcrumb)
+      "navigation" -> RRWebBreadcrumbEvent().apply {
+        category = breadcrumb.category
+        data = breadcrumb.data
+      }
+
+      else -> {
+        val nativeBreadcrumb = super.convert(breadcrumb)
+
+        // ignore native navigation breadcrumbs
+        if (nativeBreadcrumb is RRWebBreadcrumbEvent) {
+          if (nativeBreadcrumb.category == "navigation") {
+            return null
+          }
+        }
+
+        nativeBreadcrumb
+      }
+    }
+  }
+
+  private fun convertTouchBreadcrumb(breadcrumb: Breadcrumb): RRWebEvent {
+    val rrWebEvent = RRWebBreadcrumbEvent()
+    rrWebEvent.category = "ui.tap"
+    rrWebEvent.message = getTouchPathMessage(breadcrumb.data)
+    rrWebEvent.level = breadcrumb.level
+    rrWebEvent.data = breadcrumb.data
+    rrWebEvent.timestamp = breadcrumb.timestamp.time
+    rrWebEvent.breadcrumbTimestamp = breadcrumb.timestamp.time / 1000.0
+    rrWebEvent.breadcrumbType = "default"
+    return rrWebEvent
+  }
+
+  @TestOnly
+  fun getTouchPathMessage(data: Map<String, Any?>): String {
+    var message = data["view.id"] as String? ?: ""
+    if (data.containsKey("label")) {
+      message = if (message.isNotEmpty()) {
+        "$message, label: ${data["label"]}"
+      } else {
+        data["label"] as String
+      }
+    }
+
+    if (data.containsKey("view.class")) {
+      message = "${data["view.class"]}($message)"
+    }
+
+    return message
+  }
+
+  private fun convertNetworkBreadcrumb(breadcrumb: Breadcrumb): RRWebEvent? {
+    var rrWebEvent = super.convert(breadcrumb)
+    if (rrWebEvent == null &&
+      breadcrumb.data.containsKey("start_timestamp") && breadcrumb.data.containsKey("end_timestamp")
+    ) {
+      rrWebEvent = RRWebSpanEvent().apply {
+        op = "resource.http"
+        timestamp = breadcrumb.timestamp.time
+        description = breadcrumb.data["url"] as String
+        startTimestamp = (breadcrumb.data["start_timestamp"] as Long) / 1000.0
+        endTimestamp = (breadcrumb.data["end_timestamp"] as Long) / 1000.0
+        data = breadcrumb.data.filterKeys { key -> supportedNetworkData.contains(key) }
+          .mapKeys { (key, _) -> key.snakeToCamelCase() }
+      }
+    }
+    return rrWebEvent
+  }
+
+  private fun String.snakeToCamelCase(): String {
+    return replace(snakecasePattern) { it.value.last().uppercase() }
+  }
+}

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterReplayBreadcrumbConverter.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterReplayBreadcrumbConverter.kt
@@ -12,13 +12,12 @@ private const val MILLIS_PER_SECOND = 1000.0
 
 class SentryFlutterReplayBreadcrumbConverter : DefaultReplayBreadcrumbConverter() {
   internal companion object {
-    private val snakecasePattern by lazy(NONE) { "_[a-z]".toRegex() }
     private val supportedNetworkData =
-      setOf(
-        "status_code",
-        "method",
-        "response_body_size",
-        "request_body_size",
+      mapOf(
+        "status_code" to "statusCode",
+        "method" to "method",
+        "response_body_size" to "responseBodySize",
+        "request_body_size" to "requestBodySize",
       )
   }
 
@@ -79,12 +78,10 @@ class SentryFlutterReplayBreadcrumbConverter : DefaultReplayBreadcrumbConverter(
           endTimestamp = doubleTimestamp(breadcrumb.data["end_timestamp"] as Long)
           data =
             breadcrumb.data
-              .filterKeys { key -> supportedNetworkData.contains(key) }
-              .mapKeys { (key, _) -> key.snakeToCamelCase() }
+              .filterKeys { key -> supportedNetworkData.containsKey(key) }
+              .mapKeys { (key, _) -> supportedNetworkData[key] }
         }
     }
     return rrWebEvent
   }
-
-  private fun String.snakeToCamelCase(): String = replace(snakecasePattern) { it.value.last().uppercase() }
 }

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterReplayBreadcrumbConverter.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterReplayBreadcrumbConverter.kt
@@ -5,6 +5,7 @@ import io.sentry.android.replay.DefaultReplayBreadcrumbConverter
 import io.sentry.rrweb.RRWebBreadcrumbEvent
 import io.sentry.rrweb.RRWebEvent
 import io.sentry.rrweb.RRWebSpanEvent
+import java.util.Date
 import kotlin.LazyThreadSafetyMode.NONE
 
 class SentryFlutterReplayBreadcrumbConverter : DefaultReplayBreadcrumbConverter() {
@@ -53,9 +54,13 @@ class SentryFlutterReplayBreadcrumbConverter : DefaultReplayBreadcrumbConverter(
       level = breadcrumb.level
       data = breadcrumb.data
       timestamp = breadcrumb.timestamp.time
-      breadcrumbTimestamp = breadcrumb.timestamp.time / 1000.0
+      breadcrumbTimestamp = doubleTimestamp(breadcrumb.timestamp)
       breadcrumbType = "default"
     }
+
+  private fun doubleTimestamp(date: Date) = doubleTimestamp(date.time)
+
+  private fun doubleTimestamp(timestamp: Long) = timestamp / 1000.0
 
   private fun getTouchPathMessage(data: Map<String, Any?>): String {
     var message = data["view.id"] as String? ?: ""
@@ -86,8 +91,8 @@ class SentryFlutterReplayBreadcrumbConverter : DefaultReplayBreadcrumbConverter(
           op = "resource.http"
           timestamp = breadcrumb.timestamp.time
           description = breadcrumb.data["url"] as String
-          startTimestamp = (breadcrumb.data["start_timestamp"] as Long) / 1000.0
-          endTimestamp = (breadcrumb.data["end_timestamp"] as Long) / 1000.0
+          startTimestamp = doubleTimestamp(breadcrumb.data["start_timestamp"] as Long)
+          endTimestamp = doubleTimestamp(breadcrumb.data["end_timestamp"] as Long)
           data =
             breadcrumb.data
               .filterKeys { key -> supportedNetworkData.contains(key) }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Adds breadcrumbs to replays

#skip-changelog

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
* [ ] Improve touch events in general - currently, they're only added for widgets that have keys
* [ ] improve network breadcrumbs - we can capture request and response size
