### PR TITLE
chore(deps): update Cocoa SDK to v8.43.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
-- Replay: improve performance of screenshot data to native recorder ([#2530](https://github.com/getsentry/sentry-dart/pull/2530))
+- Replay: improve iOS native interop performance ([#2530](https://github.com/getsentry/sentry-dart/pull/2530))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Bump Android SDK from v7.19.0 to v7.19.1 ([#2536](https://github.com/getsentry/sentry-dart/pull/2536))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#7191)
   - [diff](https://github.com/getsentry/sentry-java/compare/7.19.0...7.19.1)
+- Bump Cocoa SDK from v8.42.0 to v8.43.0-beta.1 ([#2542](https://github.com/getsentry/sentry-dart/pull/2542))
+  - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8430-beta1)
+  - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.42.0...8.43.0-beta.1)
 
 ## 8.12.0
 

--- a/flutter/example/ios/Runner/Runner.entitlements
+++ b/flutter/example/ios/Runner/Runner.entitlements
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/flutter/ios/Classes/SentryFlutter.swift
+++ b/flutter/ios/Classes/SentryFlutter.swift
@@ -117,6 +117,13 @@ public final class SentryFlutter {
                 (replayOptions["sessionSampleRate"] as? NSNumber)?.floatValue ?? 0
             options.experimental.sessionReplay.onErrorSampleRate =
                 (replayOptions["onErrorSampleRate"] as? NSNumber)?.floatValue ?? 0
+          
+            // TMP: this doesn't actually mask, just ensures we show the correct
+            // value in tags. https://github.com/getsentry/sentry-cocoa/issues/4666
+            options.experimental.sessionReplay.maskAllText =
+                (replayOptions["maskAllText"] as? Bool) ?? false
+            options.experimental.sessionReplay.maskAllImages =
+                (replayOptions["maskAllImages"] as? Bool) ?? false
         }
 #endif
     }

--- a/flutter/ios/Classes/SentryFlutter.swift
+++ b/flutter/ios/Classes/SentryFlutter.swift
@@ -117,7 +117,7 @@ public final class SentryFlutter {
                 (replayOptions["sessionSampleRate"] as? NSNumber)?.floatValue ?? 0
             options.experimental.sessionReplay.onErrorSampleRate =
                 (replayOptions["onErrorSampleRate"] as? NSNumber)?.floatValue ?? 0
-          
+
             // TMP: this doesn't actually mask, just ensures we show the correct
             // value in tags. https://github.com/getsentry/sentry-cocoa/issues/4666
             options.experimental.sessionReplay.maskAllText =

--- a/flutter/ios/Classes/SentryFlutterReplayScreenshotProvider.m
+++ b/flutter/ios/Classes/SentryFlutterReplayScreenshotProvider.m
@@ -17,7 +17,6 @@
 }
 
 - (void)imageWithView:(UIView *_Nonnull)view
-              options:(id<SentryRedactOptions> _Nonnull)options
            onComplete:(void (^_Nonnull)(UIImage *_Nonnull))onComplete {
   // Replay ID may be null if session replay is disabled.
   // Replay is still captured for on-error replays.

--- a/flutter/ios/sentry_flutter.podspec
+++ b/flutter/ios/sentry_flutter.podspec
@@ -16,7 +16,7 @@ Sentry SDK for Flutter with support to native through sentry-cocoa.
                          :tag => s.version.to_s }
   s.source_files     = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
-  s.dependency 'Sentry/HybridSDK', '8.42.0'
+  s.dependency 'Sentry/HybridSDK', '8.43.0-beta.1'
   s.ios.dependency 'Flutter'
   s.osx.dependency 'FlutterMacOS'
   s.ios.deployment_target = '12.0'

--- a/flutter/lib/src/native/sentry_native_channel.dart
+++ b/flutter/lib/src/native/sentry_native_channel.dart
@@ -71,6 +71,10 @@ class SentryNativeChannel
       'replay': <String, dynamic>{
         'sessionSampleRate': options.experimental.replay.sessionSampleRate,
         'onErrorSampleRate': options.experimental.replay.onErrorSampleRate,
+        // TMP: this doesn't actually mask, just ensures we show the correct
+        // value in tags. https://github.com/getsentry/sentry-cocoa/issues/4666
+        'maskAllText': options.experimental.privacyForReplay.maskAllText,
+        'maskAllImages': options.experimental.privacyForReplay.maskAllImages,
       },
       'enableSpotlight': options.spotlight.enabled,
       'spotlightUrl': options.spotlight.url,

--- a/flutter/test/integrations/init_native_sdk_test.dart
+++ b/flutter/test/integrations/init_native_sdk_test.dart
@@ -68,6 +68,8 @@ void main() {
       'replay': <String, dynamic>{
         'sessionSampleRate': null,
         'onErrorSampleRate': null,
+        'maskAllText': true,
+        'maskAllImages': true,
       },
       'enableSpotlight': false,
       'spotlightUrl': null,
@@ -177,6 +179,8 @@ void main() {
       'replay': <String, dynamic>{
         'sessionSampleRate': 0.1,
         'onErrorSampleRate': 0.2,
+        'maskAllText': true,
+        'maskAllImages': true,
       },
       'enableSpotlight': true,
       'spotlightUrl': 'http://localhost:8969/stream',


### PR DESCRIPTION
Updating to a [Cocoa SDK beta release](https://github.com/getsentry/sentry-cocoa/releases/tag/8.43.0-beta.1) in order to release a Flutter beta with a fix for #2521 

closes #2521 
closes #2537

## Changelog
### 8.43.0-beta.1

#### Improvements

- Improve compiler error message for missing Swift declarations due to APPLICATION_EXTENSION_API_ONLY ([#4603](https://github-redirect.dependabot.com/getsentry/sentry-cocoa/issues/4603))
- Mask screenshots for errors ([#4623](https://github-redirect.dependabot.com/getsentry/sentry-cocoa/issues/4623))
- Slightly speed up serializing scope ([#4661](https://github-redirect.dependabot.com/getsentry/sentry-cocoa/issues/4661))

#### Features

- Show session replay options as replay tags ([#4639](https://github-redirect.dependabot.com/getsentry/sentry-cocoa/issues/4639))

#### Fixes

- `SentrySdkInfo.packages` should be an array ([#4626](https://github-redirect.dependabot.com/getsentry/sentry-cocoa/issues/4626))
- Use the same SdkInfo for envelope header and event ([#4629](https://github-redirect.dependabot.com/getsentry/sentry-cocoa/issues/4629))

#### Internal

- Remove loading `integrations` names from `event.extra` ([#4627](https://github-redirect.dependabot.com/getsentry/sentry-cocoa/issues/4627))
- Add Hybrid SDKs API to add extra SDK packages ([#4637](https://github-redirect.dependabot.com/getsentry/sentry-cocoa/issues/4637))

### 8.42.1

#### Fixes

- Fixes Session replay screenshot provider crash ([#4649](https://github-redirect.dependabot.com/getsentry/sentry-cocoa/issues/4649))
- Session Replay wrong clipping order ([#4651](https://github-redirect.dependabot.com/getsentry/sentry-cocoa/issues/4651))