### PR TITLE
add webview and video widgets to the sample app

### DIFF
--- a/flutter/example/pubspec.yaml
+++ b/flutter/example/pubspec.yaml
@@ -35,6 +35,9 @@ dependencies:
   http: ^1.0.0
   hive: any  # This gets constrained by `sentry_hive`
   sqlite3_flutter_libs: ^0.5.0
+  flutter_inappwebview: ^6.1.5
+  webview_flutter: ^4.10.0
+  video_player: ^2.9.2
 
 dev_dependencies:
   flutter_lints: ^2.0.0


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Trying out if we can mask webviews & videos. Because webviews & video components are not part of the flutter core framework (instead, they're separate 3rd party plugins), we cannot checks by widget type. We could, in theory, check the name as a string but that would not work in obfuscated apps and would be counterproductive because then users would see the widgets obfuscated while testing locally (in debug builds) while they would be clearly visible when deployed in release mode (and obfuscated).

Therefore, I'd say we do not obfuscate these by default and let users do so with custom masking introduced by #2324 

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Part of https://github.com/getsentry/sentry-dart/issues/1193#issuecomment-2332229529

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
