### PR TITLE
fix: navigation breadcrumb with missing `to` crashes native

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@
 
 - Disable `ScreenshotIntegration`, `WidgetsBindingIntegration` and `SentryWidget` in multi-view apps #2366 ([#2366](https://github.com/getsentry/sentry-dart/pull/2366))
 
-### Fixes 
+### Fixes
 
 - Reference to `SentryWidgetsFlutterBinding` in warning message in `FramesTrackingIntegration` ([#2704](https://github.com/getsentry/sentry-dart/pull/2704))
+- Replay video interuption if a `navigation` breadcrumb is missing `to` route info ([#2720](https://github.com/getsentry/sentry-dart/pull/2720))
 
 ### Deprecations
 

--- a/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterReplayBreadcrumbConverter.kt
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterReplayBreadcrumbConverter.kt
@@ -28,7 +28,13 @@ class SentryFlutterReplayBreadcrumbConverter : DefaultReplayBreadcrumbConverter(
       "sentry.event" -> null
       "sentry.transaction" -> null
       "http" -> convertNetworkBreadcrumb(breadcrumb)
-      "navigation" -> newRRWebBreadcrumb(breadcrumb)
+      "navigation" -> {
+        if (breadcrumb.data.containsKey("to") && breadcrumb.data["to"] is String) {
+          newRRWebBreadcrumb(breadcrumb)
+        } else {
+          null
+        }
+      }
       "ui.click" ->
         newRRWebBreadcrumb(breadcrumb).apply {
           category = "ui.tap"


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
fixes #2719 
fixes #2721 


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?

manually by setting the navigation breadcrumb `data.to` field to `null` in the `RouteObserverBreadcrumb` 


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
