### PR TITLE
Provide a way to cause an example native crash from Flutter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Add `SentryFlutter.nativeCrash()` using MethodChannels for Android and iOS ([#2239](https://github.com/getsentry/sentry-dart/pull/2239))
+  - This can be used to test if native crash reporting works  
 - Add `ignoreRoutes` parameter to `SentryNavigatorObserver`. ([#2218](https://github.com/getsentry/sentry-dart/pull/2218))
     - This will ignore the Routes and prevent the Route from being pushed to the Sentry server.
     - Ignored routes will also create no TTID and TTFD spans.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Add `SentryFlutter.nativeCrash()` using MethodChannels for Android and iOS ([#2239](https://github.com/getsentry/sentry-dart/pull/2239))
 - Add `ignoreRoutes` parameter to `SentryNavigatorObserver`. ([#2218](https://github.com/getsentry/sentry-dart/pull/2218))
     - This will ignore the Routes and prevent the Route from being pushed to the Sentry server.
     - Ignored routes will also create no TTID and TTFD spans.

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -476,5 +476,4 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
       )
     result.success(serializedScope)
   }
-
 }

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -74,6 +74,7 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
       "removeTag" -> removeTag(call.argument("key"), result)
       "loadContexts" -> loadContexts(result)
       "displayRefreshRate" -> displayRefreshRate(result)
+      "nativeCrash" -> crash(result)
       else -> result.notImplemented()
     }
   }
@@ -465,5 +466,9 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         currentScope,
       )
     result.success(serializedScope)
+  }
+
+  private fun crash(result: Result) {
+    error("This is a fatal error caused by SentryFlutter.nativeCrash.")
   }
 }

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -50,8 +50,8 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
     sentryFlutter =
       SentryFlutter(
-        androidSdk = androidSdk,
-        nativeSdk = nativeSdk,
+        androidSdk = ANDROID_SDK,
+        nativeSdk = NATIVE_SDK,
       )
   }
 
@@ -415,16 +415,17 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
   }
 
   companion object {
+    private const val FLUTTER_SDK = "sentry.dart.flutter"
+    private const val ANDROID_SDK = "sentry.java.android.flutter"
+    private const val NATIVE_SDK = "sentry.native.android.flutter"
+    private const val NATIVE_CRASH_WAIT_TIME = 500L
 
-    private const val flutterSdk = "sentry.dart.flutter"
-    private const val androidSdk = "sentry.java.android.flutter"
-    private const val nativeSdk = "sentry.native.android.flutter"
     private fun setEventOriginTag(event: SentryEvent) {
       event.sdk?.let {
         when (it.name) {
-          flutterSdk -> setEventEnvironmentTag(event, "flutter", "dart")
-          androidSdk -> setEventEnvironmentTag(event, environment = "java")
-          nativeSdk -> setEventEnvironmentTag(event, environment = "native")
+          FLUTTER_SDK -> setEventEnvironmentTag(event, "flutter", "dart")
+          ANDROID_SDK -> setEventEnvironmentTag(event, environment = "java")
+          NATIVE_SDK -> setEventEnvironmentTag(event, environment = "native")
           else -> return
         }
       }
@@ -441,7 +442,7 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
     private fun addPackages(event: SentryEvent, sdk: SdkVersion?) {
       event.sdk?.let {
-        if (it.name == flutterSdk) {
+        if (it.name == FLUTTER_SDK) {
           sdk?.packageSet?.forEach { sentryPackage ->
             it.addPackage(sentryPackage.name, sentryPackage.version)
           }
@@ -450,6 +451,13 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
           }
         }
       }
+    }
+
+    private fun crash() {
+      val exception = RuntimeException("FlutterSentry Native Integration: Sample RuntimeException")
+      val mainThread = Looper.getMainLooper().thread
+      mainThread.uncaughtExceptionHandler.uncaughtException(mainThread, exception)
+      mainThread.join(NATIVE_CRASH_WAIT_TIME)
     }
   }
 
@@ -469,11 +477,4 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     result.success(serializedScope)
   }
 
