### PR TITLE
fix: cocoa SDK init after hot-restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@
 ### Fixes
 
 - OS & device contexts missing on Windows ([#2439](https://github.com/getsentry/sentry-dart/pull/2439))
-- native iOS/macOS SDK session didn't start after Flutter hot-restart ([#2452](https://github.com/getsentry/sentry-dart/pull/2452))
+- Native iOS/macOS SDK session didn't start after Flutter hot-restart ([#2452](https://github.com/getsentry/sentry-dart/pull/2452))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
     },
     appRunner: () => runApp(MyApp()),
   );
-  ```  
+  ```
 - Linux native error & obfuscation support ([#2431](https://github.com/getsentry/sentry-dart/pull/2431))
 - Improve Device context on plain Dart and Flutter desktop apps ([#2441](https://github.com/getsentry/sentry-dart/pull/2441))
 - Add debounce to capturing screenshots ([#2368](https://github.com/getsentry/sentry-dart/pull/2368))
@@ -53,6 +53,7 @@
 ### Fixes
 
 - OS & device contexts missing on Windows ([#2439](https://github.com/getsentry/sentry-dart/pull/2439))
+- native iOS/macOS SDK session didn't start after Flutter hot-restart ([#2452](https://github.com/getsentry/sentry-dart/pull/2452))
 
 ### Dependencies
 

--- a/flutter/ios/Classes/SentryFlutterPluginApple.swift
+++ b/flutter/ios/Classes/SentryFlutterPluginApple.swift
@@ -329,7 +329,7 @@ public class SentryFlutterPluginApple: NSObject, FlutterPlugin {
         let appIsActive = NSApplication.shared.isActive
         #endif
 
-        // We send a SentryHybridSdkDidBecomeActive to the Sentry Cocoa SDK, so the SDK will mimics
+        // We send a SentryHybridSdkDidBecomeActive to the Sentry Cocoa SDK, to mimic
         // the didBecomeActiveNotification notification. This is needed for session, OOM tracking, replays, etc.
         if appIsActive {
             NotificationCenter.default.post(name: Notification.Name("SentryHybridSdkDidBecomeActive"), object: nil)


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Fixes #2412 by letting the CocoaSDK know it should start the session when we init it.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

See issue description in https://github.com/getsentry/sentry-cocoa/issues/4575

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
