### PR TITLE
fix: capture replay call on iOS

### DIFF
--- a/flutter/ios/Classes/SentryFlutterPluginApple.swift
+++ b/flutter/ios/Classes/SentryFlutterPluginApple.swift
@@ -182,7 +182,7 @@ public class SentryFlutterPluginApple: NSObject, FlutterPlugin {
         case "nativeCrash":
             crash()
 
-        case "sendReplayForEvent":
+        case "captureReplay":
 #if canImport(UIKit) && !SENTRY_NO_UIKIT && (os(iOS) || os(tvOS))
             PrivateSentrySDKOnly.captureReplay()
             result(PrivateSentrySDKOnly.getReplayId())


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Looks like a merge issue slipped in at some point. We need integration tests for replay.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps

#skip-changelog
