### PR TITLE
feat(js-sdk): enable global error handler and dedupe integration

### DIFF
--- a/flutter/example/integration_test/web_sdk_test.dart
+++ b/flutter/example/integration_test/web_sdk_test.dart
@@ -45,7 +45,7 @@ void main() {
             .dartify() as List<Object?>;
 
         expect(dsn, fakeDsn);
-        expect(defaultIntegrations, isEmpty);
+        expect(defaultIntegrations, isNotEmpty);
       });
     });
 

--- a/flutter/lib/src/web/html_sentry_js_binding.dart
+++ b/flutter/lib/src/web/html_sentry_js_binding.dart
@@ -13,8 +13,24 @@ class HtmlSentryJsBinding implements SentryJsBinding {
 
   @override
   void init(Map<String, dynamic> options) {
+    if (options['defaultIntegrations'] != null) {
+      options['defaultIntegrations'] = options['defaultIntegrations']
+          .map((String integration) => _createIntegration(integration));
+    }
+
     _sentry ??= context['Sentry'] as JsObject;
     _sentry!.callMethod('init', [JsObject.jsify(options)]);
+  }
+
+  JsObject? _createIntegration(String integration) {
+    switch (integration) {
+      case SentryJsIntegrationName.globalHandlers:
+      case SentryJsIntegrationName.dedupe:
+        final jsIntegration = _sentry?.callMethod(integration, []);
+        return jsIntegration is JsObject ? jsIntegration : null;
+      default:
+        return null;
+    }
   }
 
   @override

--- a/flutter/lib/src/web/sentry_js_binding.dart
+++ b/flutter/lib/src/web/sentry_js_binding.dart
@@ -6,3 +6,11 @@ abstract class SentryJsBinding {
   void init(Map<String, dynamic> options);
   void close();
 }
+
+/// Names of the JS integrations that we want to add when initializing the JS SDK
+class SentryJsIntegrationName {
+  const SentryJsIntegrationName._();
+
+  static const String globalHandlers = 'globalHandlersIntegration';
+  static const String dedupe = 'dedupeIntegration';
+}

--- a/flutter/lib/src/web/sentry_web.dart
+++ b/flutter/lib/src/web/sentry_web.dart
@@ -27,11 +27,15 @@ class SentryWeb with SentryNativeSafeInvoker implements SentryNativeBinding {
         'environment': _options.environment,
         'release': _options.release,
         'dist': _options.dist,
-        'sampleRate': _options.sampleRate,
+        'sampleRate': _options.sampleRate ?? 1,
+        'tracesSampleRate': 0,
         'attachStacktrace': _options.attachStacktrace,
         'maxBreadcrumbs': _options.maxBreadcrumbs,
         // using defaultIntegrations ensures that we can control which integrations are added
-        'defaultIntegrations': <String>[],
+        'defaultIntegrations': <String>{
+          SentryJsIntegrationName.globalHandlers,
+          SentryJsIntegrationName.dedupe
+        },
       };
       _binding.init(jsOptions);
     });

--- a/flutter/lib/src/web/web_sentry_js_binding.dart
+++ b/flutter/lib/src/web/web_sentry_js_binding.dart
@@ -10,7 +10,22 @@ SentryJsBinding createJsBinding() {
 class WebSentryJsBinding implements SentryJsBinding {
   @override
   void init(Map<String, dynamic> options) {
+    if (options['defaultIntegrations'] != null) {
+      options['defaultIntegrations'] = options['defaultIntegrations']
+          .map((String integration) => _createIntegration(integration));
+    }
     _init(options.jsify());
+  }
+
+  JSObject? _createIntegration(String integration) {
+    switch (integration) {
+      case SentryJsIntegrationName.globalHandlers:
+        return _globalHandlersIntegration();
+      case SentryJsIntegrationName.dedupe:
+        return _dedupeIntegration();
+      default:
+        return null;
+    }
   }
 
   @override
@@ -28,6 +43,12 @@ external void _init(JSAny? options);
 
 @JS('Sentry.close')
 external void _close();
+
+@JS('Sentry.globalHandlersIntegration')
+external JSObject _globalHandlersIntegration();
+
+@JS('Sentry.dedupeIntegration')
+external JSObject _dedupeIntegration();
 
 @JS('globalThis')
 external JSObject get globalThis;

--- a/flutter/test/web/sentry_web_test.dart
+++ b/flutter/test/web/sentry_web_test.dart
@@ -73,6 +73,11 @@ void main() {
         expect(jsOptions['attachStacktrace'], expectedAttachStacktrace);
         expect(jsOptions['maxBreadcrumbs'], expectedMaxBreadcrumbs);
         expect(jsOptions['debug'], expectedDebug);
+        expect(jsOptions['defaultIntegrations'].length, 2);
+        expect(jsOptions['defaultIntegrations'][0].toString(),
+            contains('name: GlobalHandlers'));
+        expect(jsOptions['defaultIntegrations'][1].toString(),
+            contains('name: Dedupe'));
       });
 
       test('options getter returns the original options', () {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Enable global error handler and dedupe integration

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Part of JS SDK integration

## :green_heart: How did you test it?
Unit, manual

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes


#skip-changelog
