### PR TITLE
Added frame rate and relative frame delay to span metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
     ),
   );
   ```
+- Added new measurement `frames.relative_delay` to spans. This metric is the frame delay divided by the span duration. It provides a relative measure of frame delay to better assess the impact of frame delay.
+- Added new measurement `frames.rate` to spans. This metric estimates the frame rate based on the span duration and the number of frames.
 
 ### Enhancements
 

--- a/flutter/lib/src/span_frame_metrics_collector.dart
+++ b/flutter/lib/src/span_frame_metrics_collector.dart
@@ -16,6 +16,8 @@ class SpanFrameMetricsCollector implements PerformanceContinuousCollector {
   static const framesDelayKey = 'frames.delay';
   static const slowFramesKey = 'frames.slow';
   static const frozenFramesKey = 'frames.frozen';
+  static const estimatedFrameRateKey = 'frames.rate';
+  static const relativeFrameDelayKey = 'frames.relative_delay';
 
   final SentryFlutterOptions options;
   final FrameCallbackHandler _frameCallbackHandler;
@@ -302,11 +304,20 @@ class SpanFrameMetricsCollector implements PerformanceContinuousCollector {
       return {};
     }
 
+    final numberOfFrames =
+        (spanDuration - framesDelay) / expectedFrameDuration!.inMilliseconds;
+
+    final estimatedFrameRate = (numberOfFrames / (spanDuration / 1000)).toInt();
+
+    final relativeFrameDelay = framesDelay ~/ spanDuration;
+
     return {
       SpanFrameMetricsCollector.totalFramesKey: totalFramesCount,
       SpanFrameMetricsCollector.framesDelayKey: framesDelay,
       SpanFrameMetricsCollector.slowFramesKey: slowFramesCount,
       SpanFrameMetricsCollector.frozenFramesKey: frozenFramesCount,
+      SpanFrameMetricsCollector.estimatedFrameRateKey: estimatedFrameRate,
+      SpanFrameMetricsCollector.relativeFrameDelayKey: relativeFrameDelay,
     };
   }
 

--- a/flutter/test/span_frame_metrics_collector_test.dart
+++ b/flutter/test/span_frame_metrics_collector_test.dart
@@ -230,11 +230,15 @@ void main() {
 
     await Future<void>.delayed(Duration(milliseconds: 500));
     await tracer.finish(endTimestamp: endTimestamp);
+    final frameDuration = endTimestamp.difference(startTimestamp);
+    final expectedRelativeFrameDelay =
+        expectedFramesDelay ~/ frameDuration.inMilliseconds;
 
     expect(child.data['frames.slow'], expectedSlowFrames);
     expect(child.data['frames.frozen'], expectedFrozenFrames);
     expect(child.data['frames.delay'], expectedFramesDelay);
     expect(child.data['frames.total'], expectedTotalFrames);
+    expect(child.data['frames.relative_delay'], expectedRelativeFrameDelay);
 
     // total frames is hardcoded here since it depends on span duration as well
     // and we are deviating from the default 800ms to 1600ms for the whole transaction


### PR DESCRIPTION
## :scroll: Description


- Added new measurement `frames.relative_delay` to spans. This metric is the frame delay divided by the span duration. It provides a relative measure of frame delay to better assess the impact of frame delay.
- Added new measurement `frames.rate` to spans. This metric estimates the frame rate based on the span duration and the number of frames.


## :bulb: Motivation and Context
The goal of this MR is to add some new metrics to improve the user's ability to prioritize poor performing spans.

In reviewing the documentation of [frames delay](https://develop.sentry.dev/sdk/telemetry/traces/frames-delay/#:~:text=Now%2C%20when%20prioritizing%20the%20user%2Dperceived%20degraded%20responsiveness%20by%20frames%20delay%2C%20we%20get%201%2C%203%2C%202%20instead%20of%203%2C%202%2C%201%20when%20looking%20at%20slow%20and%20frozen%20frames.), I noticed the example prioritization scenarios don't account for how long the span was.

For example if Scenario 1 had a frame delay of 2400ms but hypothetically the span duration was 5x the span duration of Scenario 3, wouldn't that mean that over the entire span, Scenario 3 actually had less frame delay?

Hence the metric of relative_delay.

I added frames.rate as the variables needed to calculate it were present.


## :green_heart: How did you test it?

Wrote one test for relative frame delay
Otherwise, tested locally to evaluate the reported estimated frame rate.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes*
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
