### PR TITLE
enh: cache parsed dsn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Enhancements
+
+- Cache parsed DSN ([#2365](https://github.com/getsentry/sentry-dart/pull/2365))
+
 ## 8.10.0-beta.2
 
 ### Fixes

--- a/dart/lib/src/sentry.dart
+++ b/dart/lib/src/sentry.dart
@@ -273,7 +273,7 @@ class Sentry {
     }
 
     // try parsing the dsn
-    Dsn.parse(options.dsn!);
+    options.parsedDsn;
 
     return true;
   }

--- a/dart/lib/src/sentry_baggage.dart
+++ b/dart/lib/src/sentry_baggage.dart
@@ -95,9 +95,7 @@ class SentryBaggage {
   setValuesFromScope(Scope scope, SentryOptions options) {
     final propagationContext = scope.propagationContext;
     setTraceId(propagationContext.traceId.toString());
-    if (options.parsedDsn != null) {
-      setPublicKey(options.parsedDsn!.publicKey);
-    }
+    setPublicKey(options.parsedDsn.publicKey);
     if (options.release != null) {
       setRelease(options.release!);
     }

--- a/dart/lib/src/sentry_baggage.dart
+++ b/dart/lib/src/sentry_baggage.dart
@@ -95,8 +95,8 @@ class SentryBaggage {
   setValuesFromScope(Scope scope, SentryOptions options) {
     final propagationContext = scope.propagationContext;
     setTraceId(propagationContext.traceId.toString());
-    if (options.dsn != null) {
-      setPublicKey(Dsn.parse(options.dsn!).publicKey);
+    if (options.parsedDsn != null) {
+      setPublicKey(options.parsedDsn!.publicKey);
     }
     if (options.release != null) {
       setRelease(options.release!);

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -25,19 +25,24 @@ class SentryOptions {
 
   /// The DSN tells the SDK where to send the events to. If an empty string is
   /// used, the SDK will not send any events.
-  String? get dsn => _dsn;
+  String? dsn;
 
-  set dsn(String? value) {
-    _dsn = value;
-
-    assert(_dsn != null);
-    assert(_dsn!.isNotEmpty);
-    parsedDsn = Dsn.parse(_dsn!);
+  /// Uses the cached DSN if it exists otherwise parses the DSN at most once.
+  @internal
+  Dsn get parsedDsn {
+    if (cachedDsn != null) {
+      return cachedDsn!;
+    }
+    if (dsn == null || dsn!.isEmpty) {
+      throw StateError('DSN is null or empty');
+    }
+    cachedDsn = Dsn.parse(dsn!);
+    return cachedDsn!;
   }
 
-  @internal
-  late Dsn parsedDsn;
-  String? _dsn;
+  /// The cached dsn which is set at most once.
+  @visibleForTesting
+  Dsn? cachedDsn;
 
   /// If [compressPayload] is `true` the outgoing HTTP payloads are compressed
   /// using gzip. Otherwise, the payloads are sent in plain UTF8-encoded JSON
@@ -537,8 +542,7 @@ class SentryOptions {
   /// iOS only supports http proxies, while macOS also supports socks.
   SentryProxy? proxy;
 
-  SentryOptions({String? dsn, PlatformChecker? checker}) {
-    _dsn = dsn;
+  SentryOptions({this.dsn, PlatformChecker? checker}) {
     if (checker != null) {
       platformChecker = checker;
     }

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -27,22 +27,16 @@ class SentryOptions {
   /// used, the SDK will not send any events.
   String? dsn;
 
-  /// Uses the cached DSN if it exists otherwise parses the DSN at most once.
+  /// Evaluates and parses the DSN. May throw an exception if the DSN is invalid.
   @internal
-  Dsn get parsedDsn {
-    if (cachedDsn != null) {
-      return cachedDsn!;
-    }
+  late final Dsn parsedDsn = _parseDsn();
+
+  Dsn _parseDsn() {
     if (dsn == null || dsn!.isEmpty) {
       throw StateError('DSN is null or empty');
     }
-    cachedDsn = Dsn.parse(dsn!);
-    return cachedDsn!;
+    return Dsn.parse(dsn!);
   }
-
-  /// The cached dsn which is set at most once.
-  @visibleForTesting
-  Dsn? cachedDsn;
 
   /// If [compressPayload] is `true` the outgoing HTTP payloads are compressed
   /// using gzip. Otherwise, the payloads are sent in plain UTF8-encoded JSON

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -23,19 +23,32 @@ class SentryOptions {
   /// Default Log level if not specified Default is DEBUG
   static final SentryLevel _defaultDiagnosticLevel = SentryLevel.debug;
 
-  /// The DSN tells the SDK where to send the events to. If an empty string is
-  /// used, the SDK will not send any events.
-  String? dsn;
+  String? _dsn;
+  Dsn? _parsedDsn;
 
-  /// Evaluates and parses the DSN. May throw an exception if the DSN is invalid.
+  /// The DSN tells the SDK where to send the events to.
+  /// If an empty string is used, the SDK will not send any events.
+  String? get dsn => _dsn;
+
+  set dsn(String? value) {
+    if (_dsn != value) {
+      _dsn = value;
+      _parsedDsn = null; // Invalidate the cached parsed DSN
+    }
+  }
+
+  /// Evaluates and parses the DSN.
   @internal
-  late final Dsn parsedDsn = _parseDsn();
+  Dsn get parsedDsn {
+    _parsedDsn ??= _parseDsn();
+    return _parsedDsn!;
+  }
 
   Dsn _parseDsn() {
-    if (dsn == null || dsn!.isEmpty) {
+    if (_dsn == null || _dsn!.isEmpty) {
       throw StateError('DSN is null or empty');
     }
-    return Dsn.parse(dsn!);
+    return Dsn.parse(_dsn!);
   }
 
   /// If [compressPayload] is `true` the outgoing HTTP payloads are compressed
@@ -536,7 +549,8 @@ class SentryOptions {
   /// iOS only supports http proxies, while macOS also supports socks.
   SentryProxy? proxy;
 
-  SentryOptions({this.dsn, PlatformChecker? checker}) {
+  SentryOptions({String? dsn, PlatformChecker? checker}) {
+    this.dsn = dsn;
     if (checker != null) {
       platformChecker = checker;
     }

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -25,7 +25,19 @@ class SentryOptions {
 
   /// The DSN tells the SDK where to send the events to. If an empty string is
   /// used, the SDK will not send any events.
-  String? dsn;
+  String? get dsn => _dsn;
+
+  set dsn(String? value) {
+    _dsn = value;
+
+    assert(_dsn != null);
+    assert(_dsn!.isNotEmpty);
+    parsedDsn = Dsn.parse(_dsn!);
+  }
+
+  @internal
+  late Dsn parsedDsn;
+  String? _dsn;
 
   /// If [compressPayload] is `true` the outgoing HTTP payloads are compressed
   /// using gzip. Otherwise, the payloads are sent in plain UTF8-encoded JSON
@@ -525,7 +537,8 @@ class SentryOptions {
   /// iOS only supports http proxies, while macOS also supports socks.
   SentryProxy? proxy;
 
-  SentryOptions({this.dsn, PlatformChecker? checker}) {
+  SentryOptions({String? dsn, PlatformChecker? checker}) {
+    _dsn = dsn;
     if (checker != null) {
       platformChecker = checker;
     }

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -38,6 +38,7 @@ class SentryOptions {
   }
 
   /// Evaluates and parses the DSN.
+  /// May throw an exception if the DSN is invalid.
   @internal
   Dsn get parsedDsn {
     _parsedDsn ??= _parseDsn();

--- a/dart/lib/src/sentry_tracer.dart
+++ b/dart/lib/src/sentry_tracer.dart
@@ -377,7 +377,7 @@ class SentryTracer extends ISentrySpan {
 
     _sentryTraceContextHeader = SentryTraceContextHeader(
       _rootSpan.context.traceId,
-      Dsn.parse(_hub.options.dsn!).publicKey,
+      _hub.options.parsedDsn!.publicKey,
       release: _hub.options.release,
       environment: _hub.options.environment,
       userId: null, // because of PII not sending it for now

--- a/dart/lib/src/sentry_tracer.dart
+++ b/dart/lib/src/sentry_tracer.dart
@@ -377,7 +377,7 @@ class SentryTracer extends ISentrySpan {
 
     _sentryTraceContextHeader = SentryTraceContextHeader(
       _rootSpan.context.traceId,
-      _hub.options.parsedDsn!.publicKey,
+      _hub.options.parsedDsn.publicKey,
       release: _hub.options.release,
       environment: _hub.options.environment,
       userId: null, // because of PII not sending it for now

--- a/dart/lib/src/transport/http_transport.dart
+++ b/dart/lib/src/transport/http_transport.dart
@@ -31,7 +31,7 @@ class HttpTransport implements Transport {
 
   HttpTransport._(this._options, this._rateLimiter)
       : _requestHandler =
-            HttpTransportRequestHandler(_options, _options.parsedDsn!.postUri);
+            HttpTransportRequestHandler(_options, _options.parsedDsn.postUri);
 
   @override
   Future<SentryId?> send(SentryEnvelope envelope) async {

--- a/dart/lib/src/transport/http_transport.dart
+++ b/dart/lib/src/transport/http_transport.dart
@@ -30,8 +30,8 @@ class HttpTransport implements Transport {
   }
 
   HttpTransport._(this._options, this._rateLimiter)
-      : _requestHandler = HttpTransportRequestHandler(
-            _options, Dsn.parse(_options.dsn!).postUri);
+      : _requestHandler =
+            HttpTransportRequestHandler(_options, _options.parsedDsn!.postUri);
 
   @override
   Future<SentryId?> send(SentryEnvelope envelope) async {

--- a/dart/lib/src/transport/http_transport_request_handler.dart
+++ b/dart/lib/src/transport/http_transport_request_handler.dart
@@ -17,7 +17,7 @@ class HttpTransportRequestHandler {
   late _CredentialBuilder _credentialBuilder;
 
   HttpTransportRequestHandler(this._options, this._requestUri)
-      : _dsn = _options.parsedDsn!,
+      : _dsn = _options.parsedDsn,
         _headers = _buildHeaders(
           _options.platformChecker.isWeb,
           _options.sentryClientName,

--- a/dart/lib/src/transport/http_transport_request_handler.dart
+++ b/dart/lib/src/transport/http_transport_request_handler.dart
@@ -17,7 +17,7 @@ class HttpTransportRequestHandler {
   late _CredentialBuilder _credentialBuilder;
 
   HttpTransportRequestHandler(this._options, this._requestUri)
-      : _dsn = Dsn.parse(_options.dsn!),
+      : _dsn = _options.parsedDsn!,
         _headers = _buildHeaders(
           _options.platformChecker.isWeb,
           _options.sentryClientName,

--- a/dart/test/sentry_options_test.dart
+++ b/dart/test/sentry_options_test.dart
@@ -199,30 +199,27 @@ void main() {
     expect(options.enableDartSymbolication, true);
   });
 
-  test('parsedDsn is correctly cached', () {
+  test('parsedDsn is correctly parsed and cached', () {
     final options = defaultTestOptions();
-
-    // Ensure _cachedDsn is null before accessing parsedDsn
-    expect(options.cachedDsn, isNull);
 
     // Access parsedDsn for the first time
     final parsedDsn1 = options.parsedDsn;
 
-    // _cachedDsn should now be set
-    expect(options.cachedDsn, isNotNull);
+    // Verify that parsedDsn is not null
+    expect(parsedDsn1, isNotNull);
 
     // Access parsedDsn again
     final parsedDsn2 = options.parsedDsn;
 
-    // Should return the cached instance
+    // Should return the same instance since it's cached
     expect(identical(parsedDsn1, parsedDsn2), isTrue);
 
-    // Is the same as calling Dsn.parse
+    // Verify the parsed DSN fields
     final manuallyParsedDsn = Dsn.parse(options.dsn!);
-    expect(options.parsedDsn.publicKey, manuallyParsedDsn.publicKey);
-    expect(options.parsedDsn.postUri, manuallyParsedDsn.postUri);
-    expect(options.parsedDsn.projectId, manuallyParsedDsn.projectId);
-    expect(options.parsedDsn.secretKey, manuallyParsedDsn.secretKey);
-    expect(options.parsedDsn.uri, manuallyParsedDsn.uri);
+    expect(parsedDsn1.publicKey, manuallyParsedDsn.publicKey);
+    expect(parsedDsn1.postUri, manuallyParsedDsn.postUri);
+    expect(parsedDsn1.secretKey, manuallyParsedDsn.secretKey);
+    expect(parsedDsn1.projectId, manuallyParsedDsn.projectId);
+    expect(parsedDsn1.uri, manuallyParsedDsn.uri);
   });
 }

--- a/dart/test/sentry_options_test.dart
+++ b/dart/test/sentry_options_test.dart
@@ -219,4 +219,16 @@ void main() {
     expect(parsedDsn1.projectId, manuallyParsedDsn.projectId);
     expect(parsedDsn1.uri, manuallyParsedDsn.uri);
   });
+
+  test('parsedDsn throws when DSN is null', () {
+    final options = defaultTestOptions()..dsn = null;
+
+    expect(() => options.parsedDsn, throwsA(isA<StateError>()));
+  });
+
+  test('parsedDsn throws when DSN is empty', () {
+    final options = defaultTestOptions()..dsn = '';
+
+    expect(() => options.parsedDsn, throwsA(isA<StateError>()));
+  });
 }

--- a/dart/test/sentry_options_test.dart
+++ b/dart/test/sentry_options_test.dart
@@ -205,9 +205,6 @@ void main() {
     // Access parsedDsn for the first time
     final parsedDsn1 = options.parsedDsn;
 
-    // Verify that parsedDsn is not null
-    expect(parsedDsn1, isNotNull);
-
     // Access parsedDsn again
     final parsedDsn2 = options.parsedDsn;
 

--- a/dart/test/sentry_options_test.dart
+++ b/dart/test/sentry_options_test.dart
@@ -198,4 +198,31 @@ void main() {
 
     expect(options.enableDartSymbolication, true);
   });
+
+  test('parsedDsn is correctly cached', () {
+    final options = defaultTestOptions();
+
+    // Ensure _cachedDsn is null before accessing parsedDsn
+    expect(options.cachedDsn, isNull);
+
+    // Access parsedDsn for the first time
+    final parsedDsn1 = options.parsedDsn;
+
+    // _cachedDsn should now be set
+    expect(options.cachedDsn, isNotNull);
+
+    // Access parsedDsn again
+    final parsedDsn2 = options.parsedDsn;
+
+    // Should return the cached instance
+    expect(identical(parsedDsn1, parsedDsn2), isTrue);
+
+    // Is the same as calling Dsn.parse
+    final manuallyParsedDsn = Dsn.parse(options.dsn!);
+    expect(options.parsedDsn.publicKey, manuallyParsedDsn.publicKey);
+    expect(options.parsedDsn.postUri, manuallyParsedDsn.postUri);
+    expect(options.parsedDsn.projectId, manuallyParsedDsn.projectId);
+    expect(options.parsedDsn.secretKey, manuallyParsedDsn.secretKey);
+    expect(options.parsedDsn.uri, manuallyParsedDsn.uri);
+  });
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Parses and caches the dsn when accessing it.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previously we parse it every time when we access it instead of caching it

Closes #2364 

## :green_heart: How did you test it?
Unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
