### PR TITLE
feat: add an option to configure native backend on windows & linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,27 @@
 # Changelog
 
+## Unreleased
+
+### Changes
+
+- Windows & Linux native crash handlers: add `SENTRY_NATIVE_BACKEND` env var with default setting of `none`. ([#2522](https://github.com/getsentry/sentry-dart/pull/2522))
+  Native crash reporting support with `sentry-native`'s `crashpad` was added in v8.11.0 and has caused build-time issues
+  for some users, because it required newer build tools (newer versions of MSVC/Clang/GCC) than base Flutter SDK.
+  This broke the ability to build the app for some users compiling Windows and Linux apps with older toolchains.
+
+  To avoid this issue, we're disabling the native crash handling by default for Linux and Windows for now.
+  You can enable manually by setting `SENTRY_NATIVE_BACKEND=crashpad` environment variable app build.
+  You can read more about available backends that fit your use-case in [sentry-native docs](https://docs.sentry.io/platforms/native/configuration/backends/).
+
+  We plan to change the default to back to `crashpad` in the next major SDK release.
+
 ## 8.11.1
 
 ### Improvements
 
 - Check for type before casting in TTID ([#2497](https://github.com/getsentry/sentry-dart/pull/2497))
 
-### Fixes 
+### Fixes
 
 - SentryWidgetsFlutterBinding initializing even if a binding already exists ([#2494](https://github.com/getsentry/sentry-dart/pull/2494))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@
   This broke the ability to build the app for some users compiling Windows and Linux apps with older toolchains.
 
   To avoid this issue, we're disabling the native crash handling by default for Linux and Windows for now.
-  You can enable manually by setting `SENTRY_NATIVE_BACKEND=crashpad` environment variable before running `flutter build`.
+  You can enable it manually by setting the `SENTRY_NATIVE_BACKEND=crashpad` environment variable before running `flutter build`.
   You can read more about available backends that fit your use-case in [sentry-native docs](https://docs.sentry.io/platforms/native/configuration/backends/).
 
-  We plan to change the default to back to `crashpad` in the next major SDK release.
+  We plan to change the default back to `crashpad` in the next major SDK release.
 
 ## 8.11.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
   This broke the ability to build the app for some users compiling Windows and Linux apps with older toolchains.
 
   To avoid this issue, we're disabling the native crash handling by default for Linux and Windows for now.
-  You can enable manually by setting `SENTRY_NATIVE_BACKEND=crashpad` environment variable app build.
+  You can enable manually by setting `SENTRY_NATIVE_BACKEND=crashpad` environment variable before running `flutter build`.
   You can read more about available backends that fit your use-case in [sentry-native docs](https://docs.sentry.io/platforms/native/configuration/backends/).
 
   We plan to change the default to back to `crashpad` in the next major SDK release.

--- a/flutter/linux/CMakeLists.txt
+++ b/flutter/linux/CMakeLists.txt
@@ -3,6 +3,8 @@
 # the plugin to fail to compile for some customers of the plugin.
 cmake_minimum_required(VERSION 3.10)
 
+set(SENTRY_BACKEND "crashpad" CACHE STRING "The sentry backend responsible for reporting crashes" FORCE)
+
 include("${CMAKE_CURRENT_SOURCE_DIR}/../sentry-native/sentry-native.cmake")
 
 # Even though sentry_flutter doesn't actually provide a useful plugin, we need to accommodate the Flutter tooling.

--- a/flutter/sentry-native/sentry-native.cmake
+++ b/flutter/sentry-native/sentry-native.cmake
@@ -2,8 +2,15 @@ load_cache("${CMAKE_CURRENT_LIST_DIR}" READ_WITH_PREFIX SENTRY_NATIVE_ repo vers
 message(STATUS "Fetching Sentry native version: ${SENTRY_NATIVE_version} from ${SENTRY_NATIVE_repo}")
 
 set(SENTRY_SDK_NAME "sentry.native.flutter" CACHE STRING "The SDK name to report when sending events." FORCE)
-set(SENTRY_BACKEND "crashpad" CACHE STRING "The sentry backend responsible for reporting crashes" FORCE)
 set(SENTRY_BUILD_SHARED_LIBS ON CACHE BOOL "Build shared libraries (.dll/.so) instead of static ones (.lib/.a)" FORCE)
+
+# Note: the backend is also set in linux/CMakeLists.txt and windows/CMakeLists.txt. This overwrites those if user sets an env var.
+if("$ENV{SENTRY_NATIVE_BACKEND}" STREQUAL "")
+    # Until sentry-dart v9, we disable native backend by default.
+    set(SENTRY_BACKEND "none" CACHE STRING "The sentry backend responsible for reporting crashes" FORCE)
+else()
+    set(SENTRY_BACKEND $ENV{SENTRY_NATIVE_BACKEND} CACHE STRING "The sentry backend responsible for reporting crashes" FORCE)
+endif()
 
 include(FetchContent)
 FetchContent_Declare(
@@ -17,15 +24,19 @@ FetchContent_MakeAvailable(sentry-native)
 
 # List of absolute paths to libraries that should be bundled with the plugin.
 # This list could contain prebuilt libraries, or libraries created by an external build triggered from this build file.
-if(WIN32)
-    set(sentry_flutter_bundled_libraries
-        $<TARGET_FILE:crashpad_handler>
-        $<TARGET_FILE:crashpad_wer>
-        PARENT_SCOPE)
+if(SENTRY_BACKEND STREQUAL "crashpad")
+    if(WIN32)
+        set(sentry_flutter_bundled_libraries
+            $<TARGET_FILE:crashpad_handler>
+            $<TARGET_FILE:crashpad_wer>
+            PARENT_SCOPE)
+    else()
+        set(sentry_flutter_bundled_libraries
+            $<TARGET_FILE:crashpad_handler>
+            PARENT_SCOPE)
+    endif()
 else()
-    set(sentry_flutter_bundled_libraries
-        $<TARGET_FILE:crashpad_handler>
-        PARENT_SCOPE)
+    set(sentry_flutter_bundled_libraries "" PARENT_SCOPE)
 endif()
 
 # `*_plugin` is the name of the plugin library as expected by flutter.

--- a/flutter/test/sentry_native/sentry_native_test_ffi.dart
+++ b/flutter/test/sentry_native/sentry_native_test_ffi.dart
@@ -12,254 +12,305 @@ import 'package:sentry_flutter/src/native/factory.dart';
 import '../mocks.dart';
 import '../mocks.mocks.dart';
 
-late final String repoRootDir;
-late final List<String> expectedDistFiles;
+enum NativeBackend { default_, crashpad, breakpad, inproc, none }
+
+extension on NativeBackend {
+  // TODO change default to crashpad in v9
+  String get actualValue => this == NativeBackend.default_ ? 'none' : name;
+}
 
 // NOTE: Don't run/debug this main(), it likely won't work.
 // You can use main() in `sentry_native_test.dart`.
 void main() {
-  repoRootDir = Directory.current.path.endsWith('/test')
+  final repoRootDir = Directory.current.path.endsWith('/test')
       ? Directory.current.parent.path
       : Directory.current.path;
 
-  expectedDistFiles = platform.instance.isWindows
-      ? ['sentry.dll', 'crashpad_handler.exe', 'crashpad_wer.dll']
-      : ['libsentry.so', 'crashpad_handler'];
+  // assert(NativeBackend.values.length == 4);
+  for (final backend in NativeBackend.values) {
+    group(backend.name, () {
+      late final NativeTestHelper helper;
+      setUpAll(() async {
+        late final List<String> expectedDistFiles;
+        if (backend.actualValue == 'crashpad') {
+          expectedDistFiles = platform.instance.isWindows
+              ? ['sentry.dll', 'crashpad_handler.exe', 'crashpad_wer.dll']
+              : ['libsentry.so', 'crashpad_handler'];
+        } else {
+          expectedDistFiles =
+              platform.instance.isWindows ? ['sentry.dll'] : ['libsentry.so'];
+        }
 
-  setUpAll(() async {
-    Directory.current =
-        await _buildSentryNative('$repoRootDir/temp/native-test');
-    SentryNative.dynamicLibraryDirectory = '${Directory.current.path}/';
-    SentryNative.crashpadPath =
-        '${Directory.current.path}/${expectedDistFiles.firstWhere((f) => f.contains('crashpad_handler'))}';
-  });
+        helper = NativeTestHelper(
+          repoRootDir,
+          backend,
+          expectedDistFiles,
+          '$repoRootDir/temp/native-test-${backend.name}',
+        );
 
-  late SentryNative sut;
-  late SentryFlutterOptions options;
+        Directory.current = await helper._buildSentryNative();
+        SentryNative.dynamicLibraryDirectory = '${Directory.current.path}/';
+        if (backend.actualValue == 'crashpad') {
+          SentryNative.crashpadPath =
+              '${Directory.current.path}/${expectedDistFiles.firstWhere((f) => f.contains('crashpad_handler'))}';
+        }
+      });
 
-  setUp(() {
-    options = SentryFlutterOptions(dsn: fakeDsn)
-      // ignore: invalid_use_of_internal_member
-      ..automatedTestMode = true
-      ..debug = true;
-    sut = createBinding(options) as SentryNative;
-  });
+      late SentryNative sut;
+      late SentryFlutterOptions options;
 
-  test('expected output files', () {
-    for (var name in expectedDistFiles) {
-      if (!File(name).existsSync()) {
-        fail('Native distribution file $name does not exist');
-      }
-    }
-  });
+      setUp(() {
+        options = SentryFlutterOptions(dsn: fakeDsn)
+          // ignore: invalid_use_of_internal_member
+          ..automatedTestMode = true
+          ..debug = true;
+        sut = createBinding(options) as SentryNative;
+      });
 
-  test('options', () {
-    options
-      ..debug = true
-      ..environment = 'foo'
-      ..release = 'foo@bar+1'
-      ..enableAutoSessionTracking = true
-      ..dist = 'distfoo'
-      ..maxBreadcrumbs = 42;
+      test('native CMake was configured with configured backend', () async {
+        final cmakeCacheTxt =
+            await File('${helper.cmakeBuildDir}/CMakeCache.txt').readAsLines();
+        expect(cmakeCacheTxt,
+            contains('SENTRY_BACKEND:STRING=${backend.actualValue}'));
+      });
 
-    final cOptions = sut.createOptions(options);
-    try {
-      expect(
-          SentryNative.native
-              .options_get_dsn(cOptions)
-              .cast<Utf8>()
-              .toDartString(),
-          fakeDsn);
-      expect(
-          SentryNative.native
-              .options_get_environment(cOptions)
-              .cast<Utf8>()
-              .toDartString(),
-          'foo');
-      expect(
-          SentryNative.native
-              .options_get_release(cOptions)
-              .cast<Utf8>()
-              .toDartString(),
-          'foo@bar+1');
-      expect(
-          SentryNative.native.options_get_auto_session_tracking(cOptions), 1);
-      expect(SentryNative.native.options_get_max_breadcrumbs(cOptions), 42);
-    } finally {
-      SentryNative.native.options_free(cOptions);
-    }
-  });
+      test('expected output files', () {
+        for (var name in helper.expectedDistFiles) {
+          if (!File(name).existsSync()) {
+            fail('Native distribution file $name does not exist');
+          }
+        }
+      });
 
-  test('SDK version', () {
-    expect(_configuredSentryNativeVersion.length, greaterThanOrEqualTo(5));
-    expect(SentryNative.native.sdk_version().cast<Utf8>().toDartString(),
-        _configuredSentryNativeVersion);
-  });
+      test('options', () {
+        options
+          ..debug = true
+          ..environment = 'foo'
+          ..release = 'foo@bar+1'
+          ..enableAutoSessionTracking = true
+          ..dist = 'distfoo'
+          ..maxBreadcrumbs = 42;
 
-  test('SDK name', () {
-    expect(SentryNative.native.sdk_name().cast<Utf8>().toDartString(),
-        'sentry.native.flutter');
-  });
+        final cOptions = sut.createOptions(options);
+        try {
+          expect(
+              SentryNative.native
+                  .options_get_dsn(cOptions)
+                  .cast<Utf8>()
+                  .toDartString(),
+              fakeDsn);
+          expect(
+              SentryNative.native
+                  .options_get_environment(cOptions)
+                  .cast<Utf8>()
+                  .toDartString(),
+              'foo');
+          expect(
+              SentryNative.native
+                  .options_get_release(cOptions)
+                  .cast<Utf8>()
+                  .toDartString(),
+              'foo@bar+1');
+          expect(
+              SentryNative.native.options_get_auto_session_tracking(cOptions),
+              1);
+          expect(SentryNative.native.options_get_max_breadcrumbs(cOptions), 42);
+        } finally {
+          SentryNative.native.options_free(cOptions);
+        }
+      });
 
-  test('init', () async {
-    addTearDown(sut.close);
-    await sut.init(MockHub());
-  });
+      test('SDK version', () {
+        expect(helper.configuredSentryNativeVersion.length,
+            greaterThanOrEqualTo(5));
+        expect(SentryNative.native.sdk_version().cast<Utf8>().toDartString(),
+            helper.configuredSentryNativeVersion);
+      });
 
-  test('app start', () {
-    expect(sut.fetchNativeAppStart(), null);
-  });
+      test('SDK name', () {
+        expect(SentryNative.native.sdk_name().cast<Utf8>().toDartString(),
+            'sentry.native.flutter');
+      });
 
-  test('frames tracking', () {
-    sut.beginNativeFrames();
-    expect(sut.endNativeFrames(SentryId.newId()), null);
-  });
+      test('init', () async {
+        addTearDown(sut.close);
+        await sut.init(MockHub());
+      });
 
-  test('hang tracking', () {
-    sut.pauseAppHangTracking();
-    sut.resumeAppHangTracking();
-  });
+      test('app start', () {
+        expect(sut.fetchNativeAppStart(), null);
+      });
 
-  test('setUser', () async {
-    final user = SentryUser(
-      id: "fixture-id",
-      username: 'username',
-      email: 'mail@domain.tld',
-      ipAddress: '1.2.3.4',
-      name: 'User Name',
-      data: {
-        'str': 'foo-bar',
-        'double': 1.0,
-        'int': 1,
-        'int64': 0x7FFFFFFF + 1,
-        'boo': true,
-        'inner-map': {'str': 'inner'},
-        'unsupported': Object()
-      },
-    );
+      test('frames tracking', () {
+        sut.beginNativeFrames();
+        expect(sut.endNativeFrames(SentryId.newId()), null);
+      });
 
-    await sut.setUser(user);
-  });
+      test('hang tracking', () {
+        sut.pauseAppHangTracking();
+        sut.resumeAppHangTracking();
+      });
 
-  test('addBreadcrumb', () async {
-    final breadcrumb = Breadcrumb(
-      type: 'type',
-      message: 'message',
-      category: 'category',
-    );
-    await sut.addBreadcrumb(breadcrumb);
-  });
+      test('setUser', () async {
+        final user = SentryUser(
+          id: "fixture-id",
+          username: 'username',
+          email: 'mail@domain.tld',
+          ipAddress: '1.2.3.4',
+          name: 'User Name',
+          data: {
+            'str': 'foo-bar',
+            'double': 1.0,
+            'int': 1,
+            'int64': 0x7FFFFFFF + 1,
+            'boo': true,
+            'inner-map': {'str': 'inner'},
+            'unsupported': Object()
+          },
+        );
 
-  test('clearBreadcrumbs', () async {
-    await sut.clearBreadcrumbs();
-  });
+        await sut.setUser(user);
+      });
 
-  test('displayRefreshRate', () async {
-    expect(sut.displayRefreshRate(), isNull);
-  });
+      test('addBreadcrumb', () async {
+        final breadcrumb = Breadcrumb(
+          type: 'type',
+          message: 'message',
+          category: 'category',
+        );
+        await sut.addBreadcrumb(breadcrumb);
+      });
 
-  test('setContexts', () async {
-    final value = {'object': Object()};
-    await sut.setContexts('fixture-key', value);
-  });
+      test('clearBreadcrumbs', () async {
+        await sut.clearBreadcrumbs();
+      });
 
-  test('removeContexts', () async {
-    await sut.removeContexts('fixture-key');
-  });
+      test('displayRefreshRate', () async {
+        expect(sut.displayRefreshRate(), isNull);
+      });
 
-  test('setExtra', () async {
-    final value = {'object': Object()};
-    await sut.setExtra('fixture-key', value);
-  });
+      test('setContexts', () async {
+        final value = {'object': Object()};
+        await sut.setContexts('fixture-key', value);
+      });
 
-  test('removeExtra', () async {
-    await sut.removeExtra('fixture-key');
-  });
+      test('removeContexts', () async {
+        await sut.removeContexts('fixture-key');
+      });
 
-  test('setTag', () async {
-    await sut.setTag('fixture-key', 'fixture-value');
-  });
+      test('setExtra', () async {
+        final value = {'object': Object()};
+        await sut.setExtra('fixture-key', value);
+      });
 
-  test('removeTag', () async {
-    await sut.removeTag('fixture-key');
-  });
+      test('removeExtra', () async {
+        await sut.removeExtra('fixture-key');
+      });
 
-  test('startProfiler', () {
-    expect(() => sut.startProfiler(SentryId.newId()), throwsUnsupportedError);
-  });
+      test('setTag', () async {
+        await sut.setTag('fixture-key', 'fixture-value');
+      });
 
-  test('discardProfiler', () async {
-    expect(() => sut.discardProfiler(SentryId.newId()), throwsUnsupportedError);
-  });
+      test('removeTag', () async {
+        await sut.removeTag('fixture-key');
+      });
 
-  test('collectProfile', () async {
-    final traceId = SentryId.newId();
-    const startTime = 42;
-    const endTime = 50;
-    expect(() => sut.collectProfile(traceId, startTime, endTime),
-        throwsUnsupportedError);
-  });
+      test('startProfiler', () {
+        expect(
+            () => sut.startProfiler(SentryId.newId()), throwsUnsupportedError);
+      });
 
-  test('captureEnvelope', () async {
-    final data = Uint8List.fromList([1, 2, 3]);
-    expect(() => sut.captureEnvelope(data, false), throwsUnsupportedError);
-  });
+      test('discardProfiler', () async {
+        expect(() => sut.discardProfiler(SentryId.newId()),
+            throwsUnsupportedError);
+      });
 
-  test('loadContexts', () async {
-    expect(await sut.loadContexts(), isNull);
-  });
+      test('collectProfile', () async {
+        final traceId = SentryId.newId();
+        const startTime = 42;
+        const endTime = 50;
+        expect(() => sut.collectProfile(traceId, startTime, endTime),
+            throwsUnsupportedError);
+      });
 
-  test('loadDebugImages', () async {
-    final list = await sut.loadDebugImages(SentryStackTrace(frames: []));
-    expect(list, isNotEmpty);
-    expect(list![0].type, platform.instance.isWindows ? 'pe' : 'elf');
-    expect(list[0].debugId!.length, greaterThan(30));
-    expect(
-        list[0].debugFile, platform.instance.isWindows ? isNotEmpty : isNull);
-    expect(list[0].imageSize, greaterThan(0));
-    expect(list[0].imageAddr, startsWith('0x'));
-    expect(list[0].imageAddr?.length, greaterThan(2));
-    expect(list[0].codeId!.length, greaterThan(10));
-    expect(list[0].codeFile, isNotEmpty);
-    expect(
-      File(list[0].codeFile!),
-      (File file) => file.existsSync(),
-    );
-  });
-}
+      test('captureEnvelope', () async {
+        final data = Uint8List.fromList([1, 2, 3]);
+        expect(() => sut.captureEnvelope(data, false), throwsUnsupportedError);
+      });
 
-/// Runs [command] with command's stdout and stderr being forwrarded to
-/// test runner's respective streams. It buffers stdout and returns it.
-///
-/// Returns [_CommandResult] with exitCode and stdout as a single sting
-Future<void> _exec(String executable, List<String> arguments) async {
-  final process = await Process.start(executable, arguments);
+      test('loadContexts', () async {
+        expect(await sut.loadContexts(), isNull);
+      });
 
-  // forward standard streams
-  unawaited(stderr.addStream(process.stderr));
-  unawaited(stdout.addStream(process.stdout));
-
-  int exitCode = await process.exitCode;
-  if (exitCode != 0) {
-    throw Exception(
-        "$executable ${arguments.join(' ')} failed with exit code $exitCode");
+      test('loadDebugImages', () async {
+        final list = await sut.loadDebugImages(SentryStackTrace(frames: []));
+        expect(list, isNotEmpty);
+        expect(list![0].type, platform.instance.isWindows ? 'pe' : 'elf');
+        expect(list[0].debugId!.length, greaterThan(30));
+        expect(list[0].debugFile,
+            platform.instance.isWindows ? isNotEmpty : isNull);
+        expect(list[0].imageSize, greaterThan(0));
+        expect(list[0].imageAddr, startsWith('0x'));
+        expect(list[0].imageAddr?.length, greaterThan(2));
+        expect(list[0].codeId!.length, greaterThan(10));
+        expect(list[0].codeFile, isNotEmpty);
+        expect(
+          File(list[0].codeFile!),
+          (File file) => file.existsSync(),
+        );
+      });
+    });
   }
 }
 
-/// Compile sentry-native using CMake, as if it was part of a Flutter app.
-/// Returns the directory containing built libraries
-Future<String> _buildSentryNative(String nativeTestRoot) async {
-  final cmakeBuildDir = '$nativeTestRoot/build';
-  final cmakeConfDir = '$nativeTestRoot/conf';
-  final buildOutputDir = '$nativeTestRoot/dist/';
+class NativeTestHelper {
+  final String repoRootDir;
+  final NativeBackend nativeBackend;
+  final List<String> expectedDistFiles;
+  final String nativeTestRoot;
+  late final cmakeBuildDir = '$nativeTestRoot/build';
+  late final cmakeConfDir = '$nativeTestRoot/conf';
+  late final buildOutputDir = '$nativeTestRoot/dist/';
 
-  if (!_builtVersionIsExpected(cmakeBuildDir, buildOutputDir)) {
-    Directory(cmakeConfDir).createSync(recursive: true);
-    Directory(buildOutputDir).createSync(recursive: true);
-    File('$cmakeConfDir/main.c').writeAsStringSync('''
+  NativeTestHelper(this.repoRootDir, this.nativeBackend, this.expectedDistFiles,
+      this.nativeTestRoot);
+
+  /// Runs [command] with command's stdout and stderr being forwrarded to
+  /// test runner's respective streams. It buffers stdout and returns it.
+  ///
+  /// Returns [_CommandResult] with exitCode and stdout as a single sting
+  Future<void> _exec(String executable, List<String> arguments) async {
+    final env = Map.of(Platform.environment);
+    if (nativeBackend != NativeBackend.default_) {
+      env['SENTRY_NATIVE_BACKEND'] = nativeBackend.name;
+    } else {
+      env.remove('SENTRY_NATIVE_BACKEND');
+    }
+
+    final process = await Process.start(executable, arguments,
+        environment: env, includeParentEnvironment: false);
+
+    // forward standard streams
+    unawaited(stderr.addStream(process.stderr));
+    unawaited(stdout.addStream(process.stdout));
+
+    int exitCode = await process.exitCode;
+    if (exitCode != 0) {
+      throw Exception(
+          "$executable ${arguments.join(' ')} failed with exit code $exitCode");
+    }
+  }
+
+  /// Compile sentry-native using CMake, as if it was part of a Flutter app.
+  /// Returns the directory containing built libraries
+  Future<String> _buildSentryNative() async {
+    if (!_builtVersionIsExpected()) {
+      Directory(cmakeConfDir).createSync(recursive: true);
+      Directory(buildOutputDir).createSync(recursive: true);
+      File('$cmakeConfDir/main.c').writeAsStringSync('''
 int main(int argc, char *argv[]) { return 0; }
 ''');
-    File('$cmakeConfDir/CMakeLists.txt').writeAsStringSync('''
+      File('$cmakeConfDir/CMakeLists.txt').writeAsStringSync('''
 cmake_minimum_required(VERSION 3.14)
 project(sentry-native-flutter-test)
 add_subdirectory(../../../${platform.instance.operatingSystem} plugin)
@@ -272,39 +323,40 @@ list(APPEND PLUGIN_BUNDLED_LIBRARIES \${sentry_flutter_bundled_libraries})
 install(FILES "\${PLUGIN_BUNDLED_LIBRARIES}" DESTINATION "${buildOutputDir.replaceAll('\\', '/')}" COMPONENT Runtime)
 set(CMAKE_INSTALL_PREFIX "${buildOutputDir.replaceAll('\\', '/')}")
 ''');
-    await _exec('cmake', ['-B', cmakeBuildDir, cmakeConfDir]);
-    await _exec('cmake',
-        ['--build', cmakeBuildDir, '--config', 'Release', '--parallel']);
-    await _exec('cmake', [
-      '--install',
-      cmakeBuildDir,
-      '--config',
-      'Release',
-    ]);
-    if (platform.instance.isLinux) {
-      await _exec('chmod', ['+x', '$buildOutputDir/crashpad_handler']);
+      await _exec('cmake', ['-B', cmakeBuildDir, cmakeConfDir]);
+      await _exec('cmake',
+          ['--build', cmakeBuildDir, '--config', 'Release', '--parallel']);
+      await _exec('cmake', [
+        '--install',
+        cmakeBuildDir,
+        '--config',
+        'Release',
+      ]);
+      if (platform.instance.isLinux) {
+        await _exec('chmod', ['+x', '$buildOutputDir/crashpad_handler']);
+      }
     }
-  }
-  return buildOutputDir;
-}
-
-bool _builtVersionIsExpected(String cmakeBuildDir, String buildOutputDir) {
-  final buildCmake = File(
-      '$cmakeBuildDir/_deps/sentry-native-build/sentry-config-version.cmake');
-  if (!buildCmake.existsSync()) return false;
-
-  if (!buildCmake
-      .readAsStringSync()
-      .contains('set(PACKAGE_VERSION "$_configuredSentryNativeVersion")')) {
-    return false;
+    return buildOutputDir;
   }
 
-  return !expectedDistFiles
-      .any((name) => !File('$buildOutputDir/$name').existsSync());
-}
+  bool _builtVersionIsExpected() {
+    final buildCmake = File(
+        '$cmakeBuildDir/_deps/sentry-native-build/sentry-config-version.cmake');
+    if (!buildCmake.existsSync()) return false;
 
-final _configuredSentryNativeVersion =
-    File('$repoRootDir/sentry-native/CMakeCache.txt')
-        .readAsLinesSync()
-        .map((line) => line.startsWith('version=') ? line.substring(8) : null)
-        .firstWhere((line) => line != null)!;
+    if (!buildCmake
+        .readAsStringSync()
+        .contains('set(PACKAGE_VERSION "$configuredSentryNativeVersion")')) {
+      return false;
+    }
+
+    return !expectedDistFiles
+        .any((name) => !File('$buildOutputDir/$name').existsSync());
+  }
+
+  late final configuredSentryNativeVersion =
+      File('$repoRootDir/sentry-native/CMakeCache.txt')
+          .readAsLinesSync()
+          .map((line) => line.startsWith('version=') ? line.substring(8) : null)
+          .firstWhere((line) => line != null)!;
+}

--- a/flutter/windows/CMakeLists.txt
+++ b/flutter/windows/CMakeLists.txt
@@ -4,6 +4,14 @@
 # customers of the plugin.
 cmake_minimum_required(VERSION 3.14)
 
+if(FLUTTER_TARGET_PLATFORM EQUAL "windows-arm64")
+    set(native_backend "breakpad")
+else()
+    set(native_backend "crashpad")
+endif()
+
+set(SENTRY_BACKEND ${native_backend} CACHE STRING "The sentry backend responsible for reporting crashes" FORCE)
+
 include("${CMAKE_CURRENT_SOURCE_DIR}/../sentry-native/sentry-native.cmake")
 
 # Even though sentry_flutter doesn't actually provide a useful plugin, we need to accommodate the Flutter tooling.


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Since v8.11.0 was released, there were a couple of issues reported with builds breaking. All of these were about a crashpad backend (which is the default one).

Because the change was introduced in a minor release, we shouldn't have a breaking change and we're making a native crash handler an opt-in.
Also, because we the reported issues were about building the backend, we're only changing that part of the native integration, while still leaving obfuscation support untouched.

What this PR effectively does:
- add `SENTRY_NATIVE_BACKEND` env var that is picked up during build (can be one of `crashpad, breakpad, inproc, none`
- sets the default value of `SENTRY_NATIVE_BACKEND` to `none` - this will change in v9
- adds future default values to windows & linux cmakelists, although they're currently overwritten.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- #2498 
- #2496 
- #2479
- #2514

## :green_heart: How did you test it?

Manually


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
