### PR TITLE
fix: iOS warning of missing method channel callback setReplayConfig

### DIFF
--- a/flutter/lib/src/native/cocoa/sentry_native_cocoa.dart
+++ b/flutter/lib/src/native/cocoa/sentry_native_cocoa.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:ffi';
 import 'dart:typed_data';
 import 'dart:ui';
@@ -5,6 +6,7 @@ import 'dart:ui';
 import 'package:meta/meta.dart';
 
 import '../../../sentry_flutter.dart';
+import '../../replay/replay_config.dart';
 import '../../screenshot/recorder.dart';
 import '../../screenshot/recorder_config.dart';
 import '../sentry_native_channel.dart';
@@ -66,6 +68,11 @@ class SentryNativeCocoa extends SentryNativeChannel {
     }
 
     return super.init(hub);
+  }
+
+  @override
+  FutureOr<void> setReplayConfig(ReplayConfig config) {
+    // Note: unused on iOS.
   }
 
   @override

--- a/flutter/lib/src/native/sentry_native_channel.dart
+++ b/flutter/lib/src/native/sentry_native_channel.dart
@@ -221,7 +221,7 @@ class SentryNativeChannel
   bool get supportsReplay => false;
 
   @override
-  Future<void> setReplayConfig(ReplayConfig config) =>
+  FutureOr<void> setReplayConfig(ReplayConfig config) =>
       channel.invokeMethod('setReplayConfig', {
         'width': config.width,
         'height': config.height,

--- a/flutter/test/sentry_native_channel_test.dart
+++ b/flutter/test/sentry_native_channel_test.dart
@@ -335,12 +335,16 @@ void main() {
             ReplayConfig(width: 1.1, height: 2.2, frameRate: 3, bitRate: 4);
         await sut.setReplayConfig(config);
 
-        verify(channel.invokeMethod('setReplayConfig', {
-          'width': config.width,
-          'height': config.height,
-          'frameRate': config.frameRate,
-          'bitRate': config.bitRate,
-        }));
+        if (mockPlatform.isAndroid) {
+          verify(channel.invokeMethod('setReplayConfig', {
+            'width': config.width,
+            'height': config.height,
+            'frameRate': config.frameRate,
+            'bitRate': config.bitRate,
+          }));
+        } else {
+          verifyNever(channel.invokeMethod('setReplayConfig', any));
+        }
       });
 
       test('captureReplay', () async {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

#skip-changelog

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
