### PR TITLE
Print a warning if the rate limit was reached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Add SentryReplayQuality setting (`options.experimental.replay.quality`) ([#2582](https://github.com/getsentry/sentry-dart/pull/2582))
 - SPM Support ([#2280](https://github.com/getsentry/sentry-dart/pull/2280))
 
+### Enhancements
+
+- Print a warning if the rate limit was reached ([#2595](https://github.com/getsentry/sentry-dart/pull/2595))
+
 ### Fixes
 
 - WASM compat for Drift ([#2580](https://github.com/getsentry/sentry-dart/pull/2580))

--- a/dart/lib/src/transport/http_transport.dart
+++ b/dart/lib/src/transport/http_transport.dart
@@ -52,9 +52,7 @@ class HttpTransport implements Transport {
     }
     if (response.statusCode == 429) {
       _options.logger(
-          SentryLevel.warning,
-          'Rate limit reached, failed to send envelope'
-      );
+          SentryLevel.warning, 'Rate limit reached, failed to send envelope');
     }
     return SentryId.empty();
   }

--- a/dart/lib/src/transport/http_transport.dart
+++ b/dart/lib/src/transport/http_transport.dart
@@ -50,6 +50,12 @@ class HttpTransport implements Transport {
     if (response.statusCode == 200) {
       return _parseEventId(response);
     }
+    if (response.statusCode == 429) {
+      _options.logger(
+          SentryLevel.warning,
+          'Rate limit reached, failed to send envelope'
+      );
+    }
     return SentryId.empty();
   }
 

--- a/dart/test/transport/http_transport_test.dart
+++ b/dart/test/transport/http_transport_test.dart
@@ -83,6 +83,9 @@ void main() {
       expect(mockRateLimiter.errorCode, 429);
       expect(mockRateLimiter.retryAfterHeader, '1');
       expect(mockRateLimiter.sentryRateLimitHeader, isNull);
+
+      expect(fixture.loggedLevel, SentryLevel.warning);
+      expect(fixture.loggedMessage, 'Rate limit reached, failed to send envelope');
     });
 
     test('sentryRateLimitHeader', () async {
@@ -207,6 +210,9 @@ void main() {
       await sut.send(envelope);
 
       expect(fixture.clientReportRecorder.discardedEvents.isEmpty, isTrue);
+
+      expect(fixture.loggedLevel, SentryLevel.warning);
+      expect(fixture.loggedMessage, 'Rate limit reached, failed to send envelope');
     });
 
     test('does record lost event for error >= 500', () async {
@@ -237,6 +243,8 @@ class Fixture {
   late var clientReportRecorder = MockClientReportRecorder();
 
   HttpTransport getSut(http.Client client, RateLimiter rateLimiter) {
+    options.debug = true;
+    options.logger = mockLogger;
     options.httpClient = client;
     options.recorder = clientReportRecorder;
     options.clock = () {
@@ -253,5 +261,19 @@ class Fixture {
     );
     final tracer = SentryTracer(context, MockHub());
     return SentryTransaction(tracer);
+  }
+
+  SentryLevel? loggedLevel;
+  String? loggedMessage;
+
+  void mockLogger(
+      SentryLevel level,
+      String message, {
+        String? logger,
+        Object? exception,
+        StackTrace? stackTrace,
+      }) {
+    loggedLevel = level;
+    loggedMessage = message;
   }
 }

--- a/dart/test/transport/http_transport_test.dart
+++ b/dart/test/transport/http_transport_test.dart
@@ -85,7 +85,8 @@ void main() {
       expect(mockRateLimiter.sentryRateLimitHeader, isNull);
 
       expect(fixture.loggedLevel, SentryLevel.warning);
-      expect(fixture.loggedMessage, 'Rate limit reached, failed to send envelope');
+      expect(
+          fixture.loggedMessage, 'Rate limit reached, failed to send envelope');
     });
 
     test('sentryRateLimitHeader', () async {
@@ -212,7 +213,8 @@ void main() {
       expect(fixture.clientReportRecorder.discardedEvents.isEmpty, isTrue);
 
       expect(fixture.loggedLevel, SentryLevel.warning);
-      expect(fixture.loggedMessage, 'Rate limit reached, failed to send envelope');
+      expect(
+          fixture.loggedMessage, 'Rate limit reached, failed to send envelope');
     });
 
     test('does record lost event for error >= 500', () async {
@@ -267,12 +269,12 @@ class Fixture {
   String? loggedMessage;
 
   void mockLogger(
-      SentryLevel level,
-      String message, {
-        String? logger,
-        Object? exception,
-        StackTrace? stackTrace,
-      }) {
+    SentryLevel level,
+    String message, {
+    String? logger,
+    Object? exception,
+    StackTrace? stackTrace,
+  }) {
     loggedLevel = level;
     loggedMessage = message;
   }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

- Log a warning if 429 rate limit header is received in `HttpTransport`

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #2551

## :green_heart: How did you test it?

Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes

