### PR TITLE
Update tests for new `options.debug` behaviour

### DIFF
--- a/dart/test/sentry_test.dart
+++ b/dart/test/sentry_test.dart
@@ -440,7 +440,7 @@ void main() {
       (options) {
         options.dsn = fakeDsn;
         expect(options.environment, 'debug');
-        expect(options.debug, false);
+        expect(options.debug, true);
       },
       options: sentryOptions,
     );
@@ -500,7 +500,8 @@ void main() {
     });
 
     test('throw is handled and logged', () async {
-      final sentryOptions = defaultTestOptions()
+      // Use release mode in platform checker to avoid additional log
+      final sentryOptions = defaultTestOptions(FakePlatformChecker.releaseMode())
         ..automatedTestMode = false
         ..debug = true
         ..logger = fixture.mockLogger;

--- a/dart/test/sentry_test.dart
+++ b/dart/test/sentry_test.dart
@@ -501,10 +501,11 @@ void main() {
 
     test('throw is handled and logged', () async {
       // Use release mode in platform checker to avoid additional log
-      final sentryOptions = defaultTestOptions(FakePlatformChecker.releaseMode())
-        ..automatedTestMode = false
-        ..debug = true
-        ..logger = fixture.mockLogger;
+      final sentryOptions =
+          defaultTestOptions(FakePlatformChecker.releaseMode())
+            ..automatedTestMode = false
+            ..debug = true
+            ..logger = fixture.mockLogger;
 
       final exception = Exception("Exception in options callback");
       await Sentry.init(

--- a/flutter/test/sentry_flutter_test.dart
+++ b/flutter/test/sentry_flutter_test.dart
@@ -622,7 +622,7 @@ void main() {
 
       await SentryFlutter.init(
         (options) {
-          expect(false, options.debug);
+          expect(true, options.debug);
           expect('debug', options.environment);
           expect(sdkName, options.sdk.name);
           expect(sdkVersion, options.sdk.version);


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->

Update tests for new `options.debug` behaviour

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes test expectations that changed when new options.debug was introduced.
