### PR TITLE
fix: catch errors thrown during `handleBeginFrame` and `handleDrawFrame`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@
 - Linux native error & obfuscation support ([#2431](https://github.com/getsentry/sentry-dart/pull/2431))
 - Improve Device context on plain Dart and Flutter desktop apps ([#2441](https://github.com/getsentry/sentry-dart/pull/2441))
 
+### Fixes
+
+- Catch errors thrown during `handleBeginFrame` and `handleDrawFrame` ([#2446](https://github.com/getsentry/sentry-dart/pull/2446))
+
 ### Dependencies
 
 - Bump Cocoa SDK from v8.40.1 to v8.41.0 ([#2442](https://github.com/getsentry/sentry-dart/pull/2442))

--- a/flutter/lib/src/binding_wrapper.dart
+++ b/flutter/lib/src/binding_wrapper.dart
@@ -88,6 +88,8 @@ mixin SentryWidgetsBindingMixin on WidgetsBinding {
   FrameTimingCallback? _frameTimingCallback;
   ClockProvider? _clock;
 
+  SentryOptions get _options => Sentry.currentHub.options;
+
   @internal
   void registerFramesTracking(
       FrameTimingCallback callback, ClockProvider clock) {
@@ -110,7 +112,11 @@ mixin SentryWidgetsBindingMixin on WidgetsBinding {
   void handleBeginFrame(Duration? rawTimeStamp) {
     try {
       _startTimestamp = _clock?.call();
-    } catch (_) {}
+    } catch (_) {
+      if (_options.automatedTestMode) {
+        rethrow;
+      }
+    }
 
     super.handleBeginFrame(rawTimeStamp);
   }
@@ -126,6 +132,10 @@ mixin SentryWidgetsBindingMixin on WidgetsBinding {
           _startTimestamp!.isBefore(endTimestamp)) {
         _frameTimingCallback?.call(_startTimestamp!, endTimestamp);
       }
-    } catch (_) {}
+    } catch (_) {
+      if (_options.automatedTestMode) {
+        rethrow;
+      }
+    }
   }
 }

--- a/flutter/lib/src/binding_wrapper.dart
+++ b/flutter/lib/src/binding_wrapper.dart
@@ -1,10 +1,10 @@
 // ignore_for_file: invalid_use_of_internal_member
 
 import 'package:flutter/foundation.dart';
-
-import '../sentry_flutter.dart';
 import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
+
+import '../sentry_flutter.dart';
 
 /// The methods and properties are modelled after the the real binding class.
 @experimental
@@ -108,7 +108,9 @@ mixin SentryWidgetsBindingMixin on WidgetsBinding {
 
   @override
   void handleBeginFrame(Duration? rawTimeStamp) {
-    _startTimestamp = _clock?.call();
+    try {
+      _startTimestamp = _clock?.call();
+    } catch (_) {}
 
     super.handleBeginFrame(rawTimeStamp);
   }
@@ -117,11 +119,13 @@ mixin SentryWidgetsBindingMixin on WidgetsBinding {
   void handleDrawFrame() {
     super.handleDrawFrame();
 
-    final endTimestamp = _clock?.call();
-    if (_startTimestamp != null &&
-        endTimestamp != null &&
-        _startTimestamp!.isBefore(endTimestamp)) {
-      _frameTimingCallback?.call(_startTimestamp!, endTimestamp);
-    }
+    try {
+      final endTimestamp = _clock?.call();
+      if (_startTimestamp != null &&
+          endTimestamp != null &&
+          _startTimestamp!.isBefore(endTimestamp)) {
+        _frameTimingCallback?.call(_startTimestamp!, endTimestamp);
+      }
+    } catch (_) {}
   }
 }

--- a/flutter/test/sentry_flutter_widgets_binding_test.dart
+++ b/flutter/test/sentry_flutter_widgets_binding_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sentry_flutter/src/binding_wrapper.dart';
+
+import 'binding.dart';
+
+void main() {
+  // Make sure whatever error happens during the frame processing we catch it
+  // Otherwise it would disrupt the frame processing and freeze the UI
+  group('$SentryWidgetsBindingMixin', () {
+    late SentryAutomatedTestWidgetsFlutterBinding binding;
+
+    setUp(() {
+      binding = SentryAutomatedTestWidgetsFlutterBinding.ensureInitialized();
+      // reset state
+      binding.removeFramesTracking();
+    });
+
+    test('frame processing continues execution when clock throws', () {
+      binding.registerFramesTracking(
+        (_, __) {},
+        () => throw Exception('Clock error'),
+      );
+
+      expect(
+        () {
+          binding.handleBeginFrame(null);
+          binding.handleDrawFrame();
+        },
+        returnsNormally,
+      );
+    });
+
+    test('frame processing execution when callback throws', () {
+      binding.registerFramesTracking(
+        (_, __) {
+          throw Exception('Callback error');
+        },
+        () => DateTime.now(),
+      );
+
+      expect(
+        () {
+          binding.handleBeginFrame(null);
+          binding.handleDrawFrame();
+        },
+        returnsNormally,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Catch errors thrown during `handleBeginFrame` and `handleDrawFrame`

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If these aren't caught, it could potentially disrupt the frame processing and thus freeze the UI -> not good

## :green_heart: How did you test it?
Unit test, manual

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
