### PR TITLE
Fallback to main window and main screen for macOS display refresh rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fallback to main window and main screen for macOS display refresh rate ([#2621](https://github.com/getsentry/sentry-dart/pull/2621))
+
 ## 8.13.0-beta.3
 
 ### Enhancements

--- a/flutter/ios/sentry_flutter/Sources/sentry_flutter/SentryFlutterPlugin.swift
+++ b/flutter/ios/sentry_flutter/Sources/sentry_flutter/SentryFlutterPlugin.swift
@@ -758,7 +758,7 @@ public class SentryFlutterPlugin: NSObject, FlutterPlugin {
         }
 
         guard let mode = CGDisplayCopyDisplayMode(displayID) else {
-            print("Cannot read mode from display idntifier to read display refresh rate.")
+            print("Cannot read mode from display identifier to read display refresh rate.")
             result(nil)
             return
         }

--- a/flutter/ios/sentry_flutter/Sources/sentry_flutter/SentryFlutterPlugin.swift
+++ b/flutter/ios/sentry_flutter/Sources/sentry_flutter/SentryFlutterPlugin.swift
@@ -742,12 +742,8 @@ public class SentryFlutterPlugin: NSObject, FlutterPlugin {
     #elseif os(macOS)
     private func displayRefreshRate(_ result: @escaping FlutterResult) {
         // We don't use CADisplayLink for macOS because it's only available starting with macOS 14
-        guard let window = NSApplication.shared.keyWindow else {
-            result(nil)
-            return
-        }
-
-        guard let screen = window.screen else {
+        let window = NSApplication.shared.keyWindow ?? NSApplication.shared.mainWindow
+        guard let screen = window?.screen ?? NSScreen.main else {
             result(nil)
             return
         }

--- a/flutter/ios/sentry_flutter/Sources/sentry_flutter/SentryFlutterPlugin.swift
+++ b/flutter/ios/sentry_flutter/Sources/sentry_flutter/SentryFlutterPlugin.swift
@@ -743,6 +743,7 @@ public class SentryFlutterPlugin: NSObject, FlutterPlugin {
     private func displayRefreshRate(_ result: @escaping FlutterResult) {
         // We don't use CADisplayLink for macOS because it's only available starting with macOS 14
         let window = NSApplication.shared.keyWindow ?? NSApplication.shared.mainWindow
+        // Refresh rate can be incorrect on multi-screen setups where users move their application.
         guard let screen = window?.screen ?? NSScreen.main else {
             result(nil)
             return

--- a/flutter/ios/sentry_flutter/Sources/sentry_flutter/SentryFlutterPlugin.swift
+++ b/flutter/ios/sentry_flutter/Sources/sentry_flutter/SentryFlutterPlugin.swift
@@ -744,7 +744,8 @@ public class SentryFlutterPlugin: NSObject, FlutterPlugin {
         // We don't use CADisplayLink for macOS because it's only available starting with macOS 14
         let window = NSApplication.shared.keyWindow ?? NSApplication.shared.mainWindow
         // Refresh rate can be incorrect on multi-screen setups where users move their application.
-        guard let screen = window?.screen ?? NSScreen.main else {
+      guard let screen = window?.screen ?? NSScreen.main else {
+            print("Cannot find screen to read display refresh rate.")
             result(nil)
             return
         }
@@ -752,10 +753,12 @@ public class SentryFlutterPlugin: NSObject, FlutterPlugin {
         guard let displayID =
                 screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID else {
             result(nil)
+            print("Cannot read display identifier from screen to read display refresh rate.")
             return
         }
 
         guard let mode = CGDisplayCopyDisplayMode(displayID) else {
+            print("Cannot read mode from display idntifier to read display refresh rate.")
             result(nil)
             return
         }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Fallback to main window and main screen for macOS display refresh rate, as `NSApplication.shared.keyWindow` might be null when we load the screen refresh rate.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #2301
Relates to #2299

## :green_heart: How did you test it?

Ran sample app on macOS.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes
