### PR TITLE
flutter-example: migrate legacy buildscript

### DIFF
--- a/flutter/example/android/app/CMakeLists.txt
+++ b/flutter/example/android/app/CMakeLists.txt
@@ -1,14 +1,13 @@
 cmake_minimum_required(VERSION 3.6)
 project(sentry-sample LANGUAGES C CXX)
 
+include("${CMAKE_CURRENT_SOURCE_DIR}/../../../sentry-native/sentry-native.cmake")
 add_library(native-sample SHARED src/main/cpp/native-sample.cpp)
 
 find_library(LOG_LIB log)
 
-include (${ANDROID_GRADLE_NATIVE_BUNDLE_PLUGIN_MK})
-
 target_link_libraries(
-    native-sample PRIVATE
-    ${LOG_LIB}
-    ${ANDROID_GRADLE_NATIVE_MODULES}
+        native-sample PRIVATE
+        ${LOG_LIB}
+        sentry_flutter_plugin # Use the alias defined in sentry-native.cmake
 )

--- a/flutter/example/android/app/CMakeLists.txt
+++ b/flutter/example/android/app/CMakeLists.txt
@@ -7,7 +7,7 @@ add_library(native-sample SHARED src/main/cpp/native-sample.cpp)
 find_library(LOG_LIB log)
 
 target_link_libraries(
-        native-sample PRIVATE
-        ${LOG_LIB}
-        sentry_flutter_plugin # Use the alias defined in sentry-native.cmake
+    native-sample PRIVATE
+    ${LOG_LIB}
+    sentry_flutter_plugin # Use the alias defined in sentry-native.cmake
 )

--- a/flutter/example/android/app/build.gradle
+++ b/flutter/example/android/app/build.gradle
@@ -1,14 +1,19 @@
+plugins {
+    id "com.android.application"
+    id "kotlin-android"
+    id "dev.flutter.flutter-gradle-plugin"
+
+//    uncomment this to upload proguard mapping file and debug symbols to Sentry
+//    and also set the token (sentry.properties) file
+//    id "io.sentry.android.gradle"
+}
+
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
 if (localPropertiesFile.exists()) {
     localPropertiesFile.withReader('UTF-8') { reader ->
         localProperties.load(reader)
     }
-}
-
-def flutterRoot = localProperties.getProperty('flutter.sdk')
-if (flutterRoot == null) {
-    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
 }
 
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
@@ -21,15 +26,6 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
-apply plugin: 'com.ydq.android.gradle.native-aar.import'
-
-// uncomment this to upload proguard mapping file and debug symbols to Sentry
-// and also set the token (sentry.properties) file
-// apply plugin: 'io.sentry.android.gradle'
-
 android {
     namespace = "io.sentry.samples.flutter"
     compileOptions {
@@ -41,7 +37,7 @@ android {
         languageVersion = "1.4"
     }
 
-    compileSdkVersion 34
+    compileSdkVersion 35
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -50,7 +46,7 @@ android {
     defaultConfig {
         applicationId "io.sentry.samples.flutter"
         minSdkVersion flutter.minSdkVersion
-        targetSdkVersion 34
+        targetSdkVersion 35
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
 
@@ -99,7 +95,6 @@ flutter {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "androidx.annotation:annotation:1.1.0"
 }
 

--- a/flutter/example/android/app/src/main/cpp/native-sample.cpp
+++ b/flutter/example/android/app/src/main/cpp/native-sample.cpp
@@ -13,11 +13,10 @@ JNIEXPORT void JNICALL Java_io_sentry_samples_flutter_MainActivity_crash(JNIEnv 
 }
 
 JNIEXPORT void JNICALL Java_io_sentry_samples_flutter_MainActivity_message(JNIEnv *env, jclass cls) {
-    // __android_log_print(ANDROID_LOG_WARN, TAG, "Sending message.");
     sentry_value_t event = sentry_value_new_message_event(
-            /*   level */ SENTRY_LEVEL_INFO,
-            /*  logger */ "native",
-            /* message */ "message from C++!"
+            SENTRY_LEVEL_INFO,
+            "native",
+            "message from C++!"
     );
     sentry_capture_event(event);
 }

--- a/flutter/example/android/app/src/main/cpp/native-sample.cpp
+++ b/flutter/example/android/app/src/main/cpp/native-sample.cpp
@@ -13,10 +13,11 @@ JNIEXPORT void JNICALL Java_io_sentry_samples_flutter_MainActivity_crash(JNIEnv 
 }
 
 JNIEXPORT void JNICALL Java_io_sentry_samples_flutter_MainActivity_message(JNIEnv *env, jclass cls) {
+    // __android_log_print(ANDROID_LOG_WARN, TAG, "Sending message.");
     sentry_value_t event = sentry_value_new_message_event(
-            SENTRY_LEVEL_INFO,
-            "native",
-            "message from C++!"
+            /*   level */ SENTRY_LEVEL_INFO,
+            /*  logger */ "native",
+            /* message */ "message from C++!"
     );
     sentry_capture_event(event);
 }

--- a/flutter/example/android/build.gradle
+++ b/flutter/example/android/build.gradle
@@ -1,19 +1,3 @@
-buildscript {
-    ext.kotlin_version = '2.0.21'
-
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'io.sentry:sentry-android-gradle-plugin:4.12.0'
-        classpath 'com.android.tools.build:gradle:8.3.2'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'io.github.howardpang:androidNativeBundle:1.1.5'
-    }
-}
-
 allprojects {
     repositories {
         google()

--- a/flutter/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/flutter/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Oct 16 15:46:36 CEST 2024
+#Wed Jan 29 14:45:29 CET 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/flutter/example/android/settings.gradle
+++ b/flutter/example/android/settings.gradle
@@ -1,11 +1,26 @@
-include ':app'
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        file("local.properties").withInputStream { properties.load(it) }
+        def flutterSdkPath = properties.getProperty("flutter.sdk")
+        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+        return flutterSdkPath
+    }()
 
-def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
-def properties = new Properties()
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
 
-assert localPropertiesFile.exists()
-localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
 
-def flutterSdkPath = properties.getProperty("flutter.sdk")
-assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
-apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "8.2.2" apply false
+    id "org.jetbrains.kotlin.android" version "2.0.21" apply false
+    id "io.sentry.android.gradle" version "4.14.1" apply false
+}
+
+include ":app"


### PR DESCRIPTION
#skip-changelog

Flutter beta CI jobs errored urging us to upgrade the example from the legacy buildscript to using plugin blocks

I also removed the nativeBundle dependency as I wasn't able to build with it (it also only supports AGP up to 8.0.2) and replace it with updating the cmakelists

See https://docs.flutter.dev/release/breaking-changes/flutter-gradle-plugin-apply