### PR TITLE
Fix print recursion detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix print recursion detection ([#2624](https://github.com/getsentry/sentry-dart/pull/2624))
+
 ## 8.13.0-beta.3
 
 ### Enhancements

--- a/dart/lib/src/sentry_run_zoned_guarded.dart
+++ b/dart/lib/src/sentry_run_zoned_guarded.dart
@@ -16,7 +16,7 @@ class SentryRunZonedGuarded {
     Map<Object?, Object?>? zoneValues,
     ZoneSpecification? zoneSpecification,
   }) {
-    final sentryOnError = (exception, stackTrace) {
+    final sentryOnError = (exception, stackTrace) async {
       final options = hub.options;
       await _captureError(hub, options, exception, stackTrace);
 
@@ -29,7 +29,7 @@ class SentryRunZonedGuarded {
 
     final sentryZoneSpecification = ZoneSpecification.from(
       zoneSpecification ?? ZoneSpecification(),
-      print: (self, parent, zone, line) async {
+      print: (self, parent, zone, line) {
         final options = hub.options;
 
         if (userPrint != null) {
@@ -61,13 +61,12 @@ class SentryRunZonedGuarded {
 
         try {
           _isPrinting = true;
-          // If we await, sub-sequent print calls would be detected as recursions, when they are not.
-          unawaited(hub.addBreadcrumb(
+          hub.addBreadcrumb(
             Breadcrumb.console(
               message: line,
               level: SentryLevel.debug,
             ),
-          ));
+          );
           parent.print(zone, line);
         } finally {
           _isPrinting = false;

--- a/dart/lib/src/sentry_run_zoned_guarded.dart
+++ b/dart/lib/src/sentry_run_zoned_guarded.dart
@@ -61,12 +61,12 @@ class SentryRunZonedGuarded {
 
         try {
           _isPrinting = true;
-          hub.addBreadcrumb(
+          unawaited(hub.addBreadcrumb(
             Breadcrumb.console(
               message: line,
               level: SentryLevel.debug,
             ),
-          );
+          ));
           parent.print(zone, line);
         } finally {
           _isPrinting = false;

--- a/dart/lib/src/sentry_run_zoned_guarded.dart
+++ b/dart/lib/src/sentry_run_zoned_guarded.dart
@@ -16,7 +16,7 @@ class SentryRunZonedGuarded {
     Map<Object?, Object?>? zoneValues,
     ZoneSpecification? zoneSpecification,
   }) {
-    final sentryOnError = (exception, stackTrace) async {
+    final sentryOnError = (exception, stackTrace) {
       final options = hub.options;
       await _captureError(hub, options, exception, stackTrace);
 
@@ -61,12 +61,13 @@ class SentryRunZonedGuarded {
 
         try {
           _isPrinting = true;
-          await hub.addBreadcrumb(
+          // If we await, sub-sequent print calls would be detected as recursions, when they are not.
+          unawaited(hub.addBreadcrumb(
             Breadcrumb.console(
               message: line,
               level: SentryLevel.debug,
             ),
-          );
+          ));
           parent.print(zone, line);
         } finally {
           _isPrinting = false;


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Bug introduced in #2088 refactoring. There the addBreadcrumb call was not awaited, and we probably introduced this as the compiler issues a warning.

<img width="476" alt="Bildschirmfoto 2025-01-28 um 15 13 00" src="https://github.com/user-attachments/assets/3d2888a0-6cfc-4501-8e7a-36c078846357" />

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #2581
Relates to #2088

## :green_heart: How did you test it?

Ran in test app.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
