### PR TITLE
fix: try/catch critical paths

### DIFF
--- a/dart/lib/src/sentry.dart
+++ b/dart/lib/src/sentry.dart
@@ -187,6 +187,9 @@ class Sentry {
           exception: error,
           stackTrace: stackTrace,
         );
+        if (options.automatedTestMode) {
+          rethrow;
+        }
       }
     }
   }

--- a/flutter/lib/src/integrations/frames_tracking_integration.dart
+++ b/flutter/lib/src/integrations/frames_tracking_integration.dart
@@ -15,9 +15,12 @@ class FramesTrackingIntegration implements Integration<SentryFlutterOptions> {
   SentryWidgetsBindingMixin? _widgetsBinding;
 
   @override
-  Future<void> call(Hub hub, SentryFlutterOptions options) async {
+  void call(Hub hub, SentryFlutterOptions options) {
     _options = options;
+    _initializeFramesTracking(options);
+  }
 
+  void _initializeFramesTracking(SentryFlutterOptions options) async {
     if (!options.enableFramesTracking) {
       return options.logger(SentryLevel.debug,
           '$FramesTrackingIntegration disabled: enableFramesTracking option is false');

--- a/flutter/lib/src/integrations/native_app_start_integration.dart
+++ b/flutter/lib/src/integrations/native_app_start_integration.dart
@@ -32,7 +32,7 @@ class NativeAppStartIntegration extends Integration<SentryFlutterOptions> {
   bool _allowProcessing = true;
 
   @override
-  void call(Hub hub, SentryFlutterOptions options) async {
+  void call(Hub hub, SentryFlutterOptions options) {
     void timingsCallback(List<FrameTiming> timings) async {
       if (!_allowProcessing) {
         return;

--- a/flutter/lib/src/navigation/sentry_navigator_observer.dart
+++ b/flutter/lib/src/navigation/sentry_navigator_observer.dart
@@ -164,6 +164,9 @@ class SentryNavigatorObserver extends RouteObserver<PageRoute<dynamic>> {
         exception: error,
         stackTrace: stackTrace,
       );
+      if (_hub.options.automatedTestMode) {
+        rethrow;
+      }
     }
   }
 
@@ -192,6 +195,9 @@ class SentryNavigatorObserver extends RouteObserver<PageRoute<dynamic>> {
         exception: error,
         stackTrace: stackTrace,
       );
+      if (_hub.options.automatedTestMode) {
+        rethrow;
+      }
     }
   }
 
@@ -223,6 +229,9 @@ class SentryNavigatorObserver extends RouteObserver<PageRoute<dynamic>> {
         exception: error,
         stackTrace: stackTrace,
       );
+      if (_hub.options.automatedTestMode) {
+        rethrow;
+      }
     }
   }
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
try/catch critical paths. If errors are thrown here it will lock the UI from processing either runApp or the page navigation

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Potentially fix #2491 

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
