### PR TITLE
feat: Debouncing of SentryWidgetsBindingObserver.didChangeMetrics. #400

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 SentryNavigatorObserver(ignoreRoutes: ["/ignoreThisRoute"]),
 ```
 
+### Improvements
+
+- Debouncing of SentryWidgetsBindingObserver.didChangeMetrics with delay of 100ms. ([#2232](https://github.com/getsentry/sentry-dart/pull/2232))
+
 ### Dependencies
 
 - Bump Android SDK from v7.13.0 to v7.14.0 ([#2228](https://github.com/getsentry/sentry-dart/pull/2228))

--- a/flutter/lib/src/utils/debouncer.dart
+++ b/flutter/lib/src/utils/debouncer.dart
@@ -1,0 +1,18 @@
+import 'dart:async';
+import 'package:flutter/foundation.dart';
+
+class Debouncer {
+  final int milliseconds;
+  Timer? _timer;
+
+  Debouncer({required this.milliseconds});
+
+  void run(VoidCallback action) {
+    _timer?.cancel();
+    _timer = Timer(Duration(milliseconds: milliseconds), action);
+  }
+
+  void dispose() {
+    _timer?.cancel();
+  }
+}

--- a/flutter/lib/src/utils/debouncer.dart
+++ b/flutter/lib/src/utils/debouncer.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:flutter/foundation.dart';
 
+@internal
 class Debouncer {
   final int milliseconds;
   Timer? _timer;

--- a/flutter/lib/src/utils/debouncer.dart
+++ b/flutter/lib/src/utils/debouncer.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 
 @internal
 class Debouncer {

--- a/flutter/lib/src/widgets_binding_observer.dart
+++ b/flutter/lib/src/widgets_binding_observer.dart
@@ -4,6 +4,7 @@ import 'dart:ui';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import '../sentry_flutter.dart';
+import 'utils/debouncer.dart';
 
 /// This is a `WidgetsBindingObserver` which can observe some events of a
 /// Flutter application.
@@ -50,6 +51,8 @@ class SentryWidgetsBindingObserver with WidgetsBindingObserver {
   // ignore: deprecated_member_use
   final StreamController<SingletonFlutterWindow?> _screenSizeStreamController;
 
+  final _didChangeMetricsDebouncer = Debouncer(milliseconds: 100);
+
   /// This method records lifecycle events.
   /// It tries to mimic the behavior of ActivityBreadcrumbsIntegration of Sentry
   /// Android for lifecycle events.
@@ -88,9 +91,12 @@ class SentryWidgetsBindingObserver with WidgetsBindingObserver {
     if (!_options.enableWindowMetricBreadcrumbs) {
       return;
     }
-    // ignore: deprecated_member_use
-    final window = _options.bindingUtils.instance?.window;
-    _screenSizeStreamController.add(window);
+
+    _didChangeMetricsDebouncer.run(() {
+      // ignore: deprecated_member_use
+      final window = _options.bindingUtils.instance?.window;
+      _screenSizeStreamController.add(window);
+    });
   }
 
   void _onScreenSizeChanged(Map<String, dynamic> data) {

--- a/flutter/test/widgets_binding_observer_test.dart
+++ b/flutter/test/widgets_binding_observer_test.dart
@@ -436,7 +436,7 @@ void main() {
 
       verifyNever(hub.addBreadcrumb(captureAny));
 
-      //waiting for debouncing with 100ms added https://github.com/getsentry/sentry-dart/issues/400
+      // waiting for debouncing with 100ms added https://github.com/getsentry/sentry-dart/issues/400
       await tester.pump(Duration(milliseconds: 150));
 
       verify(hub.addBreadcrumb(captureAny));

--- a/flutter/test/widgets_binding_observer_test.dart
+++ b/flutter/test/widgets_binding_observer_test.dart
@@ -193,7 +193,7 @@ void main() {
       // ignore: deprecated_member_use
       window.physicalSizeTestValue = Size(newWidth, newHeight);
 
-      //waiting for debouncing with 100ms added https://github.com/getsentry/sentry-dart/issues/400
+      // waiting for debouncing with 100ms added https://github.com/getsentry/sentry-dart/issues/400
       await tester.pump(Duration(milliseconds: 150));
 
       final breadcrumb =
@@ -233,7 +233,7 @@ void main() {
       // ignore: deprecated_member_use
       window.devicePixelRatioTestValue = newPixelRatio;
 
-      //waiting for debouncing with 100ms added https://github.com/getsentry/sentry-dart/issues/400
+      // waiting for debouncing with 100ms added https://github.com/getsentry/sentry-dart/issues/400
       await tester.pump(Duration(milliseconds: 150));
 
       final breadcrumb =
@@ -271,7 +271,7 @@ void main() {
       // ignore: deprecated_member_use
       window.viewInsetsTestValue = WindowPadding.zero;
 
-      //waiting for debouncing with 100ms added https://github.com/getsentry/sentry-dart/issues/400
+      // waiting for debouncing with 100ms added https://github.com/getsentry/sentry-dart/issues/400
       await tester.pump(Duration(milliseconds: 150));
 
       verifyNever(hub.addBreadcrumb(captureAny));
@@ -295,7 +295,7 @@ void main() {
 
       window.onMetricsChanged!();
 
-      //waiting for debouncing with 100ms added https://github.com/getsentry/sentry-dart/issues/400
+      // waiting for debouncing with 100ms added https://github.com/getsentry/sentry-dart/issues/400
       await tester.pump(Duration(milliseconds: 150));
 
       verifyNever(hub.addBreadcrumb(captureAny));
@@ -470,7 +470,7 @@ void main() {
 
       verifyNever(hub.addBreadcrumb(captureAny));
 
-      //waiting for debouncing with 100ms added https://github.com/getsentry/sentry-dart/issues/400
+      // waiting for debouncing with 100ms added https://github.com/getsentry/sentry-dart/issues/400
       await tester.pump(Duration(milliseconds: 150));
 
       verify(hub.addBreadcrumb(captureAny)).called(1);

--- a/flutter/test/widgets_binding_observer_test.dart
+++ b/flutter/test/widgets_binding_observer_test.dart
@@ -193,6 +193,9 @@ void main() {
       // ignore: deprecated_member_use
       window.physicalSizeTestValue = Size(newWidth, newHeight);
 
+      //waiting for debouncing with 100ms added https://github.com/getsentry/sentry-dart/issues/400
+      await tester.pump(Duration(milliseconds: 150));
+
       final breadcrumb =
           verify(hub.addBreadcrumb(captureAny)).captured.single as Breadcrumb;
 
@@ -230,6 +233,9 @@ void main() {
       // ignore: deprecated_member_use
       window.devicePixelRatioTestValue = newPixelRatio;
 
+      //waiting for debouncing with 100ms added https://github.com/getsentry/sentry-dart/issues/400
+      await tester.pump(Duration(milliseconds: 150));
+
       final breadcrumb =
           verify(hub.addBreadcrumb(captureAny)).captured.single as Breadcrumb;
 
@@ -265,6 +271,9 @@ void main() {
       // ignore: deprecated_member_use
       window.viewInsetsTestValue = WindowPadding.zero;
 
+      //waiting for debouncing with 100ms added https://github.com/getsentry/sentry-dart/issues/400
+      await tester.pump(Duration(milliseconds: 150));
+
       verifyNever(hub.addBreadcrumb(captureAny));
 
       instance.removeObserver(observer);
@@ -285,6 +294,9 @@ void main() {
       final window = instance.window;
 
       window.onMetricsChanged!();
+
+      //waiting for debouncing with 100ms added https://github.com/getsentry/sentry-dart/issues/400
+      await tester.pump(Duration(milliseconds: 150));
 
       verifyNever(hub.addBreadcrumb(captureAny));
 
@@ -397,6 +409,71 @@ void main() {
       window.onTextScaleFactorChanged!();
 
       verifyNever(hub.addBreadcrumb(captureAny));
+
+      instance.removeObserver(observer);
+    });
+
+    testWidgets('debouncing didChangeMetrics with 100ms delay',
+        (WidgetTester tester) async {
+      final hub = MockHub();
+
+      final observer = SentryWidgetsBindingObserver(
+        hub: hub,
+        options: flutterTrackingEnabledOptions,
+      );
+      final instance = tester.binding;
+      instance.addObserver(observer);
+
+      // ignore: deprecated_member_use
+      final window = instance.window;
+
+      // ignore: deprecated_member_use
+      window.physicalSizeTestValue = window.physicalSize;
+
+      const newPixelRatio = 1.7;
+      // ignore: deprecated_member_use
+      window.devicePixelRatioTestValue = newPixelRatio;
+
+      verifyNever(hub.addBreadcrumb(captureAny));
+
+      //waiting for debouncing with 100ms added https://github.com/getsentry/sentry-dart/issues/400
+      await tester.pump(Duration(milliseconds: 150));
+
+      verify(hub.addBreadcrumb(captureAny));
+
+      instance.removeObserver(observer);
+    });
+
+    testWidgets('debouncing: didChangeMetrics is called only once in 100ms',
+        (WidgetTester tester) async {
+      final hub = MockHub();
+
+      final observer = SentryWidgetsBindingObserver(
+        hub: hub,
+        options: flutterTrackingEnabledOptions,
+      );
+      final instance = tester.binding;
+      instance.addObserver(observer);
+
+      // ignore: deprecated_member_use
+      final window = instance.window;
+
+      // ignore: deprecated_member_use
+      window.physicalSizeTestValue = window.physicalSize;
+
+      // ignore: deprecated_member_use
+      window.devicePixelRatioTestValue = 2.1;
+      // ignore: deprecated_member_use
+      window.devicePixelRatioTestValue = 2.2;
+      // ignore: deprecated_member_use
+      window.devicePixelRatioTestValue = 2.3;
+
+      verifyNever(hub.addBreadcrumb(captureAny));
+
+      //waiting for debouncing with 100ms added https://github.com/getsentry/sentry-dart/issues/400
+      await tester.pump(Duration(milliseconds: 150));
+
+      verify(hub.addBreadcrumb(captureAny)).called(1);
 
       instance.removeObserver(observer);
     });


### PR DESCRIPTION
## :scroll: Description
Debouncing the SentryWidgetsBindingObserver.didChangeMetrics method. 
This was called up to approx. 20 times if the window size was changed on flutter desktop, approx. 10 on flutter web and 4-5 times on mobile if the screen was rotated. 
Setting the debouncing to 100ms seems to be enough to debounce 95% - 99% of the duplicate calls and also make sure, that the delay after the windows is resized or rotated is not to big.

## :bulb: Motivation and Context
close #400 


## :green_heart: How did you test it?
On simulator/emulator, web application and desktop application.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes