### PR TITLE
fix/screenshot masking during changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@
 
 - Add `beforeCapture` for View Hierarchy ([#2523](https://github.com/getsentry/sentry-dart/pull/2523))
   - View hierarchy calls are now debounced for 2 seconds.
-  
+
 ### Enhancements
 
 - Replay: improve iOS native interop performance ([#2530](https://github.com/getsentry/sentry-dart/pull/2530))
 - Replay: improve orientation change tracking accuracy on Android ([#2540](https://github.com/getsentry/sentry-dart/pull/2540))
+
+### Fixes
+
+- Replay: fix masking for frames captured during UI changes ([#2553](https://github.com/getsentry/sentry-dart/pull/2553))
 
 ### Dependencies
 

--- a/flutter/example/devtools_options.yaml
+++ b/flutter/example/devtools_options.yaml
@@ -1,0 +1,3 @@
+description: This file stores settings for Dart & Flutter DevTools.
+documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
+extensions:

--- a/flutter/example/integration_test/integration_test.dart
+++ b/flutter/example/integration_test/integration_test.dart
@@ -20,6 +20,8 @@ void main() {
   const fakeDsn = 'https://abc@def.ingest.sentry.io/1234567';
 
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  IntegrationTestWidgetsFlutterBinding.instance.framePolicy =
+      LiveTestWidgetsFlutterBindingFramePolicy.fullyLive;
 
   tearDown(() async {
     await Sentry.close();

--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -79,7 +79,7 @@ Future<void> setupSentry(
       // We can enable Sentry debug logging during development. This is likely
       // going to log too much for your app, but can be useful when figuring out
       // configuration issues, e.g. finding out why your events are not uploaded.
-      options.debug = true;
+      options.debug = kDebugMode;
       options.spotlight = Spotlight(enabled: true);
       options.enableTimeToFullDisplayTracing = true;
       options.enableMetrics = true;

--- a/flutter/lib/src/event_processor/screenshot_event_processor.dart
+++ b/flutter/lib/src/event_processor/screenshot_event_processor.dart
@@ -125,6 +125,6 @@ class ScreenshotEventProcessor implements EventProcessor {
   }
 
   @internal
-  Future<Uint8List?> createScreenshot() =>
-      _recorder.capture((screenshot) => Future.value(screenshot.data));
+  Future<Uint8List?> createScreenshot() => _recorder.capture(
+      (screenshot) => screenshot.pngData.then((v) => v.buffer.asUint8List()));
 }

--- a/flutter/lib/src/event_processor/screenshot_event_processor.dart
+++ b/flutter/lib/src/event_processor/screenshot_event_processor.dart
@@ -125,6 +125,6 @@ class ScreenshotEventProcessor implements EventProcessor {
   }
 
   @internal
-  Future<Uint8List?> createScreenshot() => _recorder
-      .capture((ScreenshotPng screenshot) => Future.value(screenshot.data));
+  Future<Uint8List?> createScreenshot() =>
+      _recorder.capture((screenshot) => Future.value(screenshot.data));
 }

--- a/flutter/lib/src/event_processor/screenshot_event_processor.dart
+++ b/flutter/lib/src/event_processor/screenshot_event_processor.dart
@@ -133,11 +133,16 @@ class ScreenshotEventProcessor implements EventProcessor {
     } else {
       // If masking is enabled, we need to use [ScreenshotStabilizer].
       final completer = Completer<Uint8List?>();
-      final stabilizer =
-          ScreenshotStabilizer(_recorder, _options, (screenshot) async {
-        final pngData = await screenshot.pngData;
-        completer.complete(pngData.buffer.asUint8List());
-      });
+      final stabilizer = ScreenshotStabilizer(
+        _recorder,
+        _options,
+        (screenshot) async {
+          final pngData = await screenshot.pngData;
+          completer.complete(pngData.buffer.asUint8List());
+        },
+        // This limits the amount of time to take a stable masked screenshot.
+        maxTries: 5,
+      );
       unawaited(
           stabilizer.capture(Duration.zero).onError(completer.completeError));
       final uint8List = await completer.future;

--- a/flutter/lib/src/event_processor/screenshot_event_processor.dart
+++ b/flutter/lib/src/event_processor/screenshot_event_processor.dart
@@ -125,20 +125,6 @@ class ScreenshotEventProcessor implements EventProcessor {
   }
 
   @internal
-  Future<Uint8List?> createScreenshot() =>
-      _recorder.capture(_convertImageToUint8List);
-
-  Future<Uint8List?> _convertImageToUint8List(Screenshot screenshot) async {
-    final byteData =
-        await screenshot.image.toByteData(format: ImageByteFormat.png);
-
-    final bytes = byteData?.buffer.asUint8List();
-    if (bytes?.isNotEmpty == true) {
-      return bytes;
-    } else {
-      _options.logger(
-          SentryLevel.debug, 'Screenshot is 0 bytes, not attaching the image.');
-      return null;
-    }
-  }
+  Future<Uint8List?> createScreenshot() => _recorder
+      .capture((ScreenshotPng screenshot) => Future.value(screenshot.data));
 }

--- a/flutter/lib/src/event_processor/screenshot_event_processor.dart
+++ b/flutter/lib/src/event_processor/screenshot_event_processor.dart
@@ -148,7 +148,12 @@ class ScreenshotEventProcessor implements EventProcessor {
         unawaited(
             stabilizer.capture(Duration.zero).onError(completer.completeError));
         // DO NOT return completer.future directly - we need to dispose first.
-        return await completer.future;
+        return await completer.future.timeout(const Duration(seconds: 1),
+            onTimeout: () {
+          _options.logger(
+              SentryLevel.warning, 'Timed out taking a stable screenshot.');
+          return null;
+        });
       } finally {
         stabilizer.dispose();
       }

--- a/flutter/lib/src/native/cocoa/cocoa_replay_recorder.dart
+++ b/flutter/lib/src/native/cocoa/cocoa_replay_recorder.dart
@@ -1,0 +1,40 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:meta/meta.dart';
+
+import '../../../sentry_flutter.dart';
+import '../../replay/replay_recorder.dart';
+import '../../screenshot/recorder.dart';
+import '../../screenshot/recorder_config.dart';
+import '../../screenshot/stabilizer.dart';
+
+@internal
+class CocoaReplayRecorder {
+  final SentryFlutterOptions _options;
+  final ScreenshotRecorder _recorder;
+  late final ScreenshotStabilizer<void> _stabilizer;
+  var _completer = Completer<Uint8List?>();
+
+  CocoaReplayRecorder(this._options)
+      : _recorder =
+            ReplayScreenshotRecorder(ScreenshotRecorderConfig(), _options) {
+    _stabilizer = ScreenshotStabilizer(_recorder, _options, (screenshot) async {
+      final pngData = await screenshot.pngData;
+      _options.logger(
+          SentryLevel.debug,
+          'Replay: captured screenshot ('
+          '${screenshot.width}x${screenshot.height} pixels, '
+          '${pngData.lengthInBytes} bytes)');
+      _completer.complete(pngData.buffer.asUint8List());
+    });
+  }
+
+  Future<Uint8List?> captureScreenshot() async {
+    _completer = Completer<Uint8List?>();
+    _stabilizer.ensureFrameAndAddCallback((msSinceEpoch) {
+      _stabilizer.capture(msSinceEpoch).onError(_completer.completeError);
+    });
+    return _completer.future;
+  }
+}

--- a/flutter/lib/src/native/cocoa/sentry_native_cocoa.dart
+++ b/flutter/lib/src/native/cocoa/sentry_native_cocoa.dart
@@ -9,7 +9,7 @@ import '../../replay/replay_config.dart';
 import '../../replay/replay_recorder.dart';
 import '../../screenshot/recorder.dart';
 import '../../screenshot/recorder_config.dart';
-import '../../screenshot/retrier.dart';
+import '../../screenshot/stabilizer.dart';
 import '../native_memory.dart';
 import '../sentry_native_channel.dart';
 import 'binding.dart' as cocoa;
@@ -55,7 +55,7 @@ class SentryNativeCocoa extends SentryNativeChannel {
             }
 
             final completer = Completer<Uint8List?>();
-            final retrier = ScreenshotRetrier(_replayRecorder!, options,
+            final stabilizer = ScreenshotStabilizer(_replayRecorder!, options,
                 (screenshot) async {
               final pngData = await screenshot.pngData;
               options.logger(
@@ -65,8 +65,8 @@ class SentryNativeCocoa extends SentryNativeChannel {
                   '${pngData.lengthInBytes} bytes)');
               completer.complete(pngData.buffer.asUint8List());
             });
-            retrier.ensureFrameAndAddCallback((msSinceEpoch) {
-              retrier.capture(msSinceEpoch).onError(completer.completeError);
+            stabilizer.ensureFrameAndAddCallback((msSinceEpoch) {
+              stabilizer.capture(msSinceEpoch).onError(completer.completeError);
             });
             final uint8List = await completer.future;
 

--- a/flutter/lib/src/native/cocoa/sentry_native_cocoa.dart
+++ b/flutter/lib/src/native/cocoa/sentry_native_cocoa.dart
@@ -55,14 +55,15 @@ class SentryNativeCocoa extends SentryNativeChannel {
             }
 
             final completer = Completer<Uint8List?>();
-            final retrier =
-                ScreenshotRetrier(_replayRecorder!, options, (image) async {
+            final retrier = ScreenshotRetrier(_replayRecorder!, options,
+                (screenshot) async {
+              final pngData = await screenshot.pngData;
               options.logger(
                   SentryLevel.debug,
                   'Replay: captured screenshot ('
-                  '${image.width}x${image.height} pixels, '
-                  '${image.data.lengthInBytes} bytes)');
-              completer.complete(image.data);
+                  '${screenshot.width}x${screenshot.height} pixels, '
+                  '${pngData.lengthInBytes} bytes)');
+              completer.complete(pngData.buffer.asUint8List());
             });
             retrier.ensureFrameAndAddCallback((msSinceEpoch) {
               retrier.capture(msSinceEpoch).onError(completer.completeError);

--- a/flutter/lib/src/native/java/android_replay_recorder.dart
+++ b/flutter/lib/src/native/java/android_replay_recorder.dart
@@ -2,6 +2,7 @@ import 'package:meta/meta.dart';
 
 import '../../../sentry_flutter.dart';
 import '../../replay/scheduled_recorder.dart';
+import '../../screenshot/recorder.dart';
 import '../sentry_safe_method_channel.dart';
 
 @internal

--- a/flutter/lib/src/native/java/android_replay_recorder.dart
+++ b/flutter/lib/src/native/java/android_replay_recorder.dart
@@ -2,7 +2,7 @@ import 'package:meta/meta.dart';
 
 import '../../../sentry_flutter.dart';
 import '../../replay/scheduled_recorder.dart';
-import '../../screenshot/recorder.dart';
+import '../../screenshot/screenshot.dart';
 import '../sentry_safe_method_channel.dart';
 
 @internal
@@ -16,19 +16,20 @@ class AndroidReplayRecorder extends ScheduledScreenshotRecorder {
   }
 
   Future<void> _addReplayScreenshot(
-      ScreenshotPng screenshot, bool isNewlyCaptured) async {
+      Screenshot screenshot, bool isNewlyCaptured) async {
     final timestamp = screenshot.timestamp.millisecondsSinceEpoch;
     final filePath = "$_cacheDir/$timestamp.png";
 
-    options.logger(
-        SentryLevel.debug,
-        '$logName: saving ${isNewlyCaptured ? 'new' : 'repeated'} screenshot to'
-        ' $filePath (${screenshot.width}x${screenshot.height} pixels, '
-        '${screenshot.data.lengthInBytes} bytes)');
     try {
+      final pngData = await screenshot.pngData;
+      options.logger(
+          SentryLevel.debug,
+          '$logName: saving ${isNewlyCaptured ? 'new' : 'repeated'} screenshot to'
+          ' $filePath (${screenshot.width}x${screenshot.height} pixels, '
+          '${pngData.lengthInBytes} bytes)');
       await options.fileSystem
           .file(filePath)
-          .writeAsBytes(screenshot.data.buffer.asUint8List(), flush: true);
+          .writeAsBytes(pngData.buffer.asUint8List(), flush: true);
 
       await _channel.invokeMethod(
         'addReplayScreenshot',

--- a/flutter/lib/src/replay/replay_recorder.dart
+++ b/flutter/lib/src/replay/replay_recorder.dart
@@ -16,8 +16,8 @@ class ReplayScreenshotRecorder extends ScreenshotRecorder {
 
   @override
   @protected
-  Future<void> executeTask(void Function() task, Flow flow) {
-    // Future() schedules the task to be executed asynchronously with TImer.run.
+  Future<void> executeTask(Future<void> Function() task, Flow flow) {
+    // Future() schedules the task to be executed asynchronously with Timer.run.
     return Future(task);
   }
 }

--- a/flutter/lib/src/replay/scheduled_recorder.dart
+++ b/flutter/lib/src/replay/scheduled_recorder.dart
@@ -3,15 +3,15 @@ import 'dart:async';
 import 'package:meta/meta.dart';
 
 import '../../sentry_flutter.dart';
-import '../screenshot/recorder.dart';
 import '../screenshot/retrier.dart';
+import '../screenshot/screenshot.dart';
 import 'replay_recorder.dart';
 import 'scheduled_recorder_config.dart';
 import 'scheduler.dart';
 
 @internal
 typedef ScheduledScreenshotRecorderCallback = Future<void> Function(
-    ScreenshotPng screenshot, bool isNewlyCaptured);
+    Screenshot screenshot, bool isNewlyCaptured);
 
 @internal
 class ScheduledScreenshotRecorder extends ReplayScreenshotRecorder {
@@ -102,7 +102,7 @@ class ScheduledScreenshotRecorder extends ReplayScreenshotRecorder {
     }
   }
 
-  Future<void> _onImageCaptured(ScreenshotPng screenshot) async {
+  Future<void> _onImageCaptured(Screenshot screenshot) async {
     if (_status == _Status.running) {
       await _onScreenshot(screenshot, true);
       // _idleFrameFiller.actualFrameReceived(screenshot);
@@ -114,7 +114,7 @@ class ScheduledScreenshotRecorder extends ReplayScreenshotRecorder {
   }
 
   Future<void> _onScreenshot(
-      ScreenshotPng screenshot, bool isNewlyCaptured) async {
+      Screenshot screenshot, bool isNewlyCaptured) async {
     if (_status == _Status.running) {
       await _callback(screenshot, isNewlyCaptured);
     } else {
@@ -138,11 +138,11 @@ class ScheduledScreenshotRecorder extends ReplayScreenshotRecorder {
 //   final ScheduledScreenshotRecorderCallback _callback;
 //   var _status = _Status.running;
 //   Future<void>? _scheduled;
-//   ScreenshotPng? _mostRecent;
+//   Screenshot? _mostRecent;
 
 //   _IdleFrameFiller(this._interval, this._callback);
 
-//   void actualFrameReceived(ScreenshotPng screenshot) {
+//   void actualFrameReceived(Screenshot screenshot) {
 //     // We store the most recent frame but only repost it when the most recent
 //     // one is the same instance (unchanged).
 //     _mostRecent = screenshot;
@@ -171,7 +171,7 @@ class ScheduledScreenshotRecorder extends ReplayScreenshotRecorder {
 //     }
 //   }
 
-//   void repostLater(Duration delay, ScreenshotPng screenshot) {
+//   void repostLater(Duration delay, Screenshot screenshot) {
 //     _scheduled = Future.delayed(delay, () async {
 //       if (_status == _Status.stopped) {
 //         return;

--- a/flutter/lib/src/replay/scheduled_recorder.dart
+++ b/flutter/lib/src/replay/scheduled_recorder.dart
@@ -82,6 +82,7 @@ class ScheduledScreenshotRecorder extends ReplayScreenshotRecorder {
     options.logger(SentryLevel.debug, "$logName: stopping capture.");
     _status = _Status.stopped;
     await _stopScheduler();
+    _stabilizer.dispose();
     // await Future.wait([_stopScheduler(), _idleFrameFiller.stop()]);
     options.logger(SentryLevel.debug, "$logName: capture stopped.");
   }

--- a/flutter/lib/src/replay/scheduler.dart
+++ b/flutter/lib/src/replay/scheduler.dart
@@ -2,7 +2,7 @@ import 'package:flutter/scheduler.dart';
 import 'package:meta/meta.dart';
 
 @internal
-typedef SchedulerCallback = void Function(Duration);
+typedef SchedulerCallback = Future<void> Function(Duration);
 
 /// This is a low-priority scheduler.
 /// We're not using Timer.periodic() because it may schedule a callback
@@ -16,6 +16,7 @@ class Scheduler {
   final Duration _interval;
   bool _running = false;
   Future<void>? _scheduled;
+  Future<void>? _runningCallback;
 
   final void Function(FrameCallback callback) _addPostFrameCallback;
 
@@ -46,13 +47,16 @@ class Scheduler {
 
   @pragma('vm:prefer-inline')
   void _runAfterNextFrame() {
-    _scheduled = null;
-    _addPostFrameCallback(_run);
+    final runningCallback = _runningCallback ?? Future.value();
+    runningCallback.whenComplete(() {
+      _scheduled = null;
+      _addPostFrameCallback(_run);
+    });
   }
 
   void _run(Duration sinceSchedulerEpoch) {
     if (!_running) return;
-    _callback(sinceSchedulerEpoch);
+    _runningCallback = _callback(sinceSchedulerEpoch);
     _scheduleNext();
   }
 }

--- a/flutter/lib/src/screenshot/recorder.dart
+++ b/flutter/lib/src/screenshot/recorder.dart
@@ -22,7 +22,6 @@ class ScreenshotRecorder {
   @protected
   final SentryFlutterOptions options;
 
-  @protected
   final String logName;
   bool _warningLogged = false;
   late final SentryMaskingConfig? _maskingConfig;

--- a/flutter/lib/src/screenshot/recorder.dart
+++ b/flutter/lib/src/screenshot/recorder.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 import 'dart:developer';
 import 'dart:ui';
+// ignore: unnecessary_import // backcompatibility for Flutter < 3.3
+import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';

--- a/flutter/lib/src/screenshot/recorder.dart
+++ b/flutter/lib/src/screenshot/recorder.dart
@@ -60,9 +60,10 @@ class ScreenshotRecorder {
   /// To prevent accidental addition of await before that happens,
   ///
   /// THIS FUNCTION MUST NOT BE ASYNC.
-  Future<R> capture<R>(Future<R> Function(ScreenshotPng) callback) {
+  Future<R> capture<R>(Future<R> Function(ScreenshotPng) callback,
+      [Flow? flow]) {
     try {
-      final flow = Flow.begin();
+      flow ??= Flow.begin();
       Timeline.startSync('Sentry::captureScreenshot', flow: flow);
       final context = sentryScreenshotWidgetGlobalKey.currentContext;
       final renderObject =
@@ -213,7 +214,7 @@ class _Capture<R> {
           final imageData =
               await finalImage.toByteData(format: ImageByteFormat.png);
           final png = ScreenshotPng(finalImage.width, finalImage.height,
-              imageData!.buffer.asUint8List(), timestamp);
+              imageData!.buffer.asUint8List(), timestamp, flow);
           Timeline.finishSync(); // Sentry::screenshotToPng
 
           Timeline.startSync('Sentry::screenshotCallback', flow: flow);
@@ -310,8 +311,10 @@ class ScreenshotPng {
   final int height;
   final Uint8List data;
   final DateTime timestamp;
+  final Flow flow;
 
-  const ScreenshotPng(this.width, this.height, this.data, this.timestamp);
+  const ScreenshotPng(
+      this.width, this.height, this.data, this.timestamp, this.flow);
 
   bool hasSameImageAs(ScreenshotPng other) {
     if (other.width != width || other.height != height) {

--- a/flutter/lib/src/screenshot/recorder.dart
+++ b/flutter/lib/src/screenshot/recorder.dart
@@ -112,7 +112,7 @@ class ScreenshotRecorder {
   }
 
   @protected
-  Future<void> executeTask(void Function() task, Flow flow) {
+  Future<void> executeTask(Future<void> Function() task, Flow flow) {
     // Future.sync() starts executing the function synchronously, until the
     // first await, i.e. it's the same as if the code was executed directly.
     return Future.sync(task);
@@ -180,7 +180,7 @@ class _Capture<R> {
   /// - call the callback
   ///
   /// See [task] which is what gets completed with the callback result.
-  void Function() createTask(
+  Future<void> Function() createTask(
     Future<Image> futureImage,
     Future<R> Function(ScreenshotPng) callback,
     List<WidgetFilterItem>? obscureItems,

--- a/flutter/lib/src/screenshot/retrier.dart
+++ b/flutter/lib/src/screenshot/retrier.dart
@@ -66,10 +66,17 @@ class ScreenshotRetrier<R> {
       throw Exception('Failed to capture a stable screenshot. '
           'Giving up after $_tries tries.');
     } else {
-      ensureFrameAndAddCallback((Duration sinceSchedulerEpoch) {
+      final completer = Completer<void>();
+      ensureFrameAndAddCallback((Duration sinceSchedulerEpoch) async {
         _tries++;
-        _recorder.capture(_onImageCaptured, screenshot.flow);
+        try {
+          await _recorder.capture(_onImageCaptured, screenshot.flow);
+          completer.complete();
+        } catch (e, stackTrace) {
+          completer.completeError(e, stackTrace);
+        }
       });
+      return completer.future;
     }
   }
 }

--- a/flutter/lib/src/screenshot/retrier.dart
+++ b/flutter/lib/src/screenshot/retrier.dart
@@ -1,0 +1,64 @@
+import 'dart:async';
+
+import 'package:flutter/scheduler.dart';
+import 'package:meta/meta.dart';
+
+import '../../sentry_flutter.dart';
+import 'recorder.dart';
+
+/// We're facing an issue: the tree walked with visitChildElements() is out of
+/// sync to what is currently rendered by RenderRepaintBoundary.toImage(),
+/// even though there's no async gap between these two. This causes masks to
+/// be off during repaints, e.g. when scrolling a view or when text is rendered
+/// in different places between two screens. This is most easily reproducible
+/// when there's no animation between the two screens.
+/// For example, Spotube's Search vs Library (2nd and 3rd bottom bar buttons).
+///
+/// To get around this issue, we're taking two subsequent screenshots
+/// (after two frames) and only actually capture a screenshot if the
+/// two are exactly the same.
+/// We only do these if masking is enabled.
+@internal
+class ScreenshotRetrier<R> {
+  final SentryFlutterOptions _options;
+  final ScreenshotRecorder _recorder;
+  final Future<R> Function(ScreenshotPng screenshot) _callback;
+  ScreenshotPng? _previousScreenshot;
+  int _tries = 0;
+  bool stopped = false;
+
+  ScreenshotRetrier(this._recorder, this._options, this._callback) {
+    assert(_options.screenshotRetries >= 1,
+        "Cannot use ScreenshotRetrier if we cannot retry at least once.");
+  }
+
+  void ensureFrameAndAddCallback(FrameCallback callback) {
+    _options.bindingUtils.instance!
+      ..ensureVisualUpdate()
+      ..addPostFrameCallback(callback);
+  }
+
+  Future<void> capture(Duration sinceSchedulerEpoch) {
+    _tries++;
+    return _recorder.capture(_onImageCaptured);
+  }
+
+  Future<void> _onImageCaptured(ScreenshotPng screenshot) async {
+    if (stopped) {
+      _tries = 0;
+      return;
+    }
+
+    final prevScreenshot = _previousScreenshot;
+    _previousScreenshot = screenshot;
+    if (prevScreenshot != null && prevScreenshot.hasSameImageAs(screenshot)) {
+      _tries = 0;
+      await _callback(screenshot);
+    } else if (_tries > _options.screenshotRetries) {
+      throw Exception('Failed to capture a stable screenshot. '
+          'Giving up after $_tries tries.');
+    } else {
+      ensureFrameAndAddCallback(capture);
+    }
+  }
+}

--- a/flutter/lib/src/screenshot/screenshot.dart
+++ b/flutter/lib/src/screenshot/screenshot.dart
@@ -1,0 +1,80 @@
+import 'dart:async';
+import 'dart:developer';
+import 'dart:ffi';
+import 'dart:ui';
+// ignore: unnecessary_import // backcompatibility for Flutter < 3.3
+import 'dart:typed_data';
+
+import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
+
+@internal
+class Screenshot {
+  final Image _image;
+  final DateTime timestamp;
+  final Flow flow;
+  Future<ByteData>? _rawData;
+  Future<ByteData>? _pngData;
+
+  Screenshot(this._image, this.timestamp, this.flow);
+  Screenshot._cloned(
+      this._image, this.timestamp, this.flow, this._rawData, this._pngData);
+
+  int get width => _image.width;
+  int get height => _image.height;
+
+  Future<ByteData> get rawData {
+    _rawData ??= _image
+        .toByteData(format: ImageByteFormat.rawUnmodified)
+        .then((data) => data!);
+    return _rawData!;
+  }
+
+  Future<ByteData> get pngData {
+    _pngData ??=
+        _image.toByteData(format: ImageByteFormat.png).then((data) => data!);
+    return _pngData!;
+  }
+
+  Future<bool> hasSameImageAs(Screenshot other) async {
+    if (other.width != width || other.height != height) {
+      return false;
+    }
+
+    final thisData = await rawData;
+    final otherData = await other.rawData;
+    if (thisData.lengthInBytes != otherData.lengthInBytes) {
+      return false;
+    }
+    if (identical(thisData, otherData)) {
+      return true;
+    }
+
+    // Note: listEquals() is slow because it compares each byte pair.
+    // Ideally, we would use memcmp with Uint8List.address but that's only
+    // available since Dart 3.5.0.
+    // For now, the best we can do is compare by chunks
+    var pos = 0;
+    while (pos + 8 < thisData.lengthInBytes) {
+      if (thisData.getInt64(pos) != otherData.getInt64(pos)) {
+        return false;
+      }
+      pos += 8;
+    }
+    while (pos < thisData.lengthInBytes) {
+      if (thisData.getUint8(pos) != otherData.getUint8(pos)) {
+        return false;
+      }
+      pos++;
+    }
+    return true;
+  }
+
+  Screenshot clone() {
+    assert(!_image.debugDisposed);
+    return Screenshot._cloned(
+        _image.clone(), timestamp, flow, _rawData, _pngData);
+  }
+
+  void dispose() => _image.dispose();
+}

--- a/flutter/lib/src/screenshot/screenshot.dart
+++ b/flutter/lib/src/screenshot/screenshot.dart
@@ -82,7 +82,7 @@ class Screenshot {
 
     // Compare any remaining bytes.
     final bytesA = dataA.buffer.asUint8List(wordsA.lengthInBytes);
-    final bytesB = dataA.buffer.asUint8List(wordsA.lengthInBytes);
+    final bytesB = dataB.buffer.asUint8List(wordsA.lengthInBytes);
     for (var i = 0; i < bytesA.lengthInBytes; i++) {
       if (bytesA[i] != bytesB[i]) {
         return false;

--- a/flutter/lib/src/screenshot/screenshot.dart
+++ b/flutter/lib/src/screenshot/screenshot.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 import 'dart:developer';
 import 'dart:ui';
+// ignore: unnecessary_import // backcompatibility for Flutter < 3.3
+import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 import 'package:meta/meta.dart';

--- a/flutter/lib/src/screenshot/screenshot.dart
+++ b/flutter/lib/src/screenshot/screenshot.dart
@@ -55,9 +55,6 @@ class Screenshot {
   void dispose() => _image.dispose();
 
   /// Efficiently compares two memory regions for data equality..
-  /// Ideally, we would use memcmp with Uint8List.address but that's only
-  /// available since Dart 3.5.0.
-  /// For now, the best we can do is compare by chunks of 8 bytes.
   @visibleForTesting
   static bool listEquals(ByteData dataA, ByteData dataB) {
     if (identical(dataA, dataB)) {
@@ -66,6 +63,12 @@ class Screenshot {
     if (dataA.lengthInBytes != dataB.lengthInBytes) {
       return false;
     }
+
+    /// Ideally, we would use memcmp with Uint8List.address but that's only
+    /// available since Dart 3.5.0. The relevant code is commented out below and
+    /// Should be used once we can bump the Dart SDK in the next major version.
+    /// For now, the best we can do is compare by chunks of 8 bytes.
+    // return 0 == memcmp(dataA.address, dataB.address, dataA.lengthInBytes);
 
     final numWords = dataA.lengthInBytes ~/ 8;
     final wordsA = dataA.buffer.asUint64List(0, numWords);
@@ -89,3 +92,9 @@ class Screenshot {
     return true;
   }
 }
+
+// /// Compares the first num bytes of the block of memory pointed by ptr1 to the
+// /// first num bytes pointed by ptr2, returning zero if they all match or a value
+// ///  different from zero representing which is greater if they do not.
+// @Native<Int32 Function(Pointer, Pointer, Int32)>(symbol: 'memcmp', isLeaf: true)
+// external int memcmp(Pointer<Uint8> ptr1, Pointer<Uint8> ptr2, int len);

--- a/flutter/lib/src/screenshot/screenshot.dart
+++ b/flutter/lib/src/screenshot/screenshot.dart
@@ -14,6 +14,7 @@ class Screenshot {
   final Flow flow;
   Future<ByteData>? _rawData;
   Future<ByteData>? _pngData;
+  bool _disposed = false;
 
   Screenshot(this._image, this.timestamp, this.flow);
   Screenshot._cloned(
@@ -49,12 +50,19 @@ class Screenshot {
   }
 
   Screenshot clone() {
-    assert(!_image.debugDisposed);
+    assert(!_disposed, 'Cannot clone a disposed screenshot');
     return Screenshot._cloned(
         _image.clone(), timestamp, flow, _rawData, _pngData);
   }
 
-  void dispose() => _image.dispose();
+  void dispose() {
+    if (!_disposed) {
+      _disposed = true;
+      _image.dispose();
+      _rawData = null;
+      _pngData = null;
+    }
+  }
 
   /// Efficiently compares two memory regions for data equality..
   @visibleForTesting

--- a/flutter/lib/src/screenshot/screenshot.dart
+++ b/flutter/lib/src/screenshot/screenshot.dart
@@ -1,9 +1,6 @@
 import 'dart:async';
 import 'dart:developer';
-import 'dart:ffi';
 import 'dart:ui';
-// ignore: unnecessary_import // backcompatibility for Flutter < 3.3
-import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 import 'package:meta/meta.dart';
@@ -24,16 +21,21 @@ class Screenshot {
   int get height => _image.height;
 
   Future<ByteData> get rawData {
-    _rawData ??= _image
-        .toByteData(format: ImageByteFormat.rawUnmodified)
-        .then((data) => data!);
+    _rawData ??= _encode(ImageByteFormat.rawUnmodified);
     return _rawData!;
   }
 
   Future<ByteData> get pngData {
-    _pngData ??=
-        _image.toByteData(format: ImageByteFormat.png).then((data) => data!);
+    _pngData ??= _encode(ImageByteFormat.png);
     return _pngData!;
+  }
+
+  Future<ByteData> _encode(ImageByteFormat format) async {
+    Timeline.startSync('Sentry::screenshotTo${format.name}', flow: flow);
+    final result =
+        await _image.toByteData(format: format).then((data) => data!);
+    Timeline.finishSync();
+    return result;
   }
 
   Future<bool> hasSameImageAs(Screenshot other) async {
@@ -41,33 +43,7 @@ class Screenshot {
       return false;
     }
 
-    final thisData = await rawData;
-    final otherData = await other.rawData;
-    if (thisData.lengthInBytes != otherData.lengthInBytes) {
-      return false;
-    }
-    if (identical(thisData, otherData)) {
-      return true;
-    }
-
-    // Note: listEquals() is slow because it compares each byte pair.
-    // Ideally, we would use memcmp with Uint8List.address but that's only
-    // available since Dart 3.5.0.
-    // For now, the best we can do is compare by chunks
-    var pos = 0;
-    while (pos + 8 < thisData.lengthInBytes) {
-      if (thisData.getInt64(pos) != otherData.getInt64(pos)) {
-        return false;
-      }
-      pos += 8;
-    }
-    while (pos < thisData.lengthInBytes) {
-      if (thisData.getUint8(pos) != otherData.getUint8(pos)) {
-        return false;
-      }
-      pos++;
-    }
-    return true;
+    return listEquals(await rawData, await other.rawData);
   }
 
   Screenshot clone() {
@@ -77,4 +53,39 @@ class Screenshot {
   }
 
   void dispose() => _image.dispose();
+
+  /// Efficiently compares two memory regions for data equality..
+  /// Ideally, we would use memcmp with Uint8List.address but that's only
+  /// available since Dart 3.5.0.
+  /// For now, the best we can do is compare by chunks of 8 bytes.
+  @visibleForTesting
+  static bool listEquals(ByteData dataA, ByteData dataB) {
+    if (identical(dataA, dataB)) {
+      return true;
+    }
+    if (dataA.lengthInBytes != dataB.lengthInBytes) {
+      return false;
+    }
+
+    final numWords = dataA.lengthInBytes ~/ 8;
+    final wordsA = dataA.buffer.asUint64List(0, numWords);
+    final wordsB = dataB.buffer.asUint64List(0, numWords);
+
+    for (var i = 0; i < wordsA.length; i++) {
+      if (wordsA[i] != wordsB[i]) {
+        return false;
+      }
+    }
+
+    // Compare any remaining bytes.
+    final bytesA = dataA.buffer.asUint8List(wordsA.lengthInBytes);
+    final bytesB = dataA.buffer.asUint8List(wordsA.lengthInBytes);
+    for (var i = 0; i < bytesA.lengthInBytes; i++) {
+      if (bytesA[i] != bytesB[i]) {
+        return false;
+      }
+    }
+
+    return true;
+  }
 }

--- a/flutter/lib/src/screenshot/screenshot.dart
+++ b/flutter/lib/src/screenshot/screenshot.dart
@@ -72,19 +72,27 @@ class Screenshot {
     /// For now, the best we can do is compare by chunks of 8 bytes.
     // return 0 == memcmp(dataA.address, dataB.address, dataA.lengthInBytes);
 
-    final numWords = dataA.lengthInBytes ~/ 8;
-    final wordsA = dataA.buffer.asUint64List(0, numWords);
-    final wordsB = dataB.buffer.asUint64List(0, numWords);
+    late final int processed;
+    try {
+      final numWords = dataA.lengthInBytes ~/ 8;
+      final wordsA = dataA.buffer.asUint64List(0, numWords);
+      final wordsB = dataB.buffer.asUint64List(0, numWords);
 
-    for (var i = 0; i < wordsA.length; i++) {
-      if (wordsA[i] != wordsB[i]) {
-        return false;
+      for (var i = 0; i < wordsA.length; i++) {
+        if (wordsA[i] != wordsB[i]) {
+          return false;
+        }
       }
+      processed = wordsA.lengthInBytes;
+    } on UnsupportedError {
+      // This should only trigger on dart2js:
+      // Unsupported operation: Uint64List not supported by dart2js.
+      processed = 0;
     }
 
     // Compare any remaining bytes.
-    final bytesA = dataA.buffer.asUint8List(wordsA.lengthInBytes);
-    final bytesB = dataB.buffer.asUint8List(wordsA.lengthInBytes);
+    final bytesA = dataA.buffer.asUint8List(processed);
+    final bytesB = dataB.buffer.asUint8List(processed);
     for (var i = 0; i < bytesA.lengthInBytes; i++) {
       if (bytesA[i] != bytesB[i]) {
         return false;

--- a/flutter/lib/src/screenshot/stabilizer.dart
+++ b/flutter/lib/src/screenshot/stabilizer.dart
@@ -18,9 +18,8 @@ import 'screenshot.dart';
 /// To get around this issue, we're taking two subsequent screenshots
 /// (after two frames) and only actually capture a screenshot if the
 /// two are exactly the same.
-/// We only do these if masking is enabled.
 @internal
-class ScreenshotRetrier<R> {
+class ScreenshotStabilizer<R> {
   final SentryFlutterOptions _options;
   final ScreenshotRecorder _recorder;
   final Future<R> Function(Screenshot screenshot) _callback;
@@ -28,9 +27,9 @@ class ScreenshotRetrier<R> {
   int _tries = 0;
   bool stopped = false;
 
-  ScreenshotRetrier(this._recorder, this._options, this._callback) {
+  ScreenshotStabilizer(this._recorder, this._options, this._callback) {
     assert(_options.screenshotRetries >= 1,
-        "Cannot use ScreenshotRetrier if we cannot retry at least once.");
+        "Cannot use ScreenshotStabilizer if we cannot retry at least once.");
   }
 
   void ensureFrameAndAddCallback(FrameCallback callback) {

--- a/flutter/lib/src/screenshot/stabilizer.dart
+++ b/flutter/lib/src/screenshot/stabilizer.dart
@@ -32,13 +32,17 @@ class ScreenshotStabilizer<R> {
         "Cannot use ScreenshotStabilizer if we cannot retry at least once.");
   }
 
+  void dispose() {
+    _previousScreenshot?.dispose();
+  }
+
   void ensureFrameAndAddCallback(FrameCallback callback) {
     _options.bindingUtils.instance!
       ..ensureVisualUpdate()
       ..addPostFrameCallback(callback);
   }
 
-  Future<void> capture(Duration sinceSchedulerEpoch) {
+  Future<void> capture(Duration _) {
     _tries++;
     return _recorder.capture(_onImageCaptured);
   }

--- a/flutter/lib/src/screenshot/stabilizer.dart
+++ b/flutter/lib/src/screenshot/stabilizer.dart
@@ -77,9 +77,20 @@ class ScreenshotStabilizer<R> {
             'Giving up after $_tries tries.');
       } else {
         // Add a delay to give the UI a chance to stabilize.
-        if (_tries > 0) {
-          await Future<void>.delayed(
-              Duration(milliseconds: min(100, 10 * (_tries - 1))));
+        // Only do this on every other frame so that there's a greater chance
+        // of two subsequent frames being the same.
+        final sleepMs = _tries % 2 == 1 ? min(100, 10 * (_tries - 1)) : 0;
+
+        if (_tries > 1) {
+          _options.logger(
+              SentryLevel.debug,
+              '${_recorder.logName}: '
+              'Retrying screenshot capture due to UI changes. '
+              'Delay before next capture: $sleepMs ms.');
+        }
+
+        if (sleepMs > 0) {
+          await Future<void>.delayed(Duration(milliseconds: sleepMs));
         }
 
         final completer = Completer<void>();

--- a/flutter/lib/src/screenshot/stabilizer.dart
+++ b/flutter/lib/src/screenshot/stabilizer.dart
@@ -65,7 +65,7 @@ class ScreenshotStabilizer<R> {
       return;
     }
 
-    final prevScreenshot = _previousScreenshot;
+    var prevScreenshot = _previousScreenshot;
     try {
       _previousScreenshot = screenshot.clone();
       if (prevScreenshot != null &&
@@ -85,8 +85,18 @@ class ScreenshotStabilizer<R> {
         return;
       }
     } finally {
+      // [prevScreenshot] and [screenshot] are unnecessary after this line.
       // Note: we need to dispose (free the memory) before recursion.
+      // Also, we need to reset the variable to null so that the whole object
+      // can be garbage collected.
       prevScreenshot?.dispose();
+      prevScreenshot = null;
+      // Note: while the caller will also do `screenshot.dispose()`,
+      // it would be a problem in a long recursion because we only return
+      // from this function when the screenshot is ultimately stable.
+      // At that point, the caller would have accumulated a lot of screenshots
+      // on stack. This would lead to OOM.
+      screenshot.dispose();
     }
 
     if (maxTries != null && _tries >= maxTries!) {

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -11,7 +11,7 @@ import 'binding_wrapper.dart';
 import 'navigation/time_to_display_tracker.dart';
 import 'renderer/renderer.dart';
 import 'screenshot/sentry_screenshot_quality.dart';
-import 'screenshot/retrier.dart';
+import 'screenshot/stabilizer.dart';
 import 'event_processor/screenshot_event_processor.dart';
 import 'sentry_flutter.dart';
 import 'sentry_privacy_options.dart';
@@ -206,7 +206,7 @@ class SentryFlutterOptions extends SentryOptions {
   /// from the function, no screenshot will be attached.
   BeforeCaptureCallback? beforeCaptureScreenshot;
 
-  /// See [ScreenshotRetrier]
+  /// See [ScreenshotStabilizer]
   @meta.internal
   int screenshotRetries = 5;
 

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -205,6 +205,10 @@ class SentryFlutterOptions extends SentryOptions {
   /// from the function, no screenshot will be attached.
   BeforeCaptureCallback? beforeCaptureScreenshot;
 
+  /// See [ScreenshotRetrier]
+  @meta.internal
+  int screenshotRetries = 5;
+
   /// Enable or disable automatic breadcrumbs for User interactions Using [Listener]
   ///
   /// Requires adding the [SentryUserInteractionWidget] to the widget tree.

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -11,7 +11,6 @@ import 'binding_wrapper.dart';
 import 'navigation/time_to_display_tracker.dart';
 import 'renderer/renderer.dart';
 import 'screenshot/sentry_screenshot_quality.dart';
-import 'screenshot/stabilizer.dart';
 import 'event_processor/screenshot_event_processor.dart';
 import 'sentry_flutter.dart';
 import 'sentry_privacy_options.dart';
@@ -205,10 +204,6 @@ class SentryFlutterOptions extends SentryOptions {
   /// relevant if `attachScreenshot` is set to true. When false is returned
   /// from the function, no screenshot will be attached.
   BeforeCaptureCallback? beforeCaptureScreenshot;
-
-  /// See [ScreenshotStabilizer]
-  @meta.internal
-  int screenshotRetries = 5;
 
   /// Enable or disable automatic breadcrumbs for User interactions Using [Listener]
   ///

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -11,6 +11,7 @@ import 'binding_wrapper.dart';
 import 'navigation/time_to_display_tracker.dart';
 import 'renderer/renderer.dart';
 import 'screenshot/sentry_screenshot_quality.dart';
+import 'screenshot/retrier.dart';
 import 'event_processor/screenshot_event_processor.dart';
 import 'sentry_flutter.dart';
 import 'sentry_privacy_options.dart';

--- a/flutter/test/event_processor/screenshot_event_processor_test.dart
+++ b/flutter/test/event_processor/screenshot_event_processor_test.dart
@@ -11,6 +11,8 @@ import 'package:sentry_flutter/src/renderer/renderer.dart';
 import '../mocks.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
+import '../replay/replay_test_util.dart';
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   late Fixture fixture;
@@ -40,7 +42,7 @@ void main() {
       final throwable = Exception();
       event = SentryEvent(throwable: throwable);
       hint = Hint();
-      await sut.apply(event, hint);
+      await tester.pumpAndWaitUntil(sut.apply(event, hint));
 
       expect(hint.screenshot != null, added);
       if (expectedMaxWidthOrHeight != null) {
@@ -57,6 +59,12 @@ void main() {
   }
 
   testWidgets('adds screenshot attachment dart:io', (tester) async {
+    await _addScreenshotAttachment(tester, null, added: true, isWeb: false);
+  });
+
+  testWidgets('adds screenshot attachment with masking enabled dart:io',
+      (tester) async {
+    fixture.options.experimental.privacy.maskAllText = true;
     await _addScreenshotAttachment(tester, null, added: true, isWeb: false);
   });
 

--- a/flutter/test/event_processor/screenshot_event_processor_test.dart
+++ b/flutter/test/event_processor/screenshot_event_processor_test.dart
@@ -68,6 +68,27 @@ void main() {
     await _addScreenshotAttachment(tester, null, added: true, isWeb: false);
   });
 
+  testWidgets('does not block if the screenshot fails to stabilize',
+      (tester) async {
+    fixture.options.automatedTestMode = false;
+    fixture.options.experimental.privacy.maskAllText = true;
+    // Run with real async https://stackoverflow.com/a/54021863
+    await tester.runAsync(() async {
+      final sut = fixture.getSut(null, false);
+
+      await tester.pumpWidget(SentryScreenshotWidget(
+          child: Text('Catching Pokémon is a snap!',
+              textDirection: TextDirection.ltr)));
+
+      final throwable = Exception();
+      event = SentryEvent(throwable: throwable);
+      hint = Hint();
+      await sut.apply(event, hint);
+
+      expect(hint.screenshot, isNull);
+    });
+  });
+
   testWidgets('adds screenshot attachment with canvasKit renderer',
       (tester) async {
     await _addScreenshotAttachment(tester, FlutterRenderer.canvasKit,

--- a/flutter/test/replay/replay_test_util.dart
+++ b/flutter/test/replay/replay_test_util.dart
@@ -1,0 +1,30 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+
+extension ReplayWidgetTesterUtil on WidgetTester {
+  Future<T> pumpAndWaitUntil<T>(Future<T> future,
+      {bool requiredToComplete = true}) async {
+    final timeout =
+        requiredToComplete ? Duration(seconds: 10) : Duration(seconds: 1);
+    final startTime = DateTime.now();
+    bool completed = false;
+    do {
+      await pumpAndSettle(const Duration(seconds: 1));
+      await Future<void>.delayed(const Duration(milliseconds: 1));
+      completed = await future
+          .then((v) => true)
+          .timeout(const Duration(milliseconds: 10), onTimeout: () => false);
+    } while (!completed && DateTime.now().difference(startTime) < timeout);
+
+    if (requiredToComplete) {
+      if (!completed) {
+        throw TimeoutException(
+            'Future not completed', DateTime.now().difference(startTime));
+      }
+      return future;
+    } else {
+      return Future.value(null);
+    }
+  }
+}

--- a/flutter/test/replay/scheduler_test.dart
+++ b/flutter/test/replay/scheduler_test.dart
@@ -104,7 +104,7 @@ class _Fixture {
 
   Future<void> drawFrame() {
     registeredCallback = Completer<FrameCallback>();
-    return registeredCallback.future
-        .then((fn) => fn(Duration(milliseconds: ++_frames)));
+    final timestamp = Duration(milliseconds: ++_frames);
+    return registeredCallback.future.then((fn) => fn(timestamp));
   }
 }

--- a/flutter/test/replay/scheduler_test.dart
+++ b/flutter/test/replay/scheduler_test.dart
@@ -67,7 +67,7 @@ void main() {
     await fixture.drawFrame();
     await fixture.drawFrame();
     expect(fixture.calls, 1);
-    
+
     guard.complete();
     await fixture.drawFrame();
     expect(fixture.calls, 2);

--- a/flutter/test/screenshot/recorder_test.dart
+++ b/flutter/test/screenshot/recorder_test.dart
@@ -142,8 +142,7 @@ class _Fixture {
     return fixture;
   }
 
-  Future<String?> capture() => sut.capture<String?>((Screenshot screenshot) {
-        final image = screenshot.image;
-        return Future.value("${image.width}x${image.height}");
+  Future<String?> capture() => sut.capture<String?>((screenshot) {
+        return Future.value("${screenshot.width}x${screenshot.height}");
       });
 }

--- a/flutter/test/screenshot/recorder_test.dart
+++ b/flutter/test/screenshot/recorder_test.dart
@@ -23,55 +23,68 @@ void main() async {
   // The `device screen resolution = logical resolution * devicePixelRatio`
 
   testWidgets('captures full resolution images - portrait', (tester) async {
-    await tester.binding.setSurfaceSize(Size(2000, 4000));
-    final fixture = await _Fixture.create(tester);
+    await tester.runAsync(() async {
+      await tester.binding.setSurfaceSize(Size(20, 40));
+      final fixture = await _Fixture.create(tester);
 
-    //devicePixelRatio is 3.0 therefore the resolution multiplied by 3
-    expect(await fixture.capture(), '6000x12000');
+      //devicePixelRatio is 3.0 therefore the resolution multiplied by 3
+      expect(await fixture.capture(), '60x120');
+    });
   });
 
   testWidgets('captures full resolution images - landscape', (tester) async {
-    await tester.binding.setSurfaceSize(Size(4000, 2000));
-    final fixture = await _Fixture.create(tester);
+    await tester.runAsync(() async {
+      await tester.binding.setSurfaceSize(Size(40, 20));
+      final fixture = await _Fixture.create(tester);
 
-    //devicePixelRatio is 3.0 therefore the resolution multiplied by 3
-    expect(await fixture.capture(), '12000x6000');
+      //devicePixelRatio is 3.0 therefore the resolution multiplied by 3
+      expect(await fixture.capture(), '120x60');
+    });
   });
 
   testWidgets('captures high resolution images - portrait', (tester) async {
-    await tester.binding.setSurfaceSize(Size(2000, 4000));
-    final targetResolution = SentryScreenshotQuality.high.targetResolution();
-    final fixture = await _Fixture.create(tester,
-        width: targetResolution, height: targetResolution);
+    await tester.runAsync(() async {
+      await tester.binding.setSurfaceSize(Size(20, 40));
+      final targetResolution = SentryScreenshotQuality.high.targetResolution();
+      final fixture = await _Fixture.create(tester,
+          width: targetResolution, height: targetResolution);
 
-    expect(await fixture.capture(), '960x1920');
+      expect(await fixture.capture(), '960x1920');
+    });
   });
 
   testWidgets('captures high resolution images - landscape', (tester) async {
-    await tester.binding.setSurfaceSize(Size(4000, 2000));
-    final targetResolution = SentryScreenshotQuality.high.targetResolution();
-    final fixture = await _Fixture.create(tester,
-        width: targetResolution, height: targetResolution);
+    await tester.runAsync(() async {
+      await tester.binding.setSurfaceSize(Size(40, 20));
+      final targetResolution = SentryScreenshotQuality.high.targetResolution();
+      final fixture = await _Fixture.create(tester,
+          width: targetResolution, height: targetResolution);
 
-    expect(await fixture.capture(), '1920x960');
+      expect(await fixture.capture(), '1920x960');
+    });
   });
 
   testWidgets('captures medium resolution images', (tester) async {
-    await tester.binding.setSurfaceSize(Size(2000, 4000));
-    final targetResolution = SentryScreenshotQuality.medium.targetResolution();
-    final fixture = await _Fixture.create(tester,
-        width: targetResolution, height: targetResolution);
+    await tester.runAsync(() async {
+      await tester.binding.setSurfaceSize(Size(20, 40));
+      final targetResolution =
+          SentryScreenshotQuality.medium.targetResolution();
+      final fixture = await _Fixture.create(tester,
+          width: targetResolution, height: targetResolution);
 
-    expect(await fixture.capture(), '640x1280');
+      expect(await fixture.capture(), '640x1280');
+    });
   });
 
   testWidgets('captures low resolution images', (tester) async {
-    await tester.binding.setSurfaceSize(Size(2000, 4000));
-    final targetResolution = SentryScreenshotQuality.low.targetResolution();
-    final fixture = await _Fixture.create(tester,
-        width: targetResolution, height: targetResolution);
+    await tester.runAsync(() async {
+      await tester.binding.setSurfaceSize(Size(20, 40));
+      final targetResolution = SentryScreenshotQuality.low.targetResolution();
+      final fixture = await _Fixture.create(tester,
+          width: targetResolution, height: targetResolution);
 
-    expect(await fixture.capture(), '427x854');
+      expect(await fixture.capture(), '427x854');
+    });
   });
 
   testWidgets('propagates errors in test-mode', (tester) async {

--- a/flutter/test/screenshot/recorder_test.dart
+++ b/flutter/test/screenshot/recorder_test.dart
@@ -3,6 +3,7 @@
 @TestOn('vm')
 library dart_test;
 
+import 'dart:typed_data';
 import 'dart:ui';
 
 import 'package:flutter/widgets.dart' as widgets;
@@ -11,6 +12,7 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:sentry_flutter/src/replay/replay_recorder.dart';
 import 'package:sentry_flutter/src/screenshot/recorder.dart';
 import 'package:sentry_flutter/src/screenshot/recorder_config.dart';
+import 'package:sentry_flutter/src/screenshot/screenshot.dart';
 
 import '../mocks.dart';
 import 'test_widget.dart';
@@ -134,6 +136,64 @@ void main() async {
       final sut = ScreenshotRecorder(ScreenshotRecorderConfig(),
           defaultTestOptions()..experimental.privacy.maskAllText = false);
       expect(sut.hasWidgetFilter, isTrue);
+    });
+  });
+
+  group('$Screenshot', () {
+    test('listEquals()', () {
+      expect(
+          Screenshot.listEquals(
+            Uint8List(0).buffer.asByteData(),
+            Uint8List(0).buffer.asByteData(),
+          ),
+          isTrue);
+      expect(
+          Screenshot.listEquals(
+            Uint8List.fromList([1, 2, 3]).buffer.asByteData(),
+            Uint8List.fromList([1, 2, 3]).buffer.asByteData(),
+          ),
+          isTrue);
+      expect(
+          Screenshot.listEquals(
+            Uint8List.fromList([1, 0, 3]).buffer.asByteData(),
+            Uint8List.fromList([1, 2, 3]).buffer.asByteData(),
+          ),
+          isFalse);
+      expect(
+          Screenshot.listEquals(
+            Uint8List.fromList([1, 2, 3, 4, 5, 6, 7, 8]).buffer.asByteData(),
+            Uint8List.fromList([1, 2, 3, 4, 5, 6, 7, 8]).buffer.asByteData(),
+          ),
+          isTrue);
+      expect(
+          Screenshot.listEquals(
+            Uint8List.fromList([1, 2, 3, 4, 5, 6, 0, 8]).buffer.asByteData(),
+            Uint8List.fromList([1, 2, 3, 4, 5, 6, 7, 8]).buffer.asByteData(),
+          ),
+          isFalse);
+      expect(
+          Screenshot.listEquals(
+            Uint8List.fromList([1, 2, 3, 4, 5, 6, 7, 8, 9]).buffer.asByteData(),
+            Uint8List.fromList([1, 2, 3, 4, 5, 6, 7, 8, 9]).buffer.asByteData(),
+          ),
+          isTrue);
+      expect(
+          Screenshot.listEquals(
+            Uint8List.fromList([1, 2, 3, 4, 5, 6, 7, 8, 9]).buffer.asByteData(),
+            Uint8List.fromList([1, 2, 3, 4, 5, 6, 7, 8, 0]).buffer.asByteData(),
+          ),
+          isFalse);
+
+      final dataA = Uint8List.fromList(
+              List.generate(10 * 1000 * 1000, (index) => index % 256))
+          .buffer
+          .asByteData();
+      final dataB = ByteData(dataA.lengthInBytes)
+        ..buffer.asUint8List().setAll(0, dataA.buffer.asUint8List());
+      expect(Screenshot.listEquals(dataA, dataB), isTrue);
+
+      dataB.setInt8(dataB.lengthInBytes >> 2, 0);
+      expect(Screenshot.listEquals(dataA, dataB), isFalse);
     });
   });
 }

--- a/metrics/metrics-ios.yml
+++ b/metrics/metrics-ios.yml
@@ -10,5 +10,5 @@ startupTimeTest:
   diffMax: 150
 
 binarySizeTest:
-  diffMin: 1200 KiB
-  diffMax: 1500 KiB
+  diffMin: 1400 KiB
+  diffMax: 1600 KiB


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
We're facing an issue: the tree walked with `visitChildElements()` is out of sync to what is currently rendered by `RenderRepaintBoundary.toImage()`, even though there's no async gap between these two. This causes masks to be off during repaints, e.g. when scrolling a view or when text is rendered in different places between two screens. This is most easily reproducible when there's no animation between the two screens. 

For example, Spotube's Search vs Library (2nd and 3rd bottom bar buttons). The following composition of three subsequent frames shows the transition. Note the special mode of rendering which prints masks (in the color that the text was in the original button) and then writes the text that is being masked in bright green. This way you can see that the masks move over to their new position (about 30 px higher then before) when the screen changes, but the captured image still renders the previous version of the screen. I've added a red guideline to make this change easier to see.

<img width="530" alt="image" src="https://github.com/user-attachments/assets/222c3360-13d2-460b-9857-97fb640192da" />

I've created [an issue upstream](https://github.com/flutter/flutter/issues/161228#issuecomment-2577230350) to try and get this resolved "properly". As an interim solution, we're taking two subsequent screenshots (two frames) and only actually capture a screenshot for replay if the two are exactly the same. 

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?

Mostly manually as I could not reproduce the masking issue programatically. There are some new and updated tests to cover what I could.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
