### PR TITLE
[v9] Remove deprecated loggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Increase minimum SDK version requirements to Dart v3.5.0 and Flutter v3.24.0 ([#2643](https://github.com/getsentry/sentry-dart/pull/2643))
 - Remove screenshot option `attachScreenshotOnlyWhenResumed` ([#2664](https://github.com/getsentry/sentry-dart/pull/2664))
 - Remove deprecated `beforeScreenshot` ([#2662](https://github.com/getsentry/sentry-dart/pull/2662))
+- Remove deprecated loggers ([#2685](https://github.com/getsentry/sentry-dart/pull/2685))
 
 ### Dependencies
 

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -128,7 +128,6 @@ class SentryOptions {
   /// This does not change whether an event is captured.
   MaxResponseBodySize maxResponseBodySize = MaxResponseBodySize.never;
 
-  // ignore: deprecated_member_use_from_same_package
   SentryLogger _logger = noOpLogger;
 
   /// Logger interface to log useful debugging information if debug is enabled
@@ -159,12 +158,10 @@ class SentryOptions {
 
   set debug(bool newValue) {
     _debug = newValue;
-    // ignore: deprecated_member_use_from_same_package
     if (_debug == true && logger == noOpLogger) {
       _logger = _debugLogger;
     }
     if (_debug == false && logger == _debugLogger) {
-      // ignore: deprecated_member_use_from_same_package
       _logger = noOpLogger;
     }
   }
@@ -601,6 +598,15 @@ class SentryOptions {
   }
 }
 
+@visibleForTesting
+void noOpLogger(
+  SentryLevel level,
+  String message, {
+  String? logger,
+  Object? exception,
+  StackTrace? stackTrace,
+}) {}
+
 /// This function is called with an SDK specific event object and can return a modified event
 /// object or nothing to skip reporting the event
 typedef BeforeSendCallback = FutureOr<SentryEvent?> Function(
@@ -642,32 +648,3 @@ typedef SentryLogger = void Function(
 
 typedef TracesSamplerCallback = double? Function(
     SentrySamplingContext samplingContext);
-
-/// A NoOp logger that does nothing
-@Deprecated('Will be removed in v8. Disable [debug] instead')
-void noOpLogger(
-  SentryLevel level,
-  String message, {
-  String? logger,
-  Object? exception,
-  StackTrace? stackTrace,
-}) {}
-
-/// A Logger that prints out the level and message
-@Deprecated('Will be removed in v8. Enable [debug] instead')
-void dartLogger(
-  SentryLevel level,
-  String message, {
-  String? logger,
-  Object? exception,
-  StackTrace? stackTrace,
-}) {
-  log(
-    '[${level.name}] $message',
-    level: level.toDartLogLevel(),
-    name: logger ?? 'sentry',
-    time: getUtcDateTime(),
-    error: exception,
-    stackTrace: stackTrace,
-  );
-}

--- a/dart/lib/src/sentry_run_zoned_guarded.dart
+++ b/dart/lib/src/sentry_run_zoned_guarded.dart
@@ -46,8 +46,6 @@ class SentryRunZonedGuarded {
           // We somehow landed in a recursion.
           // This happens for example if:
           // - hub.addBreadcrumb() called print() itself
-          // - This happens for example if hub.isEnabled == false and
-          //   options.logger == dartLogger
           //
           // Anyway, in order to not cause a stack overflow due to recursion
           // we drop any further print() call while adding a breadcrumb.

--- a/dart/lib/src/sentry_run_zoned_guarded.dart
+++ b/dart/lib/src/sentry_run_zoned_guarded.dart
@@ -46,6 +46,8 @@ class SentryRunZonedGuarded {
           // We somehow landed in a recursion.
           // This happens for example if:
           // - hub.addBreadcrumb() called print() itself
+          // - This happens for example if hub.isEnabled == false and
+          //   options.logger == _debugLogger
           //
           // Anyway, in order to not cause a stack overflow due to recursion
           // we drop any further print() call while adding a breadcrumb.

--- a/dart/test/sentry_options_test.dart
+++ b/dart/test/sentry_options_test.dart
@@ -35,11 +35,9 @@ void main() {
 
   test('SentryLogger sets a diagnostic logger', () {
     final options = defaultTestOptions();
-    // ignore: deprecated_member_use_from_same_package
     expect(options.logger, noOpLogger);
     options.debug = true;
 
-    // ignore: deprecated_member_use_from_same_package
     expect(options.logger, isNot(noOpLogger));
   });
 

--- a/dart/test/sentry_options_test.dart
+++ b/dart/test/sentry_options_test.dart
@@ -37,8 +37,7 @@ void main() {
     final options = defaultTestOptions();
     // ignore: deprecated_member_use_from_same_package
     expect(options.logger, noOpLogger);
-    // ignore: deprecated_member_use_from_same_package
-    options.logger = dartLogger;
+    options.debug = true;
 
     // ignore: deprecated_member_use_from_same_package
     expect(options.logger, isNot(noOpLogger));

--- a/dart/test/sentry_test.dart
+++ b/dart/test/sentry_test.dart
@@ -478,17 +478,14 @@ void main() {
       (options) {
         options.dsn = fakeDsn;
         options.debug = true;
-        // ignore: deprecated_member_use_from_same_package
         expect(options.logger, isNot(noOpLogger));
 
         options.debug = false;
-        // ignore: deprecated_member_use_from_same_package
         expect(options.logger, noOpLogger);
       },
       options: sentryOptions,
     );
 
-    // ignore: deprecated_member_use_from_same_package
     expect(sentryOptions.logger, noOpLogger);
   });
 

--- a/dart/test/sentry_test.dart
+++ b/dart/test/sentry_test.dart
@@ -489,7 +489,7 @@ void main() {
     );
 
     // ignore: deprecated_member_use_from_same_package
-    expect(sentryOptions.logger, isNot(dartLogger));
+    expect(sentryOptions.logger, noOpLogger);
   });
 
   group('Sentry init optionsConfiguration', () {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/getsentry/sentry-dart/issues/2684

## :green_heart: How did you test it?
Existing tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
