### PR TITLE
fix: add style to feedback AppBar title Text

### DIFF
--- a/flutter/lib/src/feedback/sentry_feedback_widget.dart
+++ b/flutter/lib/src/feedback/sentry_feedback_widget.dart
@@ -63,7 +63,9 @@ class _SentryFeedbackWidgetState extends State<SentryFeedbackWidget> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(widget.title),
+        title: Text(widget.title,
+          style: Theme.of(context).textTheme.titleLarge,
+        ),
       ),
       body: Padding(
         padding: const EdgeInsets.all(16.0),


### PR DESCRIPTION
## :scroll: Description
Add `Theme.of` to `AppBar` in the same way it is already applied to other text elements in this widget


## :bulb: Motivation and Context
In the absence of this change, the title text will not adopt theming configured in the app. 

As a consequence, it can be impossible for end users to read this text.

This is not a change per-se, it seems more like an omission in the existing implementation


## :green_heart: How did you test it?
Change made locally and then added as a dependency to a flutter project exhibiting the symptom mentioned above

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps

Based on https://github.com/getsentry/sentry-dart/blob/18e6fd72f17e921a090358b11e34f88663a759db/CONTRIBUTING.md I'm unclear if there is more expected from my side.
