### PR TITLE
fix(frame-tracking): app lag when long running span finishes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Fixes
 
--- Incoming Change
+- App lag with frame tracking enabled when span finishes after a long time ([#2311](https://github.com/getsentry/sentry-dart/pull/2311))
 - Only start frame tracking if we receive valid display refresh data ([#2307](https://github.com/getsentry/sentry-dart/pull/2307))
 - Rounding error used on frames.total and reject frame measurements if frames.total is less than frames.slow or frames.frozen ([#2308](https://github.com/getsentry/sentry-dart/pull/2308))
 - iOS replay integration when only `onErrorSampleRate` is specified ([#2306](https://github.com/getsentry/sentry-dart/pull/2306))

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -276,6 +276,13 @@ class SentryFlutterOptions extends SentryOptions {
   /// Defaults to `true`
   bool enableFramesTracking = true;
 
+  /// The period (in minutes) for which to retain frame information.
+  /// Used to calculate the maximum number of frames to store for active spans.
+  /// If the number of frames exceeds the maximum, the frame tracking is cancelled
+  /// and frame metrics are cleared for the current active spans.
+  /// Default value is 3 minutes.
+  int framesTrackingRetentionPeriod = 3;
+
   /// By using this, you are disabling native [Breadcrumb] tracking and instead
   /// you are just tracking [Breadcrumb]s which result from events available
   /// in the current Flutter environment.

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -276,12 +276,9 @@ class SentryFlutterOptions extends SentryOptions {
   /// Defaults to `true`
   bool enableFramesTracking = true;
 
-  /// The period (in minutes) for which to retain frame information.
-  /// Used to calculate the maximum number of frames to store for active spans.
-  /// If the number of frames exceeds the maximum, the frame tracking is cancelled
-  /// and frame metrics are cleared for the current active spans.
-  /// Default value is 3 minutes.
-  int framesTrackingRetentionPeriod = 3;
+  /// Maximum number of frames to track before clearing.
+  /// Default is 10800 frames, this equals to 3 minutes of frames at 60fps.
+  int maxFramesToTrack = 10800;
 
   /// By using this, you are disabling native [Breadcrumb] tracking and instead
   /// you are just tracking [Breadcrumb]s which result from events available

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -276,7 +276,8 @@ class SentryFlutterOptions extends SentryOptions {
   /// Defaults to `true`
   bool enableFramesTracking = true;
 
-  /// Maximum number of frames to track before clearing.
+  /// Maximum number of frames to track at a time before clearing.
+  /// Clearing cancels frame tracking for all active spans.
   /// Default is 10800 frames, this equals to 3 minutes of frames at 60fps.
   int maxFramesToTrack = 10800;
 

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -276,11 +276,6 @@ class SentryFlutterOptions extends SentryOptions {
   /// Defaults to `true`
   bool enableFramesTracking = true;
 
-  /// Maximum number of frames to track at a time before clearing.
-  /// Clearing cancels frame tracking for all active spans.
-  /// Default is 10800 frames.
-  int maxFramesToTrack = 10800;
-
   /// By using this, you are disabling native [Breadcrumb] tracking and instead
   /// you are just tracking [Breadcrumb]s which result from events available
   /// in the current Flutter environment.

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -278,7 +278,7 @@ class SentryFlutterOptions extends SentryOptions {
 
   /// Maximum number of frames to track at a time before clearing.
   /// Clearing cancels frame tracking for all active spans.
-  /// Default is 10800 frames, this equals to 3 minutes of frames at 60fps.
+  /// Default is 10800 frames.
   int maxFramesToTrack = 10800;
 
   /// By using this, you are disabling native [Breadcrumb] tracking and instead

--- a/flutter/lib/src/span_frame_metrics_collector.dart
+++ b/flutter/lib/src/span_frame_metrics_collector.dart
@@ -44,6 +44,9 @@ class SpanFrameMetricsCollector implements PerformanceContinuousCollector {
   @visibleForTesting
   int? displayRefreshRate;
 
+  @visibleForTesting
+  int maxFramesToTrack = 10800;
+
   final _stopwatch = Stopwatch();
 
   SpanFrameMetricsCollector(this.options,
@@ -118,7 +121,7 @@ class SpanFrameMetricsCollector implements PerformanceContinuousCollector {
   ///
   /// This method is called for each frame when frame tracking is active.
   Future<void> measureFrameDuration(Duration duration) async {
-    if (frames.length >= options.maxFramesToTrack) {
+    if (frames.length >= _maxFramesToTrack) {
       options.logger(SentryLevel.warning,
           'Frame tracking limit reached. Clearing frames and cancelling frame tracking for all active spans');
       clear();

--- a/flutter/lib/src/span_frame_metrics_collector.dart
+++ b/flutter/lib/src/span_frame_metrics_collector.dart
@@ -121,7 +121,7 @@ class SpanFrameMetricsCollector implements PerformanceContinuousCollector {
   ///
   /// This method is called for each frame when frame tracking is active.
   Future<void> measureFrameDuration(Duration duration) async {
-    if (frames.length >= _maxFramesToTrack) {
+    if (frames.length >= maxFramesToTrack) {
       options.logger(SentryLevel.warning,
           'Frame tracking limit reached. Clearing frames and cancelling frame tracking for all active spans');
       clear();

--- a/flutter/lib/src/span_frame_metrics_collector.dart
+++ b/flutter/lib/src/span_frame_metrics_collector.dart
@@ -91,10 +91,6 @@ class SpanFrameMetricsCollector implements PerformanceContinuousCollector {
         calculateFrameMetrics(span, endTimestamp, displayRefreshRate!);
     _applyFrameMetricsToSpan(span, frameMetrics);
 
-    for (var i = 0; i < 21000; i++) {
-      frames[DateTime.now().add(Duration(milliseconds: i))] = 14;
-    }
-
     activeSpans.remove(span);
     if (activeSpans.isEmpty) {
       clear();

--- a/flutter/lib/src/span_frame_metrics_collector.dart
+++ b/flutter/lib/src/span_frame_metrics_collector.dart
@@ -119,7 +119,7 @@ class SpanFrameMetricsCollector implements PerformanceContinuousCollector {
   /// This method is called for each frame when frame tracking is active.
   Future<void> measureFrameDuration(Duration duration) async {
     if (frames.length >= options.maxFramesToTrack) {
-      options.logger(SentryLevel.debug,
+      options.logger(SentryLevel.warning,
           'Frame tracking limit reached. Clearing frames and cancelling frame tracking for all active spans');
       clear();
       return;

--- a/flutter/lib/src/span_frame_metrics_collector.dart
+++ b/flutter/lib/src/span_frame_metrics_collector.dart
@@ -26,10 +26,12 @@ class SpanFrameMetricsCollector implements PerformanceContinuousCollector {
   /// Stores frame timestamps and their durations in milliseconds.
   /// Keys are frame timestamps, values are frame durations.
   /// The timestamps mark the end of the frame.
+  @visibleForTesting
   final frames = SplayTreeMap<DateTime, int>();
 
   /// Stores the spans that are actively being tracked.
   /// After the frames are calculated and stored in the span the span is removed from this list.
+  @visibleForTesting
   final activeSpans = SplayTreeSet<ISentrySpan>(
       (a, b) => a.startTimestamp.compareTo(b.startTimestamp));
 
@@ -60,7 +62,7 @@ class SpanFrameMetricsCollector implements PerformanceContinuousCollector {
     }
 
     final fetchedDisplayRefreshRate = await _native?.displayRefreshRate();
-    if (fetchedDisplayRefreshRate != null) {
+    if (fetchedDisplayRefreshRate != null && fetchedDisplayRefreshRate > 0) {
       options.logger(SentryLevel.debug,
           'Retrieved display refresh rate at $fetchedDisplayRefreshRate');
       displayRefreshRate = fetchedDisplayRefreshRate;
@@ -70,13 +72,20 @@ class SpanFrameMetricsCollector implements PerformanceContinuousCollector {
       startFrameTracking();
     } else {
       options.logger(SentryLevel.debug,
-          'Could not fetch display refresh rate, keeping at 60hz by default');
+          'Retrieved invalid display refresh rate: $fetchedDisplayRefreshRate. Not starting frame tracking.');
     }
   }
 
   @override
   Future<void> onSpanFinished(ISentrySpan span, DateTime endTimestamp) async {
     if (span is NoOpSentrySpan || !activeSpans.contains(span)) return;
+
+    if (displayRefreshRate == null || displayRefreshRate! <= 0) {
+      options.logger(SentryLevel.warning,
+          'Invalid display refresh rate. Skipping frame tracking for all active spans.');
+      clear();
+      return;
+    }
 
     final frameMetrics =
         calculateFrameMetrics(span, endTimestamp, displayRefreshRate!);
@@ -114,8 +123,8 @@ class SpanFrameMetricsCollector implements PerformanceContinuousCollector {
   /// This method is called for each frame when frame tracking is active.
   Future<void> measureFrameDuration(Duration duration) async {
     if (frames.length >= options.maxFramesToTrack) {
-      options.logger(
-          SentryLevel.debug, 'Frame tracking limit reached. Clearing frames.');
+      options.logger(SentryLevel.debug,
+          'Frame tracking limit reached. Clearing frames and cancelling frame tracking for all active spans');
       clear();
       return;
     }
@@ -236,11 +245,11 @@ class SpanFrameMetricsCollector implements PerformanceContinuousCollector {
 
     final spanDuration =
         spanEndTimestamp.difference(span.startTimestamp).inMilliseconds;
+    final normalFramesCount =
+        (spanDuration - (slowFramesDuration + frozenFramesDuration)) /
+            expectedFrameDuration;
     final totalFramesCount =
-        ((spanDuration - (slowFramesDuration + frozenFramesDuration)) /
-                expectedFrameDuration) +
-            slowFramesCount +
-            frozenFramesCount;
+        (normalFramesCount + slowFramesCount + frozenFramesCount).ceil();
 
     if (totalFramesCount < 0 ||
         framesDelay < 0 ||
@@ -251,8 +260,15 @@ class SpanFrameMetricsCollector implements PerformanceContinuousCollector {
       return {};
     }
 
+    if (totalFramesCount < slowFramesCount ||
+        totalFramesCount < frozenFramesCount) {
+      options.logger(SentryLevel.warning,
+          'Total frames count is less than slow or frozen frames count. Dropping frame metrics.');
+      return {};
+    }
+
     return {
-      SpanFrameMetricsCollector.totalFramesKey: totalFramesCount.toInt(),
+      SpanFrameMetricsCollector.totalFramesKey: totalFramesCount,
       SpanFrameMetricsCollector.framesDelayKey: framesDelay,
       SpanFrameMetricsCollector.slowFramesKey: slowFramesCount,
       SpanFrameMetricsCollector.frozenFramesKey: frozenFramesCount,

--- a/flutter/test/span_frame_metrics_collector_test.dart
+++ b/flutter/test/span_frame_metrics_collector_test.dart
@@ -274,7 +274,10 @@ void main() {
     sut.frames[DateTime.now()] = 1;
     sut.frameLengthLimit = 1000;
 
-    for (var i = 0; i < sut.frameLengthLimit!; i++) {
+    for (var i = 1; i <= sut.frameLengthLimit!; i++) {
+      if (i == sut.frameLengthLimit! - 1) {
+        expect(sut.frames.length, sut.frameLengthLimit! - 1);
+      }
       await sut.measureFrameDuration(Duration.zero);
     }
 

--- a/flutter/test/span_frame_metrics_collector_test.dart
+++ b/flutter/test/span_frame_metrics_collector_test.dart
@@ -269,14 +269,14 @@ void main() {
     final span = MockSentrySpan();
 
     when(span.startTimestamp).thenReturn(DateTime.now());
-
     sut.activeSpans.add(span);
     sut.frames[DateTime.now()] = 1;
-    sut.frameLengthLimit = 1000;
+    const maxFramesToTrack = 1000;
+    fixture.options.maxFramesToTrack = maxFramesToTrack;
 
-    for (var i = 1; i <= sut.frameLengthLimit!; i++) {
-      if (i == sut.frameLengthLimit! - 1) {
-        expect(sut.frames.length, sut.frameLengthLimit! - 1);
+    for (var i = 1; i <= maxFramesToTrack; i++) {
+      if (i == maxFramesToTrack - 1) {
+        expect(sut.frames.length, maxFramesToTrack - 1);
       }
       await sut.measureFrameDuration(Duration.zero);
     }

--- a/flutter/test/span_frame_metrics_collector_test.dart
+++ b/flutter/test/span_frame_metrics_collector_test.dart
@@ -272,7 +272,7 @@ void main() {
     sut.activeSpans.add(span);
     sut.frames[DateTime.now()] = 1;
     const maxFramesToTrack = 1000;
-    fixture.options.maxFramesToTrack = maxFramesToTrack;
+    sut.maxFramesToTrack = maxFramesToTrack;
 
     for (var i = 1; i <= maxFramesToTrack; i++) {
       if (i == maxFramesToTrack - 1) {

--- a/flutter/test/span_frame_metrics_collector_test.dart
+++ b/flutter/test/span_frame_metrics_collector_test.dart
@@ -261,6 +261,28 @@ void main() {
 
     expect(sut.isTrackingPaused, isTrue);
   });
+
+  test(
+      'measureFrameDuration stops and removes all frames when reaching frame limit',
+      () async {
+    final sut = fixture.sut;
+    final span = MockSentrySpan();
+
+    when(span.startTimestamp).thenReturn(DateTime.now());
+
+    sut.activeSpans.add(span);
+    sut.frames[DateTime.now()] = 1;
+    sut.frameLengthLimit = 1000;
+
+    for (var i = 0; i < sut.frameLengthLimit!; i++) {
+      await sut.measureFrameDuration(Duration.zero);
+    }
+
+    expect(sut.frames, isEmpty);
+    expect(sut.activeSpans, isEmpty);
+    expect(sut.displayRefreshRate, isNull);
+    expect(sut.isTrackingPaused, isTrue);
+  });
 }
 
 class Fixture {

--- a/flutter/test/span_frame_metrics_collector_test.dart
+++ b/flutter/test/span_frame_metrics_collector_test.dart
@@ -275,6 +275,8 @@ void main() {
     sut.maxFramesToTrack = maxFramesToTrack;
 
     for (var i = 1; i <= maxFramesToTrack; i++) {
+      await Future<void>.delayed(
+          Duration(milliseconds: 1)); // Add a small delay
       if (i == maxFramesToTrack - 1) {
         expect(sut.frames.length, maxFramesToTrack - 1);
       }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Basically when a long lasting span runs in the background (e.g 20 minutes) without ever finishing, the frame tracking keeps accumulating frames and thus takes a long time to process it.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #2298 

## :green_heart: How did you test it?
Unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
