### PR TITLE
ci: fix cocoa SDK updater script

### DIFF
--- a/flutter/scripts/generate-cocoa-bindings.sh
+++ b/flutter/scripts/generate-cocoa-bindings.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 if [[ -n ${CI:+x} ]]; then
     echo "Running in CI so we need to set up Flutter SDK first"
-    curl -Lv https://storage.googleapis.com/flutter_infra_release/releases/stable/macos/flutter_macos_3.13.3-stable.zip --output /tmp/flutter.zip
+    curl -Lv https://storage.googleapis.com/flutter_infra_release/releases/stable/macos/flutter_macos_3.27.3-stable.zip --output /tmp/flutter.zip
     unzip -q /tmp/flutter.zip -d /tmp
     export PATH=":/tmp/flutter/bin:$PATH"
     which flutter


### PR DESCRIPTION
Should fix the issue currently ocuring in the cocoa SDK updater:

```
The current Dart SDK version is 3.1.1.

Because sentry_flutter depends on http >=1.1.1 which requires SDK version >=3.2.0 <4.0.0, version solving failed.


You can try the following suggestion to make the pubspec resolve:
* Consider downgrading your constraint on http: dart pub add dev:http:^1.1.0
Exception: /Users/runner/work/_temp/ghwf/updater/scripts/update-dependency.ps1:64
Line |
  64 |  …             throw "Script execution failed: $Path $action $value | ou …
```