### PR TITLE
chore: fixup changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,6 @@
 
 ## Unreleased
 
-### Improvements
-
-- Add permissions for `INTERNET` and `ACCESS_NETWORK_STATE` in the AndroidManifest.xml of the Flutter example app. ([#2255](https://github.com/getsentry/sentry-dart/pull/2255))
-
-### Dependencies
-
-- Bump Cocoa SDK from v8.35.1 to v8.36.0 ([#2252](https://github.com/getsentry/sentry-dart/pull/2252))
-  - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8360)
-  - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.35.1...8.36.0)
-
-## 8.8.0
-
 ### Features
 
 - Session replay Alpha for Android and iOS ([#2208](https://github.com/getsentry/sentry-dart/pull/2208)).
@@ -31,8 +19,18 @@
   );
   ```
 
+### Dependencies
+
+- Bump Cocoa SDK from v8.35.1 to v8.36.0 ([#2252](https://github.com/getsentry/sentry-dart/pull/2252))
+  - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8360)
+  - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.35.1...8.36.0)
+
+## 8.8.0
+
+### Features
+
 - Add `SentryFlutter.nativeCrash()` using MethodChannels for Android and iOS ([#2239](https://github.com/getsentry/sentry-dart/pull/2239))
-  - This can be used to test if native crash reporting works  
+  - This can be used to test if native crash reporting works
 - Add `ignoreRoutes` parameter to `SentryNavigatorObserver`. ([#2218](https://github.com/getsentry/sentry-dart/pull/2218))
   - This will ignore the Routes and prevent the Route from being pushed to the Sentry server.
   - Ignored routes will also create no TTID and TTFD spans.


### PR DESCRIPTION
Fixes up changelog entry that got messed up by #2208 which had auto-merge enabled since before 8.8.0 release. The diff is not obvious at first glance: what this PR does is move replay feature to the `Unreleased` section. And removes an entry that shouldn't have been there in the first place (PR #2255)

#skip-changelog