### PR TITLE
fix: event processor failed to stop processing

### DIFF
--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -558,6 +558,7 @@ class SentryClient {
               count: spanCountBeforeEventProcessors + 1);
         }
         _options.logger(SentryLevel.debug, 'Event was dropped by a processor');
+        break;
       } else if (event is SentryTransaction &&
           processedEvent is SentryTransaction) {
         // If event processor removed only some spans we still report them as dropped


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Fixes null assertion error introduced in #2154

#skip-changelog because this was caught by try-catch so actually didn't impact end users except for a log message

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
