### PR TITLE
chore: temporarily disable sentry-native Windows integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Temporarily disable Windows native error & obfuscation support ([#2363](https://github.com/getsentry/sentry-dart/pull/2363))
+
 ## 8.10.0-beta.1
 
 ### Features

--- a/dart/lib/src/platform_checker.dart
+++ b/dart/lib/src/platform_checker.dart
@@ -44,10 +44,9 @@ class PlatformChecker {
     // the OS checks return true when the browser runs on the checked platform.
     // Example: platform.isAndroid return true if the browser is used on an
     // Android device.
-    return platform.isAndroid ||
-        platform.isIOS ||
-        platform.isMacOS ||
-        platform.isWindows;
+    return platform.isAndroid || platform.isIOS || platform.isMacOS;
+    // Temporarily disabled due to https://github.com/getsentry/sentry-dart-plugin/issues/270
+    // platform.isWindows
   }
 
   static bool _isWebWithWasmSupport() {

--- a/flutter/test/sentry_flutter_test.dart
+++ b/flutter/test/sentry_flutter_test.dart
@@ -249,8 +249,11 @@ void main() {
         hasFileSystemTransport: false,
       );
 
+      // Temporarily disabled due to https://github.com/getsentry/sentry-dart-plugin/issues/270
+      // testScopeObserver(
+      //     options: sentryFlutterOptions, expectedHasNativeScopeObserver: true);
       testScopeObserver(
-          options: sentryFlutterOptions, expectedHasNativeScopeObserver: true);
+          options: sentryFlutterOptions, expectedHasNativeScopeObserver: false);
 
       testConfiguration(
         integrations: integrations,
@@ -271,7 +274,9 @@ void main() {
           beforeIntegration: WidgetsFlutterBindingIntegration,
           afterIntegration: OnErrorIntegration);
 
-      expect(SentryFlutter.native, isNotNull);
+      // Temporarily disabled due to https://github.com/getsentry/sentry-dart-plugin/issues/270
+      // expect(SentryFlutter.native, isNotNull);
+      expect(SentryFlutter.native, isNull);
       expect(Sentry.currentHub.profilerFactory, isNull);
     }, testOn: 'vm');
 

--- a/flutter/test/sentry_native/sentry_native_test.dart
+++ b/flutter/test/sentry_native/sentry_native_test.dart
@@ -12,4 +12,7 @@ import 'sentry_native_test_web.dart'
 
 // Defining main() here allows us to manually run/debug from VSCode.
 // If we didn't need that, we could just `export` above.
-void main() => actual.main();
+
+// Temporarily disabled due to https://github.com/getsentry/sentry-dart-plugin/issues/270
+// void main() => actual.main();
+void main() {}

--- a/flutter/windows/CMakeLists.txt
+++ b/flutter/windows/CMakeLists.txt
@@ -4,8 +4,13 @@
 # customers of the plugin.
 cmake_minimum_required(VERSION 3.14)
 
-include("${CMAKE_CURRENT_SOURCE_DIR}/../sentry-native/sentry-native.cmake")
+# Temporarily disabled due to https://github.com/getsentry/sentry-dart-plugin/issues/270
+# include("${CMAKE_CURRENT_SOURCE_DIR}/../sentry-native/sentry-native.cmake")
 
-# Even though sentry_flutter doesn't actually provide a useful plugin, we need to accomodate the Flutter tooling.
-# sentry_flutter/sentry_flutter_plugin.h is included by the flutter-tool generated plugin registrar:
-target_include_directories(sentry INTERFACE ${CMAKE_CURRENT_LIST_DIR})
+# # Even though sentry_flutter doesn't actually provide a useful plugin, we need to accomodate the Flutter tooling.
+# # sentry_flutter/sentry_flutter_plugin.h is included by the flutter-tool generated plugin registrar:
+# target_include_directories(sentry INTERFACE ${CMAKE_CURRENT_LIST_DIR})
+
+# Temp code: replace with the previous code when sentry-native is enabled
+add_library(sentry_flutter_plugin temp.cpp)
+target_include_directories(sentry_flutter_plugin INTERFACE ${CMAKE_CURRENT_LIST_DIR})

--- a/flutter/windows/temp.cpp
+++ b/flutter/windows/temp.cpp
@@ -1,0 +1,1 @@
+// Temp code, see cmakelists.txt for more info


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Adding sentry-native to the build currently breaks symbol upload via sentry_dart_plugin so we need to disable it for now until the plugin is fixed.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

https://github.com/getsentry/sentry-dart-plugin/issues/270

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps


