### PR TITLE
Move application of event processors to shared function

### DIFF
--- a/dart/lib/src/event_processor/run_event_processors.dart
+++ b/dart/lib/src/event_processor/run_event_processors.dart
@@ -1,0 +1,76 @@
+import 'package:meta/meta.dart';
+
+import '../client_reports/discard_reason.dart';
+import '../event_processor.dart';
+import '../hint.dart';
+import '../protocol/sentry_event.dart';
+import '../protocol/sentry_level.dart';
+import '../protocol/sentry_transaction.dart';
+import '../sentry_options.dart';
+import '../transport/data_category.dart';
+
+@internal
+Future<SentryEvent?> runEventProcessors(
+  SentryEvent event,
+  Hint hint,
+  List<EventProcessor> eventProcessors,
+  SentryOptions options,
+) async {
+  int spanCountBeforeEventProcessors =
+      event is SentryTransaction ? event.spans.length : 0;
+
+  SentryEvent? processedEvent = event;
+  for (final processor in eventProcessors) {
+    try {
+      final e = processor.apply(processedEvent!, hint);
+      processedEvent = e is Future<SentryEvent?> ? await e : e;
+    } catch (exception, stackTrace) {
+      options.logger(
+        SentryLevel.error,
+        'An exception occurred while processing event by a processor',
+        exception: exception,
+        stackTrace: stackTrace,
+      );
+      if (options.automatedTestMode) {
+        rethrow;
+      }
+    }
+
+    final discardReason = DiscardReason.eventProcessor;
+    if (processedEvent == null) {
+      options.recorder.recordLostEvent(discardReason, _getCategory(event));
+      if (event is SentryTransaction) {
+        // We dropped the whole transaction, the dropped count includes all child spans + 1 root span
+        options.recorder.recordLostEvent(
+          discardReason,
+          DataCategory.span,
+          count: spanCountBeforeEventProcessors + 1,
+        );
+      }
+      options.logger(SentryLevel.debug, 'Event was dropped by a processor');
+      break;
+    } else if (event is SentryTransaction &&
+        processedEvent is SentryTransaction) {
+      // If event processor removed only some spans we still report them as dropped
+      final spanCountAfterEventProcessors = processedEvent.spans.length;
+      final droppedSpanCount =
+          spanCountBeforeEventProcessors - spanCountAfterEventProcessors;
+      if (droppedSpanCount > 0) {
+        options.recorder.recordLostEvent(
+          discardReason,
+          DataCategory.span,
+          count: droppedSpanCount,
+        );
+      }
+    }
+  }
+
+  return processedEvent;
+}
+
+DataCategory _getCategory(SentryEvent event) {
+  if (event is SentryTransaction) {
+    return DataCategory.transaction;
+  }
+  return DataCategory.error;
+}

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -5,7 +5,6 @@ import 'package:meta/meta.dart';
 
 import 'client_reports/client_report_recorder.dart';
 import 'client_reports/discard_reason.dart';
-import 'event_processor.dart';
 import 'event_processor/run_event_processors.dart';
 import 'hint.dart';
 import 'protocol.dart';


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->

- Move application of event processors to shared function
- Also record discard reason for scope event processors 

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #2570

## :green_heart: How did you test it?

Existing tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes
