### PR TITLE
fix: auto ip guarded by `sendDefaultPii`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Behavioral changes
 
 - ⚠️ Auto IP assignment for `SentryUser` is now guarded by `sendDefaultPii` ([#2726](https://github.com/getsentry/sentry-dart/pull/2726))
-  - If you rely on Sentry automatically processing the IP address of the user, set `options.sendDefaultPii = true` or manually set the ip address of the `SentryUser` to `{{auto}}`
+  - If you rely on Sentry automatically processing the IP address of the user, set `options.sendDefaultPii = true` or manually set the IP address of the `SentryUser` to `{{auto}}`
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+### Behavioral changes
+
 - ⚠️ Auto IP assignment for `SentryUser` is now guarded by `sendDefaultPii` ([#2726](https://github.com/getsentry/sentry-dart/pull/2726))
   - If you rely on Sentry automatically processing the IP address of the user, set `options.sendDefaultPii = true` or manually set the ip address of the `SentryUser` to `{{auto}}`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- ⚠️ Auto IP assignment for `SentryUser` is now guarded by `sendDefaultPii` ([#2726](https://github.com/getsentry/sentry-dart/pull/2726))
+  - If you rely on Sentry automatically processing the IP address of the user, set `options.sendDefaultPii = true` or manually set the ip address of the `SentryUser` to `{{auto}}`
+
 ### Features
 
 - Disable `ScreenshotIntegration`, `WidgetsBindingIntegration` and `SentryWidget` in multi-view apps #2366 ([#2366](https://github.com/getsentry/sentry-dart/pull/2366))

--- a/dart/lib/src/protocol/sentry_user.dart
+++ b/dart/lib/src/protocol/sentry_user.dart
@@ -47,7 +47,11 @@ class SentryUser {
     Map<String, dynamic>? extras,
     this.unknown,
   })  : assert(
-          id != null || username != null || email != null || segment != null,
+          id != null ||
+              username != null ||
+              email != null ||
+              ipAddress != null ||
+              segment != null,
         ),
         data = data == null ? null : Map.from(data),
         // ignore: deprecated_member_use_from_same_package

--- a/dart/lib/src/protocol/sentry_user.dart
+++ b/dart/lib/src/protocol/sentry_user.dart
@@ -47,11 +47,7 @@ class SentryUser {
     Map<String, dynamic>? extras,
     this.unknown,
   })  : assert(
-          id != null ||
-              username != null ||
-              email != null ||
-              ipAddress != null ||
-              segment != null,
+          id != null || username != null || email != null || segment != null,
         ),
         data = data == null ? null : Map.from(data),
         // ignore: deprecated_member_use_from_same_package

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -308,19 +308,16 @@ class SentryClient {
 
   SentryEvent _createUserOrSetDefaultIpAddress(SentryEvent event) {
     final user = event.user;
-    // Set default IP address if sendDefaultPii is enabled and no existing IP
-    final effectiveIpAddress =
-        user?.ipAddress ?? (_options.sendDefaultPii ? _defaultIpAddress : null);
-
-    if (user == null && effectiveIpAddress != null) {
-      return event.copyWith(user: SentryUser(ipAddress: effectiveIpAddress));
+    final effectiveIpAddress = user?.ipAddress ?? (_options.sendDefaultPii ? _defaultIpAddress : null);
+    
+    if (effectiveIpAddress != null) {
+      final updatedUser = user == null 
+          ? SentryUser(ipAddress: effectiveIpAddress)
+          : user.copyWith(ipAddress: effectiveIpAddress);
+          
+      return event.copyWith(user: updatedUser);
     }
-
-    if (user?.ipAddress == null && effectiveIpAddress != null) {
-      return event.copyWith(
-          user: user?.copyWith(ipAddress: effectiveIpAddress));
-    }
-
+    
     return event;
   }
 

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -304,12 +304,19 @@ class SentryClient {
   }
 
   SentryEvent _createUserOrSetDefaultIpAddress(SentryEvent event) {
-    var user = event.user;
+    final user = event.user;
+    // Set default IP address if sendDefaultPii is enabled and no existing IP
+    final effectiveIpAddress =
+        user?.ipAddress ?? (_options.sendDefaultPii ? _defaultIpAddress : null);
+
     if (user == null) {
-      return event.copyWith(user: SentryUser(ipAddress: _defaultIpAddress));
-    } else if (event.user?.ipAddress == null) {
-      return event.copyWith(user: user.copyWith(ipAddress: _defaultIpAddress));
+      return event.copyWith(user: SentryUser(ipAddress: effectiveIpAddress));
     }
+
+    if (user.ipAddress == null) {
+      return event.copyWith(user: user.copyWith(ipAddress: effectiveIpAddress));
+    }
+
     return event;
   }
 

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -308,16 +308,17 @@ class SentryClient {
 
   SentryEvent _createUserOrSetDefaultIpAddress(SentryEvent event) {
     final user = event.user;
-    final effectiveIpAddress = user?.ipAddress ?? (_options.sendDefaultPii ? _defaultIpAddress : null);
-    
+    final effectiveIpAddress =
+        user?.ipAddress ?? (_options.sendDefaultPii ? _defaultIpAddress : null);
+
     if (effectiveIpAddress != null) {
-      final updatedUser = user == null 
+      final updatedUser = user == null
           ? SentryUser(ipAddress: effectiveIpAddress)
           : user.copyWith(ipAddress: effectiveIpAddress);
-          
+
       return event.copyWith(user: updatedUser);
     }
-    
+
     return event;
   }
 

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -35,6 +35,9 @@ import 'version.dart';
 /// to true.
 const _defaultIpAddress = '{{auto}}';
 
+@visibleForTesting
+String get defaultIpAddress => _defaultIpAddress;
+
 /// Logs crash reports and events to the Sentry.io service.
 class SentryClient {
   final SentryOptions _options;

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -312,12 +312,13 @@ class SentryClient {
     final effectiveIpAddress =
         user?.ipAddress ?? (_options.sendDefaultPii ? _defaultIpAddress : null);
 
-    if (user == null) {
+    if (user == null && effectiveIpAddress != null) {
       return event.copyWith(user: SentryUser(ipAddress: effectiveIpAddress));
     }
 
-    if (user.ipAddress == null) {
-      return event.copyWith(user: user.copyWith(ipAddress: effectiveIpAddress));
+    if (user?.ipAddress == null && effectiveIpAddress != null) {
+      return event.copyWith(
+          user: user?.copyWith(ipAddress: effectiveIpAddress));
     }
 
     return event;

--- a/dart/test/sentry_client_test.dart
+++ b/dart/test/sentry_client_test.dart
@@ -1034,8 +1034,7 @@ void main() {
       final capturedEvent = await eventFromEnvelope(capturedEnvelope);
 
       expect(fixture.transport.envelopes.length, 1);
-      expect(capturedEvent.user, isNotNull);
-      expect(capturedEvent.user?.ipAddress, isNull);
+      expect(capturedEvent.user, isNull);
     });
 
     test('event has a user with IP address', () async {

--- a/dart/test/sentry_client_test.dart
+++ b/dart/test/sentry_client_test.dart
@@ -1013,6 +1013,7 @@ void main() {
     test('event has no user and sendDefaultPii = true', () async {
       final client = fixture.getSut(sendDefaultPii: true);
       var fakeEvent = SentryEvent();
+      expect(fakeEvent.user, isNull);
 
       await client.captureEvent(fakeEvent);
 
@@ -1027,6 +1028,7 @@ void main() {
     test('event has no user and sendDefaultPii = false', () async {
       final client = fixture.getSut(sendDefaultPii: false);
       var fakeEvent = SentryEvent();
+      expect(fakeEvent.user, isNull);
 
       await client.captureEvent(fakeEvent);
 
@@ -1040,6 +1042,7 @@ void main() {
     test('event has a user with IP address', () async {
       final client = fixture.getSut(sendDefaultPii: true);
 
+      expect(fakeEvent.user?.ipAddress, isNotNull);
       await client.captureEvent(fakeEvent);
 
       final capturedEnvelope = fixture.transport.envelopes.first;
@@ -1058,6 +1061,7 @@ void main() {
       final client = fixture.getSut(sendDefaultPii: true);
 
       final event = fakeEvent.copyWith(user: fakeUser);
+      expect(event.user?.ipAddress, isNull);
 
       await client.captureEvent(event);
 
@@ -1076,6 +1080,7 @@ void main() {
       final client = fixture.getSut(sendDefaultPii: false);
 
       final event = fakeEvent.copyWith(user: fakeUser);
+      expect(event.user?.ipAddress, isNull);
 
       await client.captureEvent(event);
 

--- a/dart/test/sentry_client_test.dart
+++ b/dart/test/sentry_client_test.dart
@@ -1003,14 +1003,14 @@ void main() {
     });
   });
 
-  group('SentryClient: sets user & user ip', () {
+  group('SentryClient: user & user ip', () {
     late Fixture fixture;
 
     setUp(() {
       fixture = Fixture();
     });
 
-    test('event has no user', () async {
+    test('event has no user and sendDefaultPii = true', () async {
       final client = fixture.getSut(sendDefaultPii: true);
       var fakeEvent = SentryEvent();
 
@@ -1021,7 +1021,21 @@ void main() {
 
       expect(fixture.transport.envelopes.length, 1);
       expect(capturedEvent.user, isNotNull);
-      expect(capturedEvent.user?.ipAddress, '{{auto}}');
+      expect(capturedEvent.user?.ipAddress, defaultIpAddress);
+    });
+
+    test('event has no user and sendDefaultPii = false', () async {
+      final client = fixture.getSut(sendDefaultPii: false);
+      var fakeEvent = SentryEvent();
+
+      await client.captureEvent(fakeEvent);
+
+      final capturedEnvelope = fixture.transport.envelopes.first;
+      final capturedEvent = await eventFromEnvelope(capturedEnvelope);
+
+      expect(fixture.transport.envelopes.length, 1);
+      expect(capturedEvent.user, isNotNull);
+      expect(capturedEvent.user?.ipAddress, isNull);
     });
 
     test('event has a user with IP address', () async {
@@ -1040,7 +1054,8 @@ void main() {
       expect(capturedEvent.user?.email, fakeEvent.user!.email);
     });
 
-    test('event has a user without IP address', () async {
+    test('event has a user without IP address and sendDefaultPii = true',
+        () async {
       final client = fixture.getSut(sendDefaultPii: true);
 
       final event = fakeEvent.copyWith(user: fakeUser);
@@ -1052,7 +1067,25 @@ void main() {
 
       expect(fixture.transport.envelopes.length, 1);
       expect(capturedEvent.user, isNotNull);
-      expect(capturedEvent.user?.ipAddress, '{{auto}}');
+      expect(capturedEvent.user?.ipAddress, defaultIpAddress);
+      expect(capturedEvent.user?.id, fakeUser.id);
+      expect(capturedEvent.user?.email, fakeUser.email);
+    });
+
+    test('event has a user without IP address and sendDefaultPii = false',
+        () async {
+      final client = fixture.getSut(sendDefaultPii: false);
+
+      final event = fakeEvent.copyWith(user: fakeUser);
+
+      await client.captureEvent(event);
+
+      final capturedEnvelope = fixture.transport.envelopes.first;
+      final capturedEvent = await eventFromEnvelope(capturedEnvelope);
+
+      expect(fixture.transport.envelopes.length, 1);
+      expect(capturedEvent.user, isNotNull);
+      expect(capturedEvent.user?.ipAddress, isNull);
       expect(capturedEvent.user?.id, fakeUser.id);
       expect(capturedEvent.user?.email, fakeUser.email);
     });

--- a/flutter/test/integrations/load_contexts_integration_test.dart
+++ b/flutter/test/integrations/load_contexts_integration_test.dart
@@ -3,9 +3,9 @@ library flutter_test;
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
+import 'package:sentry/src/sentry_tracer.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:sentry_flutter/src/integrations/load_contexts_integration.dart';
-import 'package:sentry/src/sentry_tracer.dart';
 
 import 'fixture.dart';
 
@@ -86,9 +86,10 @@ void main() {
     });
 
     test(
-        'apply default IP to user during captureEvent after loading context if ip is null',
+        'apply default IP to user during captureEvent after loading context if ip is null and sendDefaultPii is true',
         () async {
       fixture.options.enableScopeSync = true;
+      fixture.options.sendDefaultPii = true;
 
       const expectedIp = '{{auto}}';
       String? actualIp;
@@ -118,9 +119,42 @@ void main() {
     });
 
     test(
-        'apply default IP to user during captureTransaction after loading context if ip is null',
+        'does not apply default IP to user during captureEvent after loading context if ip is null and sendDefaultPii is false',
         () async {
       fixture.options.enableScopeSync = true;
+      // sendDefaultPii false is by default
+
+      String? actualIp;
+
+      const expectedId = '1';
+      String? actualId;
+
+      fixture.options.beforeSend = (event, hint) {
+        actualIp = event.user?.ipAddress;
+        actualId = event.user?.id;
+        return event;
+      };
+
+      final options = fixture.options;
+
+      final user = SentryUser(id: expectedId);
+      when(fixture.binding.loadContexts())
+          .thenAnswer((_) async => {'user': user.toJson()});
+
+      final client = SentryClient(options);
+      final event = SentryEvent();
+
+      await client.captureEvent(event);
+
+      expect(actualIp, isNull);
+      expect(actualId, expectedId);
+    });
+
+    test(
+        'apply default IP to user during captureTransaction after loading context if ip is null and sendDefaultPii is true',
+        () async {
+      fixture.options.enableScopeSync = true;
+      fixture.options.sendDefaultPii = true;
 
       const expectedIp = '{{auto}}';
       String? actualIp;
@@ -149,6 +183,41 @@ void main() {
       await client.captureTransaction(transaction);
 
       expect(actualIp, expectedIp);
+      expect(actualId, expectedId);
+    });
+
+    test(
+        'does not apply default IP to user during captureTransaction after loading context if ip is null and sendDefaultPii is false',
+        () async {
+      fixture.options.enableScopeSync = true;
+      // sendDefaultPii false is by default
+
+      String? actualIp;
+
+      const expectedId = '1';
+      String? actualId;
+
+      fixture.options.beforeSendTransaction = (transaction) {
+        actualIp = transaction.user?.ipAddress;
+        actualId = transaction.user?.id;
+        return transaction;
+      };
+
+      final options = fixture.options;
+
+      final user = SentryUser(id: expectedId);
+      when(fixture.binding.loadContexts())
+          .thenAnswer((_) async => {'user': user.toJson()});
+
+      final client = SentryClient(options);
+      final tracer =
+          SentryTracer(SentryTransactionContext('name', 'op'), fixture.hub);
+      final transaction = SentryTransaction(tracer);
+
+      // ignore: invalid_use_of_internal_member
+      await client.captureTransaction(transaction);
+
+      expect(actualIp, isNull);
       expect(actualId, expectedId);
     });
   });


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previously wasn't guarded by `sendDefaultPii` because of https://github.com/getsentry/sentry-dart/issues/1562

https://github.com/getsentry/team-sdks/issues/118 states it should only be added if `sendDefaultPii = true`
## :green_heart: How did you test it?
Unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
