### PR TITLE
fix: replay not saved during animations

### DIFF
--- a/flutter/lib/src/replay/replay_recorder.dart
+++ b/flutter/lib/src/replay/replay_recorder.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:developer';
 
-import 'package:flutter/scheduler.dart';
 import 'package:meta/meta.dart';
 
 import '../screenshot/recorder.dart';
@@ -18,9 +17,7 @@ class ReplayScreenshotRecorder extends ScreenshotRecorder {
   @override
   @protected
   Future<void> executeTask(void Function() task, Flow flow) {
-    // Schedule the task to run between frames, when the app is idle.
-    return options.bindingUtils.instance
-            ?.scheduleTask<void>(task, Priority.idle, flow: flow) ??
-        Future.sync(task);
+    // Future() schedules the task to be executed asynchronously with TImer.run.
+    return Future(task);
   }
 }

--- a/flutter/lib/src/screenshot/recorder.dart
+++ b/flutter/lib/src/screenshot/recorder.dart
@@ -111,8 +111,11 @@ class ScreenshotRecorder {
   }
 
   @protected
-  Future<void> executeTask(void Function() task, Flow flow) =>
-      Future.sync(task);
+  Future<void> executeTask(void Function() task, Flow flow) {
+    // Future.sync() starts executing the function synchronously, until the
+    // first await, i.e. it's the same as if the code was executed directly.
+    return Future.sync(task);
+  }
 
   List<WidgetFilterItem>? _obscureSync(_Capture<dynamic> capture) {
     if (_maskingConfig != null) {

--- a/flutter/test/screenshot/recorder_test.dart
+++ b/flutter/test/screenshot/recorder_test.dart
@@ -83,7 +83,7 @@ void main() async {
       });
 
     expect(
-        fixture.capture(),
+        fixture.capture,
         throwsA(predicate(
             (Exception e) => e.toString().contains('testing masking error'))));
   });
@@ -130,23 +130,18 @@ class _Fixture {
       ScreenshotRecorderConfig(width: width, height: height), options);
   late final options = defaultTestOptions()
     ..bindingUtils = TestBindingWrapper();
-  final WidgetTester _tester;
   final double? width;
   final double? height;
 
-  _Fixture(this._tester, {this.width, this.height});
+  _Fixture({this.width, this.height});
 
   static Future<_Fixture> create(WidgetTester tester,
       {double? width, double? height}) async {
-    final fixture = _Fixture(tester, width: width, height: height);
+    final fixture = _Fixture(width: width, height: height);
     await pumpTestElement(tester);
     return fixture;
   }
 
-  Future<String?> capture() async {
-    final future = sut.capture<String?>(
-        (Image image) => Future.value("${image.width}x${image.height}"));
-    await _tester.idle();
-    return future;
-  }
+  Future<String?> capture() => sut.capture<String?>(
+      (Image image) => Future.value("${image.width}x${image.height}"));
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

In a recent PR, I've changed the screenshot processing to run between frames (scheduling for when the app is idle). This breaks when there's a continuous animation on the page, e.g. a loader. Rolling this back so it runs as before.

#skip-changelog because nothing shipped yet.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
