### PR TITLE
Pass missing captureFailedRequests param to FailedRequestInterceptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Pass missing `captureFailedRequests` param to `FailedRequestInterceptor` ([#2744](https://github.com/getsentry/sentry-dart/pull/2744))
+
 ## 8.14.0-beta.1
 
 ### Behavioral changes

--- a/dio/lib/src/sentry_dio_extension.dart
+++ b/dio/lib/src/sentry_dio_extension.dart
@@ -82,6 +82,7 @@ extension SentryDioExtension on Dio {
         FailedRequestInterceptor(
           failedRequestStatusCodes: failedRequestStatusCodes,
           failedRequestTargets: failedRequestTargets,
+          captureFailedRequests: captureFailedRequests,
         ),
       );
       // ignore: invalid_use_of_internal_member

--- a/dio/lib/src/sentry_dio_extension.dart
+++ b/dio/lib/src/sentry_dio_extension.dart
@@ -48,8 +48,7 @@ extension SentryDioExtension on Dio {
     Hub? hub,
     List<SentryStatusCode> failedRequestStatusCodes =
         SentryHttpClient.defaultFailedRequestStatusCodes,
-    List<String> failedRequestTargets =
-        SentryHttpClient.defaultFailedRequestTargets,
+    List<String> failedRequestTargets = SentryHttpClient.defaultFailedRequestTargets,
     bool? captureFailedRequests,
   }) {
     hub = hub ?? HubAdapter();
@@ -80,6 +79,7 @@ extension SentryDioExtension on Dio {
       interceptors.insert(
         0,
         FailedRequestInterceptor(
+          hub: hub,
           failedRequestStatusCodes: failedRequestStatusCodes,
           failedRequestTargets: failedRequestTargets,
           captureFailedRequests: captureFailedRequests,

--- a/dio/test/sentry_dio_extension_test.dart
+++ b/dio/test/sentry_dio_extension_test.dart
@@ -11,6 +11,7 @@ import 'package:sentry_dio/src/sentry_transformer.dart';
 import 'package:sentry_dio/src/version.dart';
 import 'package:test/test.dart';
 
+import 'failed_request_interceptor_test.dart';
 import 'mocks/mock_hub.dart';
 
 void main() {
@@ -90,6 +91,17 @@ void main() {
         dio.interceptors.whereType<FailedRequestInterceptor>().length,
         1,
       );
+
+      final interceptor = dio.interceptors.whereType<FailedRequestInterceptor>().first;
+
+      final requestOptions = RequestOptions(path: 'https://example.com');
+      final error = DioError(
+        requestOptions: requestOptions,
+        response: Response(statusCode: 500, requestOptions: requestOptions),
+      );
+      interceptor.onError(error, fixture.errorInterceptorHandler);
+
+      expect(fixture.hub.captureExceptionCalls.length, 1);
     });
 
     test('addSentry does not add $FailedRequestInterceptor if override false',
@@ -184,6 +196,8 @@ void main() {
 
 class Fixture {
   final MockHub hub = MockHub();
+  final errorInterceptorHandler = MockedErrorInterceptorHandler();
+
   Dio getSut() {
     return Dio();
   }


### PR DESCRIPTION
## :scroll: Description
dio.addSentry() captureFailedRequest param  passed through to FailedRequestInterceptor.

## :bulb: Motivation and Context
Fixes #2737.

## :green_heart: How did you test it?
I have run the fix in my app and it works as expected.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes
