### PR TITLE
fix(ttfd): unfinished ttfd should match ttid duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ Navigator.push(
 - iOS replay integration when only `onErrorSampleRate` is specified ([#2306](https://github.com/getsentry/sentry-dart/pull/2306))
 - Fix TTID timing issue ([#2326](https://github.com/getsentry/sentry-dart/pull/2326))
 - Start missing TTFD for root screen transaction ([#2332](https://github.com/getsentry/sentry-dart/pull/2332))
+- Unfinished TTID or TTFD spans should be set to status `cancelled` ([#2347](https://github.com/getsentry/sentry-dart/pull/2347))
+  - This might happen if a user navigates to another screen while either span is unfinished
 - Accessing invalid json fields from `fetchNativeAppStart` should return null ([#2340](https://github.com/getsentry/sentry-dart/pull/2340))
 - Error when calling `SentryFlutter.reportFullyDisplayed()` twice ([#2339](https://github.com/getsentry/sentry-dart/pull/2339))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,8 +64,7 @@ Navigator.push(
 - iOS replay integration when only `onErrorSampleRate` is specified ([#2306](https://github.com/getsentry/sentry-dart/pull/2306))
 - Fix TTID timing issue ([#2326](https://github.com/getsentry/sentry-dart/pull/2326))
 - Start missing TTFD for root screen transaction ([#2332](https://github.com/getsentry/sentry-dart/pull/2332))
-- Unfinished TTID or TTFD spans should be set to status `cancelled` ([#2347](https://github.com/getsentry/sentry-dart/pull/2347))
-  - This might happen if a user navigates to another screen while either span is unfinished
+- Match TTFD to TTID end timespan if TTFD is unfinished when user navigates to another screen ([#2347](https://github.com/getsentry/sentry-dart/pull/2347))
 - Accessing invalid json fields from `fetchNativeAppStart` should return null ([#2340](https://github.com/getsentry/sentry-dart/pull/2340))
 - Error when calling `SentryFlutter.reportFullyDisplayed()` twice ([#2339](https://github.com/getsentry/sentry-dart/pull/2339))
 

--- a/flutter/lib/src/navigation/sentry_navigator_observer.dart
+++ b/flutter/lib/src/navigation/sentry_navigator_observer.dart
@@ -8,6 +8,8 @@ import 'package:meta/meta.dart';
 import '../native/native_frames.dart';
 import '../native/sentry_native_binding.dart';
 import 'time_to_display_tracker.dart';
+import 'time_to_full_display_tracker.dart';
+import 'time_to_initial_display_tracker.dart';
 
 import '../../sentry_flutter.dart';
 import '../event_processor/flutter_enricher_event_processor.dart';
@@ -313,10 +315,13 @@ class SentryNavigatorObserver extends RouteObserver<PageRoute<dynamic>> {
             SentrySpanOperations.uiTimeToInitialDisplay;
         final isTTFDSpan =
             child.context.operation == SentrySpanOperations.uiTimeToFullDisplay;
+        if (isTTFDSpan) {
+          endTimestamp = ttidEndTimestampProvider() ?? endTimestamp;
+        }
         if (!child.finished && (isTTIDSpan || isTTFDSpan)) {
           await child.finish(
             endTimestamp: endTimestamp,
-            status: SpanStatus.deadlineExceeded(),
+            status: SpanStatus.cancelled(),
           );
         }
       }

--- a/flutter/lib/src/navigation/sentry_navigator_observer.dart
+++ b/flutter/lib/src/navigation/sentry_navigator_observer.dart
@@ -322,7 +322,7 @@ class SentryNavigatorObserver extends RouteObserver<PageRoute<dynamic>> {
               : endTimestamp;
           await child.finish(
             endTimestamp: finishTimestamp,
-            status: SpanStatus.cancelled(),
+            status: SpanStatus.deadlineExceeded(),
           );
         }
       }

--- a/flutter/lib/src/navigation/sentry_navigator_observer.dart
+++ b/flutter/lib/src/navigation/sentry_navigator_observer.dart
@@ -9,7 +9,6 @@ import '../native/native_frames.dart';
 import '../native/sentry_native_binding.dart';
 import 'time_to_display_tracker.dart';
 import 'time_to_full_display_tracker.dart';
-import 'time_to_initial_display_tracker.dart';
 
 import '../../sentry_flutter.dart';
 import '../event_processor/flutter_enricher_event_processor.dart';
@@ -317,7 +316,7 @@ class SentryNavigatorObserver extends RouteObserver<PageRoute<dynamic>> {
             SentrySpanOperations.uiTimeToInitialDisplay;
         final isTTFDSpan =
             child.context.operation == SentrySpanOperations.uiTimeToFullDisplay;
-        if (!child.finished && (isTTIDSpan || isTTFDSpan)) {
+        if (isTTIDSpan || isTTFDSpan) {
           final finishTimestamp = isTTFDSpan
               ? (ttidEndTimestampProvider() ?? endTimestamp)
               : endTimestamp;

--- a/flutter/lib/src/navigation/time_to_full_display_tracker.dart
+++ b/flutter/lib/src/navigation/time_to_full_display_tracker.dart
@@ -35,7 +35,7 @@ class TimeToFullDisplayTracker {
   final options = Sentry.currentHub.options;
 
   // End timestamp provider is only needed when the TTFD timeout is triggered
-  EndTimestampProvider _endTimestampProvider = ttidEndTimestampProvider();
+  EndTimestampProvider _endTimestampProvider = ttidEndTimestampProvider;
   Completer<void> _completedTTFDTracking = Completer<void>();
 
   Future<void> track({
@@ -115,5 +115,5 @@ class TimeToFullDisplayTracker {
 typedef EndTimestampProvider = DateTime? Function();
 
 @internal
-EndTimestampProvider ttidEndTimestampProvider() =>
+EndTimestampProvider ttidEndTimestampProvider =
     () => TimeToInitialDisplayTracker().endTimestamp;

--- a/flutter/lib/src/navigation/time_to_initial_display_tracker.dart
+++ b/flutter/lib/src/navigation/time_to_initial_display_tracker.dart
@@ -129,4 +129,10 @@ class TimeToInitialDisplayTracker {
     // We can't clear the ttid end time stamp here, because it might be needed
     // in the [TimeToFullDisplayTracker] class
   }
+
+  @visibleForTesting
+  void clearForTest() {
+    clear();
+    _endTimestamp = null;
+  }
 }

--- a/flutter/test/navigation/time_to_display_tracker_test.dart
+++ b/flutter/test/navigation/time_to_display_tracker_test.dart
@@ -198,7 +198,7 @@ class Fixture {
   final options = defaultTestOptions()
     ..dsn = fakeDsn
     ..tracesSampleRate = 1.0;
-  late final endTimeProvider = ttidEndTimestampProvider();
+  late final endTimeProvider = ttidEndTimestampProvider;
   late final hub = Hub(options);
 
   TimeToInitialDisplayTracker? ttidTracker;

--- a/flutter/test/sentry_navigator_observer_test.dart
+++ b/flutter/test/sentry_navigator_observer_test.dart
@@ -380,8 +380,83 @@ void main() {
           .called(1);
     });
 
-    test(
-        'unfinished children will be finished with deadline_exceeded on didPush',
+    test('cancelled TTID and TTFD spans do not add measurements', () async {
+      final initialRoute = route(RouteSettings(name: 'Initial Route'));
+      final newRoute = route(RouteSettings(name: 'New Route'));
+
+      final hub = _MockHub();
+      final transaction = getMockSentryTracer(finished: false) as SentryTracer;
+
+      final mockChildTTID = MockSentrySpan();
+      final mockChildTTFD = MockSentrySpan();
+
+      when(transaction.children).thenReturn([
+        mockChildTTID,
+        mockChildTTFD,
+      ]);
+
+      when(transaction.measurements).thenReturn(<String, SentryMeasurement>{});
+
+      when(mockChildTTID.finished).thenReturn(false);
+      when(mockChildTTID.context).thenReturn(SentrySpanContext(
+          operation: SentrySpanOperations.uiTimeToInitialDisplay));
+      when(mockChildTTID.status).thenReturn(SpanStatus.cancelled());
+
+      when(mockChildTTFD.finished).thenReturn(false);
+      when(mockChildTTFD.context).thenReturn(SentrySpanContext(
+          operation: SentrySpanOperations.uiTimeToFullDisplay));
+      when(mockChildTTFD.status).thenReturn(SpanStatus.cancelled());
+
+      when(transaction.context)
+          .thenReturn(SentrySpanContext(operation: 'navigation'));
+      when(transaction.status).thenReturn(null);
+      when(transaction.finished).thenReturn(false);
+
+      when(transaction.startChild(
+        'ui.load.initial_display',
+        description: anyNamed('description'),
+        startTimestamp: anyNamed('startTimestamp'),
+      )).thenReturn(MockSentrySpan());
+
+      when(hub.getSpan()).thenReturn(transaction);
+      when(hub.startTransactionWithContext(
+        any,
+        startTimestamp: anyNamed('startTimestamp'),
+        waitForChildren: true,
+        autoFinishAfter: anyNamed('autoFinishAfter'),
+        trimEnd: true,
+        onFinish: anyNamed('onFinish'),
+      )).thenReturn(transaction);
+
+      final sut =
+          fixture.getSut(hub: hub, autoFinishAfter: Duration(seconds: 5));
+
+      // Simulate pushing the initial route
+      sut.didPush(initialRoute, null);
+
+      // Simulate navigating to a new route before TTID and TTFD spans finish
+      sut.didPush(newRoute, initialRoute);
+
+      // Allow async operations to complete
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      // Verify that the TTID and TTFD spans are finished with a cancelled status
+      verify(mockChildTTID.finish(
+              endTimestamp: anyNamed('endTimestamp'),
+              status: SpanStatus.cancelled()))
+          .called(1);
+      verify(mockChildTTFD.finish(
+              endTimestamp: anyNamed('endTimestamp'),
+              status: SpanStatus.cancelled()))
+          .called(1);
+
+      // Verify that the measurements are not added to the transaction
+      final measurements = transaction.measurements;
+      expect(measurements.containsKey('time_to_initial_display'), isFalse);
+      expect(measurements.containsKey('time_to_full_display'), isFalse);
+    });
+
+    test('unfinished children will be finished with cancelled on didPush',
         () async {
       final currentRoute = route(RouteSettings(name: 'Current Route'));
 
@@ -409,26 +484,22 @@ void main() {
 
       final sut = fixture.getSut(hub: hub);
 
-      // Push to new screen, e.g app start / root screen
       sut.didPush(currentRoute, null);
-
-      // Push to screen e.g root to user screen
       sut.didPush(currentRoute, null);
 
       await Future<void>.delayed(const Duration(milliseconds: 100));
 
       verify(mockChildA.finish(
               endTimestamp: captureAnyNamed('endTimestamp'),
-              status: SpanStatus.deadlineExceeded()))
+              status: SpanStatus.cancelled()))
           .called(1);
       verify(mockChildB.finish(
               endTimestamp: captureAnyNamed('endTimestamp'),
-              status: SpanStatus.deadlineExceeded()))
+              status: SpanStatus.cancelled()))
           .called(1);
     });
 
-    test(
-        'unfinished children will be finished with deadline_exceeded on didPop',
+    test('unfinished children will be finished with cancelled on didPop',
         () async {
       final currentRoute = route(RouteSettings(name: 'Current Route'));
 
@@ -466,11 +537,11 @@ void main() {
 
       verify(mockChildA.finish(
               endTimestamp: captureAnyNamed('endTimestamp'),
-              status: SpanStatus.deadlineExceeded()))
+              status: SpanStatus.cancelled()))
           .called(1);
       verify(mockChildB.finish(
               endTimestamp: captureAnyNamed('endTimestamp'),
-              status: SpanStatus.deadlineExceeded()))
+              status: SpanStatus.cancelled()))
           .called(1);
     });
 

--- a/flutter/test/sentry_navigator_observer_test.dart
+++ b/flutter/test/sentry_navigator_observer_test.dart
@@ -380,6 +380,7 @@ void main() {
           .called(1);
     });
 
+    // e.g when a user navigates to another screen before ttfd or ttid is finished
     test('cancelled TTID and TTFD spans do not add measurements', () async {
       final initialRoute = route(RouteSettings(name: 'Initial Route'));
       final newRoute = route(RouteSettings(name: 'New Route'));
@@ -443,11 +444,11 @@ void main() {
       // Verify that the TTID and TTFD spans are finished with a cancelled status
       verify(mockChildTTID.finish(
               endTimestamp: anyNamed('endTimestamp'),
-              status: SpanStatus.cancelled()))
+              status: SpanStatus.deadlineExceeded()))
           .called(1);
       verify(mockChildTTFD.finish(
               endTimestamp: anyNamed('endTimestamp'),
-              status: SpanStatus.cancelled()))
+              status: SpanStatus.deadlineExceeded()))
           .called(1);
 
       // Verify that the measurements are not added to the transaction
@@ -456,7 +457,8 @@ void main() {
       expect(measurements.containsKey('time_to_full_display'), isFalse);
     });
 
-    test('unfinished children will be finished with cancelled on didPush',
+    test(
+        'unfinished children will be finished with deadline_exceeded on didPush',
         () async {
       final currentRoute = route(RouteSettings(name: 'Current Route'));
 
@@ -491,15 +493,16 @@ void main() {
 
       verify(mockChildA.finish(
               endTimestamp: captureAnyNamed('endTimestamp'),
-              status: SpanStatus.cancelled()))
+              status: SpanStatus.deadlineExceeded()))
           .called(1);
       verify(mockChildB.finish(
               endTimestamp: captureAnyNamed('endTimestamp'),
-              status: SpanStatus.cancelled()))
+              status: SpanStatus.deadlineExceeded()))
           .called(1);
     });
 
-    test('unfinished children will be finished with cancelled on didPop',
+    test(
+        'unfinished children will be finished with deadline_exceeded on didPop',
         () async {
       final currentRoute = route(RouteSettings(name: 'Current Route'));
 
@@ -537,11 +540,11 @@ void main() {
 
       verify(mockChildA.finish(
               endTimestamp: captureAnyNamed('endTimestamp'),
-              status: SpanStatus.cancelled()))
+              status: SpanStatus.deadlineExceeded()))
           .called(1);
       verify(mockChildB.finish(
               endTimestamp: captureAnyNamed('endTimestamp'),
-              status: SpanStatus.cancelled()))
+              status: SpanStatus.deadlineExceeded()))
           .called(1);
     });
 

--- a/flutter/test/sentry_navigator_observer_test.dart
+++ b/flutter/test/sentry_navigator_observer_test.dart
@@ -505,7 +505,7 @@ void main() {
       final ttfdEndTimestamp =
           ttfdFinishVerification.captured.single as DateTime;
 
-      expect(ttfdEndTimestamp, equals(ttidEndTimestamp));
+      expect(ttfdEndTimestamp.toUtc(), equals(ttidEndTimestamp.toUtc()));
     });
 
     test(


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Set unfinished ttid, ttfd to cancelled

This might happen if the user navigates to another screen while ttfd is not finished

## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
