### PR TITLE
 Send Less Client Reports When Rate Limited 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ### Enhancements
 
-- Avoid sending empty client reports when Http Transport is used ([#2380](https://github.com/getsentry/sentry-dart/pull/2380))
+- Avoid sending too many empty client reports when Http Transport is used ([#2380](https://github.com/getsentry/sentry-dart/pull/2380))
 - Cache parsed DSN ([#2365](https://github.com/getsentry/sentry-dart/pull/2365))
 - Handle backpressure earlier in pipeline ([#2371](https://github.com/getsentry/sentry-dart/pull/2371))
   - Drops max un-awaited parallel tasks earlier, so event processors & callbacks are not executed for them. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
   );
   ```
 
+- Send Less Client Reports When Rate Limited ([#2380](https://github.com/getsentry/sentry-dart/pull/2380))
+
 ### Enhancements
 
 - Cache parsed DSN ([#2365](https://github.com/getsentry/sentry-dart/pull/2365))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,9 @@
   );
   ```
 
-- Send Less Client Reports When Rate Limited ([#2380](https://github.com/getsentry/sentry-dart/pull/2380))
-
 ### Enhancements
 
+- Avoid sending empty client reports when Http Transport is used ([#2380](https://github.com/getsentry/sentry-dart/pull/2380))
 - Cache parsed DSN ([#2365](https://github.com/getsentry/sentry-dart/pull/2365))
 - Handle backpressure earlier in pipeline ([#2371](https://github.com/getsentry/sentry-dart/pull/2371))
   - Drops max un-awaited parallel tasks earlier, so event processors & callbacks are not executed for them. 

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -60,8 +60,11 @@ class SentryClient {
       rateLimiter = RateLimiter(options);
       options.transport = HttpTransport(options, rateLimiter);
     }
-    options.transport =
-        ClientReportTransport(rateLimiter, options.recorder, options.transport);
+    options.transport = ClientReportTransport(
+      rateLimiter,
+      options,
+      options.transport,
+    );
     // TODO: Web might change soon to use the JS SDK so we can remove it here later on
     final enableFlutterSpotlight = (options.spotlight.enabled &&
         (options.platformChecker.isWeb ||

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -60,8 +60,7 @@ class SentryClient {
       rateLimiter = RateLimiter(options);
       options.transport = HttpTransport(options, rateLimiter);
     }
-    // rateLimiter is null if FileSystemTransport is active
-    // Native SDKs take care of rate limiting
+    // rateLimiter is null if FileSystemTransport is active since Native SDKs take care of rate limiting
     options.transport = ClientReportTransport(
       rateLimiter,
       options,

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -60,6 +60,8 @@ class SentryClient {
       rateLimiter = RateLimiter(options);
       options.transport = HttpTransport(options, rateLimiter);
     }
+    // rateLimiter is null if FileSystemTransport is active
+    // Native SDKs take care of rate limiting
     options.transport = ClientReportTransport(
       rateLimiter,
       options,

--- a/dart/lib/src/transport/client_report_transport.dart
+++ b/dart/lib/src/transport/client_report_transport.dart
@@ -1,6 +1,5 @@
 import 'package:meta/meta.dart';
 import '../../sentry.dart';
-import '../client_reports/client_report_recorder.dart';
 import '../sentry_envelope_header.dart';
 import 'rate_limiter.dart';
 

--- a/dart/lib/src/transport/client_report_transport.dart
+++ b/dart/lib/src/transport/client_report_transport.dart
@@ -1,0 +1,41 @@
+import 'package:meta/meta.dart';
+import '../../sentry.dart';
+import '../client_reports/client_report_recorder.dart';
+import 'rate_limiter.dart';
+
+/// Decorator that handles attaching of client reports in tandem with rate
+/// limiting. The rate limiter is optional.
+@internal
+class ClientReportTransport implements Transport {
+  final RateLimiter? _rateLimiter;
+  final ClientReportRecorder _recorder;
+
+  final Transport _transport;
+
+  ClientReportTransport(this._rateLimiter, this._recorder, this._transport);
+
+  @visibleForTesting
+  get rateLimiter => _rateLimiter;
+
+  @override
+  Future<SentryId?> send(SentryEnvelope envelope) async {
+    final rateLimiter = _rateLimiter;
+
+    SentryEnvelope? filteredEnvelope;
+    if (rateLimiter != null) {
+      filteredEnvelope = rateLimiter.filter(envelope);
+      // TODO handle case where we send a client reports anyway if we were rate limited too many times
+    } else {
+      filteredEnvelope = envelope;
+    }
+
+    if (filteredEnvelope == null) {
+      return SentryId.empty();
+    }
+
+    final clientReport = _recorder.flush();
+    envelope.addClientReport(clientReport);
+
+    return _transport.send(envelope);
+  }
+}

--- a/dart/lib/src/transport/client_report_transport.dart
+++ b/dart/lib/src/transport/client_report_transport.dart
@@ -1,6 +1,7 @@
 import 'package:meta/meta.dart';
 import '../../sentry.dart';
 import '../client_reports/client_report_recorder.dart';
+import '../sentry_envelope_header.dart';
 import 'rate_limiter.dart';
 
 /// Decorator that handles attaching of client reports in tandem with rate
@@ -8,34 +9,49 @@ import 'rate_limiter.dart';
 @internal
 class ClientReportTransport implements Transport {
   final RateLimiter? _rateLimiter;
-  final ClientReportRecorder _recorder;
-
+  final SentryOptions _options;
   final Transport _transport;
 
-  ClientReportTransport(this._rateLimiter, this._recorder, this._transport);
+  ClientReportTransport(this._rateLimiter, this._options, this._transport);
 
   @visibleForTesting
   get rateLimiter => _rateLimiter;
+
+  int _numberOfDroppedEnvelopes = 0;
+
+  @visibleForTesting
+  get numberOfDroppedEvents => _numberOfDroppedEnvelopes;
 
   @override
   Future<SentryId?> send(SentryEnvelope envelope) async {
     final rateLimiter = _rateLimiter;
 
-    SentryEnvelope? filteredEnvelope;
+    SentryEnvelope? filteredEnvelope = envelope;
     if (rateLimiter != null) {
       filteredEnvelope = rateLimiter.filter(envelope);
-      // TODO handle case where we send a client reports anyway if we were rate limited too many times
-    } else {
-      filteredEnvelope = envelope;
     }
-
+    if (filteredEnvelope == null) {
+      _numberOfDroppedEnvelopes += 1;
+    }
+    if (_numberOfDroppedEnvelopes >= 10) {
+      // Create new envelope that could only contain client reports
+      filteredEnvelope = SentryEnvelope(
+        SentryEnvelopeHeader(SentryId.newId(), _options.sdk),
+        [],
+      );
+    }
     if (filteredEnvelope == null) {
       return SentryId.empty();
     }
+    _numberOfDroppedEnvelopes = 0;
 
-    final clientReport = _recorder.flush();
-    envelope.addClientReport(clientReport);
+    final clientReport = _options.recorder.flush();
+    filteredEnvelope.addClientReport(clientReport);
 
-    return _transport.send(envelope);
+    if (filteredEnvelope.items.isNotEmpty) {
+      return _transport.send(filteredEnvelope);
+    } else {
+      return SentryId.empty();
+    }
   }
 }

--- a/dart/lib/src/transport/http_transport.dart
+++ b/dart/lib/src/transport/http_transport.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:http/http.dart';
+import 'package:meta/meta.dart';
+import '../client_reports/client_report_recorder.dart';
 import '../utils/transport_utils.dart';
 import 'http_transport_request_handler.dart';
 
@@ -35,14 +37,16 @@ class HttpTransport implements Transport {
 
   @override
   Future<SentryId?> send(SentryEnvelope envelope) async {
-    final filteredEnvelope = _rateLimiter.filter(envelope);
-    if (filteredEnvelope == null) {
-      return SentryId.empty();
-    }
-    filteredEnvelope.header.sentAt = _options.clock();
+    // final filteredEnvelope = _rateLimiter.filter(envelope);
+    // if (filteredEnvelope == null) {
+    //   return SentryId.empty();
+    // }
+    // final clientReport = _options.recorder.flush();
+    // envelope.addClientReport(clientReport);
 
-    final streamedRequest =
-        await _requestHandler.createRequest(filteredEnvelope);
+    envelope.header.sentAt = _options.clock();
+
+    final streamedRequest = await _requestHandler.createRequest(envelope);
 
     final response = await _options.httpClient
         .send(streamedRequest)

--- a/dart/lib/src/transport/http_transport.dart
+++ b/dart/lib/src/transport/http_transport.dart
@@ -35,13 +35,6 @@ class HttpTransport implements Transport {
 
   @override
   Future<SentryId?> send(SentryEnvelope envelope) async {
-    // final filteredEnvelope = _rateLimiter.filter(envelope);
-    // if (filteredEnvelope == null) {
-    //   return SentryId.empty();
-    // }
-    // final clientReport = _options.recorder.flush();
-    // envelope.addClientReport(clientReport);
-
     envelope.header.sentAt = _options.clock();
 
     final streamedRequest = await _requestHandler.createRequest(envelope);

--- a/dart/lib/src/transport/http_transport.dart
+++ b/dart/lib/src/transport/http_transport.dart
@@ -2,8 +2,6 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:http/http.dart';
-import 'package:meta/meta.dart';
-import '../client_reports/client_report_recorder.dart';
 import '../utils/transport_utils.dart';
 import 'http_transport_request_handler.dart';
 

--- a/dart/test/exception_identifier_test.dart
+++ b/dart/test/exception_identifier_test.dart
@@ -126,7 +126,7 @@ void main() {
 
   group('Integration test', () {
     setUp(() {
-      fixture.options.transport = MockTransport();
+      fixture.options.transport = fixture.mockTransport;
     });
 
     test(
@@ -139,7 +139,7 @@ void main() {
 
       await client.captureException(ObfuscatedException());
 
-      final transport = fixture.options.transport as MockTransport;
+      final transport = fixture.mockTransport;
       final capturedEnvelope = transport.envelopes.first;
       final capturedEvent = await eventFromEnvelope(capturedEnvelope);
 
@@ -154,7 +154,7 @@ void main() {
 
       await client.captureException(ObfuscatedException());
 
-      final transport = fixture.options.transport as MockTransport;
+      final transport = fixture.mockTransport;
       final capturedEnvelope = transport.envelopes.first;
       final capturedEvent = await eventFromEnvelope(capturedEnvelope);
 
@@ -165,6 +165,7 @@ void main() {
 }
 
 class Fixture {
+  final mockTransport = MockTransport();
   SentryOptions options = defaultTestOptions();
 }
 

--- a/dart/test/mocks/mock_transport.dart
+++ b/dart/test/mocks/mock_transport.dart
@@ -16,6 +16,8 @@ class MockTransport implements Transport {
     return _calls;
   }
 
+  bool parseFromEnvelope = true;
+
   bool called(int calls) {
     return _calls == calls;
   }
@@ -28,7 +30,9 @@ class MockTransport implements Transport {
     // failure causes. Instead, we log them and check on access to [calls].
     try {
       envelopes.add(envelope);
-      await _eventFromEnvelope(envelope);
+      if (parseFromEnvelope) {
+        await _eventFromEnvelope(envelope);
+      }
     } catch (e, stack) {
       _exceptions += '$e\n$stack\n\n';
       rethrow;

--- a/dart/test/sentry_client_test.dart
+++ b/dart/test/sentry_client_test.dart
@@ -4,22 +4,21 @@ import 'dart:typed_data';
 
 import 'package:collection/collection.dart';
 import 'package:sentry/sentry.dart';
-import 'package:sentry/src/client_reports/client_report.dart';
 import 'package:sentry/src/client_reports/discard_reason.dart';
-import 'package:sentry/src/client_reports/discarded_event.dart';
 import 'package:sentry/src/client_reports/noop_client_report_recorder.dart';
 import 'package:sentry/src/metrics/metric.dart';
 import 'package:sentry/src/sentry_item_type.dart';
 import 'package:sentry/src/sentry_stack_trace_factory.dart';
 import 'package:sentry/src/sentry_tracer.dart';
+import 'package:sentry/src/transport/client_report_transport.dart';
 import 'package:sentry/src/transport/data_category.dart';
+import 'package:sentry/src/transport/noop_transport.dart';
 import 'package:sentry/src/transport/spotlight_http_transport.dart';
 import 'package:sentry/src/utils/iterable_utils.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';
 import 'mocks/mock_client_report_recorder.dart';
-import 'mocks/mock_envelope.dart';
 import 'mocks/mock_hub.dart';
 import 'mocks/mock_platform.dart';
 import 'mocks/mock_platform_checker.dart';
@@ -1600,6 +1599,47 @@ void main() {
     });
   });
 
+  group('ClientReportTransport', () {
+    late Fixture fixture;
+
+    setUp(() {
+      fixture = Fixture();
+    });
+
+    test('set on options on init', () async {
+      fixture.getSut(
+        eventProcessor: DropAllEventProcessor(),
+        provideMockRecorder: false,
+      );
+
+      expect(fixture.options.transport is ClientReportTransport, true);
+    });
+
+    test('has rateLimiter with http transport', () async {
+      fixture.getSut(
+        eventProcessor: DropAllEventProcessor(),
+        provideMockRecorder: false,
+        transport: NoOpTransport(), // this will set http transport
+      );
+
+      expect(fixture.options.transport is ClientReportTransport, true);
+      final crt = fixture.options.transport as ClientReportTransport;
+      expect(crt.rateLimiter, isNotNull);
+    });
+
+    test('does not have rateLimiter without http transport', () async {
+      fixture.getSut(
+        eventProcessor: DropAllEventProcessor(),
+        provideMockRecorder: false,
+        transport: MockTransport(),
+      );
+
+      expect(fixture.options.transport is ClientReportTransport, true);
+      final crt = fixture.options.transport as ClientReportTransport;
+      expect(crt.rateLimiter, isNull);
+    });
+  });
+
   group('ClientReportRecorder', () {
     late Fixture fixture;
 
@@ -1616,7 +1656,6 @@ void main() {
       );
 
       expect(fixture.options.recorder is NoOpClientReportRecorder, false);
-      expect(fixture.options.recorder is MockClientReportRecorder, false);
     });
 
     test('recorder is noop if client reports are disabled', () {
@@ -1628,78 +1667,6 @@ void main() {
       );
 
       expect(fixture.options.recorder is NoOpClientReportRecorder, true);
-    });
-
-    test('captureEnvelope calls flush', () async {
-      final client = fixture.getSut(eventProcessor: DropAllEventProcessor());
-
-      final envelope = MockEnvelope();
-      envelope.items = [SentryEnvelopeItem.fromEvent(SentryEvent())];
-
-      await client.captureEnvelope(envelope);
-
-      expect(fixture.recorder.flushCalled, true);
-    });
-
-    test('captureEnvelope adds client report', () async {
-      final clientReport = ClientReport(
-        DateTime(0),
-        [DiscardedEvent(DiscardReason.rateLimitBackoff, DataCategory.error, 1)],
-      );
-      fixture.recorder.clientReport = clientReport;
-
-      final client = fixture.getSut(eventProcessor: DropAllEventProcessor());
-
-      final envelope = MockEnvelope();
-      envelope.items = [SentryEnvelopeItem.fromEvent(SentryEvent())];
-
-      await client.captureEnvelope(envelope);
-
-      expect(envelope.clientReport, clientReport);
-    });
-
-    test('captureUserFeedback calls flush', () async {
-      final client = fixture.getSut(eventProcessor: DropAllEventProcessor());
-
-      final id = SentryId.newId();
-      // ignore: deprecated_member_use_from_same_package
-      final feedback = SentryUserFeedback(
-        eventId: id,
-        comments: 'this is awesome',
-        email: 'sentry@example.com',
-        name: 'Rockstar Developer',
-      );
-      // ignore: deprecated_member_use_from_same_package
-      await client.captureUserFeedback(feedback);
-
-      expect(fixture.recorder.flushCalled, true);
-    });
-
-    test('captureUserFeedback adds client report', () async {
-      final clientReport = ClientReport(
-        DateTime(0),
-        [DiscardedEvent(DiscardReason.rateLimitBackoff, DataCategory.error, 1)],
-      );
-      fixture.recorder.clientReport = clientReport;
-
-      final client = fixture.getSut(eventProcessor: DropAllEventProcessor());
-
-      final id = SentryId.newId();
-      // ignore: deprecated_member_use_from_same_package
-      final feedback = SentryUserFeedback(
-        eventId: id,
-        comments: 'this is awesome',
-        email: 'sentry@example.com',
-        name: 'Rockstar Developer',
-      );
-      // ignore: deprecated_member_use_from_same_package
-      await client.captureUserFeedback(feedback);
-
-      final envelope = fixture.transport.envelopes.first;
-      final item = envelope.items.last;
-
-      // Only partial test, as the envelope is created internally from feedback.
-      expect(item.header.type, SentryItemType.clientReport);
     });
 
     test('record event processor dropping event', () async {
@@ -2255,14 +2222,8 @@ class Fixture {
     EventProcessor? eventProcessor,
     bool provideMockRecorder = true,
     bool debug = false,
+    Transport? transport,
   }) {
-    final hub = Hub(options);
-    _context = SentryTransactionContext(
-      'name',
-      'op',
-    );
-    tracer = SentryTracer(_context, hub);
-
     options.tracesSampleRate = 1.0;
     options.sendDefaultPii = sendDefaultPii;
     options.enableMetrics = enableMetrics;
@@ -2278,7 +2239,19 @@ class Fixture {
     if (eventProcessor != null) {
       options.addEventProcessor(eventProcessor);
     }
-    options.transport = transport;
+
+    // Internally also creates a SentryClient instance
+    final hub = Hub(options);
+    _context = SentryTransactionContext(
+      'name',
+      'op',
+    );
+    tracer = SentryTracer(_context, hub);
+
+    // Reset transport
+    options.transport = transport ?? this.transport;
+
+    // Again create SentryClient instance
     final client = SentryClient(options);
 
     if (provideMockRecorder) {

--- a/dart/test/transport/client_report_transport_test.dart
+++ b/dart/test/transport/client_report_transport_test.dart
@@ -1,0 +1,94 @@
+import 'package:sentry/sentry.dart';
+import 'package:sentry/src/client_reports/client_report.dart';
+import 'package:sentry/src/client_reports/discard_reason.dart';
+import 'package:sentry/src/client_reports/discarded_event.dart';
+import 'package:sentry/src/transport/client_report_transport.dart';
+import 'package:sentry/src/transport/data_category.dart';
+import 'package:sentry/src/transport/rate_limiter.dart';
+import 'package:test/test.dart';
+
+import '../mocks.dart';
+import '../mocks/mock_client_report_recorder.dart';
+import '../mocks/mock_envelope.dart';
+import '../mocks/mock_transport.dart';
+import '../test_utils.dart';
+
+void main() {
+  group('filter', () {
+    late Fixture fixture;
+
+    setUp(() {
+      fixture = Fixture();
+    });
+
+    test('filter called', () async {
+      final mockRateLimiter = MockRateLimiter();
+      final sut = fixture.getSut(rateLimiter: mockRateLimiter);
+
+      final envelope = MockEnvelope();
+      await sut.send(envelope);
+
+      expect(mockRateLimiter.envelopeToFilter, envelope);
+      expect(fixture.mockTransport.envelopes.first, envelope);
+    });
+
+    test('send nothing when filtered event null', () async {
+      final mockRateLimiter = MockRateLimiter()..filterReturnsNull = true;
+      final sut = fixture.getSut(rateLimiter: mockRateLimiter);
+
+      final envelope = MockEnvelope();
+      final eventId = await sut.send(envelope);
+
+      expect(eventId, SentryId.empty());
+      expect(fixture.mockTransport.called(0), true);
+    });
+  });
+
+  group('client reports', () {
+    late Fixture fixture;
+
+    setUp(() {
+      fixture = Fixture();
+    });
+
+    test('send calls flush', () async {
+      final sut = fixture.getSut();
+
+      final envelope = MockEnvelope();
+      envelope.items = [SentryEnvelopeItem.fromEvent(SentryEvent())];
+
+      await sut.send(envelope);
+
+      expect(fixture.recorder.flushCalled, true);
+    });
+
+    test('send adds client report', () async {
+      final clientReport = ClientReport(
+        DateTime(0),
+        [DiscardedEvent(DiscardReason.rateLimitBackoff, DataCategory.error, 1)],
+      );
+      fixture.recorder.clientReport = clientReport;
+
+      final sut = fixture.getSut();
+
+      final envelope = MockEnvelope();
+      envelope.items = [SentryEnvelopeItem.fromEvent(SentryEvent())];
+
+      await sut.send(envelope);
+
+      expect(envelope.clientReport, clientReport);
+    });
+  });
+}
+
+class Fixture {
+  final options = defaultTestOptions();
+
+  late var recorder = MockClientReportRecorder();
+  late var mockTransport = MockTransport();
+
+  ClientReportTransport getSut({RateLimiter? rateLimiter}) {
+    mockTransport.parseFromEnvelope = false;
+    return ClientReportTransport(rateLimiter, recorder, mockTransport);
+  }
+}

--- a/dart/test/transport/client_report_transport_test.dart
+++ b/dart/test/transport/client_report_transport_test.dart
@@ -27,6 +27,8 @@ void main() {
       final sut = fixture.getSut(rateLimiter: mockRateLimiter);
 
       final envelope = MockEnvelope();
+      envelope.items = [SentryEnvelopeItem.fromEvent(SentryEvent())];
+
       await sut.send(envelope);
 
       expect(mockRateLimiter.envelopeToFilter, envelope);
@@ -38,6 +40,8 @@ void main() {
       final sut = fixture.getSut(rateLimiter: mockRateLimiter);
 
       final envelope = MockEnvelope();
+      envelope.items = [SentryEnvelopeItem.fromEvent(SentryEvent())];
+
       final eventId = await sut.send(envelope);
 
       expect(eventId, SentryId.empty());

--- a/dart/test/transport/http_transport_test.dart
+++ b/dart/test/transport/http_transport_test.dart
@@ -1,13 +1,8 @@
-import 'dart:convert';
-
 import 'package:collection/collection.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:sentry/sentry.dart';
 import 'package:sentry/src/client_reports/discard_reason.dart';
-import 'package:sentry/src/sentry_envelope_header.dart';
-import 'package:sentry/src/sentry_envelope_item_header.dart';
-import 'package:sentry/src/sentry_item_type.dart';
 import 'package:sentry/src/sentry_tracer.dart';
 import 'package:sentry/src/transport/data_category.dart';
 import 'package:sentry/src/transport/http_transport.dart';
@@ -20,42 +15,14 @@ import '../mocks/mock_hub.dart';
 import '../test_utils.dart';
 
 void main() {
-  SentryEnvelope givenEnvelope() {
-    final filteredEnvelopeHeader = SentryEnvelopeHeader(SentryId.empty(), null);
-    final filteredItemHeader =
-        SentryEnvelopeItemHeader(SentryItemType.event, () async {
-      return 2;
-    }, contentType: 'application/json');
-    final dataFactory = () async {
-      return utf8.encode('{}');
-    };
-    final filteredItem = SentryEnvelopeItem(filteredItemHeader, dataFactory);
-    return SentryEnvelope(filteredEnvelopeHeader, [filteredItem]);
-  }
-
-  group('filter', () {
+  group('send', () {
     late Fixture fixture;
 
     setUp(() {
       fixture = Fixture();
     });
 
-    test('filter called', () async {
-      final httpMock = MockClient((http.Request request) async {
-        return http.Response('{}', 200);
-      });
-
-      fixture.options.compressPayload = false;
-      final mockRateLimiter = MockRateLimiter();
-      final sut = fixture.getSut(httpMock, mockRateLimiter);
-
-      final sentryEnvelope = givenEnvelope();
-      await sut.send(sentryEnvelope);
-
-      expect(mockRateLimiter.envelopeToFilter, sentryEnvelope);
-    });
-
-    test('send filtered event', () async {
+    test('event with http client', () async {
       List<int>? body;
 
       final httpMock = MockClient((http.Request request) async {
@@ -63,11 +30,9 @@ void main() {
         return http.Response('{}', 200);
       });
 
-      final filteredEnvelope = givenEnvelope();
-
       fixture.options.compressPayload = false;
-      final mockRateLimiter = MockRateLimiter()
-        ..filteredEnvelope = filteredEnvelope;
+      final mockRateLimiter = MockRateLimiter();
+
       final sut = fixture.getSut(httpMock, mockRateLimiter);
 
       final sentryEvent = SentryEvent();
@@ -79,34 +44,11 @@ void main() {
       await sut.send(envelope);
 
       final envelopeData = <int>[];
-      await filteredEnvelope
+      await envelope
           .envelopeStream(fixture.options)
           .forEach(envelopeData.addAll);
 
       expect(body, envelopeData);
-    });
-
-    test('send nothing when filtered event null', () async {
-      var httpCalled = false;
-      final httpMock = MockClient((http.Request request) async {
-        httpCalled = true;
-        return http.Response('{}', 200);
-      });
-
-      fixture.options.compressPayload = false;
-      final mockRateLimiter = MockRateLimiter()..filterReturnsNull = true;
-      final sut = fixture.getSut(httpMock, mockRateLimiter);
-
-      final sentryEvent = SentryEvent();
-      final envelope = SentryEnvelope.fromEvent(
-        sentryEvent,
-        fixture.options.sdk,
-        dsn: fixture.options.dsn,
-      );
-      final eventId = await sut.send(envelope);
-
-      expect(eventId, SentryId.empty());
-      expect(httpCalled, false);
     });
   });
 
@@ -130,6 +72,9 @@ void main() {
         fixture.options.sdk,
         dsn: fixture.options.dsn,
       );
+
+      mockRateLimiter.filter(envelope);
+
       await sut.send(envelope);
 
       expect(mockRateLimiter.envelopeToFilter?.header.eventId,


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

- [x] Add client reports after rate limit filtering.
- [x] Try to send client reports only after getting fully rate limited 10 times.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #2370

## :green_heart: How did you test it?

- Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes