### PR TITLE
make Sentry Native usage opt-in

### DIFF
--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -65,7 +65,7 @@ mixin SentryFlutter {
     if (options.platformChecker.hasNativeIntegration) {
       if (options.platformChecker.platform.isLinux ||
           options.platformChecker.platform.isWindows) {
-        if (options.enableNativeSdk) {
+        if (options.enableSentryNative) {
           _native = createBinding(options);
         }
       } else {

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -63,7 +63,14 @@ mixin SentryFlutter {
     sentrySetupStartTime ??= options.clock();
 
     if (options.platformChecker.hasNativeIntegration) {
-      _native = createBinding(options);
+      if (options.platformChecker.platform.isLinux ||
+          options.platformChecker.platform.isWindows) {
+        if (options.enableNativeSdk) {
+          _native = createBinding(options);
+        }
+      } else {
+        _native = createBinding(options);
+      }
     }
 
     final platformDispatcher = PlatformDispatcher.instance;

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -292,15 +292,15 @@ class SentryFlutterOptions extends SentryOptions {
   /// you must use `SentryWidgetsFlutterBinding.ensureInitialized()` instead.
   bool enableFramesTracking = true;
 
-  /// Enables the initialization of the Sentry-Native SDK.
+  /// Enables the initialization of the Sentry-Native SDK for Windows & Linux.
   ///
-  /// When enabled this will enhance Windows & Linux:
+  /// When enabled this will enhance Windows & Linux support:
   ///  - catching native crashes
   ///  - reporting richer device context
   ///  - symbolication of Dart errors
   ///
   /// Defaults to `false`
-  bool enableNativeSdk = false;
+  bool enableSentryNative = false;
 
   /// By using this, you are disabling native [Breadcrumb] tracking and instead
   /// you are just tracking [Breadcrumb]s which result from events available

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -3,15 +3,15 @@ import 'dart:async';
 import 'package:file/file.dart';
 import 'package:file/local.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart' as meta;
 import 'package:sentry/sentry.dart';
-import 'package:flutter/widgets.dart';
 
 import 'binding_wrapper.dart';
+import 'event_processor/screenshot_event_processor.dart';
 import 'navigation/time_to_display_tracker.dart';
 import 'renderer/renderer.dart';
 import 'screenshot/sentry_screenshot_quality.dart';
-import 'event_processor/screenshot_event_processor.dart';
 import 'sentry_flutter.dart';
 import 'sentry_privacy_options.dart';
 import 'sentry_replay_options.dart';
@@ -291,6 +291,16 @@ class SentryFlutterOptions extends SentryOptions {
   /// Note: If you call `WidgetsFlutterBinding.ensureInitialized()` before `SentryFlutter.init()`,
   /// you must use `SentryWidgetsFlutterBinding.ensureInitialized()` instead.
   bool enableFramesTracking = true;
+
+  /// Enables the initialization of the Sentry-Native SDK.
+  ///
+  /// When enabled this will enhance Windows & Linux:
+  ///  - catching native crashes
+  ///  - reporting richer device context
+  ///  - symbolication of Dart errors
+  ///
+  /// Defaults to `false`
+  bool enableNativeSdk = false;
 
   /// By using this, you are disabling native [Breadcrumb] tracking and instead
   /// you are just tracking [Breadcrumb]s which result from events available

--- a/flutter/test/sentry_flutter_test.dart
+++ b/flutter/test/sentry_flutter_test.dart
@@ -3,8 +3,8 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:package_info_plus/package_info_plus.dart';
-import 'package:sentry/src/platform/platform.dart';
 import 'package:sentry/src/dart_exception_type_identifier.dart';
+import 'package:sentry/src/platform/platform.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:sentry_flutter/src/file_system_transport.dart';
 import 'package:sentry_flutter/src/flutter_exception_type_identifier.dart';
@@ -16,6 +16,7 @@ import 'package:sentry_flutter/src/renderer/renderer.dart';
 import 'package:sentry_flutter/src/replay/integration.dart';
 import 'package:sentry_flutter/src/version.dart';
 import 'package:sentry_flutter/src/view_hierarchy/view_hierarchy_integration.dart';
+
 import 'mocks.dart';
 import 'mocks.mocks.dart';
 import 'sentry_flutter_util.dart';
@@ -273,7 +274,7 @@ void main() {
           beforeIntegration: WidgetsFlutterBindingIntegration,
           afterIntegration: OnErrorIntegration);
 
-      expect(SentryFlutter.native, isNotNull);
+      expect(SentryFlutter.native, isNull);
       expect(Sentry.currentHub.profilerFactory, isNull);
     }, testOn: 'vm');
 
@@ -321,7 +322,7 @@ void main() {
           beforeIntegration: WidgetsFlutterBindingIntegration,
           afterIntegration: OnErrorIntegration);
 
-      expect(SentryFlutter.native, isNotNull);
+      expect(SentryFlutter.native, isNull);
       expect(Sentry.currentHub.profilerFactory, isNull);
 
       await Sentry.close();


### PR DESCRIPTION
Only enable sentry-native usage when the `enableSentryNative` flag is true (feel free to suggest another name)

Usually we shouldn't change behaviour of features released in a minor but since this causes multiple issues imo it make sense to do it.

Note: this will be opt-out in v9

Not sure what to categorize this in the changelog