### PR TITLE
deps: change updater PR strategy to update on low-risk updates

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -33,6 +33,7 @@ jobs:
       path: metrics/flutter.properties
       name: Flutter SDK (metrics)
       changelog-entry: false
+      pr-strategy: update
     secrets:
       api-token: ${{ secrets.CI_DEPLOY_KEY }}
 
@@ -42,5 +43,6 @@ jobs:
       path: scripts/update-symbol-collector.sh
       name: Symbol collector CLI
       changelog-entry: false
+      pr-strategy: update
     secrets:
       api-token: ${{ secrets.CI_DEPLOY_KEY }}


### PR DESCRIPTION
Flutter SDK in metrics and symbol-collector update jobs aren't expected to break so there's little reason to keep old PRs
#skip-changelog