### PR TITLE
Change EnvelopeItem dataFactory to FutureOr

### DIFF
--- a/dart/lib/src/sentry_envelope.dart
+++ b/dart/lib/src/sentry_envelope.dart
@@ -123,7 +123,8 @@ class SentryEnvelope {
     final newLineData = utf8.encode('\n');
     for (final item in items) {
       try {
-        final data = await item.dataFactory();
+        final dataFuture = item.dataFactory();
+        final data = dataFuture is Future ? await dataFuture : dataFuture;
 
         // Only attachments should be filtered according to
         // SentryOptions.maxAttachmentSize
@@ -133,7 +134,7 @@ class SentryEnvelope {
         }
 
         yield newLineData;
-        yield utf8.encode(jsonEncode(await item.header.toJson(data.length)));
+        yield utf8JsonEncoder.convert(await item.header.toJson(data.length));
         yield newLineData;
         yield data;
       } catch (_) {

--- a/dart/lib/src/sentry_envelope_item.dart
+++ b/dart/lib/src/sentry_envelope_item.dart
@@ -24,7 +24,7 @@ class SentryEnvelopeItem {
       contentType: 'application/json',
     );
     return SentryEnvelopeItem(
-        header, () async => utf8JsonEncoder.convert(transaction.toJson()),
+        header, () => utf8JsonEncoder.convert(transaction.toJson()),
         originalObject: transaction);
   }
 
@@ -37,7 +37,7 @@ class SentryEnvelopeItem {
     );
     return SentryEnvelopeItem(
       header,
-      () async => attachment.bytes,
+      () => attachment.bytes,
       originalObject: attachment,
     );
   }
@@ -45,7 +45,7 @@ class SentryEnvelopeItem {
   /// Create a [SentryEnvelopeItem] which sends [SentryUserFeedback].
   @Deprecated('Will be removed in a future version.')
   factory SentryEnvelopeItem.fromUserFeedback(SentryUserFeedback feedback) {
-    final dataFactory = () async => utf8JsonEncoder.convert(feedback.toJson());
+    final dataFactory = () => utf8JsonEncoder.convert(feedback.toJson());
 
     final header = SentryEnvelopeItemHeader(
       SentryItemType.userFeedback,
@@ -65,7 +65,7 @@ class SentryEnvelopeItem {
         event.type == 'feedback' ? 'feedback' : SentryItemType.event,
         contentType: 'application/json',
       ),
-      () async => utf8JsonEncoder.convert(event.toJson()),
+      () => utf8JsonEncoder.convert(event.toJson()),
       originalObject: event,
     );
   }
@@ -77,14 +77,14 @@ class SentryEnvelopeItem {
         SentryItemType.clientReport,
         contentType: 'application/json',
       ),
-      () async => utf8JsonEncoder.convert(clientReport.toJson()),
+      () => utf8JsonEncoder.convert(clientReport.toJson()),
       originalObject: clientReport,
     );
   }
 
   /// Creates a [SentryEnvelopeItem] which holds several [Metric] data.
   factory SentryEnvelopeItem.fromMetrics(Map<int, Iterable<Metric>> buckets) {
-    final dataFactory = () async {
+    final dataFactory = () {
       final statsd = StringBuffer();
       // Encode all metrics of a bucket in statsd format, using the bucket key,
       //  which is the timestamp of the bucket.
@@ -110,5 +110,5 @@ class SentryEnvelopeItem {
   final SentryEnvelopeItemHeader header;
 
   /// Create binary data representation of item data.
-  final Future<List<int>> Function() dataFactory;
+  final FutureOr<List<int>> Function() dataFactory;
 }

--- a/flutter/lib/src/profiling.dart
+++ b/flutter/lib/src/profiling.dart
@@ -111,6 +111,6 @@ class SentryNativeProfileInfo implements SentryProfileInfo {
       SentryItemType.profile,
       contentType: 'application/json',
     );
-    return SentryEnvelopeItem(header, () => Future.value(_data));
+    return SentryEnvelopeItem(header, () => _data);
   }
 }


### PR DESCRIPTION
Review suggestion for #2417 change envelope-item data factory to FutureOr

Looking at the uses of the data factory, it's almost exclusively synchronous so I think we can change it to `FutureOr`. Even though this is changing a public API, it shouldn't require any changes by the callers because the type is compatible with Future.

#skip-changelog