### PR TITLE
Add screenshot to `SentryFeedbackWidget`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Add screenshot to `SentryFeedbackWidget` ([#2369](https://github.com/getsentry/sentry-dart/pull/2369))
+
 ### Enhancements
 
 - Cache parsed DSN ([#2365](https://github.com/getsentry/sentry-dart/pull/2365))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@
 ### Features
 
 - Add screenshot to `SentryFeedbackWidget` ([#2369](https://github.com/getsentry/sentry-dart/pull/2369))
+  - Use `SentryFlutter.captureScreenshot` to create a screenshot attachment
+  - Call `SentryFeedbackWidget` with this attachment to add it to the user feedback
+
+  ```dart
+  final id = await Sentry.captureMessage('UserFeedback');
+  final screenshot = await SentryFlutter.captureScreenshot();
+  
+  Navigator.push(
+    context,
+    MaterialPageRoute(
+      builder: (context) => SentryFeedbackWidget(
+          associatedEventId: id,
+          screenshot: screenshot,
+      ),
+      fullscreenDialog: true,
+    ),
+  );
+  ```
 
 ### Enhancements
 

--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -502,12 +502,14 @@ class MainScaffold extends StatelessWidget {
             TooltipButton(
               onPressed: () async {
                 final id = await Sentry.captureMessage('UserFeedback');
+                final screenshot = await SentryFlutter.captureScreenshot();
+
                 if (!context.mounted) return;
                 Navigator.push(
                   context,
                   MaterialPageRoute(
-                    builder: (context) =>
-                        SentryFeedbackWidget(associatedEventId: id),
+                    builder: (context) => SentryFeedbackWidget(
+                        associatedEventId: id, screenshot: screenshot),
                     fullscreenDialog: true,
                   ),
                 );

--- a/flutter/lib/src/event_processor/screenshot_event_processor.dart
+++ b/flutter/lib/src/event_processor/screenshot_event_processor.dart
@@ -30,6 +30,11 @@ class ScreenshotEventProcessor implements EventProcessor {
         _hasSentryScreenshotWidget) {
       return event;
     }
+
+    if (event.type == 'feedback') {
+      return event; // No need to attach screenshot of feedback form.
+    }
+
     final beforeScreenshot = _options.beforeScreenshot;
     if (beforeScreenshot != null) {
       try {

--- a/flutter/lib/src/event_processor/screenshot_event_processor.dart
+++ b/flutter/lib/src/event_processor/screenshot_event_processor.dart
@@ -1,12 +1,9 @@
 import 'dart:async';
-import 'dart:math';
-import 'dart:typed_data';
 import 'dart:ui';
 
 import 'package:sentry/sentry.dart';
 import '../screenshot/sentry_screenshot_widget.dart';
 import '../sentry_flutter_options.dart';
-import 'package:flutter/rendering.dart';
 import '../renderer/renderer.dart';
 import 'package:flutter/widgets.dart' as widget;
 
@@ -14,10 +11,6 @@ class ScreenshotEventProcessor implements EventProcessor {
   final SentryFlutterOptions _options;
 
   ScreenshotEventProcessor(this._options);
-
-  /// This is true when the SentryWidget is in the view hierarchy
-  bool get _hasSentryScreenshotWidget =>
-      sentryScreenshotWidgetGlobalKey.currentContext != null;
 
   @override
   Future<SentryEvent?> apply(SentryEvent event, Hint hint) async {
@@ -27,7 +20,7 @@ class ScreenshotEventProcessor implements EventProcessor {
 
     if (event.exceptions == null &&
         event.throwable == null &&
-        _hasSentryScreenshotWidget) {
+        SentryScreenshotWidget.isMounted) {
       return event;
     }
 
@@ -80,83 +73,10 @@ class ScreenshotEventProcessor implements EventProcessor {
       return event;
     }
 
-    final bytes = await _createScreenshot();
+    final bytes = await SentryScreenshotWidget.captureScreenshot(_options);
     if (bytes != null) {
       hint.screenshot = SentryAttachment.fromScreenshotData(bytes);
     }
     return event;
-  }
-
-  Future<Uint8List?> _createScreenshot() async {
-    try {
-      final renderObject =
-          sentryScreenshotWidgetGlobalKey.currentContext?.findRenderObject();
-      if (renderObject is RenderRepaintBoundary) {
-        // ignore: deprecated_member_use
-        final pixelRatio = window.devicePixelRatio;
-        var imageResult = _getImage(renderObject, pixelRatio);
-        Image image;
-        if (imageResult is Future<Image>) {
-          image = await imageResult;
-        } else {
-          image = imageResult;
-        }
-        // At the time of writing there's no other image format available which
-        // Sentry understands.
-
-        if (image.width == 0 || image.height == 0) {
-          _options.logger(SentryLevel.debug,
-              'View\'s width and height is zeroed, not taking screenshot.');
-          return null;
-        }
-
-        final targetResolution = _options.screenshotQuality.targetResolution();
-        if (targetResolution != null) {
-          var ratioWidth = targetResolution / image.width;
-          var ratioHeight = targetResolution / image.height;
-          var ratio = min(ratioWidth, ratioHeight);
-          if (ratio > 0.0 && ratio < 1.0) {
-            imageResult = _getImage(renderObject, ratio * pixelRatio);
-            if (imageResult is Future<Image>) {
-              image = await imageResult;
-            } else {
-              image = imageResult;
-            }
-          }
-        }
-        final byteData = await image.toByteData(format: ImageByteFormat.png);
-
-        final bytes = byteData?.buffer.asUint8List();
-        if (bytes?.isNotEmpty == true) {
-          return bytes;
-        } else {
-          _options.logger(SentryLevel.debug,
-              'Screenshot is 0 bytes, not attaching the image.');
-          return null;
-        }
-      }
-    } catch (exception, stackTrace) {
-      _options.logger(
-        SentryLevel.error,
-        'Taking screenshot failed.',
-        exception: exception,
-        stackTrace: stackTrace,
-      );
-      if (_options.automatedTestMode) {
-        rethrow;
-      }
-    }
-    return null;
-  }
-
-  FutureOr<Image> _getImage(
-      RenderRepaintBoundary repaintBoundary, double pixelRatio) {
-    // This one is a hack to use https://api.flutter.dev/flutter/rendering/RenderRepaintBoundary/toImage.html on versions older than 3.7 and https://api.flutter.dev/flutter/rendering/RenderRepaintBoundary/toImageSync.html on versions equal or newer than 3.7
-    try {
-      return (repaintBoundary as dynamic).toImageSync(pixelRatio: pixelRatio)
-          as Image;
-    } on NoSuchMethodError catch (_) {
-      return repaintBoundary.toImage(pixelRatio: pixelRatio);
-    }
   }
 }

--- a/flutter/lib/src/event_processor/screenshot_event_processor.dart
+++ b/flutter/lib/src/event_processor/screenshot_event_processor.dart
@@ -77,7 +77,7 @@ class ScreenshotEventProcessor implements EventProcessor {
       return event;
     }
 
-    final bytes = await captureScreenshot();
+    final bytes = await createScreenshot();
     if (bytes != null) {
       hint.screenshot = SentryAttachment.fromScreenshotData(bytes);
     }
@@ -85,7 +85,7 @@ class ScreenshotEventProcessor implements EventProcessor {
   }
 
   @internal
-  Future<Uint8List?> captureScreenshot() async {
+  Future<Uint8List?> createScreenshot() async {
     try {
       final renderObject =
           sentryScreenshotWidgetGlobalKey.currentContext?.findRenderObject();
@@ -147,7 +147,7 @@ class ScreenshotEventProcessor implements EventProcessor {
     return null;
   }
 
-  static FutureOr<Image> _getImage(
+  FutureOr<Image> _getImage(
       RenderRepaintBoundary repaintBoundary, double pixelRatio) {
     // This one is a hack to use https://api.flutter.dev/flutter/rendering/RenderRepaintBoundary/toImage.html on versions older than 3.7 and https://api.flutter.dev/flutter/rendering/RenderRepaintBoundary/toImageSync.html on versions equal or newer than 3.7
     try {

--- a/flutter/lib/src/event_processor/screenshot_event_processor.dart
+++ b/flutter/lib/src/event_processor/screenshot_event_processor.dart
@@ -1,6 +1,10 @@
 import 'dart:async';
+import 'dart:math';
+import 'dart:typed_data';
 import 'dart:ui';
 
+import 'package:flutter/rendering.dart';
+import 'package:meta/meta.dart';
 import 'package:sentry/sentry.dart';
 import '../screenshot/sentry_screenshot_widget.dart';
 import '../sentry_flutter_options.dart';
@@ -73,10 +77,84 @@ class ScreenshotEventProcessor implements EventProcessor {
       return event;
     }
 
-    final bytes = await SentryScreenshotWidget.captureScreenshot(_options);
+    final bytes = await captureScreenshot();
     if (bytes != null) {
       hint.screenshot = SentryAttachment.fromScreenshotData(bytes);
     }
     return event;
+  }
+
+  @internal
+  Future<Uint8List?> captureScreenshot() async {
+    try {
+      final renderObject =
+          sentryScreenshotWidgetGlobalKey.currentContext?.findRenderObject();
+      if (renderObject is RenderRepaintBoundary) {
+        // ignore: deprecated_member_use
+        final pixelRatio = window.devicePixelRatio;
+        var imageResult = _getImage(renderObject, pixelRatio);
+        Image image;
+        if (imageResult is Future<Image>) {
+          image = await imageResult;
+        } else {
+          image = imageResult;
+        }
+        // At the time of writing there's no other image format available which
+        // Sentry understands.
+
+        if (image.width == 0 || image.height == 0) {
+          _options.logger(SentryLevel.debug,
+              'View\'s width and height is zeroed, not taking screenshot.');
+          return null;
+        }
+
+        final targetResolution = _options.screenshotQuality.targetResolution();
+        if (targetResolution != null) {
+          var ratioWidth = targetResolution / image.width;
+          var ratioHeight = targetResolution / image.height;
+          var ratio = min(ratioWidth, ratioHeight);
+          if (ratio > 0.0 && ratio < 1.0) {
+            imageResult = _getImage(renderObject, ratio * pixelRatio);
+            if (imageResult is Future<Image>) {
+              image = await imageResult;
+            } else {
+              image = imageResult;
+            }
+          }
+        }
+        final byteData = await image.toByteData(format: ImageByteFormat.png);
+
+        final bytes = byteData?.buffer.asUint8List();
+        if (bytes?.isNotEmpty == true) {
+          return bytes;
+        } else {
+          _options.logger(SentryLevel.debug,
+              'Screenshot is 0 bytes, not attaching the image.');
+          return null;
+        }
+      }
+    } catch (exception, stackTrace) {
+      _options.logger(
+        SentryLevel.error,
+        'Taking screenshot failed.',
+        exception: exception,
+        stackTrace: stackTrace,
+      );
+      if (_options.automatedTestMode) {
+        rethrow;
+      }
+    }
+    return null;
+  }
+
+  static FutureOr<Image> _getImage(
+      RenderRepaintBoundary repaintBoundary, double pixelRatio) {
+    // This one is a hack to use https://api.flutter.dev/flutter/rendering/RenderRepaintBoundary/toImage.html on versions older than 3.7 and https://api.flutter.dev/flutter/rendering/RenderRepaintBoundary/toImageSync.html on versions equal or newer than 3.7
+    try {
+      return (repaintBoundary as dynamic).toImageSync(pixelRatio: pixelRatio)
+          as Image;
+    } on NoSuchMethodError catch (_) {
+      return repaintBoundary.toImage(pixelRatio: pixelRatio);
+    }
   }
 }

--- a/flutter/lib/src/feedback/sentry_feedback_widget.dart
+++ b/flutter/lib/src/feedback/sentry_feedback_widget.dart
@@ -21,6 +21,7 @@ class SentryFeedbackWidget extends StatefulWidget {
     this.isRequiredLabel = '(required)',
     this.isNameRequired = false,
     this.isEmailRequired = false,
+    this.screenshot,
   })  : assert(associatedEventId != const SentryId.empty()),
         _hub = hub ?? HubAdapter();
 
@@ -44,6 +45,8 @@ class SentryFeedbackWidget extends StatefulWidget {
 
   final bool isNameRequired;
   final bool isEmailRequired;
+
+  final SentryAttachment? screenshot;
 
   @override
   _SentryFeedbackWidgetState createState() => _SentryFeedbackWidgetState();
@@ -197,7 +200,12 @@ class _SentryFeedbackWidgetState extends State<SentryFeedbackWidget> {
                         name: _nameController.text,
                         associatedEventId: widget.associatedEventId,
                       );
-                      await _captureFeedback(feedback);
+                      Hint? hint;
+                      final screenshot = widget.screenshot;
+                      if (screenshot != null) {
+                        hint = Hint.withScreenshot(screenshot);
+                      }
+                      await _captureFeedback(feedback, hint);
 
                       bool mounted;
                       try {
@@ -246,7 +254,7 @@ class _SentryFeedbackWidgetState extends State<SentryFeedbackWidget> {
     return null;
   }
 
-  Future<SentryId> _captureFeedback(SentryFeedback feedback) {
-    return widget._hub.captureFeedback(feedback);
+  Future<SentryId> _captureFeedback(SentryFeedback feedback, Hint? hint) {
+    return widget._hub.captureFeedback(feedback, hint: hint);
   }
 }

--- a/flutter/lib/src/screenshot/sentry_screenshot_widget.dart
+++ b/flutter/lib/src/screenshot/sentry_screenshot_widget.dart
@@ -1,10 +1,20 @@
-import 'package:flutter/material.dart';
+import 'dart:async';
+import 'dart:math';
+import 'dart:typed_data';
+import 'dart:ui';
+
+import 'package:flutter/rendering.dart';
 import 'package:meta/meta.dart';
+
+import 'package:flutter/widgets.dart' as widgets;
+
+import '../../sentry_flutter.dart';
+import '../sentry_flutter_options.dart';
 
 /// Key which is used to identify the [RepaintBoundary]
 @internal
 final sentryScreenshotWidgetGlobalKey =
-    GlobalKey(debugLabel: 'sentry_screenshot_widget');
+    widgets.GlobalKey(debugLabel: 'sentry_screenshot_widget');
 
 /// You can add screenshots of [child] to crash reports by adding this widget.
 /// Ideally you are adding it around your app widget like in the following
@@ -21,19 +31,99 @@ final sentryScreenshotWidgetGlobalKey =
 ///   information see https://flutter.dev/docs/development/tools/web-renderers
 /// - You can only have one [SentryScreenshotWidget] widget in your widget tree at all
 ///   times.
-class SentryScreenshotWidget extends StatefulWidget {
-  final Widget child;
+class SentryScreenshotWidget extends widgets.StatefulWidget {
+  final widgets.Widget child;
 
   const SentryScreenshotWidget({super.key, required this.child});
 
   @override
   _SentryScreenshotWidgetState createState() => _SentryScreenshotWidgetState();
+
+  /// This is true when the [SentryScreenshotWidget] is in the widget tree.
+  static bool get isMounted =>
+      sentryScreenshotWidgetGlobalKey.currentContext != null;
+
+  @internal
+  static Future<Uint8List?> captureScreenshot(
+      SentryFlutterOptions options) async {
+    try {
+      final renderObject =
+          sentryScreenshotWidgetGlobalKey.currentContext?.findRenderObject();
+      if (renderObject is RenderRepaintBoundary) {
+        // ignore: deprecated_member_use
+        final pixelRatio = window.devicePixelRatio;
+        var imageResult = _getImage(renderObject, pixelRatio);
+        Image image;
+        if (imageResult is Future<Image>) {
+          image = await imageResult;
+        } else {
+          image = imageResult;
+        }
+        // At the time of writing there's no other image format available which
+        // Sentry understands.
+
+        if (image.width == 0 || image.height == 0) {
+          options.logger(SentryLevel.debug,
+              'View\'s width and height is zeroed, not taking screenshot.');
+          return null;
+        }
+
+        final targetResolution = options.screenshotQuality.targetResolution();
+        if (targetResolution != null) {
+          var ratioWidth = targetResolution / image.width;
+          var ratioHeight = targetResolution / image.height;
+          var ratio = min(ratioWidth, ratioHeight);
+          if (ratio > 0.0 && ratio < 1.0) {
+            imageResult = _getImage(renderObject, ratio * pixelRatio);
+            if (imageResult is Future<Image>) {
+              image = await imageResult;
+            } else {
+              image = imageResult;
+            }
+          }
+        }
+        final byteData = await image.toByteData(format: ImageByteFormat.png);
+
+        final bytes = byteData?.buffer.asUint8List();
+        if (bytes?.isNotEmpty == true) {
+          return bytes;
+        } else {
+          options.logger(SentryLevel.debug,
+              'Screenshot is 0 bytes, not attaching the image.');
+          return null;
+        }
+      }
+    } catch (exception, stackTrace) {
+      options.logger(
+        SentryLevel.error,
+        'Taking screenshot failed.',
+        exception: exception,
+        stackTrace: stackTrace,
+      );
+      if (options.automatedTestMode) {
+        rethrow;
+      }
+    }
+    return null;
+  }
+
+  static FutureOr<Image> _getImage(
+      RenderRepaintBoundary repaintBoundary, double pixelRatio) {
+    // This one is a hack to use https://api.flutter.dev/flutter/rendering/RenderRepaintBoundary/toImage.html on versions older than 3.7 and https://api.flutter.dev/flutter/rendering/RenderRepaintBoundary/toImageSync.html on versions equal or newer than 3.7
+    try {
+      return (repaintBoundary as dynamic).toImageSync(pixelRatio: pixelRatio)
+          as Image;
+    } on NoSuchMethodError catch (_) {
+      return repaintBoundary.toImage(pixelRatio: pixelRatio);
+    }
+  }
 }
 
-class _SentryScreenshotWidgetState extends State<SentryScreenshotWidget> {
+class _SentryScreenshotWidgetState
+    extends widgets.State<SentryScreenshotWidget> {
   @override
-  Widget build(BuildContext context) {
-    return RepaintBoundary(
+  widgets.Widget build(widgets.BuildContext context) {
+    return widgets.RepaintBoundary(
       key: sentryScreenshotWidgetGlobalKey,
       child: widget.child,
     );

--- a/flutter/lib/src/screenshot/sentry_screenshot_widget.dart
+++ b/flutter/lib/src/screenshot/sentry_screenshot_widget.dart
@@ -1,14 +1,6 @@
-import 'dart:async';
-import 'dart:math';
-import 'dart:typed_data';
-import 'dart:ui';
-
-import 'package:flutter/rendering.dart';
 import 'package:meta/meta.dart';
 
 import 'package:flutter/widgets.dart' as widgets;
-
-import '../../sentry_flutter.dart';
 
 /// Key which is used to identify the [RepaintBoundary]
 @internal
@@ -41,81 +33,6 @@ class SentryScreenshotWidget extends widgets.StatefulWidget {
   /// This is true when the [SentryScreenshotWidget] is in the widget tree.
   static bool get isMounted =>
       sentryScreenshotWidgetGlobalKey.currentContext != null;
-
-  @internal
-  static Future<Uint8List?> captureScreenshot(
-      SentryFlutterOptions options) async {
-    try {
-      final renderObject =
-          sentryScreenshotWidgetGlobalKey.currentContext?.findRenderObject();
-      if (renderObject is RenderRepaintBoundary) {
-        // ignore: deprecated_member_use
-        final pixelRatio = window.devicePixelRatio;
-        var imageResult = _getImage(renderObject, pixelRatio);
-        Image image;
-        if (imageResult is Future<Image>) {
-          image = await imageResult;
-        } else {
-          image = imageResult;
-        }
-        // At the time of writing there's no other image format available which
-        // Sentry understands.
-
-        if (image.width == 0 || image.height == 0) {
-          options.logger(SentryLevel.debug,
-              'View\'s width and height is zeroed, not taking screenshot.');
-          return null;
-        }
-
-        final targetResolution = options.screenshotQuality.targetResolution();
-        if (targetResolution != null) {
-          var ratioWidth = targetResolution / image.width;
-          var ratioHeight = targetResolution / image.height;
-          var ratio = min(ratioWidth, ratioHeight);
-          if (ratio > 0.0 && ratio < 1.0) {
-            imageResult = _getImage(renderObject, ratio * pixelRatio);
-            if (imageResult is Future<Image>) {
-              image = await imageResult;
-            } else {
-              image = imageResult;
-            }
-          }
-        }
-        final byteData = await image.toByteData(format: ImageByteFormat.png);
-
-        final bytes = byteData?.buffer.asUint8List();
-        if (bytes?.isNotEmpty == true) {
-          return bytes;
-        } else {
-          options.logger(SentryLevel.debug,
-              'Screenshot is 0 bytes, not attaching the image.');
-          return null;
-        }
-      }
-    } catch (exception, stackTrace) {
-      options.logger(
-        SentryLevel.error,
-        'Taking screenshot failed.',
-        exception: exception,
-        stackTrace: stackTrace,
-      );
-      if (options.automatedTestMode) {
-        rethrow;
-      }
-    }
-    return null;
-  }
-
-  static FutureOr<Image> _getImage(
-      RenderRepaintBoundary repaintBoundary, double pixelRatio) {
-    // This one is a hack to use https://api.flutter.dev/flutter/rendering/RenderRepaintBoundary/toImage.html on versions older than 3.7 and https://api.flutter.dev/flutter/rendering/RenderRepaintBoundary/toImageSync.html on versions equal or newer than 3.7
-    try {
-      return (repaintBoundary as dynamic).toImageSync(pixelRatio: pixelRatio)
-          as Image;
-    } on NoSuchMethodError catch (_) {
-      return repaintBoundary.toImage(pixelRatio: pixelRatio);
-    }
-  }
 }
 
 class _SentryScreenshotWidgetState

--- a/flutter/lib/src/screenshot/sentry_screenshot_widget.dart
+++ b/flutter/lib/src/screenshot/sentry_screenshot_widget.dart
@@ -9,7 +9,6 @@ import 'package:meta/meta.dart';
 import 'package:flutter/widgets.dart' as widgets;
 
 import '../../sentry_flutter.dart';
-import '../sentry_flutter_options.dart';
 
 /// Key which is used to identify the [RepaintBoundary]
 @internal

--- a/flutter/lib/src/screenshot/sentry_screenshot_widget.dart
+++ b/flutter/lib/src/screenshot/sentry_screenshot_widget.dart
@@ -1,11 +1,10 @@
+import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
-
-import 'package:flutter/widgets.dart' as widgets;
 
 /// Key which is used to identify the [RepaintBoundary]
 @internal
 final sentryScreenshotWidgetGlobalKey =
-    widgets.GlobalKey(debugLabel: 'sentry_screenshot_widget');
+    GlobalKey(debugLabel: 'sentry_screenshot_widget');
 
 /// You can add screenshots of [child] to crash reports by adding this widget.
 /// Ideally you are adding it around your app widget like in the following
@@ -22,8 +21,8 @@ final sentryScreenshotWidgetGlobalKey =
 ///   information see https://flutter.dev/docs/development/tools/web-renderers
 /// - You can only have one [SentryScreenshotWidget] widget in your widget tree at all
 ///   times.
-class SentryScreenshotWidget extends widgets.StatefulWidget {
-  final widgets.Widget child;
+class SentryScreenshotWidget extends StatefulWidget {
+  final Widget child;
 
   const SentryScreenshotWidget({super.key, required this.child});
 
@@ -35,11 +34,10 @@ class SentryScreenshotWidget extends widgets.StatefulWidget {
       sentryScreenshotWidgetGlobalKey.currentContext != null;
 }
 
-class _SentryScreenshotWidgetState
-    extends widgets.State<SentryScreenshotWidget> {
+class _SentryScreenshotWidgetState extends State<SentryScreenshotWidget> {
   @override
-  widgets.Widget build(widgets.BuildContext context) {
-    return widgets.RepaintBoundary(
+  Widget build(BuildContext context) {
+    return RepaintBoundary(
       key: sentryScreenshotWidgetGlobalKey,
       child: widget.child,
     );

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -9,7 +9,6 @@ import 'event_processor/android_platform_exception_event_processor.dart';
 import 'event_processor/flutter_enricher_event_processor.dart';
 import 'event_processor/flutter_exception_event_processor.dart';
 import 'event_processor/platform_exception_event_processor.dart';
-import 'event_processor/screenshot_event_processor.dart';
 import 'event_processor/url_filter/url_filter_event_processor.dart';
 import 'event_processor/widget_event_processor.dart';
 import 'file_system_transport.dart';

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -9,6 +9,7 @@ import 'event_processor/android_platform_exception_event_processor.dart';
 import 'event_processor/flutter_enricher_event_processor.dart';
 import 'event_processor/flutter_exception_event_processor.dart';
 import 'event_processor/platform_exception_event_processor.dart';
+import 'event_processor/screenshot_event_processor.dart';
 import 'event_processor/url_filter/url_filter_event_processor.dart';
 import 'event_processor/widget_event_processor.dart';
 import 'file_system_transport.dart';
@@ -282,6 +283,27 @@ mixin SentryFlutter {
     } else {
       await _native!.resumeAppHangTracking();
     }
+  }
+
+  /// Uses [SentryScreenshotWidget] to capture the current screen as a
+  /// [SentryAttachment].
+  static Future<SentryAttachment?> captureScreenshot() async {
+    // ignore: invalid_use_of_internal_member
+    final options = Sentry.currentHub.options;
+    if (!SentryScreenshotWidget.isMounted) {
+      options.logger(
+        SentryLevel.debug,
+        'SentryScreenshotWidget could not be found in the widget tree.',
+      );
+      return null;
+    }
+    if (options is SentryFlutterOptions) {
+      final bytes = await SentryScreenshotWidget.captureScreenshot(options);
+      if (bytes != null) {
+        return SentryAttachment.fromScreenshotData(bytes);
+      }
+    }
+    return null;
   }
 
   @internal

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -307,7 +307,7 @@ mixin SentryFlutter {
       return null;
     }
     final processor = processors.first;
-    final bytes = await processor.captureScreenshot();
+    final bytes = await processor.createScreenshot();
     if (bytes != null) {
       return SentryAttachment.fromScreenshotData(bytes);
     } else {

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -9,6 +9,7 @@ import 'event_processor/android_platform_exception_event_processor.dart';
 import 'event_processor/flutter_enricher_event_processor.dart';
 import 'event_processor/flutter_exception_event_processor.dart';
 import 'event_processor/platform_exception_event_processor.dart';
+import 'event_processor/screenshot_event_processor.dart';
 import 'event_processor/url_filter/url_filter_event_processor.dart';
 import 'event_processor/widget_event_processor.dart';
 import 'file_system_transport.dart';
@@ -296,13 +297,22 @@ mixin SentryFlutter {
       );
       return null;
     }
-    if (options is SentryFlutterOptions) {
-      final bytes = await SentryScreenshotWidget.captureScreenshot(options);
-      if (bytes != null) {
-        return SentryAttachment.fromScreenshotData(bytes);
-      }
+    final processors =
+        options.eventProcessors.whereType<ScreenshotEventProcessor>();
+    if (processors.isEmpty) {
+      options.logger(
+        SentryLevel.debug,
+        'ScreenshotEventProcessor could not be found.',
+      );
+      return null;
     }
-    return null;
+    final processor = processors.first;
+    final bytes = await processor.captureScreenshot();
+    if (bytes != null) {
+      return SentryAttachment.fromScreenshotData(bytes);
+    } else {
+      return null;
+    }
   }
 
   @internal

--- a/flutter/test/event_processor/screenshot_event_processor_test.dart
+++ b/flutter/test/event_processor/screenshot_event_processor_test.dart
@@ -96,6 +96,36 @@ void main() {
         added: true, isWeb: false, expectedMaxWidthOrHeight: widthOrHeight);
   });
 
+  testWidgets('does not add screenshot for feedback events', (tester) async {
+    await tester.runAsync(() async {
+      final sut = fixture.getSut(null, false);
+
+      await tester.pumpWidget(
+        SentryScreenshotWidget(
+          child: Text('Catching Pokémon is a snap!',
+              textDirection: TextDirection.ltr),
+        ),
+      );
+
+      final feedback = SentryFeedback(
+        message: 'message',
+        contactEmail: 'foo@bar.com',
+        name: 'Joe Dirt',
+        associatedEventId: null,
+      );
+      final feedbackEvent = SentryEvent(
+        type: 'feedback',
+        contexts: Contexts(feedback: feedback),
+        level: SentryLevel.info,
+      );
+
+      final hint = Hint();
+      await sut.apply(feedbackEvent, hint);
+
+      expect(hint.screenshot, isNull);
+    });
+  });
+
   group('beforeScreenshot', () {
     testWidgets('does add screenshot if beforeScreenshot returns true',
         (tester) async {

--- a/flutter/test/feedback/sentry_feedback_widget_test.dart
+++ b/flutter/test/feedback/sentry_feedback_widget_test.dart
@@ -143,6 +143,15 @@ void main() {
     });
 
     testWidgets('does call hub captureFeedback on submit', (tester) async {
+      await fixture.pumpFeedbackWidget(
+        tester,
+        (hub) => SentryFeedbackWidget(
+          hub: hub,
+          associatedEventId:
+              SentryId.fromId('1988bb1b6f0d4c509e232f0cb9aaeaea'),
+        ),
+      );
+
       when(fixture.hub.captureFeedback(
         any,
         hint: anyNamed('hint'),

--- a/flutter/test/feedback/sentry_feedback_widget_test.dart
+++ b/flutter/test/feedback/sentry_feedback_widget_test.dart
@@ -104,16 +104,45 @@ void main() {
       fixture = Fixture();
     });
 
-    testWidgets('does call hub captureFeedback on submit', (tester) async {
+    testWidgets('does add screenshot attachment to hint', (tester) async {
+      final screenshot = SentryAttachment.fromIntList([0, 0, 0, 0], 'test.png');
+
       await fixture.pumpFeedbackWidget(
         tester,
         (hub) => SentryFeedbackWidget(
           hub: hub,
-          associatedEventId:
-              SentryId.fromId('1988bb1b6f0d4c509e232f0cb9aaeaea'),
+          screenshot: screenshot,
         ),
       );
 
+      when(fixture.hub.captureFeedback(
+        any,
+        hint: anyNamed('hint'),
+        withScope: anyNamed('withScope'),
+      )).thenAnswer(
+          (_) async => SentryId.fromId('1988bb1b6f0d4c509e232f0cb9aaeaea'));
+
+      await tester.enterText(
+          find.byKey(ValueKey('sentry_feedback_name_textfield')),
+          "fixture-name");
+      await tester.enterText(
+          find.byKey(ValueKey('sentry_feedback_email_textfield')),
+          "fixture-email");
+      await tester.enterText(
+          find.byKey(ValueKey('sentry_feedback_message_textfield')),
+          "fixture-message");
+      await tester.tap(find.text('Send Bug Report'));
+      await tester.pumpAndSettle();
+
+      verify(fixture.hub.captureFeedback(
+        any,
+        hint: argThat(predicate<Hint>((hint) => hint.screenshot == screenshot),
+            named: 'hint'),
+        withScope: anyNamed('withScope'),
+      )).called(1);
+    });
+
+    testWidgets('does call hub captureFeedback on submit', (tester) async {
       when(fixture.hub.captureFeedback(
         any,
         hint: anyNamed('hint'),

--- a/min_version_test/lib/main.dart
+++ b/min_version_test/lib/main.dart
@@ -144,7 +144,7 @@ class _MyHomePageState extends State<MyHomePage> {
             Text(
               '$_counter',
               // ignore: deprecated_member_use
-              style: Theme.of(context).textTheme.headline4,
+              style: Theme.of(context).textTheme.headlineMedium,
             ),
           ],
         ),


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->


Add the option to add a screenshot `SentryAttachment` to the `SentryFeedbackWidget`

<img width="2265" alt="Bildschirmfoto 2024-10-22 um 17 20 47" src="https://github.com/user-attachments/assets/75f17ed4-6ff8-4309-b749-ee4eaedcd6bb">

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes to #1593

## :green_heart: How did you test it?

Unit tests, example app.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes

