### PR TITLE
chore: ignore dart:html warnings

### DIFF
--- a/dart/example_web_legacy/web/main.dart
+++ b/dart/example_web_legacy/web/main.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+// ignore: deprecated_member_use
 import 'dart:html';
 
 import 'package:sentry/sentry.dart';

--- a/dart/lib/src/event_processor/enricher/html_enricher_event_processor.dart
+++ b/dart/lib/src/event_processor/enricher/html_enricher_event_processor.dart
@@ -1,3 +1,4 @@
+// ignore: deprecated_member_use
 import 'dart:html' as html show window, Window;
 
 import '../../../sentry.dart';

--- a/dart/lib/src/origin_html.dart
+++ b/dart/lib/src/origin_html.dart
@@ -1,3 +1,4 @@
+// ignore: deprecated_member_use
 import 'dart:html';
 
 /// request origin, used for browser stacktrace

--- a/dart/lib/src/platform/_html_platform.dart
+++ b/dart/lib/src/platform/_html_platform.dart
@@ -1,4 +1,6 @@
+// ignore: deprecated_member_use
 import 'dart:html' as html;
+
 import 'platform.dart';
 
 const Platform instance = WebPlatform();

--- a/flutter/lib/src/event_processor/url_filter/html_url_filter_event_processor.dart
+++ b/flutter/lib/src/event_processor/url_filter/html_url_filter_event_processor.dart
@@ -1,9 +1,11 @@
+// ignore: deprecated_member_use
 import 'dart:html' as html show window, Window;
+
+// ignore: implementation_imports
+import 'package:sentry/src/utils/regex_utils.dart';
 
 import '../../../sentry_flutter.dart';
 import 'url_filter_event_processor.dart';
-// ignore: implementation_imports
-import 'package:sentry/src/utils/regex_utils.dart';
 
 // ignore_for_file: invalid_use_of_internal_member
 

--- a/flutter/lib/src/integrations/connectivity/html_connectivity_provider.dart
+++ b/flutter/lib/src/integrations/connectivity/html_connectivity_provider.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+// ignore: deprecated_member_use
 import 'dart:html' as html;
 
 import 'connectivity_provider.dart';

--- a/flutter/lib/src/web/script_loader/html_script_dom_api.dart
+++ b/flutter/lib/src/web/script_loader/html_script_dom_api.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
+// ignore: deprecated_member_use
 import 'dart:html';
+// ignore: deprecated_member_use
 import 'dart:js_util' as js_util;
 
 import '../../../sentry_flutter.dart';

--- a/flutter/test/web/html_utils.dart
+++ b/flutter/test/web/html_utils.dart
@@ -1,3 +1,4 @@
+// ignore: deprecated_member_use
 import 'dart:html';
 
 void injectMetaTag(Map<String, String> attributes) {


### PR DESCRIPTION
#skip-changelog

we're gonna move away from dart:html in v9 so it's fine to ignore it in v8