### PR TITLE
fix: disable native orientation change on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 - Replay: improve performance of screenshot data to native recorder ([#2530](https://github.com/getsentry/sentry-dart/pull/2530))
+- Replay: improve orientation change tracking accuracy on Android ([#2540](https://github.com/getsentry/sentry-dart/pull/2540))
 
 ### Dependencies
 

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutter.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutter.kt
@@ -165,6 +165,11 @@ class SentryFlutter(
   ) {
     options.sessionSampleRate = data["sessionSampleRate"] as? Double
     options.onErrorSampleRate = data["onErrorSampleRate"] as? Double
+
+    // Disable native tracking of orientation change (causes replay restart)
+    // because we don't have the new size from Flutter yet. Instead, we'll
+    // trigger onConfigurationChanged() manually in setReplayConfig().
+    options.setTrackOrientationChange(false)
   }
 }
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

This option was added in #2536

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