-  private fun crash() {
-    val exception = RuntimeException("FlutterSentry Native Integration: Sample RuntimeException")
-    val mainThread = Looper.getMainLooper().thread
-    mainThread.uncaughtExceptionHandler.uncaughtException(mainThread, exception)
-    private const val waitTime = 500
-    mainThread.join(waitTime)
-  }
 }

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -75,7 +75,7 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
       "removeTag" -> removeTag(call.argument("key"), result)
       "loadContexts" -> loadContexts(result)
       "displayRefreshRate" -> displayRefreshRate(result)
-      "nativeCrash" -> crash(result)
+      "nativeCrash" -> crash()
       else -> result.notImplemented()
     }
   }
@@ -469,10 +469,11 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     result.success(serializedScope)
   }
 
-  private fun crash(result: Result) {
+  private fun crash() {
     val exception = RuntimeException("FlutterSentry Native Integration: Sample RuntimeException")
     val mainThread = Looper.getMainLooper().thread
     mainThread.uncaughtExceptionHandler.uncaughtException(mainThread, exception)
-    mainThread.join(500)
+    private const val waitTime = 500
+    mainThread.join(waitTime)
   }
 }

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -3,6 +3,7 @@ package io.sentry.flutter
 import android.app.Activity
 import android.content.Context
 import android.os.Build
+import android.os.Looper
 import android.util.Log
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
@@ -469,6 +470,9 @@ class SentryFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
   }
 
   private fun crash(result: Result) {
-    error("This is a fatal error caused by SentryFlutter.nativeCrash.")
+    val exception = RuntimeException("FlutterSentry Native Integration: Sample RuntimeException")
+    val mainThread = Looper.getMainLooper().thread
+    mainThread.uncaughtExceptionHandler.uncaughtException(mainThread, exception)
+    mainThread.join(500)
   }
 }

--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -758,6 +758,12 @@ class AndroidExample extends StatelessWidget {
         },
         child: const Text('Platform exception'),
       ),
+      ElevatedButton(
+        onPressed: () async {
+          SentryFlutter.nativeCrash();
+        },
+        child: const Text('Sentry.nativeCrash'),
+      ),
     ]);
   }
 }
@@ -869,6 +875,12 @@ class CocoaExample extends StatelessWidget {
             await execute('crash');
           },
           child: const Text('Objective-C SEGFAULT'),
+        ),
+        ElevatedButton(
+          onPressed: () async {
+            SentryFlutter.nativeCrash();
+          },
+          child: const Text('Sentry.nativeCrash'),
         ),
       ],
     );

--- a/flutter/ios/Classes/SentryFlutterPluginApple.swift
+++ b/flutter/ios/Classes/SentryFlutterPluginApple.swift
@@ -174,6 +174,9 @@ public class SentryFlutterPluginApple: NSObject, FlutterPlugin {
         case "resumeAppHangTracking":
             resumeAppHangTracking(result)
 
+        case "nativeCrash":
+            crash()
+
         default:
             result(FlutterMethodNotImplemented)
         }
@@ -728,6 +731,10 @@ public class SentryFlutterPluginApple: NSObject, FlutterPlugin {
     private func resumeAppHangTracking(_ result: @escaping FlutterResult) {
         SentrySDK.resumeAppHangTracking()
         result("")
+    }
+
+    private func crash() {
+        SentrySDK.crash()
     }
 }
 

--- a/flutter/lib/src/native/sentry_native_binding.dart
+++ b/flutter/lib/src/native/sentry_native_binding.dart
@@ -57,4 +57,6 @@ abstract class SentryNativeBinding {
   Future<void> pauseAppHangTracking();
 
   Future<void> resumeAppHangTracking();
+
+  Future<void> nativeCrash();
 }

--- a/flutter/lib/src/native/sentry_native_channel.dart
+++ b/flutter/lib/src/native/sentry_native_channel.dart
@@ -194,4 +194,7 @@ class SentryNativeChannel
   @override
   Future<void> resumeAppHangTracking() =>
       _channel.invokeMethod('resumeAppHangTracking');
