### PR TITLE
fix: precise android replay frame timestamps

### DIFF
--- a/flutter/lib/src/event_processor/screenshot_event_processor.dart
+++ b/flutter/lib/src/event_processor/screenshot_event_processor.dart
@@ -128,8 +128,9 @@ class ScreenshotEventProcessor implements EventProcessor {
   Future<Uint8List?> createScreenshot() =>
       _recorder.capture(_convertImageToUint8List);
 
-  Future<Uint8List?> _convertImageToUint8List(Image image) async {
-    final byteData = await image.toByteData(format: ImageByteFormat.png);
+  Future<Uint8List?> _convertImageToUint8List(Screenshot screenshot) async {
+    final byteData =
+        await screenshot.image.toByteData(format: ImageByteFormat.png);
 
     final bytes = byteData?.buffer.asUint8List();
     if (bytes?.isNotEmpty == true) {

--- a/flutter/lib/src/native/cocoa/sentry_native_cocoa.dart
+++ b/flutter/lib/src/native/cocoa/sentry_native_cocoa.dart
@@ -45,7 +45,8 @@ class SentryNativeCocoa extends SentryNativeChannel {
               });
             }
 
-            return _replayRecorder?.capture((image) async {
+            return _replayRecorder?.capture((screenshot) async {
+              final image = screenshot.image;
               final imageData =
                   await image.toByteData(format: ImageByteFormat.png);
               if (imageData != null) {

--- a/flutter/lib/src/native/java/android_replay_recorder.dart
+++ b/flutter/lib/src/native/java/android_replay_recorder.dart
@@ -16,7 +16,7 @@ class AndroidReplayRecorder extends ScheduledScreenshotRecorder {
 
   Future<void> _addReplayScreenshot(
       ScreenshotPng screenshot, bool isNewlyCaptured) async {
-    final timestamp = DateTime.now().millisecondsSinceEpoch;
+    final timestamp = screenshot.timestamp.millisecondsSinceEpoch;
     final filePath = "$_cacheDir/$timestamp.png";
 
     options.logger(

--- a/flutter/lib/src/replay/scheduled_recorder.dart
+++ b/flutter/lib/src/replay/scheduled_recorder.dart
@@ -5,6 +5,7 @@ import 'dart:ui';
 import 'package:meta/meta.dart';
 
 import '../../sentry_flutter.dart';
+import '../screenshot/recorder.dart';
 import 'replay_recorder.dart';
 import 'scheduled_recorder_config.dart';
 import 'scheduler.dart';
@@ -95,11 +96,13 @@ class ScheduledScreenshotRecorder extends ReplayScreenshotRecorder {
 
   void _capture(Duration sinceSchedulerEpoch) => capture(_onImageCaptured);
 
-  Future<void> _onImageCaptured(Image image) async {
+  Future<void> _onImageCaptured(Screenshot capturedScreenshot) async {
+    final image = capturedScreenshot.image;
     if (_status == _Status.running) {
       var imageData = await image.toByteData(format: ImageByteFormat.png);
       if (imageData != null) {
-        final screenshot = ScreenshotPng(image.width, image.height, imageData);
+        final screenshot = ScreenshotPng(
+            image.width, image.height, imageData, capturedScreenshot.timestamp);
         await _onScreenshot(screenshot, true);
         _idleFrameFiller.actualFrameReceived(screenshot);
       } else {
@@ -133,8 +136,9 @@ class ScreenshotPng {
   final int width;
   final int height;
   final ByteData data;
+  final DateTime timestamp;
 
-  const ScreenshotPng(this.width, this.height, this.data);
+  const ScreenshotPng(this.width, this.height, this.data, this.timestamp);
 }
 
 // Workaround for https://github.com/getsentry/sentry-java/issues/3677

--- a/flutter/test/screenshot/recorder_test.dart
+++ b/flutter/test/screenshot/recorder_test.dart
@@ -144,8 +144,10 @@ class _Fixture {
   }
 
   Future<String?> capture() async {
-    final future = sut.capture<String?>(
-        (Image image) => Future.value("${image.width}x${image.height}"));
+    final future = sut.capture<String?>((Screenshot screenshot) {
+      final image = screenshot.image;
+      return Future.value("${image.width}x${image.height}");
+    });
     await _tester.idle();
     return future;
   }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

As processing the screenshot can take some time, we should store the timestamp at the time the image was captured. 

#skip-changelog


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
