### PR TITLE
fix: masking semi-transparent widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@
   });
   ```
 
+### Fixes
+
+- Masking semi-transparent widgets ([#2472](https://github.com/getsentry/sentry-dart/pull/2472))
+
 ## 8.11.0-beta.2
 
 ### Features

--- a/flutter/lib/src/screenshot/recorder.dart
+++ b/flutter/lib/src/screenshot/recorder.dart
@@ -148,7 +148,7 @@ extension on widgets.BuildContext {
     WidgetFilterColorScheme? result;
     visitAncestorElements((el) {
       result = getElementColorScheme(el);
-      return result != null;
+      return result == null;
     });
 
     if (result == null) {

--- a/flutter/lib/src/screenshot/recorder.dart
+++ b/flutter/lib/src/screenshot/recorder.dart
@@ -182,14 +182,14 @@ extension on widgets.BuildContext {
   WidgetFilterColorScheme? getElementColorScheme(widgets.Element el) {
     final widget = el.widget;
     if (widget is material.MaterialApp || widget is material.Scaffold) {
-      final colorScheme = material.Theme.of(this).colorScheme;
+      final colorScheme = material.Theme.of(el).colorScheme;
       return WidgetFilterColorScheme(
         background: colorScheme.surface.asOpaque(),
         defaultMask: colorScheme.primary.asOpaque(),
         defaultTextMask: colorScheme.primary.asOpaque(),
       );
     } else if (widget is cupertino.CupertinoApp) {
-      final colorScheme = cupertino.CupertinoTheme.of(this);
+      final colorScheme = cupertino.CupertinoTheme.of(el);
       final textColor = colorScheme.textTheme.textStyle.foreground?.color ??
           colorScheme.textTheme.textStyle.color ??
           colorScheme.primaryColor;

--- a/flutter/lib/src/screenshot/recorder.dart
+++ b/flutter/lib/src/screenshot/recorder.dart
@@ -3,6 +3,8 @@ import 'dart:ui';
 
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart' as widgets;
+import 'package:flutter/material.dart' as material;
+import 'package:flutter/cupertino.dart' as cupertino;
 import 'package:meta/meta.dart';
 
 import '../../sentry_flutter.dart';
@@ -79,10 +81,13 @@ class ScreenshotRecorder {
 
       final filter = _widgetFilter;
       if (filter != null) {
+        final colorScheme = context.findColorScheme();
         filter.obscure(
-          context,
-          pixelRatio,
-          Rect.fromLTWH(0, 0, srcWidth * pixelRatio, srcHeight * pixelRatio),
+          context: context,
+          pixelRatio: pixelRatio,
+          colorScheme: colorScheme,
+          bounds: Rect.fromLTWH(
+              0, 0, srcWidth * pixelRatio, srcHeight * pixelRatio),
         );
       }
 
@@ -135,5 +140,65 @@ class ScreenshotRecorder {
       paint.color = item.color;
       canvas.drawRect(item.bounds, paint);
     }
+  }
+}
+
+extension on widgets.BuildContext {
+  WidgetFilterColorScheme findColorScheme() {
+    WidgetFilterColorScheme? result;
+    visitAncestorElements((el) {
+      result = getElementColorScheme(el);
+      return result != null;
+    });
+
+    if (result == null) {
+      int limit = 20;
+      visitor(widgets.Element el) {
+        // Don't take too much time trying to find the theme.
+        if (limit-- < 0) {
+          return;
+        }
+
+        result ??= getElementColorScheme(el);
+        if (result == null) {
+          el.visitChildren(visitor);
+        }
+      }
+
+      visitChildElements(visitor);
+    }
+
+    assert(material.Colors.white.isOpaque);
+    assert(material.Colors.black.isOpaque);
+    result ??= const WidgetFilterColorScheme(
+      background: material.Colors.white,
+      defaultMask: material.Colors.black,
+      defaultTextMask: material.Colors.black,
+    );
+
+    return result!;
+  }
+
+  WidgetFilterColorScheme? getElementColorScheme(widgets.Element el) {
+    final widget = el.widget;
+    if (widget is material.MaterialApp || widget is material.Scaffold) {
+      final colorScheme = material.Theme.of(this).colorScheme;
+      return WidgetFilterColorScheme(
+        background: colorScheme.surface.asOpaque(),
+        defaultMask: colorScheme.primary.asOpaque(),
+        defaultTextMask: colorScheme.primary.asOpaque(),
+      );
+    } else if (widget is cupertino.CupertinoApp) {
+      final colorScheme = cupertino.CupertinoTheme.of(this);
+      final textColor = colorScheme.textTheme.textStyle.foreground?.color ??
+          colorScheme.textTheme.textStyle.color ??
+          colorScheme.primaryColor;
+      return WidgetFilterColorScheme(
+        background: colorScheme.scaffoldBackgroundColor.asOpaque(),
+        defaultMask: colorScheme.primaryColor.asOpaque(),
+        defaultTextMask: textColor.asOpaque(),
+      );
+    }
+    return null;
   }
 }

--- a/flutter/lib/src/screenshot/widget_filter.dart
+++ b/flutter/lib/src/screenshot/widget_filter.dart
@@ -1,5 +1,5 @@
+import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
-import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
 
 import '../../sentry_flutter.dart';
@@ -11,7 +11,7 @@ class WidgetFilter {
   final items = <WidgetFilterItem>[];
   final SentryLogger logger;
   final SentryMaskingConfig config;
-  static const _defaultColor = Color.fromARGB(255, 0, 0, 0);
+  late WidgetFilterColorScheme _scheme;
   late double _pixelRatio;
   late Rect _bounds;
   final _warnedWidgets = <int>{};
@@ -22,9 +22,18 @@ class WidgetFilter {
 
   WidgetFilter(this.config, this.logger);
 
-  void obscure(BuildContext context, double pixelRatio, Rect bounds) {
+  void obscure({
+    required BuildContext context,
+    required double pixelRatio,
+    required Rect bounds,
+    required WidgetFilterColorScheme colorScheme,
+  }) {
     _pixelRatio = pixelRatio;
     _bounds = bounds;
+    _scheme = colorScheme;
+    assert(colorScheme.background.isOpaque);
+    assert(colorScheme.defaultMask.isOpaque);
+    assert(colorScheme.defaultTextMask.isOpaque);
     items.clear();
     if (context is Element) {
       _process(context);
@@ -81,7 +90,7 @@ class WidgetFilter {
               stackTrace: stackTrace);
         }
         if (parent == null) {
-          return WidgetFilterItem(_defaultColor, _bounds);
+          return WidgetFilterItem(_scheme.defaultMask, _bounds);
         }
         element = parent;
         widget = element.widget;
@@ -126,11 +135,24 @@ class WidgetFilter {
 
     Color? color;
     if (widget is Text) {
-      color = (widget).style?.color;
+      color = widget.style?.color;
+      if (color == null && renderBox is RenderParagraph) {
+        color = renderBox.text.style?.color;
+      }
+      color ??= _scheme.defaultTextMask;
     } else if (widget is EditableText) {
-      color = (widget).style.color;
+      color = widget.style.color ?? _scheme.defaultTextMask;
     } else if (widget is Image) {
-      color = (widget).color;
+      color = widget.color;
+    }
+
+    // We need to make the color non-transparent or the mask would
+    // also be partially transparent.
+    if (color == null) {
+      color = _scheme.defaultMask;
+    } else if (!color.isOpaque) {
+      color = Color.alphaBlend(color, _scheme.background);
+      assert(color.isOpaque, 'Mask color must be opaque: $color');
     }
 
     // test-only code
@@ -142,7 +164,8 @@ class WidgetFilter {
       return true;
     }());
 
-    return WidgetFilterItem(color ?? _defaultColor, rect);
+    assert(color.isOpaque);
+    return WidgetFilterItem(color, rect);
   }
 
   // We cut off some widgets early because they're not visible at all.
@@ -206,4 +229,25 @@ extension on Element {
     });
     return result;
   }
+}
+
+@internal
+extension Opaqueness on Color {
+  @pragma('vm:prefer-inline')
+  bool get isOpaque => alpha == 0xff;
+
+  @pragma('vm:prefer-inline')
+  Color asOpaque() => isOpaque ? this : Color.fromARGB(0xff, red, green, blue);
+}
+
+@internal
+class WidgetFilterColorScheme {
+  final Color defaultMask;
+  final Color defaultTextMask;
+  final Color background;
+
+  const WidgetFilterColorScheme(
+      {required this.defaultMask,
+      required this.defaultTextMask,
+      required this.background});
 }

--- a/flutter/lib/src/screenshot/widget_filter.dart
+++ b/flutter/lib/src/screenshot/widget_filter.dart
@@ -152,7 +152,6 @@ class WidgetFilter {
       color = _scheme.defaultMask;
     } else if (!color.isOpaque) {
       color = Color.alphaBlend(color, _scheme.background);
-      assert(color.isOpaque, 'Mask color must be opaque: $color');
     }
 
     // test-only code
@@ -164,7 +163,7 @@ class WidgetFilter {
       return true;
     }());
 
-    assert(color.isOpaque);
+    assert(color.isOpaque, 'Mask color must be opaque: $color');
     return WidgetFilterItem(color, rect);
   }
 

--- a/flutter/test/screenshot/widget_filter_test.dart
+++ b/flutter/test/screenshot/widget_filter_test.dart
@@ -1,5 +1,5 @@
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:sentry_flutter/src/screenshot/widget_filter.dart';
@@ -14,6 +14,10 @@ void main() async {
   const defaultBounds = Rect.fromLTRB(0, 0, 1000, 1000);
   final rootBundle = TestAssetBundle();
   final otherBundle = TestAssetBundle();
+  final colorScheme = WidgetFilterColorScheme(
+      defaultMask: Colors.white,
+      defaultTextMask: Colors.green,
+      background: Colors.red);
 
   final createSut = ({bool redactImages = false, bool redactText = false}) {
     final replayOptions = SentryPrivacyOptions();
@@ -30,14 +34,22 @@ void main() async {
     testWidgets('redacts the correct number of elements', (tester) async {
       final sut = createSut(redactText: true);
       final element = await pumpTestElement(tester);
-      sut.obscure(element, 1.0, defaultBounds);
+      sut.obscure(
+          context: element,
+          pixelRatio: 1.0,
+          bounds: defaultBounds,
+          colorScheme: colorScheme);
       expect(sut.items.length, 5);
     });
 
     testWidgets('does not redact text when disabled', (tester) async {
       final sut = createSut(redactText: false);
       final element = await pumpTestElement(tester);
-      sut.obscure(element, 1.0, defaultBounds);
+      sut.obscure(
+          context: element,
+          pixelRatio: 1.0,
+          bounds: defaultBounds,
+          colorScheme: colorScheme);
       expect(sut.items.length, 0);
     });
 
@@ -45,14 +57,22 @@ void main() async {
         (tester) async {
       final sut = createSut(redactText: true);
       final element = await pumpTestElement(tester);
-      sut.obscure(element, 1.0, Rect.fromLTRB(0, 0, 100, 100));
+      sut.obscure(
+          context: element,
+          pixelRatio: 1.0,
+          bounds: Rect.fromLTRB(0, 0, 100, 100),
+          colorScheme: colorScheme);
       expect(sut.items.length, 1);
     });
 
     testWidgets('correctly determines sizes', (tester) async {
       final sut = createSut(redactText: true);
       final element = await pumpTestElement(tester);
-      sut.obscure(element, 1.0, defaultBounds);
+      sut.obscure(
+          context: element,
+          pixelRatio: 1.0,
+          bounds: defaultBounds,
+          colorScheme: colorScheme);
       expect(sut.items.length, 5);
       expect(boundsRect(sut.items[0]), '624x48');
       expect(boundsRect(sut.items[1]), '169x20');
@@ -66,7 +86,11 @@ void main() async {
     testWidgets('redacts the correct number of elements', (tester) async {
       final sut = createSut(redactImages: true);
       final element = await pumpTestElement(tester);
-      sut.obscure(element, 1.0, defaultBounds);
+      sut.obscure(
+          context: element,
+          pixelRatio: 1.0,
+          bounds: defaultBounds,
+          colorScheme: colorScheme);
       expect(sut.items.length, 3);
     });
 
@@ -106,7 +130,11 @@ void main() async {
     testWidgets('does not redact text when disabled', (tester) async {
       final sut = createSut(redactImages: false);
       final element = await pumpTestElement(tester);
-      sut.obscure(element, 1.0, defaultBounds);
+      sut.obscure(
+          context: element,
+          pixelRatio: 1.0,
+          bounds: defaultBounds,
+          colorScheme: colorScheme);
       expect(sut.items.length, 0);
     });
 
@@ -114,14 +142,22 @@ void main() async {
         (tester) async {
       final sut = createSut(redactImages: true);
       final element = await pumpTestElement(tester);
-      sut.obscure(element, 1.0, Rect.fromLTRB(0, 0, 500, 100));
+      sut.obscure(
+          context: element,
+          pixelRatio: 1.0,
+          bounds: Rect.fromLTRB(0, 0, 500, 100),
+          colorScheme: colorScheme);
       expect(sut.items.length, 1);
     });
 
     testWidgets('correctly determines sizes', (tester) async {
       final sut = createSut(redactImages: true);
       final element = await pumpTestElement(tester);
-      sut.obscure(element, 1.0, defaultBounds);
+      sut.obscure(
+          context: element,
+          pixelRatio: 1.0,
+          bounds: defaultBounds,
+          colorScheme: colorScheme);
       expect(sut.items.length, 3);
       expect(boundsRect(sut.items[0]), '1x1');
       expect(boundsRect(sut.items[1]), '1x1');
@@ -134,7 +170,11 @@ void main() async {
     final element = await pumpTestElement(tester, children: [
       SentryMask(Padding(padding: EdgeInsets.all(100), child: Text('foo'))),
     ]);
-    sut.obscure(element, 1.0, defaultBounds);
+    sut.obscure(
+        context: element,
+        pixelRatio: 1.0,
+        bounds: defaultBounds,
+        colorScheme: colorScheme);
     expect(sut.items.length, 1);
     expect(boundsRect(sut.items[0]), '344x248');
   });
@@ -146,7 +186,11 @@ void main() async {
       SentryUnmask(newImage()),
       SentryUnmask(SentryMask(Text('foo'))),
     ]);
-    sut.obscure(element, 1.0, defaultBounds);
+    sut.obscure(
+        context: element,
+        pixelRatio: 1.0,
+        bounds: defaultBounds,
+        colorScheme: colorScheme);
     expect(sut.items, isEmpty);
   });
 
@@ -155,11 +199,19 @@ void main() async {
     final element = await pumpTestElement(tester, children: [
       Padding(padding: EdgeInsets.all(100), child: Text('foo')),
     ]);
-    sut.obscure(element, 1.0, defaultBounds);
+    sut.obscure(
+        context: element,
+        pixelRatio: 1.0,
+        bounds: defaultBounds,
+        colorScheme: colorScheme);
     expect(sut.items.length, 1);
     expect(boundsRect(sut.items[0]), '144x48');
     sut.throwInObscure = true;
-    sut.obscure(element, 1.0, defaultBounds);
+    sut.obscure(
+        context: element,
+        pixelRatio: 1.0,
+        bounds: defaultBounds,
+        colorScheme: colorScheme);
     expect(sut.items.length, 1);
     expect(boundsRect(sut.items[0]), '344x248');
   });


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

- fixes masking semi-transparent widgets (originally the mask would also be semi-transparent).
- improves color-matching for text that doesn't have a color specified directly


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

closes #2454 


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes -- no, see https://github.com/getsentry/sentry-dart/issues/2473
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
