### PR TITLE
Only access renderObject if `hasSize` is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@
   - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8360)
   - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.35.1...8.36.0)
 
+### Fixes
+
+- Only access renderObject if `hasSize` is true ([#2263](https://github.com/getsentry/sentry-dart/pull/2263))
+
 ## 8.8.0
 
 ### Features

--- a/flutter/lib/src/view_hierarchy/sentry_tree_walker.dart
+++ b/flutter/lib/src/view_hierarchy/sentry_tree_walker.dart
@@ -255,7 +255,7 @@ class _TreeWalker {
     double? alpha;
 
     final renderObject = element.renderObject;
-    if (renderObject is RenderBox) {
+    if (renderObject is RenderBox && renderObject.hasSize) {
       final offset = renderObject.localToGlobal(Offset.zero);
       if (offset.dx > 0) {
         x = offset.dx;


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Guard access to `renderObject` in tree walker

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is related to #1881, but probably does not fix the underlying issues.

## :green_heart: How did you test it?

Run app where I provoked a rendering issue by putting a `ListView` inside a `Column`. Flutter still recorded those errors, but we are not emitting errors from the sentry tree walker anymore.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps

I'm not sure that this will resolve the issue reported in #1881, as we have no info on how to reproduce those.
