### PR TITLE
experiment: mask CustomPaint widget

### DIFF
--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -91,6 +91,7 @@ Future<void> setupSentry(
 
       options.experimental.replay.sessionSampleRate = 1.0;
       options.experimental.replay.onErrorSampleRate = 1.0;
+      options.experimental.replay.maskAllText = false;
 
       _isIntegrationTest = isIntegrationTest;
       if (_isIntegrationTest) {
@@ -198,6 +199,17 @@ class MainScaffold extends StatelessWidget {
       body: SingleChildScrollView(
         child: Column(
           children: [
+            const CustomPaint(
+                child: Center(
+              child: Text(
+                'Custom paint',
+                style: TextStyle(
+                  fontSize: 40.0,
+                  fontWeight: FontWeight.w900,
+                  color: Color.fromARGB(255, 166, 7, 7),
+                ),
+              ),
+            )),
             if (_isIntegrationTest) const IntegrationTestWidget(),
             const Center(child: Text('Trigger an action.\n')),
             const Padding(

--- a/flutter/lib/src/replay/widget_filter.dart
+++ b/flutter/lib/src/replay/widget_filter.dart
@@ -197,7 +197,8 @@ class WidgetFilterItem {
   const WidgetFilterItem(this.color, this.bounds);
 }
 
-extension on Element {
+@internal
+extension ElementParentFinder on Element {
   Element? get parent {
     Element? result;
     visitAncestorElements((el) {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Masking `CustomPaint` which is used to render custom graphics. The problem with the solution in this PR is that this widget is used for builtin widgets too, such us buttons, ...

As such, I don't think we can reliably filter out only user-defined CustomPaint widgets. Therefore, users should add custom masking using #2324 

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Part of https://github.com/getsentry/sentry-dart/issues/1193#issuecomment-2332229529

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
