### PR TITLE
Set platform in sentry frames for better raw stacktrace representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Features
+
+- Add dart platform to sentry frames ([#2193](https://github.com/getsentry/sentry-dart/pull/2193))
+  - This allows viewing the correct dart formatted raw stacktrace in the Sentry UI
+
 ### Fixes
 
 - Disable sff & frame delay detection on web, linux and windows ([#2182](https://github.com/getsentry/sentry-dart/pull/2182))

--- a/dart/lib/src/sentry_stack_trace_factory.dart
+++ b/dart/lib/src/sentry_stack_trace_factory.dart
@@ -103,6 +103,7 @@ class SentryStackTraceFactory {
       // least we get an indication something's wrong and are able to fix it.
     }
 
+    final platform = _options.platformChecker.isWeb ? 'javascript' : 'dart';
     final fileName =
         frame.uri.pathSegments.isNotEmpty ? frame.uri.pathSegments.last : null;
     final abs = '$eventOrigin${_absolutePathForCrashReport(frame)}';
@@ -114,6 +115,7 @@ class SentryStackTraceFactory {
       inApp: _isInApp(frame),
       fileName: fileName,
       package: frame.package,
+      platform: platform,
     );
 
     final line = frame.line;
@@ -124,12 +126,6 @@ class SentryStackTraceFactory {
     final column = frame.column;
     if (column != null && column >= 0) {
       sentryStackFrame = sentryStackFrame.copyWith(colNo: frame.column);
-    }
-
-    if (sentryStackFrame.platform == null) {
-      sentryStackFrame = sentryStackFrame.copyWith(
-          platform: sentryStackFrame.platform ??
-              (_options.platformChecker.isWeb ? 'javascript' : 'dart'));
     }
     return sentryStackFrame;
   }

--- a/dart/lib/src/sentry_stack_trace_factory.dart
+++ b/dart/lib/src/sentry_stack_trace_factory.dart
@@ -125,6 +125,12 @@ class SentryStackTraceFactory {
     if (column != null && column >= 0) {
       sentryStackFrame = sentryStackFrame.copyWith(colNo: frame.column);
     }
+
+    if (sentryStackFrame.platform == null) {
+      sentryStackFrame = sentryStackFrame.copyWith(
+          platform: sentryStackFrame.platform ??
+              (_options.platformChecker.isWeb ? 'javascript' : 'dart'));
+    }
     return sentryStackFrame;
   }
 

--- a/dart/test/stack_trace_test.dart
+++ b/dart/test/stack_trace_test.dart
@@ -24,7 +24,8 @@ void main() {
           'lineno': 1,
           'colno': 2,
           'in_app': false,
-          'filename': 'core'
+          'filename': 'core',
+          'platform': 'dart',
         },
       );
     });
@@ -124,7 +125,8 @@ void main() {
           'lineno': 46,
           'colno': 9,
           'in_app': true,
-          'filename': 'test.dart'
+          'filename': 'test.dart',
+          'platform': 'dart',
         },
         {
           'abs_path': '${eventOrigin}test.dart',
@@ -132,7 +134,8 @@ void main() {
           'lineno': 50,
           'colno': 3,
           'in_app': true,
-          'filename': 'test.dart'
+          'filename': 'test.dart',
+          'platform': 'dart',
         },
       ]);
     });
@@ -153,7 +156,8 @@ void main() {
           'lineno': 46,
           'colno': 9,
           'in_app': true,
-          'filename': 'test.dart'
+          'filename': 'test.dart',
+          'platform': 'dart',
         },
         {
           'abs_path': '<asynchronous suspension>',
@@ -164,7 +168,8 @@ void main() {
           'lineno': 50,
           'colno': 3,
           'in_app': true,
-          'filename': 'test.dart'
+          'filename': 'test.dart',
+          'platform': 'dart',
         },
       ]);
     });
@@ -230,7 +235,8 @@ isolate_instructions: 10fa27070, vm_instructions: 10fa21e20
           'function': 'PlatformDispatcher._dispatchPointerDataPacket',
           'lineno': 341,
           'abs_path': '${eventOrigin}dart:ui/platform_dispatcher.dart',
-          'in_app': false
+          'in_app': false,
+          'platform': 'dart',
         },
         {
           'filename': 'main.dart',
@@ -238,14 +244,16 @@ isolate_instructions: 10fa27070, vm_instructions: 10fa21e20
           'function': 'MainScaffold.build.<fn>',
           'lineno': 131,
           'abs_path': '${eventOrigin}package:example/main.dart',
-          'in_app': true
+          'in_app': true,
+          'platform': 'dart',
         },
         {
           'filename': 'main.dart',
           'function': 'asyncThrows',
           'lineno': 404,
           'abs_path': '${eventOrigin}main.dart',
-          'in_app': true
+          'in_app': true,
+          'platform': 'dart',
         }
       ]);
     });

--- a/dart/test/test_utils.dart
+++ b/dart/test/test_utils.dart
@@ -124,7 +124,15 @@ Future testCaptureException(
   }
   expect(
     topFrame.keys,
-    <String>['filename', 'function', 'lineno', 'colno', 'abs_path', 'in_app'],
+    <String>[
+      'filename',
+      'function',
+      'lineno',
+      'colno',
+      'abs_path',
+      'in_app',
+      'platform'
+    ],
   );
 
   if (isWeb) {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Sets either dart or javascript platform to frames for raw stacktrace representation


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Issue: https://github.com/getsentry/sentry-dart/issues/2040

## :green_heart: How did you test it?
Unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
