### PR TITLE
ci: add experiment records flag to microbenchmark test

### DIFF
--- a/flutter/microbenchmarks/analysis_options.yaml
+++ b/flutter/microbenchmarks/analysis_options.yaml
@@ -5,3 +5,5 @@ analyzer:
     avoid_print: ignore
     implementation_imports: ignore
     invalid_use_of_internal_member: ignore
+  enable-experiment:
+    - records


### PR DESCRIPTION
#skip-changelog

fixes dart analyzer issue flagging this as an experimental feature