### PR TITLE
fix: total frame rounding and reject invalid frame measurements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixes
 
+- Reject frame measurements if frames.total is less than frames.slow or frames.frozen ([#2308](https://github.com/getsentry/sentry-dart/pull/2308))
 - iOS replay integration when only `onErrorSampleRate` is specified ([#2306](https://github.com/getsentry/sentry-dart/pull/2306))
 
 ## 8.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Fixes
 
-- Reject frame measurements if frames.total is less than frames.slow or frames.frozen ([#2308](https://github.com/getsentry/sentry-dart/pull/2308))
+- Rounding error used on frames.total and reject frame measurements if frames.total is less than frames.slow or frames.frozen ([#2308](https://github.com/getsentry/sentry-dart/pull/2308))
 - iOS replay integration when only `onErrorSampleRate` is specified ([#2306](https://github.com/getsentry/sentry-dart/pull/2306))
 
 ## 8.9.0

--- a/flutter/lib/src/span_frame_metrics_collector.dart
+++ b/flutter/lib/src/span_frame_metrics_collector.dart
@@ -223,11 +223,11 @@ class SpanFrameMetricsCollector implements PerformanceContinuousCollector {
 
     final spanDuration =
         spanEndTimestamp.difference(span.startTimestamp).inMilliseconds;
+    final normalFramesCount =
+        (spanDuration - (slowFramesDuration + frozenFramesDuration)) /
+            expectedFrameDuration;
     final totalFramesCount =
-        ((spanDuration - (slowFramesDuration + frozenFramesDuration)) /
-                expectedFrameDuration) +
-            slowFramesCount +
-            frozenFramesCount;
+        (normalFramesCount + slowFramesCount + frozenFramesCount).ceil();
 
     if (totalFramesCount < 0 ||
         framesDelay < 0 ||
@@ -246,7 +246,7 @@ class SpanFrameMetricsCollector implements PerformanceContinuousCollector {
     }
 
     return {
-      SpanFrameMetricsCollector.totalFramesKey: totalFramesCount.toInt(),
+      SpanFrameMetricsCollector.totalFramesKey: totalFramesCount,
       SpanFrameMetricsCollector.framesDelayKey: framesDelay,
       SpanFrameMetricsCollector.slowFramesKey: slowFramesCount,
       SpanFrameMetricsCollector.frozenFramesKey: frozenFramesCount,

--- a/flutter/lib/src/span_frame_metrics_collector.dart
+++ b/flutter/lib/src/span_frame_metrics_collector.dart
@@ -238,6 +238,13 @@ class SpanFrameMetricsCollector implements PerformanceContinuousCollector {
       return {};
     }
 
+    if (totalFramesCount < slowFramesCount ||
+        totalFramesCount < frozenFramesCount) {
+      options.logger(SentryLevel.warning,
+          'Total frames count is less than slow or frozen frames count. Dropping frame metrics.');
+      return {};
+    }
+
     return {
       SpanFrameMetricsCollector.totalFramesKey: totalFramesCount.toInt(),
       SpanFrameMetricsCollector.framesDelayKey: framesDelay,

--- a/flutter/test/mocks.dart
+++ b/flutter/test/mocks.dart
@@ -171,7 +171,7 @@ class TestBindingWrapper implements BindingWrapper {
 
 // All these values are based on the fakeFrameDurations list.
 // The expected total frames is also based on the span duration of 1000ms and the slow and frozen frames.
-const expectedTotalFrames = 17;
+const expectedTotalFrames = 18;
 const expectedFramesDelay = 722;
 const expectedSlowFrames = 2;
 const expectedFrozenFrames = 1;

--- a/flutter/test/span_frame_metrics_collector_test.dart
+++ b/flutter/test/span_frame_metrics_collector_test.dart
@@ -162,7 +162,7 @@ void main() {
 
     final metrics = sut.calculateFrameMetrics(span, span.endTimestamp!, 60);
 
-    expect(metrics['frames.total'], 31);
+    expect(metrics['frames.total'], 32);
     expect(metrics['frames.slow'], 0);
     expect(metrics['frames.delay'], 0);
     expect(metrics['frames.frozen'], 0);
@@ -182,7 +182,7 @@ void main() {
 
     final metrics = sut.calculateFrameMetrics(span, span.endTimestamp!, 60);
 
-    expect(metrics['frames.total'], 29);
+    expect(metrics['frames.total'], 30);
     expect(metrics['frames.slow'], 1);
     expect(metrics['frames.delay'], 42);
     expect(metrics['frames.frozen'], 0);
@@ -201,7 +201,7 @@ void main() {
 
     final metrics = sut.calculateFrameMetrics(span, span.endTimestamp!, 60);
 
-    expect(metrics['frames.total'], 29);
+    expect(metrics['frames.total'], 30);
     expect(metrics['frames.slow'], 1);
     expect(metrics['frames.delay'], 42);
     expect(metrics['frames.frozen'], 0);


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
in some edge cases total frames is less than slow frames, this is due to rounding down instead of up

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes https://github.com/getsentry/sentry-dart/issues/2304
