### PR TITLE
fix: message of frames tracking warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes 
+
+- Reference to `SentryWidgetsFlutterBinding` in warning message in `FramesTrackingIntegration` ([#2704](https://github.com/getsentry/sentry-dart/pull/2704))
+
 ### Deprecations
 
 - Deprecate `autoAppStart` and `setAppStartEnd` ([#2681](https://github.com/getsentry/sentry-dart/pull/2681))

--- a/flutter/lib/src/integrations/frames_tracking_integration.dart
+++ b/flutter/lib/src/integrations/frames_tracking_integration.dart
@@ -32,7 +32,7 @@ class FramesTrackingIntegration implements Integration<SentryFlutterOptions> {
     if (widgetsBinding == null ||
         widgetsBinding is! SentryWidgetsBindingMixin) {
       return options.logger(SentryLevel.warning,
-          '$FramesTrackingIntegration disabled: incompatible binding, SentryFlutterWidgetsBinding has not been instantiated. Please, use SentryFlutterWidgetsBinding.ensureInitialized() instead of FlutterWidgetsBinding.ensureInitialized()');
+          '$FramesTrackingIntegration disabled: incompatible binding, SentryWidgetsFlutterBinding has not been instantiated. Please, use SentryWidgetsFlutterBinding.ensureInitialized() instead of WidgetsFlutterBinding.ensureInitialized()');
     }
     _widgetsBinding = widgetsBinding;
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Fixes wrong warning message in frames tracking integration

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/getsentry/sentry-dart/issues/2703
