### PR TITLE
feat: improve obscure rectangle fit/size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Session replay Alpha for Android and iOS ([#2208](https://github.com/getsentry/sentry-dart/pull/2208)).
+- Session replay Alpha for Android and iOS ([#2208](https://github.com/getsentry/sentry-dart/pull/2208), [#2236](https://github.com/getsentry/sentry-dart/pull/2236)).
 
   To try out replay, you can set following options (access is limited to early access orgs on Sentry. If you're interested, [sign up for the waitlist](https://sentry.io/lp/mobile-replay-beta/)):
 

--- a/flutter/lib/src/replay/widget_filter.dart
+++ b/flutter/lib/src/replay/widget_filter.dart
@@ -66,7 +66,7 @@ class WidgetFilter {
 
     final renderObject = element.renderObject;
     if (renderObject is! RenderBox) {
-      _cantObscure(widget, "it's renderObject is not a RenderBox");
+      _cantObscure(widget, "its renderObject is not a RenderBox");
       return false;
     }
 

--- a/flutter/test/replay/test_widget.dart
+++ b/flutter/test/replay/test_widget.dart
@@ -32,6 +32,19 @@ Future<Element> pumpTestElement(WidgetTester tester) async {
                   Opacity(opacity: 0, child: newImage()),
                   Offstage(offstage: true, child: Text('Offstage text')),
                   Offstage(offstage: true, child: newImage()),
+                  Text(dummyText),
+                  SizedBox(
+                      width: 100,
+                      height: 20,
+                      child: Stack(children: [
+                        Positioned(
+                            top: 0, left: 0, width: 50, child: Text(dummyText)),
+                        Positioned(
+                            top: 0,
+                            left: 0,
+                            width: 50,
+                            child: newImage(width: 500, height: 500)),
+                      ]))
                 ],
               ),
             ),
@@ -43,7 +56,7 @@ Future<Element> pumpTestElement(WidgetTester tester) async {
   return TestWidgetsFlutterBinding.instance.rootElement!;
 }
 
-Image newImage() => Image.memory(
+Image newImage({double width = 1, double height = 1}) => Image.memory(
       Uint8List.fromList([
         66, 77, 142, 0, 0, 0, 0, 0, 0, 0, 138, 0, 0, 0, 124, 0, 0, 0, 1, 0,
         0, 0, 255, 255, 255, 255, 1, 0, 32, 0, 3, 0, 0, 0, 4, 0, 0, 0, 19,
@@ -54,6 +67,8 @@ Image newImage() => Image.memory(
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 135, 135, 135, 255,
         // This comment prevents dartfmt reformatting this to single-item lines.
       ]),
-      width: 1,
-      height: 1,
+      width: width,
+      height: height,
     );
+
+const dummyText = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.';

--- a/flutter/test/replay/widget_filter_test.dart
+++ b/flutter/test/replay/widget_filter_test.dart
@@ -15,12 +15,15 @@ void main() async {
             redactText: redactText,
           );
 
+  boundsRect(WidgetFilterItem item) =>
+      '${item.bounds.width.floor()}x${item.bounds.height.floor()}';
+
   group('redact text', () {
     testWidgets('redacts the correct number of elements', (tester) async {
       final sut = createSut(redactText: true);
       final element = await pumpTestElement(tester);
       sut.obscure(element, 1.0, defaultBounds);
-      expect(sut.items.length, 2);
+      expect(sut.items.length, 4);
     });
 
     testWidgets('does not redact text when disabled', (tester) async {
@@ -37,6 +40,17 @@ void main() async {
       sut.obscure(element, 1.0, Rect.fromLTRB(0, 0, 100, 100));
       expect(sut.items.length, 1);
     });
+
+    testWidgets('correctly determines sizes', (tester) async {
+      final sut = createSut(redactText: true);
+      final element = await pumpTestElement(tester);
+      sut.obscure(element, 1.0, defaultBounds);
+      expect(sut.items.length, 4);
+      expect(boundsRect(sut.items[0]), '624x48');
+      expect(boundsRect(sut.items[1]), '169x20');
+      expect(boundsRect(sut.items[2]), '800x192');
+      expect(boundsRect(sut.items[3]), '50x20');
+    });
   });
 
   group('redact images', () {
@@ -44,7 +58,7 @@ void main() async {
       final sut = createSut(redactImages: true);
       final element = await pumpTestElement(tester);
       sut.obscure(element, 1.0, defaultBounds);
-      expect(sut.items.length, 2);
+      expect(sut.items.length, 3);
     });
 
     testWidgets('does not redact text when disabled', (tester) async {
@@ -60,6 +74,16 @@ void main() async {
       final element = await pumpTestElement(tester);
       sut.obscure(element, 1.0, Rect.fromLTRB(0, 0, 500, 100));
       expect(sut.items.length, 1);
+    });
+
+    testWidgets('correctly determines sizes', (tester) async {
+      final sut = createSut(redactImages: true);
+      final element = await pumpTestElement(tester);
+      sut.obscure(element, 1.0, defaultBounds);
+      expect(sut.items.length, 3);
+      expect(boundsRect(sut.items[0]), '1x1');
+      expect(boundsRect(sut.items[1]), '1x1');
+      expect(boundsRect(sut.items[2]), '50x20');
     });
   });
 }


### PR DESCRIPTION
Improves the size of obscure rectangle in replay to better match the actual content
| Original | Before the change | After the change |
|---------|---------|---------|
| ![image](https://github.com/user-attachments/assets/42fdbb83-1e63-4473-98ec-e8a907ed4a5a) | ![image](https://github.com/user-attachments/assets/14fc0b6c-7ec6-490c-8476-046c081d1cf7)  |   ![image](https://github.com/user-attachments/assets/6b918668-9b55-4047-be92-c32cf503bbb1) | 


