### PR TITLE
Handle backpressure earlier in pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@
 ### Enhancements
 
 - Cache parsed DSN ([#2365](https://github.com/getsentry/sentry-dart/pull/2365))
-
+- Handle backpressure earlier in pipeline ([#2371](https://github.com/getsentry/sentry-dart/pull/2371))
+  - Drops max un-awaited parallel tasks earlier, so event processors & callbacks are not executed for them. 
+  - Change by setting `SentryOptions.maxQueueSize`. Default is 30.
+  
 ## 8.10.0-beta.2
 
 ### Fixes

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -25,7 +25,6 @@ import 'transport/http_transport.dart';
 import 'transport/noop_transport.dart';
 import 'transport/rate_limiter.dart';
 import 'transport/spotlight_http_transport.dart';
-import 'transport/task_queue.dart';
 import 'utils/isolate_utils.dart';
 import 'utils/regex_utils.dart';
 import 'utils/stacktrace_utils.dart';
@@ -39,10 +38,6 @@ const _defaultIpAddress = '{{auto}}';
 /// Logs crash reports and events to the Sentry.io service.
 class SentryClient {
   final SentryOptions _options;
-  late final _taskQueue = TaskQueue<SentryId?>(
-    _options.maxQueueSize,
-    _options.logger,
-  );
 
   final Random? _random;
 
@@ -630,9 +625,6 @@ class SentryClient {
   Future<SentryId?> _attachClientReportsAndSend(SentryEnvelope envelope) {
     final clientReport = _options.recorder.flush();
     envelope.addClientReport(clientReport);
-    return _taskQueue.enqueue(
-      () => _options.transport.send(envelope),
-      SentryId.empty(),
-    );
+    return _options.transport.send(envelope);
   }
 }

--- a/dart/lib/src/transport/task_queue.dart
+++ b/dart/lib/src/transport/task_queue.dart
@@ -3,28 +3,39 @@ import 'dart:async';
 import 'package:meta/meta.dart';
 
 import '../../sentry.dart';
+import '../client_reports/client_report_recorder.dart';
+import '../client_reports/discard_reason.dart';
+import 'data_category.dart';
 
 typedef Task<T> = Future<T> Function();
 
 @internal
 abstract class TaskQueue<T> {
-  Future<T> enqueue(Task<T> task, T fallbackResult, String warning);
+  Future<T> enqueue(Task<T> task, T fallbackResult, DataCategory category);
 }
 
 @internal
 class DefaultTaskQueue<T> implements TaskQueue<T> {
-  DefaultTaskQueue(this._maxQueueSize, this._logger);
+  DefaultTaskQueue(this._maxQueueSize, this._logger, this._recorder);
 
   final int _maxQueueSize;
   final SentryLogger _logger;
+  final ClientReportRecorder _recorder;
 
   int _queueCount = 0;
 
   @override
-  Future<T> enqueue(Task<T> task, T fallbackResult, String taskName) async {
+  Future<T> enqueue(
+    Task<T> task,
+    T fallbackResult,
+    DataCategory category,
+  ) async {
     if (_queueCount >= _maxQueueSize) {
-      _logger(SentryLevel.warning,
-          '$taskName dropped due to backpressure. Avoid capturing in a tight loop.');
+      _recorder.recordLostEvent(DiscardReason.queueOverflow, category);
+      _logger(
+        SentryLevel.warning,
+        'Task dropped due to reaching max ($_maxQueueSize} parallel tasks.).',
+      );
       return fallbackResult;
     } else {
       _queueCount++;
@@ -40,7 +51,11 @@ class DefaultTaskQueue<T> implements TaskQueue<T> {
 @internal
 class NoOpTaskQueue<T> implements TaskQueue<T> {
   @override
-  Future<T> enqueue(Task<T> task, T fallbackResult, String warning) {
+  Future<T> enqueue(
+    Task<T> task,
+    T fallbackResult,
+    DataCategory category,
+  ) {
     return task();
   }
 }

--- a/dart/lib/src/transport/task_queue.dart
+++ b/dart/lib/src/transport/task_queue.dart
@@ -1,21 +1,30 @@
 import 'dart:async';
 
+import 'package:meta/meta.dart';
+
 import '../../sentry.dart';
 
 typedef Task<T> = Future<T> Function();
 
-class TaskQueue<T> {
-  TaskQueue(this._maxQueueSize, this._logger);
+@internal
+abstract class TaskQueue<T> {
+  Future<T> enqueue(Task<T> task, T fallbackResult, String warning);
+}
+
+@internal
+class DefaultTaskQueue<T> implements TaskQueue<T> {
+  DefaultTaskQueue(this._maxQueueSize, this._logger);
 
   final int _maxQueueSize;
   final SentryLogger _logger;
 
   int _queueCount = 0;
 
-  Future<T> enqueue(Task<T> task, T fallbackResult) async {
+  @override
+  Future<T> enqueue(Task<T> task, T fallbackResult, String taskName) async {
     if (_queueCount >= _maxQueueSize) {
       _logger(SentryLevel.warning,
-          'Task dropped due to backpressure. Avoid capturing in a tight loop.');
+          '$taskName dropped due to backpressure. Avoid capturing in a tight loop.');
       return fallbackResult;
     } else {
       _queueCount++;
@@ -25,5 +34,13 @@ class TaskQueue<T> {
         _queueCount--;
       }
     }
+  }
+}
+
+@internal
+class NoOpTaskQueue<T> implements TaskQueue<T> {
+  @override
+  Future<T> enqueue(Task<T> task, T fallbackResult, String warning) {
+    return task();
   }
 }

--- a/dart/test/transport/tesk_queue_test.dart
+++ b/dart/test/transport/tesk_queue_test.dart
@@ -1,8 +1,11 @@
 import 'dart:async';
 
+import 'package:sentry/src/client_reports/discard_reason.dart';
+import 'package:sentry/src/transport/data_category.dart';
 import 'package:sentry/src/transport/task_queue.dart';
 import 'package:test/test.dart';
 
+import '../mocks/mock_client_report_recorder.dart';
 import '../test_utils.dart';
 
 void main() {
@@ -25,7 +28,7 @@ void main() {
           await Future.delayed(Duration(milliseconds: 1));
           completedTasks += 1;
           return 1 + 1;
-        }, -1, 'foo'));
+        }, -1, DataCategory.error));
       }
 
       // This will always await the other futures, even if they are running longer, as it was scheduled after them.
@@ -48,7 +51,7 @@ void main() {
           print('Completed task $i');
           completedTasks += 1;
           return 1 + 1;
-        }, -1, 'foo'));
+        }, -1, DataCategory.error));
       }
 
       print('Started waiting for first 5 tasks');
@@ -62,7 +65,7 @@ void main() {
           print('Completed task $i');
           completedTasks += 1;
           return 1 + 1;
-        }, -1, 'foo'));
+        }, -1, DataCategory.error));
       }
 
       print('Started waiting for second 5 tasks');
@@ -83,7 +86,7 @@ void main() {
           await Future.delayed(Duration(milliseconds: 1));
           completedTasks += 1;
           return 1 + 1;
-        }, -1, 'foo');
+        }, -1, DataCategory.error);
       }
       expect(completedTasks, 10);
     });
@@ -98,12 +101,35 @@ void main() {
           await sut.enqueue(() async {
             completedTasks += 1;
             throw Error();
-          }, -1, 'foo');
+          }, -1, DataCategory.error);
         } catch (_) {
           // Ignore
         }
       }
       expect(completedTasks, 10);
+    });
+
+    test('recording dropped event when category set', () async {
+      final sut = fixture.getSut(maxQueueSize: 5);
+
+      for (int i = 0; i < 10; i++) {
+        unawaited(sut.enqueue(() async {
+          print('Task $i');
+          return 1 + 1;
+        }, -1, DataCategory.error));
+      }
+
+      // This will always await the other futures, even if they are running longer, as it was scheduled after them.
+      print('Started waiting for first 5 tasks');
+      await Future.delayed(Duration(milliseconds: 1));
+      print('Stopped waiting for first 5 tasks');
+
+      expect(fixture.clientReportRecorder.discardedEvents.length, 5);
+      for (final event in fixture.clientReportRecorder.discardedEvents) {
+        expect(event.reason, DiscardReason.queueOverflow);
+        expect(event.category, DataCategory.error);
+        expect(event.quantity, 1);
+      }
     });
   });
 }
@@ -111,7 +137,9 @@ void main() {
 class Fixture {
   final options = defaultTestOptions();
 
+  late var clientReportRecorder = MockClientReportRecorder();
+
   TaskQueue<int> getSut({required int maxQueueSize}) {
-    return DefaultTaskQueue(maxQueueSize, options.logger);
+    return DefaultTaskQueue(maxQueueSize, options.logger, clientReportRecorder);
   }
 }

--- a/dart/test/transport/tesk_queue_test.dart
+++ b/dart/test/transport/tesk_queue_test.dart
@@ -25,7 +25,7 @@ void main() {
           await Future.delayed(Duration(milliseconds: 1));
           completedTasks += 1;
           return 1 + 1;
-        }, -1));
+        }, -1, 'foo'));
       }
 
       // This will always await the other futures, even if they are running longer, as it was scheduled after them.
@@ -48,7 +48,7 @@ void main() {
           print('Completed task $i');
           completedTasks += 1;
           return 1 + 1;
-        }, -1));
+        }, -1, 'foo'));
       }
 
       print('Started waiting for first 5 tasks');
@@ -62,7 +62,7 @@ void main() {
           print('Completed task $i');
           completedTasks += 1;
           return 1 + 1;
-        }, -1));
+        }, -1, 'foo'));
       }
 
       print('Started waiting for second 5 tasks');
@@ -83,7 +83,7 @@ void main() {
           await Future.delayed(Duration(milliseconds: 1));
           completedTasks += 1;
           return 1 + 1;
-        }, -1);
+        }, -1, 'foo');
       }
       expect(completedTasks, 10);
     });
@@ -98,7 +98,7 @@ void main() {
           await sut.enqueue(() async {
             completedTasks += 1;
             throw Error();
-          }, -1);
+          }, -1, 'foo');
         } catch (_) {
           // Ignore
         }
@@ -112,6 +112,6 @@ class Fixture {
   final options = defaultTestOptions();
 
   TaskQueue<int> getSut({required int maxQueueSize}) {
-    return TaskQueue(maxQueueSize, options.logger);
+    return DefaultTaskQueue(maxQueueSize, options.logger);
   }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Move the task queue where we limit the number of consecutive un-awaited SDK tasks to the earliest possible point in the SDK. That way we don't run event processors on events/transactions that will get dropped eventually.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Relates to #2360
Relates to #2368

## :green_heart: How did you test it?

CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

@buenaflor I think we should also keep #2368, as it is debouncing based on time, and the task queue is about how many parallel tasks can be scheduled with sentry, independent from their duration. WDYT?
