### PR TITLE
fix build error for latest flutter beta (3.27.0)

### DIFF
--- a/.github/workflows/flutter_test.yml
+++ b/.github/workflows/flutter_test.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: build apk
         working-directory: ./flutter/example/android
-        run: flutter build apk --debug
+        run: flutter build apk --debug --target-platform=android-x64
 
       - name: launch android emulator & run android native test
         uses: reactivecircus/android-emulator-runner@62dbb605bba737720e10b196cb4220d374026a6d #pin@v2.33.0


### PR DESCRIPTION
## :scroll: Description
Adding `--target-platform=android-x64` to the build command.


## :bulb: Motivation and Context
close #2381 


## :green_heart: How did you test it?
local and ci

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps

_#skip-changelog_