### PR TITLE
feat(android): use debug image loading by address api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 
 ### Dependencies
 
+- Bump Android SDK from v7.20.1 to v7.22.0 ([#2660](https://github.com/getsentry/sentry-dart/pull/2660))
+  - [changelog](https://github.com/getsentry/sentry-java/blob/7.x.x/CHANGELOG.md#7220)
+  - [diff](https://github.com/getsentry/sentry-java/compare/7.20.1...7.22.0)
 - Bump Native SDK from v0.7.19 to v0.7.20 ([#2652](https://github.com/getsentry/sentry-dart/pull/2652))
   - [changelog](https://github.com/getsentry/sentry-native/blob/master/CHANGELOG.md#0720)
   - [diff](https://github.com/getsentry/sentry-native/compare/0.7.19...0.7.20)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Enhancements 
 
 - Ues debug image loading by address API for Android ([#2706](https://github.com/getsentry/sentry-dart/pull/2706))
+  - This reduces the envelope size and data transferred across method channels
+  - If debug images received by `loadDebugImagesForAddresses` are empty, the SDK loads all debug images as fallback
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements 
+
+- Ues debug image loading by address API for Android ([#2706](https://github.com/getsentry/sentry-dart/pull/2706))
+
 ### Deprecations
 
 - Deprecate `autoAppStart` and `setAppStartEnd` ([#2681](https://github.com/getsentry/sentry-dart/pull/2681))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements 
 
-- Ues debug image loading by address API for Android ([#2706](https://github.com/getsentry/sentry-dart/pull/2706))
+- Use `loadDebugImagesForAddresses` API for Android ([#2706](https://github.com/getsentry/sentry-dart/pull/2706))
   - This reduces the envelope size and data transferred across method channels
   - If debug images received by `loadDebugImagesForAddresses` are empty, the SDK loads all debug images as fallback
 

--- a/flutter/android/build.gradle
+++ b/flutter/android/build.gradle
@@ -60,7 +60,7 @@ android {
 }
 
 dependencies {
-    api 'io.sentry:sentry-android:7.20.1'
+    api 'io.sentry:sentry-android:7.22.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     // Required -- JUnit 4 framework

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -103,12 +103,7 @@ class SentryFlutterPlugin :
       "displayRefreshRate" -> displayRefreshRate(result)
       "nativeCrash" -> crash()
       "setReplayConfig" -> setReplayConfig(call, result)
-      "addReplayScreenshot" -> addReplayScreenshot(
-        call.argument("path"),
-        call.argument("timestamp"),
-        result,
-      )
-
+      "addReplayScreenshot" -> addReplayScreenshot(call.argument("path"), call.argument("timestamp"), result)
       "captureReplay" -> captureReplay(call.argument("isCrash"), result)
       else -> result.notImplemented()
     }
@@ -171,8 +166,7 @@ class SentryFlutterPlugin :
     options.integrations.removeAll { it is ReplayIntegration }
     val cacheDirPath = options.cacheDirPath
     val replayOptions = options.sessionReplay
-    val isReplayEnabled =
-      replayOptions.isSessionReplayEnabled || replayOptions.isSessionReplayForErrorsEnabled
+    val isReplayEnabled = replayOptions.isSessionReplayEnabled || replayOptions.isSessionReplayForErrorsEnabled
     if (cacheDirPath != null && isReplayEnabled) {
       replay =
         ReplayIntegration(
@@ -491,18 +485,22 @@ class SentryFlutterPlugin :
 
   private fun loadImageList(
     call: MethodCall,
-    result: Result,
+    result: Result
   ) {
     val options = HubAdapter.getInstance().options as SentryAndroidOptions
 
     val addresses = call.arguments() as List<String>? ?: listOf()
     val debugImages =
       if (addresses.isEmpty()) {
-        options.debugImagesLoader.loadDebugImages().orEmpty().serialize()
+        options.debugImagesLoader.loadDebugImages()
+          ?.toList()
+          .serialize()
       } else {
-        options.debugImagesLoader.loadDebugImagesForAddresses(addresses.toSet())
-          .takeIf { it.isNullOrEmpty().not() }?.toList().serialize()
-          ?: options.debugImagesLoader.loadDebugImages().orEmpty().serialize()
+        options.debugImagesLoader
+          .loadDebugImagesForAddresses(addresses.toSet())
+          ?.ifEmpty { options.debugImagesLoader.loadDebugImages() }
+          ?.toList()
+          .serialize()
       }
 
     result.success(debugImages)
@@ -516,7 +514,7 @@ class SentryFlutterPlugin :
     "type" to type,
     "debug_id" to debugId,
     "code_id" to codeId,
-    "debug_file" to debugFile,
+    "debug_file" to debugFile
   )
 
   private fun closeNativeSdk(result: Result) {

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -485,16 +485,14 @@ class SentryFlutterPlugin :
 
   private fun loadImageList(
     call: MethodCall,
-    result: Result
+    result: Result,
   ) {
     val options = HubAdapter.getInstance().options as SentryAndroidOptions
 
     val addresses = call.arguments() as List<String>? ?: listOf()
     val debugImages =
       if (addresses.isEmpty()) {
-        options.debugImagesLoader.loadDebugImages()
-          ?.toList()
-          .serialize()
+        options.debugImagesLoader.loadDebugImages()?.toList().serialize()
       } else {
         options.debugImagesLoader
           .loadDebugImagesForAddresses(addresses.toSet())
@@ -507,15 +505,16 @@ class SentryFlutterPlugin :
   }
 
   private fun List<DebugImage>?.serialize() = this?.map { it.serialize() }
-  private fun DebugImage.serialize() = mapOf(
-    "image_addr" to imageAddr,
-    "image_size" to imageSize,
-    "code_file" to codeFile,
-    "type" to type,
-    "debug_id" to debugId,
-    "code_id" to codeId,
-    "debug_file" to debugFile
-  )
+  private fun DebugImage.serialize() =
+    mapOf(
+      "image_addr" to imageAddr,
+      "image_size" to imageSize,
+      "code_file" to codeFile,
+      "type" to type,
+      "debug_id" to debugId,
+      "code_id" to codeId,
+      "debug_file" to debugFile,
+    )
 
   private fun closeNativeSdk(result: Result) {
     HubAdapter.getInstance().close()

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -85,7 +85,7 @@ class SentryFlutterPlugin :
     when (call.method) {
       "initNativeSdk" -> initNativeSdk(call, result)
       "captureEnvelope" -> captureEnvelope(call, result)
-      "loadImageList" -> loadImageList(result)
+      "loadImageList" -> loadImageList(call, result)
       "closeNativeSdk" -> closeNativeSdk(result)
       "fetchNativeAppStart" -> fetchNativeAppStart(result)
       "beginNativeFrames" -> beginNativeFrames(result)
@@ -483,30 +483,31 @@ class SentryFlutterPlugin :
     result.error("3", "Envelope is null or empty", null)
   }
 
-  private fun loadImageList(result: Result) {
+  private fun loadImageList(call: MethodCall, result: Result) {
     val options = HubAdapter.getInstance().options as SentryAndroidOptions
 
-    val newDebugImages = mutableListOf<Map<String, Any?>>()
-    val debugImages: List<DebugImage>? = options.debugImagesLoader.loadDebugImages()
-
-    debugImages?.let {
-      it.forEach { image ->
-        val item = mutableMapOf<String, Any?>()
-
-        item["image_addr"] = image.imageAddr
-        item["image_size"] = image.imageSize
-        item["code_file"] = image.codeFile
-        item["type"] = image.type
-        item["debug_id"] = image.debugId
-        item["code_id"] = image.codeId
-        item["debug_file"] = image.debugFile
-
-        newDebugImages.add(item)
-      }
+    val addresses = call.arguments() as List<String>? ?: listOf()
+    val debugImages = if (addresses.isEmpty()) {
+      options.debugImagesLoader.loadDebugImages().orEmpty().serialize()
+    } else {
+      options.debugImagesLoader.loadDebugImagesForAddresses(addresses.toSet())
+        .takeIf { it.isNullOrEmpty().not() }?.toList().serialize()
+        ?: options.debugImagesLoader.loadDebugImages().orEmpty().serialize()
     }
 
-    result.success(newDebugImages)
+    result.success(debugImages)
   }
+
+  private fun List<DebugImage>?.serialize() = this?.map { it.serialize() }
+  private fun DebugImage.serialize() = mapOf(
+    "image_addr" to imageAddr,
+    "image_size" to imageSize,
+    "code_file" to codeFile,
+    "type" to type,
+    "debug_id" to debugId,
+    "code_id" to codeId,
+    "debug_file" to debugFile
+  )
 
   private fun closeNativeSdk(result: Result) {
     HubAdapter.getInstance().close()

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -103,7 +103,12 @@ class SentryFlutterPlugin :
       "displayRefreshRate" -> displayRefreshRate(result)
       "nativeCrash" -> crash()
       "setReplayConfig" -> setReplayConfig(call, result)
-      "addReplayScreenshot" -> addReplayScreenshot(call.argument("path"), call.argument("timestamp"), result)
+      "addReplayScreenshot" -> addReplayScreenshot(
+        call.argument("path"),
+        call.argument("timestamp"),
+        result,
+      )
+
       "captureReplay" -> captureReplay(call.argument("isCrash"), result)
       else -> result.notImplemented()
     }
@@ -166,7 +171,8 @@ class SentryFlutterPlugin :
     options.integrations.removeAll { it is ReplayIntegration }
     val cacheDirPath = options.cacheDirPath
     val replayOptions = options.sessionReplay
-    val isReplayEnabled = replayOptions.isSessionReplayEnabled || replayOptions.isSessionReplayForErrorsEnabled
+    val isReplayEnabled =
+      replayOptions.isSessionReplayEnabled || replayOptions.isSessionReplayForErrorsEnabled
     if (cacheDirPath != null && isReplayEnabled) {
       replay =
         ReplayIntegration(
@@ -483,17 +489,21 @@ class SentryFlutterPlugin :
     result.error("3", "Envelope is null or empty", null)
   }
 
-  private fun loadImageList(call: MethodCall, result: Result) {
+  private fun loadImageList(
+    call: MethodCall,
+    result: Result,
+  ) {
     val options = HubAdapter.getInstance().options as SentryAndroidOptions
 
     val addresses = call.arguments() as List<String>? ?: listOf()
-    val debugImages = if (addresses.isEmpty()) {
-      options.debugImagesLoader.loadDebugImages().orEmpty().serialize()
-    } else {
-      options.debugImagesLoader.loadDebugImagesForAddresses(addresses.toSet())
-        .takeIf { it.isNullOrEmpty().not() }?.toList().serialize()
-        ?: options.debugImagesLoader.loadDebugImages().orEmpty().serialize()
-    }
+    val debugImages =
+      if (addresses.isEmpty()) {
+        options.debugImagesLoader.loadDebugImages().orEmpty().serialize()
+      } else {
+        options.debugImagesLoader.loadDebugImagesForAddresses(addresses.toSet())
+          .takeIf { it.isNullOrEmpty().not() }?.toList().serialize()
+          ?: options.debugImagesLoader.loadDebugImages().orEmpty().serialize()
+      }
 
     result.success(debugImages)
   }
@@ -506,7 +516,7 @@ class SentryFlutterPlugin :
     "type" to type,
     "debug_id" to debugId,
     "code_id" to codeId,
-    "debug_file" to debugFile
+    "debug_file" to debugFile,
   )
 
   private fun closeNativeSdk(result: Result) {

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -492,7 +492,10 @@ class SentryFlutterPlugin :
     val addresses = call.arguments() as List<String>? ?: listOf()
     val debugImages =
       if (addresses.isEmpty()) {
-        options.debugImagesLoader.loadDebugImages()?.toList().serialize()
+        options.debugImagesLoader
+          .loadDebugImages()
+          ?.toList()
+          .serialize()
       } else {
         options.debugImagesLoader
           .loadDebugImagesForAddresses(addresses.toSet())
@@ -505,6 +508,7 @@ class SentryFlutterPlugin :
   }
 
   private fun List<DebugImage>?.serialize() = this?.map { it.serialize() }
+
   private fun DebugImage.serialize() =
     mapOf(
       "image_addr" to imageAddr,

--- a/flutter/example/integration_test/integration_test.dart
+++ b/flutter/example/integration_test/integration_test.dart
@@ -46,126 +46,126 @@ void main() {
 
   // Tests
 
-  testWidgets('setup sentry and render app', (tester) async {
-    await setupSentryAndApp(tester);
-
-    // Find any UI element and verify it is present.
-    expect(find.text('Open another Scaffold'), findsOneWidget);
-  });
-
-  testWidgets('setup sentry and capture event', (tester) async {
-    await setupSentryAndApp(tester);
-
-    final event = SentryEvent();
-    final sentryId = await Sentry.captureEvent(event);
-
-    expect(sentryId != const SentryId.empty(), true);
-  });
-
-  testWidgets('setup sentry and capture exception', (tester) async {
-    await setupSentryAndApp(tester);
-
-    try {
-      throw const SentryException(
-          type: 'StarError', value: 'I have a bad feeling about this...');
-    } catch (exception, stacktrace) {
-      final sentryId =
-          await Sentry.captureException(exception, stackTrace: stacktrace);
-
-      expect(sentryId != const SentryId.empty(), true);
-    }
-  });
-
-  testWidgets('setup sentry and capture message', (tester) async {
-    await setupSentryAndApp(tester);
-
-    final sentryId = await Sentry.captureMessage('hello world!');
-
-    expect(sentryId != const SentryId.empty(), true);
-  });
-
-  testWidgets('setup sentry and capture user feedback', (tester) async {
-    await setupSentryAndApp(tester);
-
-    // ignore: deprecated_member_use_from_same_package
-    // ignore: deprecated_member_use
-    final feedback = SentryUserFeedback(
-        eventId: SentryId.newId(),
-        name: 'fixture-name',
-        email: 'fixture@email.com',
-        comments: 'fixture-comments');
-    // ignore: deprecated_member_use
-    await Sentry.captureUserFeedback(feedback);
-  });
-
-  testWidgets('setup sentry and capture feedback', (tester) async {
-    await setupSentryAndApp(tester);
-
-    // ignore: deprecated_member_use_from_same_package
-    // ignore: deprecated_member_use
-    final associatedEventId = await Sentry.captureMessage('Associated');
-    final feedback = SentryFeedback(
-      message: 'message',
-      contactEmail: 'john.appleseed@apple.com',
-      name: 'John Appleseed',
-      associatedEventId: associatedEventId,
-    );
-    await Sentry.captureFeedback(feedback);
-  });
-
-  testWidgets('setup sentry and close', (tester) async {
-    await setupSentryAndApp(tester);
-
-    await Sentry.close();
-  });
-
-  testWidgets('setup sentry and add breadcrumb', (tester) async {
-    await setupSentryAndApp(tester);
-
-    final breadcrumb = Breadcrumb(message: 'fixture-message');
-    await Sentry.addBreadcrumb(breadcrumb);
-  });
-
-  testWidgets('setup sentry and configure scope', (tester) async {
-    await setupSentryAndApp(tester);
-
-    await Sentry.configureScope((scope) async {
-      await scope.setContexts('contexts-key', 'contexts-value');
-      await scope.removeContexts('contexts-key');
-
-      final user = SentryUser(id: 'fixture-id');
-      await scope.setUser(user);
-      await scope.setUser(null);
-
-      final breadcrumb = Breadcrumb(message: 'fixture-message');
-      await scope.addBreadcrumb(breadcrumb);
-      await scope.clearBreadcrumbs();
-
-      // ignore: deprecated_member_use
-      await scope.setExtra('extra-key', 'extra-value');
-      // ignore: deprecated_member_use
-      await scope.removeExtra('extra-key');
-
-      await scope.setTag('tag-key', 'tag-value');
-      await scope.removeTag('tag-key');
-    });
-  });
-
-  testWidgets('setup sentry and start transaction', (tester) async {
-    await setupSentryAndApp(tester);
-
-    final transaction = Sentry.startTransaction('transaction', 'test');
-    await transaction.finish();
-  });
-
-  testWidgets('setup sentry and start transaction with context',
-      (tester) async {
-    await setupSentryAndApp(tester);
-
-    final context = SentryTransactionContext('transaction', 'test');
-    final transaction = Sentry.startTransactionWithContext(context);
-    await transaction.finish();
-  });
+  // testWidgets('setup sentry and render app', (tester) async {
+  //   await setupSentryAndApp(tester);
+  //
+  //   // Find any UI element and verify it is present.
+  //   expect(find.text('Open another Scaffold'), findsOneWidget);
+  // });
+  //
+  // testWidgets('setup sentry and capture event', (tester) async {
+  //   await setupSentryAndApp(tester);
+  //
+  //   final event = SentryEvent();
+  //   final sentryId = await Sentry.captureEvent(event);
+  //
+  //   expect(sentryId != const SentryId.empty(), true);
+  // });
+  //
+  // testWidgets('setup sentry and capture exception', (tester) async {
+  //   await setupSentryAndApp(tester);
+  //
+  //   try {
+  //     throw const SentryException(
+  //         type: 'StarError', value: 'I have a bad feeling about this...');
+  //   } catch (exception, stacktrace) {
+  //     final sentryId =
+  //         await Sentry.captureException(exception, stackTrace: stacktrace);
+  //
+  //     expect(sentryId != const SentryId.empty(), true);
+  //   }
+  // });
+  //
+  // testWidgets('setup sentry and capture message', (tester) async {
+  //   await setupSentryAndApp(tester);
+  //
+  //   final sentryId = await Sentry.captureMessage('hello world!');
+  //
+  //   expect(sentryId != const SentryId.empty(), true);
+  // });
+  //
+  // testWidgets('setup sentry and capture user feedback', (tester) async {
+  //   await setupSentryAndApp(tester);
+  //
+  //   // ignore: deprecated_member_use_from_same_package
+  //   // ignore: deprecated_member_use
+  //   final feedback = SentryUserFeedback(
+  //       eventId: SentryId.newId(),
+  //       name: 'fixture-name',
+  //       email: 'fixture@email.com',
+  //       comments: 'fixture-comments');
+  //   // ignore: deprecated_member_use
+  //   await Sentry.captureUserFeedback(feedback);
+  // });
+  //
+  // testWidgets('setup sentry and capture feedback', (tester) async {
+  //   await setupSentryAndApp(tester);
+  //
+  //   // ignore: deprecated_member_use_from_same_package
+  //   // ignore: deprecated_member_use
+  //   final associatedEventId = await Sentry.captureMessage('Associated');
+  //   final feedback = SentryFeedback(
+  //     message: 'message',
+  //     contactEmail: 'john.appleseed@apple.com',
+  //     name: 'John Appleseed',
+  //     associatedEventId: associatedEventId,
+  //   );
+  //   await Sentry.captureFeedback(feedback);
+  // });
+  //
+  // testWidgets('setup sentry and close', (tester) async {
+  //   await setupSentryAndApp(tester);
+  //
+  //   await Sentry.close();
+  // });
+  //
+  // testWidgets('setup sentry and add breadcrumb', (tester) async {
+  //   await setupSentryAndApp(tester);
+  //
+  //   final breadcrumb = Breadcrumb(message: 'fixture-message');
+  //   await Sentry.addBreadcrumb(breadcrumb);
+  // });
+  //
+  // testWidgets('setup sentry and configure scope', (tester) async {
+  //   await setupSentryAndApp(tester);
+  //
+  //   await Sentry.configureScope((scope) async {
+  //     await scope.setContexts('contexts-key', 'contexts-value');
+  //     await scope.removeContexts('contexts-key');
+  //
+  //     final user = SentryUser(id: 'fixture-id');
+  //     await scope.setUser(user);
+  //     await scope.setUser(null);
+  //
+  //     final breadcrumb = Breadcrumb(message: 'fixture-message');
+  //     await scope.addBreadcrumb(breadcrumb);
+  //     await scope.clearBreadcrumbs();
+  //
+  //     // ignore: deprecated_member_use
+  //     await scope.setExtra('extra-key', 'extra-value');
+  //     // ignore: deprecated_member_use
+  //     await scope.removeExtra('extra-key');
+  //
+  //     await scope.setTag('tag-key', 'tag-value');
+  //     await scope.removeTag('tag-key');
+  //   });
+  // });
+  //
+  // testWidgets('setup sentry and start transaction', (tester) async {
+  //   await setupSentryAndApp(tester);
+  //
+  //   final transaction = Sentry.startTransaction('transaction', 'test');
+  //   await transaction.finish();
+  // });
+  //
+  // testWidgets('setup sentry and start transaction with context',
+  //     (tester) async {
+  //   await setupSentryAndApp(tester);
+  //
+  //   final context = SentryTransactionContext('transaction', 'test');
+  //   final transaction = Sentry.startTransactionWithContext(context);
+  //   await transaction.finish();
+  // });
 
   testWidgets('setup sentry and test loading debug image', (tester) async {
     await restoreFlutterOnErrorAfter(() async {
@@ -179,16 +179,15 @@ void main() {
     expect(allDebugImages!.length > 100, isTrue);
 
     // We can take any other random image for testing
-    // I chose this one because most of the time this will be the one loaded
-    const codeFileName = 'libflutter.so';
-    final expectedImage = allDebugImages
-        .firstWhere((image) => image.codeFile!.contains(codeFileName));
+    final expectedImage = allDebugImages.first;
     expect(expectedImage.imageAddr, isNotNull);
+    print(expectedImage.imageAddr);
+    print(expectedImage.codeFile);
     final imageAddr =
         int.parse(expectedImage.imageAddr!.replaceAll('0x', ''), radix: 16);
 
-    // Use the base image address and increase so the instructionAddress will be
-    // within the range of the image address
+    // Use the base image address and increase by offset
+    // so the instructionAddress will be within the range of the image address
     final imageOffset = (expectedImage.imageSize! / 2).toInt();
     final instructionAddr = '0x${(imageAddr + imageOffset).toRadixString(16)}';
     final sentryFrame = SentryStackFrame(instructionAddr: instructionAddr);
@@ -199,69 +198,69 @@ void main() {
     expect(debugImageByStacktrace.first, expectedImage);
   });
 
-  group('e2e', () {
-    var output = find.byKey(const Key('output'));
-    late Fixture fixture;
-
-    setUp(() {
-      fixture = Fixture();
-    });
-
-    testWidgets('captureException', (tester) async {
-      late Uri uri;
-
-      await restoreFlutterOnErrorAfter(() async {
-        await setupSentryAndApp(tester,
-            dsn: exampleDsn, beforeSendCallback: fixture.beforeSend);
-
-        await tester.tap(find.text('captureException'));
-        await tester.pumpAndSettle();
-
-        final text = output.evaluate().single.widget as Text;
-        final id = text.data!;
-
-        uri = Uri.parse(
-          'https://sentry.io/api/0/projects/$org/$slug/events/$id/',
-        );
-      });
-
-      expect(authToken, isNotEmpty);
-
-      final event = await fixture.poll(uri, authToken);
-      expect(event, isNotNull);
-
-      final sentEvents = fixture.sentEvents
-          .where((el) => el!.eventId.toString() == event!['id']);
-      expect(
-          sentEvents.length, 1); // one button click should only send one error
-      final sentEvent = sentEvents.first;
-
-      final tags = event!['tags'] as List<dynamic>;
-
-      print('event id: ${event['id']}');
-      print('event title: ${event['title']}');
-      expect(sentEvent!.eventId.toString(), event['id']);
-      expect('_Exception: Exception: captureException', event['title']);
-      expect(sentEvent.release, event['release']['version']);
-      expect(
-          2,
-          (tags.firstWhere((e) => e['value'] == sentEvent.environment) as Map)
-              .length);
-      expect(sentEvent.fingerprint, event['fingerprint'] ?? []);
-      expect(
-          2,
-          (tags.firstWhere((e) => e['value'] == SentryLevel.error.name) as Map)
-              .length);
-      expect(sentEvent.logger, event['logger']);
-
-      final dist = tags.firstWhere((element) => element['key'] == 'dist');
-      expect('1', dist['value']);
-
-      final environment =
-          tags.firstWhere((element) => element['key'] == 'environment');
-      expect('integration', environment['value']);
-    });
-  });
+  // group('e2e', () {
+  //   var output = find.byKey(const Key('output'));
+  //   late Fixture fixture;
+  //
+  //   setUp(() {
+  //     fixture = Fixture();
+  //   });
+  //
+  //   testWidgets('captureException', (tester) async {
+  //     late Uri uri;
+  //
+  //     await restoreFlutterOnErrorAfter(() async {
+  //       await setupSentryAndApp(tester,
+  //           dsn: exampleDsn, beforeSendCallback: fixture.beforeSend);
+  //
+  //       await tester.tap(find.text('captureException'));
+  //       await tester.pumpAndSettle();
+  //
+  //       final text = output.evaluate().single.widget as Text;
+  //       final id = text.data!;
+  //
+  //       uri = Uri.parse(
+  //         'https://sentry.io/api/0/projects/$org/$slug/events/$id/',
+  //       );
+  //     });
+  //
+  //     expect(authToken, isNotEmpty);
+  //
+  //     final event = await fixture.poll(uri, authToken);
+  //     expect(event, isNotNull);
+  //
+  //     final sentEvents = fixture.sentEvents
+  //         .where((el) => el!.eventId.toString() == event!['id']);
+  //     expect(
+  //         sentEvents.length, 1); // one button click should only send one error
+  //     final sentEvent = sentEvents.first;
+  //
+  //     final tags = event!['tags'] as List<dynamic>;
+  //
+  //     print('event id: ${event['id']}');
+  //     print('event title: ${event['title']}');
+  //     expect(sentEvent!.eventId.toString(), event['id']);
+  //     expect('_Exception: Exception: captureException', event['title']);
+  //     expect(sentEvent.release, event['release']['version']);
+  //     expect(
+  //         2,
+  //         (tags.firstWhere((e) => e['value'] == sentEvent.environment) as Map)
+  //             .length);
+  //     expect(sentEvent.fingerprint, event['fingerprint'] ?? []);
+  //     expect(
+  //         2,
+  //         (tags.firstWhere((e) => e['value'] == SentryLevel.error.name) as Map)
+  //             .length);
+  //     expect(sentEvent.logger, event['logger']);
+  //
+  //     final dist = tags.firstWhere((element) => element['key'] == 'dist');
+  //     expect('1', dist['value']);
+  //
+  //     final environment =
+  //         tags.firstWhere((element) => element['key'] == 'environment');
+  //     expect('integration', environment['value']);
+  //   });
+  // });
 }
 
 class Fixture {

--- a/flutter/example/integration_test/integration_test.dart
+++ b/flutter/example/integration_test/integration_test.dart
@@ -167,6 +167,38 @@ void main() {
     await transaction.finish();
   });
 
+  testWidgets('setup sentry and test loading debug image', (tester) async {
+    await restoreFlutterOnErrorAfter(() async {
+      await setupSentryAndApp(tester);
+    });
+
+    // By default it should load all debug images
+    final allDebugImages = await SentryFlutter.native
+        ?.loadDebugImages(SentryStackTrace(frames: const []));
+    // Typically loading all images results in a larger numbers
+    expect(allDebugImages!.length > 100, isTrue);
+
+    // We can take any other random image for testing
+    // I chose this one because most of the time this will be the one loaded
+    const codeFileName = 'libflutter.so';
+    final expectedImage = allDebugImages
+        .firstWhere((image) => image.codeFile!.contains(codeFileName));
+    expect(expectedImage.imageAddr, isNotNull);
+    final imageAddr =
+        int.parse(expectedImage.imageAddr!.replaceAll('0x', ''), radix: 16);
+
+    // Use the base image address and increase so the instructionAddress will be
+    // within the range of the image address
+    final imageOffset = (expectedImage.imageSize! / 2).toInt();
+    final instructionAddr = '0x${(imageAddr + imageOffset).toRadixString(16)}';
+    final sentryFrame = SentryStackFrame(instructionAddr: instructionAddr);
+
+    final debugImageByStacktrace = await SentryFlutter.native
+        ?.loadDebugImages(SentryStackTrace(frames: [sentryFrame]));
+    expect(debugImageByStacktrace!.length, 1);
+    expect(debugImageByStacktrace.first, expectedImage);
+  });
+
   group('e2e', () {
     var output = find.byKey(const Key('output'));
     late Fixture fixture;

--- a/flutter/example/integration_test/integration_test.dart
+++ b/flutter/example/integration_test/integration_test.dart
@@ -181,8 +181,6 @@ void main() {
     // We can take any other random image for testing
     final expectedImage = allDebugImages.first;
     expect(expectedImage.imageAddr, isNotNull);
-    print(expectedImage.imageAddr);
-    print(expectedImage.codeFile);
     final imageAddr =
         int.parse(expectedImage.imageAddr!.replaceAll('0x', ''), radix: 16);
 
@@ -195,7 +193,9 @@ void main() {
     final debugImageByStacktrace = await SentryFlutter.native
         ?.loadDebugImages(SentryStackTrace(frames: [sentryFrame]));
     expect(debugImageByStacktrace!.length, 1);
-    expect(debugImageByStacktrace.first, expectedImage);
+    expect(debugImageByStacktrace.first.imageAddr, isNotNull);
+    expect(debugImageByStacktrace.first.imageAddr, isNotEmpty);
+    expect(debugImageByStacktrace.first.imageAddr, expectedImage.imageAddr);
   });
 
   group('e2e', () {

--- a/flutter/example/integration_test/integration_test.dart
+++ b/flutter/example/integration_test/integration_test.dart
@@ -46,126 +46,126 @@ void main() {
 
   // Tests
 
-  // testWidgets('setup sentry and render app', (tester) async {
-  //   await setupSentryAndApp(tester);
-  //
-  //   // Find any UI element and verify it is present.
-  //   expect(find.text('Open another Scaffold'), findsOneWidget);
-  // });
-  //
-  // testWidgets('setup sentry and capture event', (tester) async {
-  //   await setupSentryAndApp(tester);
-  //
-  //   final event = SentryEvent();
-  //   final sentryId = await Sentry.captureEvent(event);
-  //
-  //   expect(sentryId != const SentryId.empty(), true);
-  // });
-  //
-  // testWidgets('setup sentry and capture exception', (tester) async {
-  //   await setupSentryAndApp(tester);
-  //
-  //   try {
-  //     throw const SentryException(
-  //         type: 'StarError', value: 'I have a bad feeling about this...');
-  //   } catch (exception, stacktrace) {
-  //     final sentryId =
-  //         await Sentry.captureException(exception, stackTrace: stacktrace);
-  //
-  //     expect(sentryId != const SentryId.empty(), true);
-  //   }
-  // });
-  //
-  // testWidgets('setup sentry and capture message', (tester) async {
-  //   await setupSentryAndApp(tester);
-  //
-  //   final sentryId = await Sentry.captureMessage('hello world!');
-  //
-  //   expect(sentryId != const SentryId.empty(), true);
-  // });
-  //
-  // testWidgets('setup sentry and capture user feedback', (tester) async {
-  //   await setupSentryAndApp(tester);
-  //
-  //   // ignore: deprecated_member_use_from_same_package
-  //   // ignore: deprecated_member_use
-  //   final feedback = SentryUserFeedback(
-  //       eventId: SentryId.newId(),
-  //       name: 'fixture-name',
-  //       email: 'fixture@email.com',
-  //       comments: 'fixture-comments');
-  //   // ignore: deprecated_member_use
-  //   await Sentry.captureUserFeedback(feedback);
-  // });
-  //
-  // testWidgets('setup sentry and capture feedback', (tester) async {
-  //   await setupSentryAndApp(tester);
-  //
-  //   // ignore: deprecated_member_use_from_same_package
-  //   // ignore: deprecated_member_use
-  //   final associatedEventId = await Sentry.captureMessage('Associated');
-  //   final feedback = SentryFeedback(
-  //     message: 'message',
-  //     contactEmail: 'john.appleseed@apple.com',
-  //     name: 'John Appleseed',
-  //     associatedEventId: associatedEventId,
-  //   );
-  //   await Sentry.captureFeedback(feedback);
-  // });
-  //
-  // testWidgets('setup sentry and close', (tester) async {
-  //   await setupSentryAndApp(tester);
-  //
-  //   await Sentry.close();
-  // });
-  //
-  // testWidgets('setup sentry and add breadcrumb', (tester) async {
-  //   await setupSentryAndApp(tester);
-  //
-  //   final breadcrumb = Breadcrumb(message: 'fixture-message');
-  //   await Sentry.addBreadcrumb(breadcrumb);
-  // });
-  //
-  // testWidgets('setup sentry and configure scope', (tester) async {
-  //   await setupSentryAndApp(tester);
-  //
-  //   await Sentry.configureScope((scope) async {
-  //     await scope.setContexts('contexts-key', 'contexts-value');
-  //     await scope.removeContexts('contexts-key');
-  //
-  //     final user = SentryUser(id: 'fixture-id');
-  //     await scope.setUser(user);
-  //     await scope.setUser(null);
-  //
-  //     final breadcrumb = Breadcrumb(message: 'fixture-message');
-  //     await scope.addBreadcrumb(breadcrumb);
-  //     await scope.clearBreadcrumbs();
-  //
-  //     // ignore: deprecated_member_use
-  //     await scope.setExtra('extra-key', 'extra-value');
-  //     // ignore: deprecated_member_use
-  //     await scope.removeExtra('extra-key');
-  //
-  //     await scope.setTag('tag-key', 'tag-value');
-  //     await scope.removeTag('tag-key');
-  //   });
-  // });
-  //
-  // testWidgets('setup sentry and start transaction', (tester) async {
-  //   await setupSentryAndApp(tester);
-  //
-  //   final transaction = Sentry.startTransaction('transaction', 'test');
-  //   await transaction.finish();
-  // });
-  //
-  // testWidgets('setup sentry and start transaction with context',
-  //     (tester) async {
-  //   await setupSentryAndApp(tester);
-  //
-  //   final context = SentryTransactionContext('transaction', 'test');
-  //   final transaction = Sentry.startTransactionWithContext(context);
-  //   await transaction.finish();
-  // });
+  testWidgets('setup sentry and render app', (tester) async {
+    await setupSentryAndApp(tester);
+
+    // Find any UI element and verify it is present.
+    expect(find.text('Open another Scaffold'), findsOneWidget);
+  });
+
+  testWidgets('setup sentry and capture event', (tester) async {
+    await setupSentryAndApp(tester);
+
+    final event = SentryEvent();
+    final sentryId = await Sentry.captureEvent(event);
+
+    expect(sentryId != const SentryId.empty(), true);
+  });
+
+  testWidgets('setup sentry and capture exception', (tester) async {
+    await setupSentryAndApp(tester);
+
+    try {
+      throw const SentryException(
+          type: 'StarError', value: 'I have a bad feeling about this...');
+    } catch (exception, stacktrace) {
+      final sentryId =
+          await Sentry.captureException(exception, stackTrace: stacktrace);
+
+      expect(sentryId != const SentryId.empty(), true);
+    }
+  });
+
+  testWidgets('setup sentry and capture message', (tester) async {
+    await setupSentryAndApp(tester);
+
+    final sentryId = await Sentry.captureMessage('hello world!');
+
+    expect(sentryId != const SentryId.empty(), true);
+  });
+
+  testWidgets('setup sentry and capture user feedback', (tester) async {
+    await setupSentryAndApp(tester);
+
+    // ignore: deprecated_member_use_from_same_package
+    // ignore: deprecated_member_use
+    final feedback = SentryUserFeedback(
+        eventId: SentryId.newId(),
+        name: 'fixture-name',
+        email: 'fixture@email.com',
+        comments: 'fixture-comments');
+    // ignore: deprecated_member_use
+    await Sentry.captureUserFeedback(feedback);
+  });
+
+  testWidgets('setup sentry and capture feedback', (tester) async {
+    await setupSentryAndApp(tester);
+
+    // ignore: deprecated_member_use_from_same_package
+    // ignore: deprecated_member_use
+    final associatedEventId = await Sentry.captureMessage('Associated');
+    final feedback = SentryFeedback(
+      message: 'message',
+      contactEmail: 'john.appleseed@apple.com',
+      name: 'John Appleseed',
+      associatedEventId: associatedEventId,
+    );
+    await Sentry.captureFeedback(feedback);
+  });
+
+  testWidgets('setup sentry and close', (tester) async {
+    await setupSentryAndApp(tester);
+
+    await Sentry.close();
+  });
+
+  testWidgets('setup sentry and add breadcrumb', (tester) async {
+    await setupSentryAndApp(tester);
+
+    final breadcrumb = Breadcrumb(message: 'fixture-message');
+    await Sentry.addBreadcrumb(breadcrumb);
+  });
+
+  testWidgets('setup sentry and configure scope', (tester) async {
+    await setupSentryAndApp(tester);
+
+    await Sentry.configureScope((scope) async {
+      await scope.setContexts('contexts-key', 'contexts-value');
+      await scope.removeContexts('contexts-key');
+
+      final user = SentryUser(id: 'fixture-id');
+      await scope.setUser(user);
+      await scope.setUser(null);
+
+      final breadcrumb = Breadcrumb(message: 'fixture-message');
+      await scope.addBreadcrumb(breadcrumb);
+      await scope.clearBreadcrumbs();
+
+      // ignore: deprecated_member_use
+      await scope.setExtra('extra-key', 'extra-value');
+      // ignore: deprecated_member_use
+      await scope.removeExtra('extra-key');
+
+      await scope.setTag('tag-key', 'tag-value');
+      await scope.removeTag('tag-key');
+    });
+  });
+
+  testWidgets('setup sentry and start transaction', (tester) async {
+    await setupSentryAndApp(tester);
+
+    final transaction = Sentry.startTransaction('transaction', 'test');
+    await transaction.finish();
+  });
+
+  testWidgets('setup sentry and start transaction with context',
+      (tester) async {
+    await setupSentryAndApp(tester);
+
+    final context = SentryTransactionContext('transaction', 'test');
+    final transaction = Sentry.startTransactionWithContext(context);
+    await transaction.finish();
+  });
 
   testWidgets('setup sentry and test loading debug image', (tester) async {
     await restoreFlutterOnErrorAfter(() async {
@@ -198,69 +198,69 @@ void main() {
     expect(debugImageByStacktrace.first, expectedImage);
   });
 
-  // group('e2e', () {
-  //   var output = find.byKey(const Key('output'));
-  //   late Fixture fixture;
-  //
-  //   setUp(() {
-  //     fixture = Fixture();
-  //   });
-  //
-  //   testWidgets('captureException', (tester) async {
-  //     late Uri uri;
-  //
-  //     await restoreFlutterOnErrorAfter(() async {
-  //       await setupSentryAndApp(tester,
-  //           dsn: exampleDsn, beforeSendCallback: fixture.beforeSend);
-  //
-  //       await tester.tap(find.text('captureException'));
-  //       await tester.pumpAndSettle();
-  //
-  //       final text = output.evaluate().single.widget as Text;
-  //       final id = text.data!;
-  //
-  //       uri = Uri.parse(
-  //         'https://sentry.io/api/0/projects/$org/$slug/events/$id/',
-  //       );
-  //     });
-  //
-  //     expect(authToken, isNotEmpty);
-  //
-  //     final event = await fixture.poll(uri, authToken);
-  //     expect(event, isNotNull);
-  //
-  //     final sentEvents = fixture.sentEvents
-  //         .where((el) => el!.eventId.toString() == event!['id']);
-  //     expect(
-  //         sentEvents.length, 1); // one button click should only send one error
-  //     final sentEvent = sentEvents.first;
-  //
-  //     final tags = event!['tags'] as List<dynamic>;
-  //
-  //     print('event id: ${event['id']}');
-  //     print('event title: ${event['title']}');
-  //     expect(sentEvent!.eventId.toString(), event['id']);
-  //     expect('_Exception: Exception: captureException', event['title']);
-  //     expect(sentEvent.release, event['release']['version']);
-  //     expect(
-  //         2,
-  //         (tags.firstWhere((e) => e['value'] == sentEvent.environment) as Map)
-  //             .length);
-  //     expect(sentEvent.fingerprint, event['fingerprint'] ?? []);
-  //     expect(
-  //         2,
-  //         (tags.firstWhere((e) => e['value'] == SentryLevel.error.name) as Map)
-  //             .length);
-  //     expect(sentEvent.logger, event['logger']);
-  //
-  //     final dist = tags.firstWhere((element) => element['key'] == 'dist');
-  //     expect('1', dist['value']);
-  //
-  //     final environment =
-  //         tags.firstWhere((element) => element['key'] == 'environment');
-  //     expect('integration', environment['value']);
-  //   });
-  // });
+  group('e2e', () {
+    var output = find.byKey(const Key('output'));
+    late Fixture fixture;
+
+    setUp(() {
+      fixture = Fixture();
+    });
+
+    testWidgets('captureException', (tester) async {
+      late Uri uri;
+
+      await restoreFlutterOnErrorAfter(() async {
+        await setupSentryAndApp(tester,
+            dsn: exampleDsn, beforeSendCallback: fixture.beforeSend);
+
+        await tester.tap(find.text('captureException'));
+        await tester.pumpAndSettle();
+
+        final text = output.evaluate().single.widget as Text;
+        final id = text.data!;
+
+        uri = Uri.parse(
+          'https://sentry.io/api/0/projects/$org/$slug/events/$id/',
+        );
+      });
+
+      expect(authToken, isNotEmpty);
+
+      final event = await fixture.poll(uri, authToken);
+      expect(event, isNotNull);
+
+      final sentEvents = fixture.sentEvents
+          .where((el) => el!.eventId.toString() == event!['id']);
+      expect(
+          sentEvents.length, 1); // one button click should only send one error
+      final sentEvent = sentEvents.first;
+
+      final tags = event!['tags'] as List<dynamic>;
+
+      print('event id: ${event['id']}');
+      print('event title: ${event['title']}');
+      expect(sentEvent!.eventId.toString(), event['id']);
+      expect('_Exception: Exception: captureException', event['title']);
+      expect(sentEvent.release, event['release']['version']);
+      expect(
+          2,
+          (tags.firstWhere((e) => e['value'] == sentEvent.environment) as Map)
+              .length);
+      expect(sentEvent.fingerprint, event['fingerprint'] ?? []);
+      expect(
+          2,
+          (tags.firstWhere((e) => e['value'] == SentryLevel.error.name) as Map)
+              .length);
+      expect(sentEvent.logger, event['logger']);
+
+      final dist = tags.firstWhere((element) => element['key'] == 'dist');
+      expect('1', dist['value']);
+
+      final environment =
+          tags.firstWhere((element) => element['key'] == 'environment');
+      expect('integration', environment['value']);
+    });
+  });
 }
 
 class Fixture {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/getsentry/sentry-dart/issues/2440

Uses api that only fetches relevant debug images and not everything that's available. This reduces the data transfer between the bridge immensely and reduces the final envelope size

## :green_heart: How did you test it?
Manual, couldn't figure out how to have automated tests for features requiring obfuscated builds

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
