### PR TITLE
deprecate: drift `SentryQueryExecutor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@
 
 ### Deprecations
 
+- Deprecate Drift `SentryQueryExecutor` ([#2715](https://github.com/getsentry/sentry-dart/pull/2715))
+  - This will be replace by `SentryQueryInterceptor` in the next major v9
+```dart
+// Example usage in Sentry Flutter v9
+final executor = NativeDatabase.memory().interceptWith(
+  SentryQueryInterceptor(databaseName: 'your_db_name'),
+);
+
+final db = AppDatabase(executor);
+```
 - Deprecate `autoAppStart` and `setAppStartEnd` ([#2681](https://github.com/getsentry/sentry-dart/pull/2681))
 
 ### Other

--- a/drift/lib/src/sentry_query_executor.dart
+++ b/drift/lib/src/sentry_query_executor.dart
@@ -17,8 +17,8 @@ typedef DatabaseOpener = FutureOr<QueryExecutor> Function();
 /// used as a default.
 @experimental
 @Deprecated(
-    'This will be replace by SentryQueryInterceptor in the next major v9 '
-    'where you can use .interceptWith(...) to attach the SentryQueryInterceptor')
+    'This will be replaced by SentryQueryInterceptor in the next major v9 '
+    'where you can use executor.interceptWith(...) to attach the SentryQueryInterceptor')
 class SentryQueryExecutor extends QueryExecutor {
   Hub _hub;
 

--- a/drift/lib/src/sentry_query_executor.dart
+++ b/drift/lib/src/sentry_query_executor.dart
@@ -16,6 +16,9 @@ typedef DatabaseOpener = FutureOr<QueryExecutor> Function();
 /// If the constructor parameter queryExecutor is null, [LazyDatabase] will be
 /// used as a default.
 @experimental
+@Deprecated(
+    'This will be replace by SentryQueryInterceptor in the next major v9. '
+    'See https://drift.simonbinder.eu/examples/tracing/ in how to attach an interceptor to your executor.')
 class SentryQueryExecutor extends QueryExecutor {
   Hub _hub;
 

--- a/drift/lib/src/sentry_query_executor.dart
+++ b/drift/lib/src/sentry_query_executor.dart
@@ -17,8 +17,8 @@ typedef DatabaseOpener = FutureOr<QueryExecutor> Function();
 /// used as a default.
 @experimental
 @Deprecated(
-    'This will be replace by SentryQueryInterceptor in the next major v9. '
-    'See https://drift.simonbinder.eu/examples/tracing/ in how to attach an interceptor to your executor.')
+    'This will be replace by SentryQueryInterceptor in the next major v9 '
+    'where you can use .interceptWith(...) to attach the SentryQueryInterceptor')
 class SentryQueryExecutor extends QueryExecutor {
   Hub _hub;
 

--- a/drift/lib/src/sentry_span_helper.dart
+++ b/drift/lib/src/sentry_span_helper.dart
@@ -1,5 +1,6 @@
-import 'package:meta/meta.dart';
+// ignore_for_file: deprecated_member_use_from_same_package
 
+import 'package:meta/meta.dart';
 import 'package:sentry/sentry.dart';
 
 import 'sentry_query_executor.dart';

--- a/drift/test/sentry_database_test.dart
+++ b/drift/test/sentry_database_test.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: invalid_use_of_internal_member, library_annotations
+// ignore_for_file: invalid_use_of_internal_member, library_annotations, deprecated_member_use_from_same_package
 
 @TestOn('vm')
 

--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -660,6 +660,7 @@ class MainScaffold extends StatelessWidget {
       bindToScope: true,
     );
 
+    // ignore: deprecated_member_use
     final executor = SentryQueryExecutor(
       () async => inMemoryExecutor(),
       databaseName: 'sentry_in_memory_db',


### PR DESCRIPTION
This will be replaced in v9 by `SentryQueryInterceptor`
