### PR TITLE
Validation for fetchedDisplayRefreshRate

### DIFF
--- a/flutter/lib/src/span_frame_metrics_collector.dart
+++ b/flutter/lib/src/span_frame_metrics_collector.dart
@@ -12,6 +12,8 @@ import 'native/sentry_native_binding.dart';
 @internal
 class SpanFrameMetricsCollector implements PerformanceContinuousCollector {
   static const _frozenFrameThresholdMs = 700;
+  static const _defaultRefreshRate = 60;
+
   static const totalFramesKey = 'frames.total';
   static const framesDelayKey = 'frames.delay';
   static const slowFramesKey = 'frames.slow';
@@ -39,7 +41,7 @@ class SpanFrameMetricsCollector implements PerformanceContinuousCollector {
   bool get isTrackingRegistered => _isTrackingRegistered;
   bool _isTrackingRegistered = false;
 
-  int displayRefreshRate = 60;
+  int displayRefreshRate = _defaultRefreshRate;
 
   final _stopwatch = Stopwatch();
 
@@ -59,7 +61,7 @@ class SpanFrameMetricsCollector implements PerformanceContinuousCollector {
     }
 
     final fetchedDisplayRefreshRate = await _native?.displayRefreshRate();
-    if (fetchedDisplayRefreshRate != null) {
+    if (fetchedDisplayRefreshRate != null && fetchedDisplayRefreshRate > 0) {
       options.logger(SentryLevel.debug,
           'Retrieved display refresh rate at $fetchedDisplayRefreshRate');
       displayRefreshRate = fetchedDisplayRefreshRate;
@@ -251,6 +253,6 @@ class SpanFrameMetricsCollector implements PerformanceContinuousCollector {
     _isTrackingPaused = true;
     frames.clear();
     activeSpans.clear();
-    displayRefreshRate = 60;
+    displayRefreshRate = _defaultRefreshRate;
   }
 }


### PR DESCRIPTION
## :scroll: Description
Additional validation for displayRefreshRate received from the native level. 

## :bulb: Motivation and Context
We noticed that following code: 

`
final fetchedDisplayRefreshRate = await _native?.displayRefreshRate();
`

sometimes returns 0. It happens only on macOS Monterey and below (At least in our cases).  

Assigning 0 to fetchedDisplayRefreshRate leads to exception:

`
 Unsupported operation: Infinity or NaN toInt 
#0      SpanFrameMetricsCollector.calculateFrameMetrics (package:sentry_flutter/src/span_frame_metrics_collector.dart)
#1      SpanFrameMetricsCollector.onSpanFinished (package:sentry_flutter/src/span_frame_metrics_collector.dart:80)
#2      SentrySpan.finish (package:sentry/src/protocol/sentry_span.dart:81)
#3      SentryTracer.finish (package:sentry/src/sentry_tracer.dart:139)
#4      SentryTracer._finishedCallback (package:sentry/src/sentry_tracer.dart:282)
#5      SentrySpan.finish (package:sentry/src/protocol/sentry_span.dart:94)
`

Also it may lead to ui issues in the app (we faced with issues  related to displaying svg resources).  

## :green_heart: How did you test it?
Using default displayRefreshRate (60) prevents exception appearing and ui issues. 

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes

