### PR TITLE
Fix typo in changelogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,7 +126,7 @@ SentryNavigatorObserver(ignoreRoutes: ["/ignoreThisRoute"]),
       (options) {
         options.dsn = 'https://example@sentry.io/add-your-dsn-here';
         options.proxy = SentryProxy(
-          type: SenryProxyType.http,
+          type: SentryProxyType.http,
           host: 'localhost',
           port: 8080,
         );


### PR DESCRIPTION
Fixes a small typo I stumbled upon when reading through the changelog.

#skip-changelog
