### PR TITLE
fix(ttfd): error when calling `reportFullyDisplayed()` twice 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Rounding error used on frames.total and reject frame measurements if frames.total is less than frames.slow or frames.frozen ([#2308](https://github.com/getsentry/sentry-dart/pull/2308))
 - iOS replay integration when only `onErrorSampleRate` is specified ([#2306](https://github.com/getsentry/sentry-dart/pull/2306))
 - Fix TTID timing issue ([#2326](https://github.com/getsentry/sentry-dart/pull/2326))
+- Error when calling `SentryFlutter.reportFullyDisplayed()` twice ([#2339](https://github.com/getsentry/sentry-dart/pull/2339))
 
 ### Deprecate
 

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -249,7 +249,7 @@ mixin SentryFlutter {
       // ignore: invalid_use_of_internal_member
       Sentry.currentHub.options.logger(
         SentryLevel.error,
-        'Error while reporting fully displayed',
+        'Error while reporting TTFD',
         exception: e,
         stackTrace: stackTrace,
       );

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -242,7 +242,18 @@ mixin SentryFlutter {
   /// Reports the time it took for the screen to be fully displayed.
   /// This requires the [SentryFlutterOptions.enableTimeToFullDisplayTracing] option to be set to `true`.
   static Future<void> reportFullyDisplayed() async {
-    return SentryNavigatorObserver.timeToDisplayTracker?.reportFullyDisplayed();
+    try {
+      return SentryNavigatorObserver.timeToDisplayTracker
+          ?.reportFullyDisplayed();
+    } catch (e, stackTrace) {
+      // ignore: invalid_use_of_internal_member
+      Sentry.currentHub.options.logger(
+        SentryLevel.error,
+        'Error while reporting fully displayed',
+        exception: e,
+        stackTrace: stackTrace,
+      );
+    }
   }
 
   /// Pauses the app hang tracking.

--- a/flutter/test/navigation/time_to_full_display_tracker_test.dart
+++ b/flutter/test/navigation/time_to_full_display_tracker_test.dart
@@ -61,6 +61,25 @@ void main() {
     expect(ttfdSpan.context.description, equals('Current route full display'));
     expect(ttfdSpan.origin, equals(SentryTraceOrigins.manualUiTimeToDisplay));
   });
+
+  test('finishing ttfd twice does not throw', () async {
+    final sut = fixture.getSut();
+    final transaction = fixture.getTransaction() as SentryTracer;
+    const finishAfterDuration = Duration(seconds: 1);
+
+    Future<void>.delayed(finishAfterDuration, () {
+      sut.reportFullyDisplayed();
+      sut.reportFullyDisplayed();
+    });
+
+    await sut.track(transaction, fixture.startTimestamp);
+  });
+
+  test('finishing ttfd without starting tracker does not throw', () async {
+    final sut = fixture.getSut();
+
+    await sut.reportFullyDisplayed();
+  });
 }
 
 class Fixture {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
When completer is already finished then calling `complete()` on it again throws a StateError

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes issue taken from SDK Crash Detection:

```
StateError: null
  #0      _AsyncCompleter.complete (dart:async/future_impl.dart:84)
  #1      TimeToFullDisplayTracker.reportFullyDisplayed (package:sentry_flutter/src/navigation/time_to_full_display_tracker.dart:80)
  #2      TimeToDisplayTracker.reportFullyDisplayed (package:sentry_flutter/src/navigation/time_to_display_tracker.dart:39)
  #3      SentryFlutter.reportFullyDisplayed (package:sentry_flutter/src/sentry_flutter.dart:245)
  #4      new Future.delayed.<fn> (dart:async/future.dart:417)
  #5      Timer._createTimer.<fn> (dart:async-patch/timer_patch.dart:18)
  #6      _Timer._runTimers (dart:isolate-patch/timer_impl.dart:398)
  #7      _Timer._handleMessage (dart:isolate-patch/timer_impl.dart:429)
  #8      _RawReceivePort._handleMessage (dart:isolate-patch/isolate_patch.dart:184)
```

## :green_heart: How did you test it?
Unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
