### PR TITLE
ci: run flutter wasm test on a separate job

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -112,7 +112,9 @@ jobs:
           # 'native/c' for now because we run coverage on Linux where these are not tested yet.
           exclude: 'lib/src/native/cocoa/binding.dart lib/src/native/c/*'
 
-      - name: Build ${{ matrix.target }}
+      - name: Build example for ${{ matrix.target }}
+        # The example currently doesn't support compiling for WASM. Should be OK once we add package:web in v9.
+        if: matrix.target != 'wasm'
         working-directory: flutter/example
         run: |
           flutter config --enable-windows-desktop

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [android, ios, macos, linux, windows, web]
+        target: [android, ios, macos, linux, windows, js, wasm]
         sdk: [stable, beta]
         # Specify which platform to run on for each target:
         include:
@@ -47,8 +47,12 @@ jobs:
             os: ubuntu
           - target: windows
             os: windows
-          - target: web
+          - target: js
             os: ubuntu
+            testArgs: ''
+          - target: wasm
+            os: ubuntu
+            testArgs: '--wasm'
         # Exclude beta for windows for now until the flutter set up action does not fail anymore
         exclude:
           - target: windows
@@ -80,17 +84,11 @@ jobs:
       - name: Pub Get
         run: flutter pub get
 
-      - name: Test web (JS)
-        if: matrix.target == 'web'
+      - name: Test web
+        if: matrix.target == 'js' || matrix.target == 'wasm'
         run: |
-          flutter test --platform chrome --test-randomize-ordering-seed=random --exclude-tags canvasKit
-          flutter test --platform chrome --test-randomize-ordering-seed=random --tags canvasKit
-
-      - name: Test web (WASM)
-        if: matrix.target == 'web'
-        run: |
-          flutter test --platform chrome --wasm --test-randomize-ordering-seed=random --exclude-tags canvasKit
-          flutter test --platform chrome --wasm --test-randomize-ordering-seed=random --tags canvasKit
+          flutter test --platform chrome ${{ matrix.testArg }} --test-randomize-ordering-seed=random --exclude-tags canvasKit
+          flutter test --platform chrome ${{ matrix.testArg }} --test-randomize-ordering-seed=random --tags canvasKit
 
       - name: Test VM with coverage
         if: matrix.target == 'linux' || matrix.target == 'macos' || matrix.target == 'windows'
@@ -132,7 +130,7 @@ jobs:
           android)
           flutter build appbundle
           ;;
-          web)
+          js)
           flutter build web
           ;;
           linux)

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -87,8 +87,8 @@ jobs:
       - name: Test web
         if: matrix.target == 'js' || matrix.target == 'wasm'
         run: |
-          flutter test --platform chrome ${{ matrix.testArg }} --test-randomize-ordering-seed=random --exclude-tags canvasKit
-          flutter test --platform chrome ${{ matrix.testArg }} --test-randomize-ordering-seed=random --tags canvasKit
+          flutter test --platform chrome ${{ matrix.testArgs }} --test-randomize-ordering-seed=random --exclude-tags canvasKit
+          flutter test --platform chrome ${{ matrix.testArgs }} --test-randomize-ordering-seed=random --tags canvasKit
 
       - name: Test VM with coverage
         if: matrix.target == 'linux' || matrix.target == 'macos' || matrix.target == 'windows'


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

This would speed up tests a little and would make it clearer what failed, directly from PR.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
