### PR TITLE
test: skip flaky sentry_navigator_observer test case

### DIFF
--- a/flutter/test/sentry_navigator_observer_test.dart
+++ b/flutter/test/sentry_navigator_observer_test.dart
@@ -519,7 +519,7 @@ void main() {
           ttfdFinishVerification.captured.single as DateTime;
 
       expect(ttfdEndTimestamp.toUtc(), equals(ttidEndTimestamp.toUtc()));
-    });
+    }, skip: 'Flaky, see https://github.com/getsentry/sentry-dart/issues/2428');
 
     test(
         'unfinished children will be finished with deadline_exceeded on didPush',


### PR DESCRIPTION
Seen this test fail multiple times recently so created an issue to fix this.