### PR TITLE
fix: wasm test for dart beta

### DIFF
--- a/dart/test/test_utils.dart
+++ b/dart/test/test_utils.dart
@@ -158,8 +158,13 @@ Future testCaptureException(
           'sentry_browser_test.dart.browser_test.dart.js',
           'sentry_browser_test.dart.browser_test.dart.wasm'
         ]));
-    expect(topFrame['function'],
-        anyOf(['Object.wrapException', 'testCaptureException']));
+    expect(
+        topFrame['function'],
+        anyOf([
+          'Object.wrapException',
+          'testCaptureException',
+          'module0.testCaptureException'
+        ]));
 
     expect(data['event_id'], sentryId.toString());
     expect(data['timestamp'], '2017-01-02T00:00:00.000Z');


### PR DESCRIPTION
dart beta changed wasm again so we need to adjust the test

#skip-changelog