### PR TITLE
Finish and start new transaction when tapping same element again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 - Finish and start new transaction when tapping same element again ([#2623](https://github.com/getsentry/sentry-dart/pull/2623))
+
 ### Dependencies
 
 - Bump Cocoa SDK from v8.44.0-beta.1 to v8.44.0 ([#2649](https://github.com/getsentry/sentry-dart/pull/2649))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Enhancements
+
+- Finish and start new transaction when tapping same element again ([#2623](https://github.com/getsentry/sentry-dart/pull/2623))
+
 ## 8.13.0-beta.3
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Fix print recursion detection ([#2624](https://github.com/getsentry/sentry-dart/pull/2624))
+
 ### Dependencies
 
 - Bump Cocoa SDK from v8.44.0-beta.1 to v8.44.0 ([#2649](https://github.com/getsentry/sentry-dart/pull/2649))

--- a/flutter/test/user_interaction/sentry_user_interaction_widget_test.dart
+++ b/flutter/test/user_interaction/sentry_user_interaction_widget_test.dart
@@ -2,11 +2,11 @@
 library flutter_test;
 // ignore_for_file: invalid_use_of_internal_member
 
-import 'dart:async';
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:sentry/src/sentry_tracer.dart';
 
@@ -459,7 +459,8 @@ void main() {
       });
     });
 
-    testWidgets('Extend timer if transaction already started for same widget',
+    testWidgets(
+        'Cancel transaction if already started for same widget and start new one',
         (tester) async {
       await tester.runAsync(() async {
         final sut = fixture.getSut(
@@ -467,21 +468,50 @@ void main() {
             enableUserInteractionBreadcrumbs: false);
 
         await tapMe(tester, sut, 'btn_1');
-        Timer? currentTimer;
+        SentryTracer? initialTracer;
 
         fixture.hub.configureScope((scope) {
-          final tracer = (scope.span as SentryTracer);
-          currentTimer = tracer.autoFinishAfterTimer;
+          initialTracer = (scope.span as SentryTracer);
         });
 
-        await tapMe(tester, sut, 'btn_1', pumpWidget: false);
+        await tapMe(tester, sut, 'btn_1');
 
-        Timer? autoFinishAfterTimer;
+        SentryTracer? tracer;
         fixture.hub.configureScope((scope) {
-          final tracer = (scope.span as SentryTracer);
-          autoFinishAfterTimer = tracer.autoFinishAfterTimer;
+          tracer = (scope.span as SentryTracer);
         });
-        expect(currentTimer, isNot(equals(autoFinishAfterTimer)));
+        expect(initialTracer?.finished, isTrue);
+        expect(initialTracer?.status, equals(SpanStatus.cancelled()));
+
+        expect(initialTracer, isNot(equals(tracer)));
+      });
+    });
+
+    testWidgets(
+        'Finish transaction if already started with children for same widget and start new one',
+        (tester) async {
+      await tester.runAsync(() async {
+        final sut = fixture.getSut(
+            enableUserInteractionTracing: true,
+            enableUserInteractionBreadcrumbs: false);
+
+        await tapMe(tester, sut, 'btn_1');
+        SentryTracer? initialTracer;
+
+        await fixture.hub.configureScope((scope) async {
+          initialTracer = (scope.span as SentryTracer);
+          final child = initialTracer?.startChild("btn_1_child");
+          await child?.finish();
+        });
+
+        await tapMe(tester, sut, 'btn_1');
+
+        SentryTracer? tracer;
+        fixture.hub.configureScope((scope) {
+          tracer = (scope.span as SentryTracer);
+        });
+        expect(initialTracer?.finished, isTrue);
+        expect(initialTracer, isNot(equals(tracer)));
       });
     });
 
@@ -534,6 +564,9 @@ class Fixture {
     double? tracesSampleRate = 1.0,
     bool sendDefaultPii = false,
   }) {
+    // Missing mock exception
+    when(_transport.send(any)).thenAnswer((_) async => SentryId.newId());
+
     _options.transport = _transport;
     _options.tracesSampleRate = tracesSampleRate;
     _options.enableUserInteractionTracing = enableUserInteractionTracing;

--- a/flutter/test/user_interaction/sentry_user_interaction_widget_test.dart
+++ b/flutter/test/user_interaction/sentry_user_interaction_widget_test.dart
@@ -2,7 +2,6 @@
 library flutter_test;
 // ignore_for_file: invalid_use_of_internal_member
 
-
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

- Finish (when there are children) or cancel transaction when tapping same element again
- Start new transaction

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #2495

## :green_heart: How did you test it?

Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes
