### PR TITLE
Deprecate `autoAppStart` and `setAppStartEnd`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Deprecations
+
+- Deprecate `autoAppStart` and `setAppStartEnd` ([#2681](https://github.com/getsentry/sentry-dart/pull/2681))
+
 ### Other
 
 - Remove macOS display refresh rate support ([#2628](https://github.com/getsentry/sentry-dart/pull/2628))

--- a/flutter/lib/src/integrations/native_app_start_integration.dart
+++ b/flutter/lib/src/integrations/native_app_start_integration.dart
@@ -18,6 +18,7 @@ class NativeAppStartIntegration extends Integration<SentryFlutterOptions> {
   DateTime? _appStartEnd;
 
   /// This timestamp marks the end of app startup. Either set by calling
+  // ignore: deprecated_member_use_from_same_package
   /// [SentryFlutter.setAppStartEnd]. The [SentryFlutterOptions.autoAppStart]
   /// option needs to be false.
   @internal
@@ -43,6 +44,7 @@ class NativeAppStartIntegration extends Integration<SentryFlutterOptions> {
 
       try {
         DateTime? appStartEnd;
+        // ignore: deprecated_member_use_from_same_package
         if (options.autoAppStart) {
           // ignore: invalid_use_of_internal_member
           appStartEnd = DateTime.fromMicrosecondsSinceEpoch(timings.first

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -230,6 +230,8 @@ mixin SentryFlutter {
   /// Manually set when your app finished startup. Make sure to set
   /// [SentryFlutterOptions.autoAppStart] to false on init. The timeout duration
   /// for this to work is 10 seconds.
+  @Deprecated(
+      'Will be removed in v9. This functionality will not be supported anymore.')
   static void setAppStartEnd(DateTime appStartEnd) {
     // ignore: invalid_use_of_internal_member
     final integrations = Sentry.currentHub.options.integrations

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -179,6 +179,8 @@ class SentryFlutterOptions extends SentryOptions {
   /// first transaction. Set to false when configuring option to disable or if
   /// you want to set the end time of app startup manually using
   /// [SentryFlutter.setAppStartEnd].
+  @Deprecated(
+      'Will be removed in v9. In order to disable app starts disable it via option.removeIntegration(...) instead')
   bool autoAppStart = true;
 
   /// Automatically attaches a screenshot when capturing an error or exception.

--- a/flutter/test/integrations/native_app_start_integration_test.dart
+++ b/flutter/test/integrations/native_app_start_integration_test.dart
@@ -118,6 +118,7 @@ void main() {
 
     test('with disabled auto app start waits until appStartEnd is set',
         () async {
+      // ignore: deprecated_member_use_from_same_package
       fixture.options.autoAppStart = false;
 
       fixture.callIntegration();
@@ -137,6 +138,7 @@ void main() {
     });
 
     test('with disabled auto app start waits until timeout', () async {
+      // ignore: deprecated_member_use_from_same_package
       fixture.options.autoAppStart = false;
 
       fixture.callIntegration();


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Part of #2631 

## :green_heart: How did you test it?
No new tests needed

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
