### PR TITLE
chore: update cocoa SDK to 8.44.0.beta-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
 - Bump Android SDK from v7.20.0 to v7.20.1 ([#2593](https://github.com/getsentry/sentry-dart/pull/2593))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#7201)
   - [diff](https://github.com/getsentry/sentry-java/compare/7.20.0...7.20.1)
+- Bump Cocoa SDK from v8.43.0 to v8.44.0-beta.1 ([#2598](https://github.com/getsentry/sentry-dart/pull/2598))
+  - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8440-beta1)
+  - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.43.0...8.44.0-beta.1)
 
 ## 8.13.0-beta.1
 

--- a/flutter/ios/sentry_flutter.podspec
+++ b/flutter/ios/sentry_flutter.podspec
@@ -16,7 +16,7 @@ Sentry SDK for Flutter with support to native through sentry-cocoa.
                          :tag => s.version.to_s }
   s.source_files     = 'sentry_flutter/Sources/**/*'
   s.public_header_files = 'sentry_flutter/Sources/**/*.h'
-  s.dependency 'Sentry/HybridSDK', '8.43.0'
+  s.dependency 'Sentry/HybridSDK', '8.44.0-beta.1'
   s.ios.dependency 'Flutter'
   s.osx.dependency 'FlutterMacOS'
   s.ios.deployment_target = '12.0'

--- a/flutter/ios/sentry_flutter/Package.swift
+++ b/flutter/ios/sentry_flutter/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .library(name: "sentry-flutter", targets: ["sentry_flutter", "sentry_flutter_objc"])
     ],
     dependencies: [
-      .package(url: "https://github.com/getsentry/sentry-cocoa", from: "8.43.0")
+      .package(url: "https://github.com/getsentry/sentry-cocoa", from: "8.44.0-beta.1")
     ],
     targets: [
         .target(

--- a/flutter/scripts/update-cocoa.sh
+++ b/flutter/scripts/update-cocoa.sh
@@ -51,6 +51,7 @@ get-repo)
 set-version)
     set_podspec_version "$2"
     set_spm_version "$2"
+    ../scripts/generate-cocoa-bindings.sh "$2"
     ;;
 *)
     echo "Unknown argument $1"


### PR DESCRIPTION
We need a beta release to prepare replay tags, so updating manually.

## 8.44.0-beta.1

### Fixes

- Don't start the SDK inside Xcode preview (#4601)

### Improvements

- Add native SDK information in the replay option event (#4663)
- Add error logging for invalid `cacheDirectoryPath` (#4693)

### Features

- SwiftUI time for initial display and time for full display (#4596)
- Add protocol for custom screenName for UIViewControllers (#4646)
- Allow hybrid SDK to set replay options tags information (#4710)
- Add threshold to always log fatal logs (#4707)

### Internal

- Change macros TEST and TESTCI to SENTRY_TEST and SENTRY_TEST_CI (#4712)
- Convert constants SentrySpanOperation to Swift (#4718)
- Convert constants SentryTraceOrigins to Swift (#4717)

## 8.43.1-beta.0

### Fixes

- Memory growth issue in profiler (#4682)
- Replace occurences of `strncpy` with `strlcpy` (#4636)
- Fix span recording for `NSFileManager.createFileAtPath` starting with iOS 18, macOS 15 and tvOS 18. This feature is experimental and must be enabled by setting the option `experimental.enableFileManagerSwizzling` to `true` (#4634)

### Internal

- Update to Xcode 16.2 in workflows (#4673)
- Add method unswizzling (#4647)