### PR TITLE
chore: disable sff & frame delay detection on web, linux and windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fixes
+
+- Disable sff & frame delay detection on web, linux and windows ([#2182](https://github.com/getsentry/sentry-dart/pull/2182))
+  - Display refresh rate is locked at 60 for these platforms which can lead to inaccurate metrics 
+
 ### Improvements
 
 - Capture meaningful stack traces when unhandled errors have empty or missing stack traces ([#2152](https://github.com/getsentry/sentry-dart/pull/2152))

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -136,6 +136,7 @@ mixin SentryFlutter {
 
     options.addEventProcessor(PlatformExceptionEventProcessor());
 
+    // Disabled for web, linux and windows until we can reliably get the display refresh rate
     if (options.platformChecker.platform.isAndroid ||
         options.platformChecker.platform.isIOS ||
         options.platformChecker.platform.isMacOS) {

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -136,7 +136,11 @@ mixin SentryFlutter {
 
     options.addEventProcessor(PlatformExceptionEventProcessor());
 
-    options.addPerformanceCollector(SpanFrameMetricsCollector(options));
+    if (options.platformChecker.platform.isAndroid ||
+        options.platformChecker.platform.isIOS ||
+        options.platformChecker.platform.isMacOS) {
+      options.addPerformanceCollector(SpanFrameMetricsCollector(options));
+    }
 
     _setSdk(options);
   }


### PR DESCRIPTION
We don't fetch the refresh rate on those platforms, it's kept at 60fps which is not always accurate.

So until we can properly implement that (if possible) let's keep it disabled