### PR TITLE
[v9]: remove `options.autoAppStart` and `setAppStartEnd`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Remove screenshot option `attachScreenshotOnlyWhenResumed` ([#2664](https://github.com/getsentry/sentry-dart/pull/2664))
 - Remove deprecated `beforeScreenshot` ([#2662](https://github.com/getsentry/sentry-dart/pull/2662))
 - Remove user segment ([#2687](https://github.com/getsentry/sentry-dart/pull/2687))
+- Remove `options.autoAppStart` and `setAppStartEnd` ([#2680](https://github.com/getsentry/sentry-dart/pull/2680))
 
 ### Dependencies
 

--- a/flutter/lib/src/integrations/native_app_start_integration.dart
+++ b/flutter/lib/src/integrations/native_app_start_integration.dart
@@ -1,8 +1,6 @@
 import 'dart:async';
 import 'dart:ui';
 
-import 'package:meta/meta.dart';
-
 import '../../sentry_flutter.dart';
 import '../frame_callback_handler.dart';
 import 'native_app_start_handler.dart';
@@ -16,17 +14,6 @@ class NativeAppStartIntegration extends Integration<SentryFlutterOptions> {
   final FrameCallbackHandler _frameCallbackHandler;
   final NativeAppStartHandler _nativeAppStartHandler;
   DateTime? _appStartEnd;
-
-  /// This timestamp marks the end of app startup. Either set by calling
-  /// [SentryFlutter.setAppStartEnd]. The [SentryFlutterOptions.autoAppStart]
-  /// option needs to be false.
-  @internal
-  set appStartEnd(DateTime appStartEnd) {
-    _appStartEnd = appStartEnd;
-    if (!_appStartEndCompleter.isCompleted) {
-      _appStartEndCompleter.complete();
-    }
-  }
 
   final Completer<void> _appStartEndCompleter = Completer<void>();
   bool _allowProcessing = true;
@@ -42,26 +29,14 @@ class NativeAppStartIntegration extends Integration<SentryFlutterOptions> {
       _allowProcessing = false;
 
       try {
-        DateTime? appStartEnd;
-        if (options.autoAppStart) {
-          // ignore: invalid_use_of_internal_member
-          appStartEnd = DateTime.fromMicrosecondsSinceEpoch(timings.first
-              .timestampInMicroseconds(FramePhase.rasterFinishWallTime));
-        } else if (_appStartEnd == null) {
-          await _appStartEndCompleter.future.timeout(
-            const Duration(seconds: 10),
-          );
-          appStartEnd = _appStartEnd;
-        } else {
-          appStartEnd = null;
-        }
-        if (appStartEnd != null) {
-          await _nativeAppStartHandler.call(
-            hub,
-            options,
-            appStartEnd: appStartEnd,
-          );
-        }
+        // ignore: invalid_use_of_internal_member
+        final appStartEnd = DateTime.fromMicrosecondsSinceEpoch(timings.first
+            .timestampInMicroseconds(FramePhase.rasterFinishWallTime));
+        await _nativeAppStartHandler.call(
+          hub,
+          options,
+          appStartEnd: appStartEnd,
+        );
       } catch (exception, stackTrace) {
         options.logger(
           SentryLevel.error,

--- a/flutter/lib/src/integrations/native_app_start_integration.dart
+++ b/flutter/lib/src/integrations/native_app_start_integration.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:ui';
 
 import '../../sentry_flutter.dart';
@@ -13,9 +12,7 @@ class NativeAppStartIntegration extends Integration<SentryFlutterOptions> {
 
   final FrameCallbackHandler _frameCallbackHandler;
   final NativeAppStartHandler _nativeAppStartHandler;
-  DateTime? _appStartEnd;
 
-  final Completer<void> _appStartEndCompleter = Completer<void>();
   bool _allowProcessing = true;
 
   @override

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -222,18 +222,6 @@ mixin SentryFlutter {
     };
   }
 
-  /// Manually set when your app finished startup. Make sure to set
-  /// [SentryFlutterOptions.autoAppStart] to false on init. The timeout duration
-  /// for this to work is 10 seconds.
-  static void setAppStartEnd(DateTime appStartEnd) {
-    // ignore: invalid_use_of_internal_member
-    final integrations = Sentry.currentHub.options.integrations
-        .whereType<NativeAppStartIntegration>();
-    for (final integration in integrations) {
-      integration.appStartEnd = appStartEnd;
-    }
-  }
-
   static void _setSdk(SentryFlutterOptions options) {
     // overwrite sdk info with current flutter sdk
     final sdk = SdkVersion(

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -12,7 +12,6 @@ import 'event_processor/screenshot_event_processor.dart';
 import 'navigation/time_to_display_tracker.dart';
 import 'renderer/renderer.dart';
 import 'screenshot/sentry_screenshot_quality.dart';
-import 'sentry_flutter.dart';
 import 'sentry_privacy_options.dart';
 import 'sentry_replay_options.dart';
 import 'user_interaction/sentry_user_interaction_widget.dart';
@@ -174,12 +173,6 @@ class SentryFlutterOptions extends SentryOptions {
 
   /// Enable auto performance tracking by default.
   bool enableAutoPerformanceTracing = true;
-
-  /// Automatically track app start measurement and send it with the
-  /// first transaction. Set to false when configuring option to disable or if
-  /// you want to set the end time of app startup manually using
-  /// [SentryFlutter.setAppStartEnd].
-  bool autoAppStart = true;
 
   /// Automatically attaches a screenshot when capturing an error or exception.
   ///

--- a/flutter/test/integrations/native_app_start_integration_test.dart
+++ b/flutter/test/integrations/native_app_start_integration_test.dart
@@ -1,7 +1,6 @@
 @TestOn('vm')
 library;
 
-import 'dart:async';
 import 'dart:core';
 import 'dart:ui';
 
@@ -114,45 +113,6 @@ void main() {
       await Future<void>.delayed(Duration(milliseconds: 10));
 
       expect(fixture.frameCallbackHandler.timingsCallback, isNull);
-    });
-
-    test('with disabled auto app start waits until appStartEnd is set',
-        () async {
-      fixture.options.autoAppStart = false;
-
-      fixture.callIntegration();
-      final timingsCallback = fixture.frameCallbackHandler.timingsCallback!;
-      timingsCallback([_fakeFrameTiming]);
-
-      expect(fixture.nativeAppStartHandler.calls, 0);
-
-      final appStartEnd = DateTime.fromMicrosecondsSinceEpoch(50);
-      fixture.sut.appStartEnd = appStartEnd;
-
-      await Future<void>.delayed(Duration(milliseconds: 10));
-
-      expect(fixture.frameCallbackHandler.timingsCallback, isNull);
-      expect(fixture.nativeAppStartHandler.calls, 1);
-      expect(fixture.nativeAppStartHandler.appStartEnd, appStartEnd);
-    });
-
-    test('with disabled auto app start waits until timeout', () async {
-      fixture.options.autoAppStart = false;
-
-      fixture.callIntegration();
-      final timingsCallback = fixture.frameCallbackHandler.timingsCallback!;
-      await expectLater(
-        () => timingsCallback([_fakeFrameTiming]),
-        throwsA(isA<TimeoutException>()),
-      );
-
-      expect(fixture.nativeAppStartHandler.calls, 0);
-
-      await Future<void>.delayed(Duration(seconds: 11));
-
-      expect(fixture.frameCallbackHandler.timingsCallback, isNull);
-      expect(fixture.nativeAppStartHandler.calls, 0);
-      expect(fixture.nativeAppStartHandler.appStartEnd, null);
     });
   });
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
v9 task

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
SDK consistency, and these APIs just make it harder to maintain it. 
Users can already disable the integration if they wish to without the `autoAppStart` flag

## :green_heart: How did you test it?
Existing tests are enough since we remove functionality

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
