### PR TITLE
feat: capture touch breadcrumbs for all buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
   );
   ```
 
+- Collect touch breadcrumbs for all buttons, not just those with `key` specified. ([#2242](https://github.com/getsentry/sentry-dart/pull/2242))
+
 ### Dependencies
 
 - Bump Cocoa SDK from v8.35.1 to v8.36.0 ([#2252](https://github.com/getsentry/sentry-dart/pull/2252))
@@ -42,7 +44,6 @@
 ### Improvements
 
 - Debouncing of SentryWidgetsBindingObserver.didChangeMetrics with delay of 100ms. ([#2232](https://github.com/getsentry/sentry-dart/pull/2232))
-- Collect touch breadcrumbs for all buttons, not just those with `key` specified. ([#2242](https://github.com/getsentry/sentry-dart/pull/2242))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 ### Improvements
 
 - Debouncing of SentryWidgetsBindingObserver.didChangeMetrics with delay of 100ms. ([#2232](https://github.com/getsentry/sentry-dart/pull/2232))
+- Collect touch breadcrumbs for all buttons, not just those with `key` specified. ([#2242](https://github.com/getsentry/sentry-dart/pull/2242))
 
 ### Dependencies
 

--- a/dart/lib/src/protocol/breadcrumb.dart
+++ b/dart/lib/src/protocol/breadcrumb.dart
@@ -105,42 +105,17 @@ class Breadcrumb {
     String? viewId,
     String? viewClass,
   }) {
-    final newData = data ?? {};
-    var path = '';
-
-    if (viewId != null) {
-      newData['view.id'] = viewId;
-      path = viewId;
-    }
-
-    if (newData.containsKey('label')) {
-      if (path.isEmpty) {
-        path = newData['label'];
-      } else {
-        path = "$path, label: ${newData['label']}";
-      }
-    }
-
-    if (viewClass != null) {
-      newData['view.class'] = viewClass;
-      if (path.isEmpty) {
-        path = viewClass;
-      } else {
-        path = "$viewClass($path)";
-      }
-    }
-
-    if (path.isNotEmpty && !newData.containsKey('path')) {
-      newData['path'] = path;
-    }
-
     return Breadcrumb(
       message: message,
       level: level,
       category: 'ui.$subCategory',
       type: 'user',
       timestamp: timestamp,
-      data: newData,
+      data: {
+        if (viewId != null) 'view.id': viewId,
+        if (viewClass != null) 'view.class': viewClass,
+        if (data != null) ...data,
+      },
     );
   }
 

--- a/dart/test/protocol/breadcrumb_test.dart
+++ b/dart/test/protocol/breadcrumb_test.dart
@@ -222,7 +222,6 @@ void main() {
           'foo': 'bar',
           'view.id': 'foo',
           'view.class': 'bar',
-          'path': 'bar(foo)',
         },
       });
     });

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterReplayBreadcrumbConverter.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterReplayBreadcrumbConverter.kt
@@ -8,6 +8,8 @@ import io.sentry.rrweb.RRWebSpanEvent
 import java.util.Date
 
 private const val MILLIS_PER_SECOND = 1000.0
+private const val MAX_PATH_ITEMS = 4
+private const val MAX_PATH_IDENTIFIER_LENGTH = 20
 
 class SentryFlutterReplayBreadcrumbConverter : DefaultReplayBreadcrumbConverter() {
   internal companion object {
@@ -85,16 +87,12 @@ class SentryFlutterReplayBreadcrumbConverter : DefaultReplayBreadcrumbConverter(
   }
 
   private fun getTouchPathMessage(maybePath: Any?): String? {
-    if (maybePath !is List<*>) {
-      return null
-    }
-
-    if (maybePath.isEmpty()) {
+    if (maybePath !is List<*> || maybePath.isEmpty()) {
       return null
     }
 
     val message = StringBuilder()
-    for (i in Math.min(3, maybePath.size - 1) downTo 0) {
+    for (i in Math.min(MAX_PATH_ITEMS, maybePath.size) - 1 downTo 0) {
       val item = maybePath[i]
       if (item !is Map<*, *>) {
         continue
@@ -104,8 +102,8 @@ class SentryFlutterReplayBreadcrumbConverter : DefaultReplayBreadcrumbConverter(
 
       var identifier = item["label"] ?: item["name"]
       if (identifier is String && identifier.isNotEmpty()) {
-        if (identifier.length > 20) {
-          identifier = identifier.substring(0, 17) + "..."
+        if (identifier.length > MAX_PATH_IDENTIFIER_LENGTH) {
+          identifier = identifier.substring(0, MAX_PATH_IDENTIFIER_LENGTH - "...".length) + "..."
         }
         message.append("(").append(identifier).append(")")
       }

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterReplayRecorder.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterReplayRecorder.kt
@@ -12,7 +12,7 @@ internal class SentryFlutterReplayRecorder(
   private val channel: MethodChannel,
   private val integration: ReplayIntegration,
 ) : Recorder {
-  override fun start(config: ScreenshotRecorderConfig) {
+  override fun start(recorderConfig: ScreenshotRecorderConfig) {
     val cacheDirPath = integration.replayCacheDir?.absolutePath
     if (cacheDirPath == null) {
       Log.w("Sentry", "Replay cache directory is null, can't start replay recorder.")
@@ -24,9 +24,9 @@ internal class SentryFlutterReplayRecorder(
           "ReplayRecorder.start",
           mapOf(
             "directory" to cacheDirPath,
-            "width" to config.recordingWidth,
-            "height" to config.recordingHeight,
-            "frameRate" to config.frameRate,
+            "width" to recorderConfig.recordingWidth,
+            "height" to recorderConfig.recordingHeight,
+            "frameRate" to recorderConfig.frameRate,
             "replayId" to integration.getReplayId().toString(),
           ),
         )

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -187,14 +187,14 @@ class SentryFlutterOptions extends SentryOptions {
   ///
   /// Requires adding the [SentryUserInteractionWidget] to the widget tree.
   /// Example:
-  /// runApp(SentryUserInteractionWidget(child: App()));
+  /// runApp(SentryWidget(child: App()));
   bool enableUserInteractionBreadcrumbs = true;
 
   /// Enables the Auto instrumentation for user interaction tracing.
   ///
   /// Requires adding the [SentryUserInteractionWidget] to the widget tree.
   /// Example:
-  /// runApp(SentryUserInteractionWidget(child: App()));
+  /// runApp(SentryWidget(child: App()));
   bool enableUserInteractionTracing = true;
 
   /// Enable or disable the tracing of time to full display (TTFD).

--- a/flutter/lib/src/user_interaction/sentry_user_interaction_widget.dart
+++ b/flutter/lib/src/user_interaction/sentry_user_interaction_widget.dart
@@ -327,28 +327,27 @@ class _SentryUserInteractionWidgetState
   }
 
   void _createBreadcrumbOnTap(UserInteractionInfo info, String? widgetKey) {
-    // ignore: invalid_use_of_internal_member
-    if (_options?.enableUserInteractionBreadcrumbs ?? false) {
-      Map<String, dynamic>? data;
-      // ignore: invalid_use_of_internal_member
-      if ((_options?.sendDefaultPii ?? false) && info.description.isNotEmpty) {
-        data = {};
-        data['label'] = info.description;
-      }
-
-      final crumb = Breadcrumb.userInteraction(
-        subCategory: 'click',
-        viewId: widgetKey,
-        viewClass: info.type, // to avoid minification
-        data: data,
-      );
-      final hint = Hint.withMap({TypeCheckHint.widget: info.element.widget});
-      _hub.addBreadcrumb(crumb, hint: hint);
+    if (!(_options?.enableUserInteractionBreadcrumbs ?? false)) {
+      return;
     }
+
+    Map<String, dynamic>? data;
+    if ((_options?.sendDefaultPii ?? false) && info.description.isNotEmpty) {
+      data = {};
+      data['label'] = info.description;
+    }
+
+    final crumb = Breadcrumb.userInteraction(
+      subCategory: 'click',
+      viewId: widgetKey,
+      viewClass: info.type, // to avoid minification
+      data: data,
+    );
+    final hint = Hint.withMap({TypeCheckHint.widget: info.element.widget});
+    _hub.addBreadcrumb(crumb, hint: hint);
   }
 
   void _startTransactionOnTap(UserInteractionInfo info, String? widgetKey) {
-    // ignore: invalid_use_of_internal_member
     if (widgetKey == null ||
         !(_options?.isTracingEnabled() ?? false) ||
         !(_options?.enableUserInteractionTracing ?? false)) {
@@ -404,9 +403,7 @@ class _SentryUserInteractionWidgetState
     _activeTransaction = _hub.startTransactionWithContext(
       transactionContext,
       waitForChildren: true,
-      autoFinishAfter:
-          // ignore: invalid_use_of_internal_member
-          _options?.idleTimeout,
+      autoFinishAfter: _options?.idleTimeout,
       trimEnd: true,
     );
 

--- a/flutter/lib/src/user_interaction/sentry_user_interaction_widget.dart
+++ b/flutter/lib/src/user_interaction/sentry_user_interaction_widget.dart
@@ -369,7 +369,6 @@ class _SentryUserInteractionWidgetState
       if (_isElementMounted(lastElement) &&
           _isElementMounted(element) &&
           lastElement?.widget == element.widget &&
-          _lastTappedWidget?.eventType == info.eventType &&
           !activeTransaction.finished) {
         // ignore: invalid_use_of_internal_member
         activeTransaction.scheduleFinish();
@@ -417,7 +416,11 @@ class _SentryUserInteractionWidgetState
     });
   }
 
-  String _findDescriptionOf(Element element, bool allowText) {
+  String _findDescriptionOf(Element element) {
+    final widget = element.widget;
+    final allowText = widget is ButtonStyleButton ||
+        widget is MaterialButton ||
+        widget is CupertinoButton;
     var description = '';
 
     // traverse tree to find a suiting element
@@ -489,7 +492,14 @@ class _SentryUserInteractionWidgetState
         return;
       }
 
-      tappedWidget = _getDescriptionFrom(element);
+      final type = _getElementType(element);
+      if (type != null) {
+        tappedWidget = UserInteractionInfo(
+          element: element,
+          description: _findDescriptionOf(element),
+          type: type,
+        );
+      }
 
       if (tappedWidget == null || !hitFound) {
         element.visitChildElements(elementFinder);
@@ -501,71 +511,36 @@ class _SentryUserInteractionWidgetState
     return tappedWidget;
   }
 
-  UserInteractionInfo? _getDescriptionFrom(Element element) {
+  String? _getElementType(Element element) {
     final widget = element.widget;
     // Used by ElevatedButton, TextButton, OutlinedButton.
     if (widget is ButtonStyleButton) {
       if (widget.enabled) {
-        return UserInteractionInfo(
-          element: element,
-          description: _findDescriptionOf(element, true),
-          type: 'ButtonStyleButton',
-          eventType: 'onClick',
-        );
+        return 'ButtonStyleButton';
       }
     } else if (widget is MaterialButton) {
       if (widget.enabled) {
-        return UserInteractionInfo(
-          element: element,
-          description: _findDescriptionOf(element, true),
-          type: 'MaterialButton',
-          eventType: 'onClick',
-        );
+        return 'MaterialButton';
       }
     } else if (widget is CupertinoButton) {
       if (widget.enabled) {
-        return UserInteractionInfo(
-          element: element,
-          description: _findDescriptionOf(element, true),
-          type: 'CupertinoButton',
-          eventType: 'onPressed',
-        );
+        return 'CupertinoButton';
       }
     } else if (widget is InkWell) {
       if (widget.onTap != null) {
-        return UserInteractionInfo(
-          element: element,
-          description: _findDescriptionOf(element, false),
-          type: 'InkWell',
-          eventType: 'onTap',
-        );
+        return 'InkWell';
       }
     } else if (widget is IconButton) {
       if (widget.onPressed != null) {
-        return UserInteractionInfo(
-          element: element,
-          description: _findDescriptionOf(element, false),
-          type: 'IconButton',
-          eventType: 'onPressed',
-        );
+        return 'IconButton';
       }
     } else if (widget is PopupMenuButton) {
       if (widget.enabled) {
-        return UserInteractionInfo(
-          element: element,
-          description: _findDescriptionOf(element, false),
-          type: 'PopupMenuButton',
-          eventType: 'onTap',
-        );
+        return 'PopupMenuButton';
       }
     } else if (widget is PopupMenuItem) {
       if (widget.enabled) {
-        return UserInteractionInfo(
-          element: element,
-          description: _findDescriptionOf(element, false),
-          type: 'PopupMenuItem',
-          eventType: 'onTap',
-        );
+        return 'PopupMenuItem';
       }
     }
 

--- a/flutter/lib/src/user_interaction/sentry_user_interaction_widget.dart
+++ b/flutter/lib/src/user_interaction/sentry_user_interaction_widget.dart
@@ -223,7 +223,7 @@ Element? _clickTrackerElement;
 /// Mostly for onPressed, onTap, and onLongPress events
 ///
 /// Example on how to set up:
-/// runApp(SentryUserInteractionWidget(child: App()));
+/// runApp(SentryWidget(child: App()));
 ///
 /// For transactions, enable it in the [SentryFlutterOptions.enableUserInteractionTracing].
 /// The idle timeout can be configured in the [SentryOptions.idleTimeout].

--- a/flutter/lib/src/user_interaction/sentry_user_interaction_widget.dart
+++ b/flutter/lib/src/user_interaction/sentry_user_interaction_widget.dart
@@ -382,7 +382,7 @@ class _SentryUserInteractionWidgetState
         return false;
       }
 
-      final widgetName = element.widget.toStringShort();
+      final widgetName = element.widget.runtimeType.toString();
       if (!widgetName.startsWith('_')) {
         final info = {
           'name': WidgetUtils.toStringValue(element.widget.key),

--- a/flutter/lib/src/user_interaction/user_interaction_info.dart
+++ b/flutter/lib/src/user_interaction/user_interaction_info.dart
@@ -6,12 +6,10 @@ class UserInteractionInfo {
   final Element element;
   final String description;
   final String type;
-  final String eventType;
 
   const UserInteractionInfo({
     required this.element,
     required this.description,
     required this.type,
-    required this.eventType,
   });
 }

--- a/flutter/lib/src/user_interaction/user_interaction_info.dart
+++ b/flutter/lib/src/user_interaction/user_interaction_info.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/widgets.dart';
+import 'package:meta/meta.dart';
 
-class UserInteractionWidget {
+@internal
+class UserInteractionInfo {
   final Element element;
   final String description;
   final String type;
   final String eventType;
 
-  const UserInteractionWidget({
+  const UserInteractionInfo({
     required this.element,
     required this.description,
     required this.type,

--- a/flutter/lib/src/user_interaction/user_interaction_info.dart
+++ b/flutter/lib/src/user_interaction/user_interaction_info.dart
@@ -4,12 +4,10 @@ import 'package:meta/meta.dart';
 @internal
 class UserInteractionInfo {
   final Element element;
-  final String description;
   final String type;
 
   const UserInteractionInfo({
     required this.element,
-    required this.description,
     required this.type,
   });
 }

--- a/flutter/test/user_interaction/sentry_user_interaction_widget_test.dart
+++ b/flutter/test/user_interaction/sentry_user_interaction_widget_test.dart
@@ -109,13 +109,24 @@ void main() {
 
         await tapMe(tester, sut, 'btn_1');
 
-        Breadcrumb? crumb;
-        fixture.hub.configureScope((scope) {
-          crumb = scope.breadcrumbs.last;
-        });
-        expect(crumb?.category, 'ui.click');
-        expect(crumb?.data?['view.id'], 'btn_1');
-        expect(crumb?.data?['view.class'], 'MaterialButton');
+        expect(
+            fixture.getBreadcrumb().data?.replaceHashCodes(),
+            equals({
+              'path': [
+                {'name': 'btn_1', 'element': 'MaterialButton'},
+                {'element': 'Column'},
+                {'element': 'Center'},
+                {'name': '[GlobalKey#00000]', 'element': 'KeyedSubtree'},
+                {'element': 'MediaQuery'},
+                {'name': '_ScaffoldSlot.body', 'element': 'LayoutId'},
+                {'element': 'CustomMultiChildLayout'},
+                {'element': 'Actions'},
+                {'element': 'AnimatedBuilder'},
+                {'element': 'DefaultTextStyle'}
+              ],
+              'view.id': 'btn_1',
+              'view.class': 'MaterialButton',
+            }));
       });
     });
 
@@ -125,11 +136,25 @@ void main() {
 
         await tapMe(tester, sut, 'btn_1');
 
-        Breadcrumb? crumb;
-        fixture.hub.configureScope((scope) {
-          crumb = scope.breadcrumbs.last;
-        });
-        expect(crumb?.data?['label'], 'Button 1');
+        expect(
+            fixture.getBreadcrumb().data?.replaceHashCodes(),
+            equals({
+              'path': [
+                {'name': 'btn_1', 'element': 'MaterialButton'},
+                {'element': 'Column'},
+                {'element': 'Center'},
+                {'name': '[GlobalKey#00000]', 'element': 'KeyedSubtree'},
+                {'element': 'MediaQuery'},
+                {'name': '_ScaffoldSlot.body', 'element': 'LayoutId'},
+                {'element': 'CustomMultiChildLayout'},
+                {'element': 'Actions'},
+                {'element': 'AnimatedBuilder'},
+                {'element': 'DefaultTextStyle'}
+              ],
+              'label': 'Button 1',
+              'view.id': 'btn_1',
+              'view.class': 'MaterialButton'
+            }));
       });
     });
 
@@ -139,11 +164,25 @@ void main() {
 
         await tapMe(tester, sut, 'btn_3');
 
-        Breadcrumb? crumb;
-        fixture.hub.configureScope((scope) {
-          crumb = scope.breadcrumbs.last;
-        });
-        expect(crumb?.data?['label'], 'My Icon');
+        expect(
+            fixture.getBreadcrumb().data?.replaceHashCodes(),
+            equals({
+              'path': [
+                {'name': 'btn_3', 'element': 'IconButton'},
+                {'element': 'Column'},
+                {'element': 'Center'},
+                {'name': '[GlobalKey#00000]', 'element': 'KeyedSubtree'},
+                {'element': 'MediaQuery'},
+                {'name': '_ScaffoldSlot.body', 'element': 'LayoutId'},
+                {'element': 'CustomMultiChildLayout'},
+                {'element': 'Actions'},
+                {'element': 'AnimatedBuilder'},
+                {'element': 'DefaultTextStyle'}
+              ],
+              'label': 'My Icon',
+              'view.id': 'btn_3',
+              'view.class': 'IconButton'
+            }));
       });
     });
 
@@ -153,11 +192,25 @@ void main() {
 
         await tapMe(tester, sut, 'btn_2');
 
-        Breadcrumb? crumb;
-        fixture.hub.configureScope((scope) {
-          crumb = scope.breadcrumbs.last;
-        });
-        expect(crumb?.data?['label'], 'Button 2');
+        expect(
+            fixture.getBreadcrumb().data?.replaceHashCodes(),
+            equals({
+              'path': [
+                {'name': 'btn_2', 'element': 'CupertinoButton'},
+                {'element': 'Column'},
+                {'element': 'Center'},
+                {'name': '[GlobalKey#00000]', 'element': 'KeyedSubtree'},
+                {'element': 'MediaQuery'},
+                {'name': '_ScaffoldSlot.body', 'element': 'LayoutId'},
+                {'element': 'CustomMultiChildLayout'},
+                {'element': 'Actions'},
+                {'element': 'AnimatedBuilder'},
+                {'element': 'DefaultTextStyle'}
+              ],
+              'label': 'Button 2',
+              'view.id': 'btn_2',
+              'view.class': 'CupertinoButton'
+            }));
       });
     });
 
@@ -183,11 +236,25 @@ void main() {
 
         await tapMe(tester, sut, 'btn_5');
 
-        Breadcrumb? crumb;
-        fixture.hub.configureScope((scope) {
-          crumb = scope.breadcrumbs.last;
-        });
-        expect(crumb?.data?['label'], 'Button 5');
+        expect(
+            fixture.getBreadcrumb().data?.replaceHashCodes(),
+            equals({
+              'path': [
+                {'name': 'btn_5', 'element': 'ButtonStyleButton'},
+                {'element': 'Stack'},
+                {'element': 'Listener'},
+                {'element': 'RawGestureDetector'},
+                {'name': 'btn_4', 'element': 'GestureDetector'},
+                {'element': 'Semantics'},
+                {'element': 'DefaultTextStyle'},
+                {'element': 'AnimatedDefaultTextStyle'},
+                {'element': 'NotificationListener<LayoutChangedNotification>'},
+                {'element': 'CustomPaint'}
+              ],
+              'label': 'Button 5',
+              'view.id': 'btn_5',
+              'view.class': 'ButtonStyleButton'
+            }));
       });
     });
 
@@ -197,13 +264,24 @@ void main() {
 
         await tapMe(tester, sut, 'popup_menu_button');
 
-        Breadcrumb? crumb;
-        fixture.hub.configureScope((scope) {
-          crumb = scope.breadcrumbs.last;
-        });
-        expect(crumb?.category, 'ui.click');
-        expect(crumb?.data?['view.id'], 'popup_menu_button');
-        expect(crumb?.data?['view.class'], 'PopupMenuButton');
+        expect(
+            fixture.getBreadcrumb().data?.replaceHashCodes(),
+            equals({
+              'path': [
+                {'name': 'popup_menu_button', 'element': 'PopupMenuButton'},
+                {'element': 'Column'},
+                {'element': 'Center'},
+                {'name': '[GlobalKey#00000]', 'element': 'KeyedSubtree'},
+                {'element': 'MediaQuery'},
+                {'name': '_ScaffoldSlot.body', 'element': 'LayoutId'},
+                {'element': 'CustomMultiChildLayout'},
+                {'element': 'Actions'},
+                {'element': 'AnimatedBuilder'},
+                {'element': 'DefaultTextStyle'}
+              ],
+              'view.id': 'popup_menu_button',
+              'view.class': 'PopupMenuButton'
+            }));
       });
     });
 
@@ -217,13 +295,56 @@ void main() {
 
         await tapMe(tester, sut, 'popup_menu_item_1');
 
-        Breadcrumb? crumb;
-        fixture.hub.configureScope((scope) {
-          crumb = scope.breadcrumbs.last;
-        });
-        expect(crumb?.category, 'ui.click');
-        expect(crumb?.data?['view.id'], 'popup_menu_item_1');
-        expect(crumb?.data?['view.class'], 'PopupMenuItem');
+        expect(
+            fixture.getBreadcrumb().data?.replaceHashCodes(),
+            equals({
+              'path': [
+                {'name': 'popup_menu_item_1', 'element': 'PopupMenuItem'},
+                {'name': '[GlobalKey#00000]', 'element': 'FadeTransition'},
+                {'element': 'ListBody'},
+                {'element': 'Padding'},
+                {'name': '[GlobalKey#00000]', 'element': 'IgnorePointer'},
+                {'element': 'Semantics'},
+                {'element': 'Listener'},
+                {
+                  'name': '[LabeledGlobalKey<RawGestureDetectorState>#00000]',
+                  'element': 'RawGestureDetector'
+                },
+                {'element': 'Listener'},
+                {'element': 'NotificationListener<ScrollMetricsNotification>'}
+              ],
+              'view.id': 'popup_menu_item_1',
+              'view.class': 'PopupMenuItem'
+            }));
+      });
+    });
+
+    testWidgets('Add crumb for button with tooltip', (tester) async {
+      await tester.runAsync(() async {
+        final sut = fixture.getSut(sendDefaultPii: true);
+
+        // open the popup menu and wait for the animation to complete
+        await tapMe(tester, sut, 'tooltip_button');
+
+        expect(
+            fixture.getBreadcrumb().data?.replaceHashCodes(),
+            equals({
+              'path': [
+                {'name': 'tooltip_button', 'element': 'ButtonStyleButton'},
+                {'element': 'Semantics'},
+                {'element': 'Listener'},
+                {'element': 'OverlayPortal'},
+                {'element': 'Tooltip', 'label': 'Tooltip message.'},
+                {'element': 'Column'},
+                {'element': 'Center'},
+                {'name': '[GlobalKey#00000]', 'element': 'KeyedSubtree'},
+                {'element': 'MediaQuery'},
+                {'name': '_ScaffoldSlot.body', 'element': 'LayoutId'}
+              ],
+              'label': 'Button text',
+              'view.id': 'tooltip_button',
+              'view.class': 'ButtonStyleButton'
+            }));
       });
     });
   });
@@ -394,6 +515,14 @@ class Fixture {
       child: MyApp(),
     );
   }
+
+  Breadcrumb getBreadcrumb() {
+    late final Breadcrumb crumb;
+    hub.configureScope((scope) {
+      crumb = scope.breadcrumbs.last;
+    });
+    return crumb;
+  }
 }
 
 class MyApp extends StatelessWidget {
@@ -420,23 +549,17 @@ class Page1 extends StatelessWidget {
           children: [
             MaterialButton(
               key: Key('btn_1'),
-              onPressed: () {
-                // print('button pressed');
-              },
+              onPressed: () {},
               child: const Text('Button 1'),
             ),
             CupertinoButton(
               key: Key('btn_2'),
-              onPressed: () {
-                // print('button pressed 2');
-              },
+              onPressed: () {},
               child: const Text('Button 2'),
             ),
             IconButton(
               key: Key('btn_3'),
-              onPressed: () {
-                // print('button pressed 3');
-              },
+              onPressed: () {},
               icon: Icon(
                 Icons.dark_mode,
                 semanticLabel: 'My Icon',
@@ -445,17 +568,13 @@ class Page1 extends StatelessWidget {
             Card(
               child: GestureDetector(
                 key: Key('btn_4'),
-                onTap: () => {
-                  // print('button pressed 4'),
-                },
+                onTap: () => {},
                 child: Stack(
                   children: [
                     //fancy card layout
                     ElevatedButton(
                       key: Key('btn_5'),
-                      onPressed: () => {
-                        // print('button pressed 5'),
-                      },
+                      onPressed: () => {},
                       child: const Text('Button 5'),
                     ),
                   ],
@@ -478,6 +597,14 @@ class Page1 extends StatelessWidget {
                 ),
               ],
             ),
+            Tooltip(
+              message: 'Tooltip message.',
+              child: ElevatedButton(
+                key: ValueKey('tooltip_button'),
+                onPressed: () {},
+                child: Text('Button text'),
+              ),
+            )
           ],
         ),
       ),
@@ -496,9 +623,7 @@ class Page2 extends StatelessWidget {
           children: [
             MaterialButton(
               key: Key('btn_page_2'),
-              onPressed: () {
-                // print('button page 2 pressed');
-              },
+              onPressed: () {},
               child: const Text('Button Page 2'),
             ),
           ],
@@ -506,4 +631,35 @@ class Page2 extends StatelessWidget {
       ),
     );
   }
+}
+
+extension on String {
+  String replaceHashCodes() => replaceAll(RegExp(r'#[\da-fA-F]{5}'), '#00000');
+}
+
+extension on Map<dynamic, dynamic> {
+  Map<dynamic, dynamic> replaceHashCodes() => map((key, value) {
+        if (value is String) {
+          value = value.replaceHashCodes();
+        } else if (value is Map) {
+          value = value.replaceHashCodes();
+        } else if (value is List) {
+          value = value.replaceHashCodes();
+        }
+        return MapEntry(key, value);
+      });
+}
+
+extension on List<dynamic> {
+  Iterable<dynamic> replaceHashCodes() => map((value) {
+        if (value is String) {
+          return value.replaceHashCodes();
+        } else if (value is Map) {
+          return value.replaceHashCodes();
+        } else if (value is List) {
+          return value.replaceHashCodes();
+        } else {
+          return value;
+        }
+      });
 }

--- a/flutter/test/user_interaction/sentry_user_interaction_widget_test.dart
+++ b/flutter/test/user_interaction/sentry_user_interaction_widget_test.dart
@@ -347,6 +347,40 @@ void main() {
             }));
       });
     });
+
+    testWidgets('Add crumb for button without key', (tester) async {
+      await tester.runAsync(() async {
+        final sut = fixture.getSut(sendDefaultPii: true);
+
+        await tester.pumpWidget(sut);
+        await tester.tap(find.byElementPredicate((element) {
+          final widget = element.widget;
+          if (widget is MaterialButton) {
+            return (widget.child as Text).data == 'Button 5';
+          }
+          return false;
+        }));
+
+        expect(
+            fixture.getBreadcrumb().data?.replaceHashCodes(),
+            equals({
+              'path': [
+                {'element': 'MaterialButton'},
+                {'element': 'Column'},
+                {'element': 'Center'},
+                {'name': '[GlobalKey#00000]', 'element': 'KeyedSubtree'},
+                {'element': 'MediaQuery'},
+                {'name': '_ScaffoldSlot.body', 'element': 'LayoutId'},
+                {'element': 'CustomMultiChildLayout'},
+                {'element': 'Actions'},
+                {'element': 'AnimatedBuilder'},
+                {'element': 'DefaultTextStyle'}
+              ],
+              'label': 'Button 5',
+              'view.class': 'MaterialButton'
+            }));
+      });
+    });
   });
 
   group('$SentryUserInteractionWidget performance', () {
@@ -486,7 +520,6 @@ Future<void> tapMe(
   if (pumpWidget) {
     await tester.pumpWidget(widget);
   }
-
   await tester.tap(find.byKey(Key(key)));
 }
 
@@ -604,7 +637,11 @@ class Page1 extends StatelessWidget {
                 onPressed: () {},
                 child: Text('Button text'),
               ),
-            )
+            ),
+            MaterialButton(
+              onPressed: () {},
+              child: const Text('Button 5'),
+            ),
           ],
         ),
       ),


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

- cleanup & refactoring in the first few commits (can be filtered out while reviewing)
- change the behaviour to capture all button presses, regardless of key being present
- add touch path, similar to RN

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

While working on replay, I've noticed touch is not normally captured as a breadcrumb unless user specifies keys for buttons.

## :green_heart: How did you test it?

- Existing tests and new ones
- manually in the example app: https://sentry-sdks.sentry.io/issues/4722238716/events/1503b86bd4754c649520d38f74a1158d/

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
