### PR TITLE
Use global ruby for  `pod  install` in min version test

### DIFF
--- a/.github/workflows/min_version_test.yml
+++ b/.github/workflows/min_version_test.yml
@@ -63,15 +63,16 @@ jobs:
         run: |
           gem uninstall cocoapods -a
           sudo gem install cocoapods
+          echo "CocoaPods version: $(pod --version)"
 
       - name: Build iOS
         run: |
           cd min_version_test
+          flutter pub get
           cd ios
           pod repo update
           pod install
           cd ..
-          flutter pub get
           flutter build ios --no-codesign
 
   build-web:

--- a/.github/workflows/min_version_test.yml
+++ b/.github/workflows/min_version_test.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           gem uninstall cocoapods -a
           sudo gem install cocoapods
-          echo "CocoaPods version: $(pod --version)"
+          echo "$(which pod)"
 
       - name: Build iOS
         run: |

--- a/.github/workflows/min_version_test.yml
+++ b/.github/workflows/min_version_test.yml
@@ -60,7 +60,12 @@ jobs:
           ruby-version: '3.1.2' # https://github.com/flutter/flutter/issues/109385#issuecomment-1212614125
 
       - name: Update Pods
-        run: sudo gem update
+        run: |
+          cd min_version_test/ios
+          sudo gem update
+          sudo pod repo update
+          sudo pod install
+
       - name: Build iOS
         run: |
           cd min_version_test

--- a/.github/workflows/min_version_test.yml
+++ b/.github/workflows/min_version_test.yml
@@ -59,16 +59,18 @@ jobs:
         with:
           ruby-version: '3.1.2' # https://github.com/flutter/flutter/issues/109385#issuecomment-1212614125
 
-      - name: Update Pods
+      - name: Uninstall existing CocoaPods and install globally
         run: |
-          cd min_version_test/ios
-          sudo gem update
-          sudo pod repo update
-          sudo pod install
+          gem uninstall cocoapods -a
+          sudo gem install cocoapods
 
       - name: Build iOS
         run: |
           cd min_version_test
+          cd ios
+          pod repo update
+          pod install
+          cd ..
           flutter pub get
           flutter build ios --no-codesign
 


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->

Min version test fails because globally installed ruby version is ignored in favor of homebrew. Newer versions miss deprecated method that oder flutter versions are using.

https://github.com/getsentry/sentry-dart/actions/runs/13788603269/job/38562413538
