### PR TITLE
[v9] Set sentry-native backend to crashpad by default and breakpad for windows arm64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased 9.0.0
 
+- Set sentry-native backend to `crashpad` by default and `breakpad` for Windows ARM64 ([#2791](https://github.com/getsentry/sentry-dart/pull/2791))
+  - Setting the `SENTRY_NATIVE_BACKEND` environment variable will override the defaults.
 - Move replay and privacy from experimental to options ([#2755](https://github.com/getsentry/sentry-dart/pull/2755))
 - Remove renderer from `flutter_context` ([#2751](https://github.com/getsentry/sentry-dart/pull/2751))
 - Cleanup platform mocking ([#2730](https://github.com/getsentry/sentry-dart/pull/2730))

--- a/flutter/sentry-native/sentry-native.cmake
+++ b/flutter/sentry-native/sentry-native.cmake
@@ -7,7 +7,7 @@ set(SENTRY_BUILD_SHARED_LIBS ON CACHE BOOL "Build shared libraries (.dll/.so) in
 # Note: the backend is also set in linux/CMakeLists.txt and windows/CMakeLists.txt. This overwrites those if user sets an env var.
 if("$ENV{SENTRY_NATIVE_BACKEND}" STREQUAL "")
     # Windows ARM64 currently has issues with crashpad so we opt for using breakpad
-    if(WIN32 AND CMAKE_SYSTEM_PROCESSOR MATCHES "ARM64")
+    if(WIN32 AND CMAKE_SYSTEM_PROCESSOR STREQUAL "ARM64")
         set(SENTRY_BACKEND "breakpad" CACHE STRING "The sentry backend responsible for reporting crashes" FORCE)
     else()
         set(SENTRY_BACKEND "crashpad" CACHE STRING "The sentry backend responsible for reporting crashes" FORCE)

--- a/flutter/sentry-native/sentry-native.cmake
+++ b/flutter/sentry-native/sentry-native.cmake
@@ -9,8 +9,6 @@ if(NOT "$ENV{SENTRY_NATIVE_BACKEND}" STREQUAL "")
     set(SENTRY_BACKEND $ENV{SENTRY_NATIVE_BACKEND} CACHE STRING "The sentry backend responsible for reporting crashes" FORCE)
 endif()
 
-message(STATUS "Sentry Native is using backend: ${SENTRY_BACKEND}")
-
 include(FetchContent)
 FetchContent_Declare(
     sentry-native

--- a/flutter/sentry-native/sentry-native.cmake
+++ b/flutter/sentry-native/sentry-native.cmake
@@ -7,6 +7,7 @@ set(SENTRY_BUILD_SHARED_LIBS ON CACHE BOOL "Build shared libraries (.dll/.so) in
 # Note: the backend is also set in linux/CMakeLists.txt and windows/CMakeLists.txt. This overwrites those if user sets an env var.
 if("$ENV{SENTRY_NATIVE_BACKEND}" STREQUAL "")
     # Windows ARM64 currently has issues with crashpad so we opt for using breakpad
+    # See: https://github.com/getsentry/sentry-dart/issues/2498
     if(WIN32 AND CMAKE_SYSTEM_PROCESSOR STREQUAL "ARM64")
         set(SENTRY_BACKEND "breakpad" CACHE STRING "The sentry backend responsible for reporting crashes" FORCE)
     else()

--- a/flutter/sentry-native/sentry-native.cmake
+++ b/flutter/sentry-native/sentry-native.cmake
@@ -6,8 +6,12 @@ set(SENTRY_BUILD_SHARED_LIBS ON CACHE BOOL "Build shared libraries (.dll/.so) in
 
 # Note: the backend is also set in linux/CMakeLists.txt and windows/CMakeLists.txt. This overwrites those if user sets an env var.
 if("$ENV{SENTRY_NATIVE_BACKEND}" STREQUAL "")
-    # Until sentry-dart v9, we disable native backend by default.
-    set(SENTRY_BACKEND "none" CACHE STRING "The sentry backend responsible for reporting crashes" FORCE)
+    # Windows ARM64 currently has issues with crashpad so we opt for using breakpad
+    if(WIN32 AND CMAKE_SYSTEM_PROCESSOR MATCHES "ARM64")
+        set(SENTRY_BACKEND "breakpad" CACHE STRING "The sentry backend responsible for reporting crashes" FORCE)
+    else()
+        set(SENTRY_BACKEND "crashpad" CACHE STRING "The sentry backend responsible for reporting crashes" FORCE)
+    endif()
 else()
     set(SENTRY_BACKEND $ENV{SENTRY_NATIVE_BACKEND} CACHE STRING "The sentry backend responsible for reporting crashes" FORCE)
 endif()

--- a/flutter/sentry-native/sentry-native.cmake
+++ b/flutter/sentry-native/sentry-native.cmake
@@ -4,18 +4,12 @@ message(STATUS "Fetching Sentry native version: ${SENTRY_NATIVE_version} from ${
 set(SENTRY_SDK_NAME "sentry.native.flutter" CACHE STRING "The SDK name to report when sending events." FORCE)
 set(SENTRY_BUILD_SHARED_LIBS ON CACHE BOOL "Build shared libraries (.dll/.so) instead of static ones (.lib/.a)" FORCE)
 
-# Note: the backend is also set in linux/CMakeLists.txt and windows/CMakeLists.txt. This overwrites those if user sets an env var.
-if("$ENV{SENTRY_NATIVE_BACKEND}" STREQUAL "")
-    # Windows ARM64 currently has issues with crashpad so we opt for using breakpad
-    # See: https://github.com/getsentry/sentry-dart/issues/2498
-    if(WIN32 AND CMAKE_SYSTEM_PROCESSOR STREQUAL "ARM64")
-        set(SENTRY_BACKEND "breakpad" CACHE STRING "The sentry backend responsible for reporting crashes" FORCE)
-    else()
-        set(SENTRY_BACKEND "crashpad" CACHE STRING "The sentry backend responsible for reporting crashes" FORCE)
-    endif()
-else()
+if(NOT "$ENV{SENTRY_NATIVE_BACKEND}" STREQUAL "")
+    # If environment variable is set, it takes highest precedence
     set(SENTRY_BACKEND $ENV{SENTRY_NATIVE_BACKEND} CACHE STRING "The sentry backend responsible for reporting crashes" FORCE)
 endif()
+
+message(STATUS "Sentry Native is using backend: ${SENTRY_BACKEND}")
 
 include(FetchContent)
 FetchContent_Declare(

--- a/flutter/test/sentry_native/sentry_native_test_ffi.dart
+++ b/flutter/test/sentry_native/sentry_native_test_ffi.dart
@@ -15,9 +15,8 @@ import '../mocks.mocks.dart';
 enum NativeBackend { default_, crashpad, breakpad, inproc, none }
 
 extension on NativeBackend {
-  // TODO change default to crashpad in v9
   NativeBackend get actualValue =>
-      this == NativeBackend.default_ ? NativeBackend.none : this;
+      this == NativeBackend.default_ ? NativeBackend.crashpad : this;
 }
 
 // NOTE: Don't run/debug this main(), it likely won't work.


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Change default backends for windows & linux

 - Default values are in the windows & linux cmakelists -> crashpad for linux & windows and breakpad for windows arm64
 - Backends set by env var take precedence so users can change them

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2641 

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
