### PR TITLE
add ignoreRoutes parameter to SentryNavigatorObserver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,20 @@
 # Changelog
 
-## 8.7.0
+## Unreleased
 
 ### Features
 
 - Add `ignoreRoutes` parameter to `SentryNavigatorObserver`. ([#2218](https://github.com/getsentry/sentry-dart/pull/2218))
-  - This will ignore the Routes and prevent the Route from being pushed to the Sentry server.
-  - Ignored routes will also create no TTID and TTFD spans.
+    - This will ignore the Routes and prevent the Route from being pushed to the Sentry server.
+    - Ignored routes will also create no TTID and TTFD spans.
 ```dart
 SentryNavigatorObserver(ignoreRoutes: ["/ignoreThisRoute"]),
 ```
+
+## 8.7.0
+
+### Features
+
 - Add support for span level measurements. ([#2214](https://github.com/getsentry/sentry-dart/pull/2214))
 - Add `ignoreTransactions` and `ignoreErrors` to options ([#2207](https://github.com/getsentry/sentry-dart/pull/2207))
   ```dart

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add `ignoreRoutes` parameter to `SentryNavigatorObserver`. ([#2218](https://github.com/getsentry/sentry-dart/pull/2218))
+  - This will ignore the Routes and prevent the Route from being pushed to the Sentry server.
+```dart
+SentryNavigatorObserver(ignoreRoutes: ["/ignoreThisRoute"]),
+```
+
 ## 8.6.0
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add `ignoreRoutes` parameter to `SentryNavigatorObserver`. ([#2218](https://github.com/getsentry/sentry-dart/pull/2218))
   - This will ignore the Routes and prevent the Route from being pushed to the Sentry server.
+  - Ignored routes will also create no TTID and TTFD spans.
 ```dart
 SentryNavigatorObserver(ignoreRoutes: ["/ignoreThisRoute"]),
 ```

--- a/flutter/test/sentry_navigator_observer_test.dart
+++ b/flutter/test/sentry_navigator_observer_test.dart
@@ -976,7 +976,28 @@ void main() {
       expect(hub.scope.transaction, 'to_test');
     });
 
-    test('ignores Route and prevents recognition of this route', () async {
+    test('ignores Route and prevents recognition of this route for didPush',
+        () async {
+      final firstRoute = route(RouteSettings(name: 'default'));
+      final secondRoute = route(RouteSettings(name: 'testRoute'));
+
+      final hub = _MockHub();
+
+      final sut = fixture.getSut(hub: hub, ignoreRoutes: ["testRoute"]);
+
+      sut.didPush(firstRoute, null);
+      expect(
+          SentryNavigatorObserver.currentRouteName, firstRoute.settings.name);
+      sut.didPush(secondRoute, firstRoute);
+      expect(
+          SentryNavigatorObserver.currentRouteName, firstRoute.settings.name);
+      sut.didPush(firstRoute, secondRoute);
+      expect(
+          SentryNavigatorObserver.currentRouteName, firstRoute.settings.name);
+    });
+
+    test('ignores Route and prevents recognition of this route for didPop',
+        () async {
       final firstRoute = route(RouteSettings(name: 'default'));
       final secondRoute = route(RouteSettings(name: 'testRoute'));
 
@@ -991,6 +1012,26 @@ void main() {
       expect(
           SentryNavigatorObserver.currentRouteName, firstRoute.settings.name);
       sut.didPop(firstRoute, secondRoute);
+      expect(
+          SentryNavigatorObserver.currentRouteName, firstRoute.settings.name);
+    });
+
+    test('ignores Route and prevents recognition of this route for didReplace',
+        () async {
+      final firstRoute = route(RouteSettings(name: 'default'));
+      final secondRoute = route(RouteSettings(name: 'testRoute'));
+
+      final hub = _MockHub();
+
+      final sut = fixture.getSut(hub: hub, ignoreRoutes: ["testRoute"]);
+
+      sut.didReplace(newRoute: firstRoute);
+      expect(
+          SentryNavigatorObserver.currentRouteName, firstRoute.settings.name);
+      sut.didReplace(newRoute: secondRoute, oldRoute: firstRoute);
+      expect(
+          SentryNavigatorObserver.currentRouteName, firstRoute.settings.name);
+      sut.didReplace(newRoute: firstRoute, oldRoute: secondRoute);
       expect(
           SentryNavigatorObserver.currentRouteName, firstRoute.settings.name);
     });

--- a/flutter/test/sentry_navigator_observer_test.dart
+++ b/flutter/test/sentry_navigator_observer_test.dart
@@ -975,6 +975,25 @@ void main() {
       observer.didReplace(newRoute: route(to), oldRoute: route(previous));
       expect(hub.scope.transaction, 'to_test');
     });
+
+    test('ignores Route and prevents recognition of this route', () async {
+      final firstRoute = route(RouteSettings(name: 'default'));
+      final secondRoute = route(RouteSettings(name: 'testRoute'));
+
+      final hub = _MockHub();
+
+      final sut = fixture.getSut(hub: hub, ignoreRoutes: ["testRoute"]);
+
+      sut.didPush(firstRoute, null);
+      expect(
+          SentryNavigatorObserver.currentRouteName, firstRoute.settings.name);
+      sut.didPush(secondRoute, firstRoute);
+      expect(
+          SentryNavigatorObserver.currentRouteName, firstRoute.settings.name);
+      sut.didPop(firstRoute, secondRoute);
+      expect(
+          SentryNavigatorObserver.currentRouteName, firstRoute.settings.name);
+    });
   });
 }
 
@@ -987,6 +1006,7 @@ class Fixture {
     RouteNameExtractor? routeNameExtractor,
     AdditionalInfoExtractor? additionalInfoProvider,
     bool enableTimeToFullDisplayTracing = false,
+    List<String>? ignoreRoutes,
   }) {
     final frameCallbackHandler = FakeFrameCallbackHandler();
     final timeToInitialDisplayTracker =
@@ -1003,6 +1023,7 @@ class Fixture {
       routeNameExtractor: routeNameExtractor,
       additionalInfoProvider: additionalInfoProvider,
       timeToDisplayTracker: timeToDisplayTracker,
+      ignoreRoutes: ignoreRoutes,
     );
   }
 


### PR DESCRIPTION
## :scroll: Description
Add `ignoreRoutes` parameter to `SentryNavigatorObserver`. This will prevent the Route from being pushed to the Sentry server.

## :bulb: Motivation and Context
Close [#2205](https://github.com/getsentry/sentry-dart/issues/2205)


## :green_heart: How did you test it?
Unittest and adapted the Sentry Flutter Example App to test it.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes