### PR TITLE
ci(linux): fix `Failed to load dynamic library 'libsqlite3.so'`

### DIFF
--- a/.github/workflows/drift.yml
+++ b/.github/workflows/drift.yml
@@ -37,7 +37,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - run: sudo apt-get -y install libsqlite3-dev
+      - name: Install libsqlite3
+        if: matrix.target == 'linux'
+        run: sudo apt-get -y install libsqlite3-dev
 
       - uses: ./.github/actions/flutter-test
         with:

--- a/.github/workflows/drift.yml
+++ b/.github/workflows/drift.yml
@@ -37,6 +37,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - run: sudo apt-get -y install libsqlite3-dev
+
       - uses: ./.github/actions/flutter-test
         with:
           directory: drift

--- a/.github/workflows/sqflite.yml
+++ b/.github/workflows/sqflite.yml
@@ -37,7 +37,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - run: sudo apt-get -y install libsqlite3-dev
+      - name: Install libsqlite3
+        if: matrix.target == 'linux'
+        run: sudo apt-get -y install libsqlite3-dev
 
       - uses: ./.github/actions/flutter-test
         with:

--- a/.github/workflows/sqflite.yml
+++ b/.github/workflows/sqflite.yml
@@ -37,6 +37,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - run: sudo apt-get -y install libsqlite3-dev
+
       - uses: ./.github/actions/flutter-test
         with:
           directory: sqflite


### PR DESCRIPTION
drift and sqflite tests are failing because libsqlite3 is missing on Linux

Example: https://github.com/getsentry/sentry-dart/actions/runs/12671780639/job/35314287776

#skip-changelog