### PR TITLE
feat: ensure repaint on replay screenshot capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Check `SentryTracer` type in TTFD tracker ([#2508](https://github.com/getsentry/sentry-dart/pull/2508))
 - Warning (in a debug build) if a potentially sensitive widget is not masked or unmasked explicitly ([#2375](https://github.com/getsentry/sentry-dart/pull/2375))
+- Replay: ensure visual update before capturing screenshots ([#2527](https://github.com/getsentry/sentry-dart/pull/2527))
 
 ### Dependencies
 

--- a/flutter/test/replay/replay_native_test.dart
+++ b/flutter/test/replay/replay_native_test.dart
@@ -137,12 +137,13 @@ void main() {
 
               final capturedImages = <String, int>{};
               when(native.handler('addReplayScreenshot', any))
-                  .thenAnswer((invocation) async {
+                  .thenAnswer((invocation) {
                 final path =
                     invocation.positionalArguments[1]["path"] as String;
                 capturedImages[path] = imageSizeBytes(fs.file(path));
                 callbackFinished.complete();
                 callbackFinished = Completer<void>();
+                return null;
               });
 
               fsImages() {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

- on iOS - ensure the screen is painted and run the capture after a frame (this was actually a bug because we could run it during widget build process)
- on Android - Previously, we only captured a new screenshot when there was a paint **after** 1 second after the previous one. So if there were frames just after the previous one we captured (like during an animation, transition, etc) and the screen "settled" in in less than a second since our last capture, we're not going to capture the new state at all. I went for the simpler route of forcing a frame but if we want, the alternative would be to register a persistent frame listener and keep the information that there was a change between the last screenshot and "now", when the time for a new screenshot comes.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
