### PR TITLE
feat: non-nullable privacy setting

### DIFF
--- a/flutter/lib/src/event_processor/screenshot_event_processor.dart
+++ b/flutter/lib/src/event_processor/screenshot_event_processor.dart
@@ -79,7 +79,8 @@ class ScreenshotEventProcessor implements EventProcessor {
     var recorder = ScreenshotRecorder(
         ScreenshotRecorderConfig(
             quality: _options.screenshot.screenshotQuality),
-        _options);
+        _options,
+        isReplayRecorder: false);
 
     Uint8List? _screenshotData;
 

--- a/flutter/lib/src/screenshot/recorder.dart
+++ b/flutter/lib/src/screenshot/recorder.dart
@@ -5,7 +5,6 @@ import 'package:flutter/rendering.dart';
 import 'package:meta/meta.dart';
 
 import '../../sentry_flutter.dart';
-import 'masking_config.dart';
 import 'recorder_config.dart';
 import 'widget_filter.dart';
 
@@ -21,13 +20,18 @@ class ScreenshotRecorder {
   WidgetFilter? _widgetFilter;
   bool warningLogged = false;
 
-  ScreenshotRecorder(this.config, this.options) {
-    /// TODO: Rewrite when default redaction value are synced with SS & SR
-    final SentryMaskingConfig maskingConfig =
-        (options.experimental.privacy ?? SentryPrivacyOptions())
-            .buildMaskingConfig();
+  // TODO: remove in the next major release, see recorder_test.dart.
+  @visibleForTesting
+  bool get hasWidgetFilter => _widgetFilter != null;
 
-    if (maskingConfig.length > 0) {
+  // TODO: remove [isReplayRecorder] parameter in the next major release, see _SentryFlutterExperimentalOptions.
+  ScreenshotRecorder(this.config, this.options,
+      {bool isReplayRecorder = true}) {
+    final privacyOptions = isReplayRecorder
+        ? options.experimental.privacyForReplay
+        : options.experimental.privacyForScreenshots;
+    final maskingConfig = privacyOptions?.buildMaskingConfig();
+    if (maskingConfig != null && maskingConfig.length > 0) {
       _widgetFilter = WidgetFilter(maskingConfig, options.logger);
     }
   }

--- a/flutter/lib/src/screenshot/recorder.dart
+++ b/flutter/lib/src/screenshot/recorder.dart
@@ -27,6 +27,7 @@ class ScreenshotRecorder {
   // TODO: remove [isReplayRecorder] parameter in the next major release, see _SentryFlutterExperimentalOptions.
   ScreenshotRecorder(this.config, this.options,
       {bool isReplayRecorder = true}) {
+		// see `options.experimental.privacy` docs for details
     final privacyOptions = isReplayRecorder
         ? options.experimental.privacyForReplay
         : options.experimental.privacyForScreenshots;

--- a/flutter/lib/src/screenshot/recorder.dart
+++ b/flutter/lib/src/screenshot/recorder.dart
@@ -27,7 +27,7 @@ class ScreenshotRecorder {
   // TODO: remove [isReplayRecorder] parameter in the next major release, see _SentryFlutterExperimentalOptions.
   ScreenshotRecorder(this.config, this.options,
       {bool isReplayRecorder = true}) {
-		// see `options.experimental.privacy` docs for details
+    // see `options.experimental.privacy` docs for details
     final privacyOptions = isReplayRecorder
         ? options.experimental.privacyForReplay
         : options.experimental.privacyForScreenshots;

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -99,8 +99,6 @@ mixin SentryFlutter {
       // ignore: invalid_use_of_internal_member
       runZonedGuardedOnError: runZonedGuardedOnError,
     );
-    // TODO: Remove when we synced SS and SR configurations and have a single default configuration
-    _setRedactionOptions(options);
 
     if (_native != null) {
       // ignore: invalid_use_of_internal_member
@@ -243,27 +241,6 @@ mixin SentryFlutter {
     );
     sdk.addPackage('pub:sentry_flutter', sdkVersion);
     options.sdk = sdk;
-  }
-
-  /// Screen redaction was previously introduced with the SessionReplay feature.
-  /// Screen redaction is enabled by default for SessionReplay.
-  /// As we also to use this feature for Screenshot, which previously was not
-  /// capable of redacting the screenshot, we need to disable redaction for Screenshot by default
-  /// so we don`t break the existing behavior.
-  /// As we have only one central place to configure the redaction,
-  /// we need to set the redaction options to full fill the above default settings.
-  /// The plan is to unify this behaviour with the next major release.
-  static void _setRedactionOptions(SentryFlutterOptions options) {
-    if (options.experimental.privacy != null) {
-      return;
-    } else if (options.screenshot.attachScreenshot == true &&
-        !options.experimental.replay.isEnabled) {
-      options.experimental.privacy = SentryPrivacyOptions()
-        ..maskAllText = false
-        ..maskAllImages = false;
-    } else {
-      options.experimental.privacy = SentryPrivacyOptions();
-    }
   }
 
   /// Reports the time it took for the screen to be fully displayed.

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -395,5 +395,28 @@ class _SentryFlutterExperimentalOptions {
   final replay = SentryReplayOptions();
 
   /// Privacy configuration for masking sensitive data in the Screenshot and Session Replay.
-  SentryPrivacyOptions? privacy;
+  /// Screen redaction was previously introduced with the SessionReplay feature.
+  /// Screen redaction is enabled by default for SessionReplay.
+  /// As we also to use privacy options for Screenshot, which previously was not
+  /// capable of redacting, we keep the existing behaviour unless expiclitly
+  /// configured (i.e. [privacy] is accessed).
+  /// The plan is to unify this behaviour with the next major release.
+  SentryPrivacyOptions get privacy {
+    // If the user explicitly sets the privacy setting, we use that.
+    // Otherwise, we use the default settings, which is no redaction for screenshots
+    // and full redaction for session replay.
+    // This property must only by accessed by user code otherwise it defeats the purpose.
+    _privacy ??= SentryPrivacyOptions();
+    return _privacy!;
+  }
+
+  /// TODO: remove when default redaction value are synced with SS & SR in the next major release
+  SentryPrivacyOptions? _privacy;
+
+  @meta.internal
+  SentryPrivacyOptions? get privacyForScreenshots => _privacy;
+
+  @meta.internal
+  SentryPrivacyOptions get privacyForReplay =>
+      _privacy ?? SentryPrivacyOptions();
 }

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -395,12 +395,15 @@ class _SentryFlutterExperimentalOptions {
   final replay = SentryReplayOptions();
 
   /// Privacy configuration for masking sensitive data in the Screenshot and Session Replay.
-  /// Screen redaction was previously introduced with the SessionReplay feature.
-  /// Screen redaction is enabled by default for SessionReplay.
-  /// As we also to use privacy options for Screenshot, which previously was not
-  /// capable of redacting, we keep the existing behaviour unless expiclitly
-  /// configured (i.e. [privacy] is accessed).
-  /// The plan is to unify this behaviour with the next major release.
+  /// Screen content masking redaction is:
+  /// - enabled by default for SessionReplay 
+  /// - disabled by default for screenshots captured with events.
+  /// In order to redact screenshots captured with events, access or change 
+  /// this property in your application: `options.experimental.privacy`.
+  /// Doing so will indicate that you want to configure privacy settings and
+  /// will enable screenshot redaction alongside the default replay redaction.
+  /// Note: this will change in a future SDK major release to enable screenshot
+  /// redaction by default for all captures.
   SentryPrivacyOptions get privacy {
     // If the user explicitly sets the privacy setting, we use that.
     // Otherwise, we use the default settings, which is no redaction for screenshots

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -396,9 +396,9 @@ class _SentryFlutterExperimentalOptions {
 
   /// Privacy configuration for masking sensitive data in the Screenshot and Session Replay.
   /// Screen content masking redaction is:
-  /// - enabled by default for SessionReplay 
+  /// - enabled by default for SessionReplay
   /// - disabled by default for screenshots captured with events.
-  /// In order to redact screenshots captured with events, access or change 
+  /// In order to redact screenshots captured with events, access or change
   /// this property in your application: `options.experimental.privacy`.
   /// Doing so will indicate that you want to configure privacy settings and
   /// will enable screenshot redaction alongside the default replay redaction.

--- a/flutter/test/replay/recorder_test.dart
+++ b/flutter/test/replay/recorder_test.dart
@@ -55,6 +55,33 @@ void main() async {
         await _Fixture.create(tester, quality: SentryScreenshotQuality.low);
     expect(fixture.capture(), completion('427x854'));
   });
+
+  // TODO: remove in the next major release, see _SentryFlutterExperimentalOptions.
+  group('Widget filter is used based on config or application', () {
+    test('Uses widget filter by default for Replay', () {
+      final sut = ScreenshotRecorder(
+        ScreenshotRecorderConfig(),
+        defaultTestOptions(),
+      );
+      expect(sut.hasWidgetFilter, isTrue);
+    });
+
+    test('Does not use widget filter by default for Screenshots', () {
+      final sut = ScreenshotRecorder(
+          ScreenshotRecorderConfig(), defaultTestOptions(),
+          isReplayRecorder: false);
+      expect(sut.hasWidgetFilter, isFalse);
+    });
+
+    test(
+        'Uses widget filter for Screenshots when privacy configured explicitly',
+        () {
+      final sut = ScreenshotRecorder(ScreenshotRecorderConfig(),
+          defaultTestOptions()..experimental.privacy.maskAllText = false,
+          isReplayRecorder: false);
+      expect(sut.hasWidgetFilter, isTrue);
+    });
+  });
 }
 
 class _Fixture {


### PR DESCRIPTION
This suggests a change on top of another PR (#2361) - I think it would be more user-friendly to provide the `options.experimental.privacy` as a non-nullable field so users can set its properties directly.

See code comments for some more details

#skip-changelog