### PR TITLE
chore(deps): update iOS SDK to 3.18.0 and Android SDK to 7.16.0

### DIFF
--- a/flutter/android/build.gradle
+++ b/flutter/android/build.gradle
@@ -60,7 +60,7 @@ android {
 }
 
 dependencies {
-    api 'io.sentry:sentry-android:7.15.0'
+    api 'io.sentry:sentry-android:7.16.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     // Required -- JUnit 4 framework

--- a/flutter/ios/sentry_flutter.podspec
+++ b/flutter/ios/sentry_flutter.podspec
@@ -16,7 +16,7 @@ Sentry SDK for Flutter with support to native through sentry-cocoa.
                          :tag => s.version.to_s }
   s.source_files     = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
-  s.dependency 'Sentry/HybridSDK', '8.37.0'
+  s.dependency 'Sentry/HybridSDK', '8.38.0'
   s.ios.dependency 'Flutter'
   s.osx.dependency 'FlutterMacOS'
   s.ios.deployment_target = '12.0'


### PR DESCRIPTION
## :scroll: Description
Updated the Android and iOS dependencies of the Sentry SDK. The iOS version is updated to 8.38.0, and the Android version to 7.16.0.


## :bulb: Motivation and Context
This update is required to ensure the SDK uses the latest versions of the dependencies on Android and iOS. It allows benefiting from the latest bug fixes and new features provided by the Sentry SDKs for these platforms.


## :green_heart: How did you test it?
Unit test, testing with widget, manual test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
