### PR TITLE
chore: fix link ci for release and changelog

### DIFF
--- a/.github/workflows/link.yml
+++ b/.github/workflows/link.yml
@@ -55,4 +55,3 @@ jobs:
     uses: ./.github/workflows/analyze.yml
     with:
       package: link
-      panaThreshold: 90

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@
 
 ### Enhancements
 
-- Enable `options.debug` when in debug mode ([#2597](https://github.com/getsentry/sentry-dart/pull/2597))
 - Print a warning if the rate limit was reached ([#2595](https://github.com/getsentry/sentry-dart/pull/2595))
 - Add replay masking config to tags and report SDKs versions ([#2592](https://github.com/getsentry/sentry-dart/pull/2592))
 

--- a/link/pubspec_overrides.yaml
+++ b/link/pubspec_overrides.yaml
@@ -1,0 +1,3 @@
+dependency_overrides:
+  sentry:
+    path: ../dart


### PR DESCRIPTION
#skip-changelog

one job (package-analysis) will fail here because in the release branch this is skipped, so we can ignore it in the PR