### PR TITLE
check `SentryTracer` type in ttfd tracker 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Manual TTID ([#2477](https://github.com/getsentry/sentry-dart/pull/2477))
 
+### Improvements
+
+- Check `SentryTracer` type in TTFD tracker ([#2508](https://github.com/getsentry/sentry-dart/pull/2508))
+
 ### Enhancements
 
 - Warning (in a debug build) if a potentially sensitive widget is not masked or unmasked explicitly ([#2375](https://github.com/getsentry/sentry-dart/pull/2375))

--- a/flutter/lib/src/navigation/time_to_full_display_tracker.dart
+++ b/flutter/lib/src/navigation/time_to_full_display_tracker.dart
@@ -3,7 +3,6 @@
 import 'dart:async';
 
 import 'package:meta/meta.dart';
-
 // ignore: implementation_imports
 import 'package:sentry/src/sentry_tracer.dart';
 
@@ -42,8 +41,11 @@ class TimeToFullDisplayTracker {
     required ISentrySpan transaction,
     required DateTime startTimestamp,
   }) async {
+    if (transaction is! SentryTracer) {
+      return;
+    }
     _startTimestamp = startTimestamp;
-    _transaction = transaction as SentryTracer;
+    _transaction = transaction;
     _ttfdSpan = transaction.startChild(
       SentrySpanOperations.uiTimeToFullDisplay,
       description: '${transaction.name} full display',


### PR DESCRIPTION
Fixes integration tests where the app starts to push a route but the test is already done / Sentry is closing