+
+  @override
+  Future<void> nativeCrash() => _channel.invokeMethod('nativeCrash');
 }

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -273,6 +273,9 @@ mixin SentryFlutter {
 
   static SentryNativeBinding? _native;
 
+  /// Use `nativeCrash()` to crash the native implementation and test/debug the crash reporting for native code.
+  /// This should not be used in production code.
+  /// Only for Android and iOS
   static Future<void> nativeCrash() {
     if (_native == null) {
       _logNativeIntegrationNotAvailable("nativeCrash");

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:ui';
 
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
 
@@ -249,11 +250,7 @@ mixin SentryFlutter {
   /// Only for iOS and macOS.
   static Future<void> pauseAppHangTracking() {
     if (_native == null) {
-      // ignore: invalid_use_of_internal_member
-      Sentry.currentHub.options.logger(
-        SentryLevel.debug,
-        'Native integration is not available. Make sure SentryFlutter is initialized before accessing the pauseAppHangTracking API.',
-      );
+      _logNativeIntegrationNotAvailable("pauseAppHangTracking");
       return Future<void>.value();
     }
     return _native!.pauseAppHangTracking();
@@ -263,11 +260,7 @@ mixin SentryFlutter {
   /// Only for iOS and macOS
   static Future<void> resumeAppHangTracking() {
     if (_native == null) {
-      // ignore: invalid_use_of_internal_member
-      Sentry.currentHub.options.logger(
-        SentryLevel.debug,
-        'Native integration is not available. Make sure SentryFlutter is initialized before accessing the resumeAppHangTracking API.',
-      );
+      _logNativeIntegrationNotAvailable("resumeAppHangTracking");
       return Future<void>.value();
     }
     return _native!.resumeAppHangTracking();
@@ -280,4 +273,21 @@ mixin SentryFlutter {
   static set native(SentryNativeBinding? value) => _native = value;
 
   static SentryNativeBinding? _native;
+
+  static Future<void> nativeCrash() {
+    const _channel = MethodChannel('example.flutter.sentry.io');
+    if (_native == null) {
+      _logNativeIntegrationNotAvailable("nativeCrash");
+      return Future<void>.value();
+    }
+    return _native!.nativeCrash();
+  }
+
+  static void _logNativeIntegrationNotAvailable(String methodName) {
+    // ignore: invalid_use_of_internal_member
+    Sentry.currentHub.options.logger(
+      SentryLevel.debug,
+      'Native integration is not available. Make sure SentryFlutter is initialized before accessing the $methodName API.',
+    );
+  }
 }

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -275,7 +275,7 @@ mixin SentryFlutter {
 
   /// Use `nativeCrash()` to crash the native implementation and test/debug the crash reporting for native code.
   /// This should not be used in production code.
-  /// Only for Android and iOS
+  /// Only for Android, iOS and macOS
   static Future<void> nativeCrash() {
     if (_native == null) {
       _logNativeIntegrationNotAvailable("nativeCrash");

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:ui';
 
-import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
 

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -275,7 +275,6 @@ mixin SentryFlutter {
   static SentryNativeBinding? _native;
 
   static Future<void> nativeCrash() {
-    const _channel = MethodChannel('example.flutter.sentry.io');
     if (_native == null) {
       _logNativeIntegrationNotAvailable("nativeCrash");
       return Future<void>.value();

--- a/flutter/test/sentry_native_channel_test.dart
+++ b/flutter/test/sentry_native_channel_test.dart
@@ -302,6 +302,15 @@ void main() {
 
         verify(channel.invokeMethod('resumeAppHangTracking'));
       });
+
+      test('nativeCrash', () async {
+        when(channel.invokeMethod('nativeCrash'))
+            .thenAnswer((_) => Future.value());
+
+        await sut.nativeCrash();
+
+        verify(channel.invokeMethod('nativeCrash'));
+      });
     });
   }
 }


### PR DESCRIPTION
## :scroll: Description
add SentryFlutter.nativeCrash() using MethodChannels for Android and iOS


## :bulb: Motivation and Context
close #219 


## :green_heart: How did you test it?
Android Emulator and iOS Simulator. Also, I added a `SentryFlutter.nativeCrash` button to the example app.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes