### PR TITLE
Fix: Improve platform memory collection on windows/linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,10 @@ This release fixes an issue where Cold starts can be incorrectly reported as War
 - Pass missing `captureFailedRequests` param to `FailedRequestInterceptor` ([#2744](https://github.com/getsentry/sentry-dart/pull/2744))
 - Bind root screen transaction to scope ([#2756](https://github.com/getsentry/sentry-dart/pull/2756))
 - Reference to `SentryWidgetsFlutterBinding` in warning message in `FramesTrackingIntegration` ([#2704](https://github.com/getsentry/sentry-dart/pull/2704))
-
+- Improve platform memory collection on windows/linux ([#2798](https://github.com/getsentry/sentry-dart/pull/2798))
+  - Fixes an issue where total memory on windows was not read.
+  - Free memory collection was removed on windows/linux, due to performance issues.
+  
 ### Deprecations
 
 - Deprecate Drift `SentryQueryExecutor` ([#2715](https://github.com/getsentry/sentry-dart/pull/2715))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Improve platform memory collection on windows/linux ([#2798](https://github.com/getsentry/sentry-dart/pull/2798))
+  - Fixes an issue where total memory on windows was not read.
+  - Free memory collection was removed on windows/linux, due to performance issues.
+
 ## 8.14.0
 
 This release fixes an issue where Cold starts can be incorrectly reported as Warm starts on Android.
@@ -28,9 +36,6 @@ This release fixes an issue where Cold starts can be incorrectly reported as War
 - Pass missing `captureFailedRequests` param to `FailedRequestInterceptor` ([#2744](https://github.com/getsentry/sentry-dart/pull/2744))
 - Bind root screen transaction to scope ([#2756](https://github.com/getsentry/sentry-dart/pull/2756))
 - Reference to `SentryWidgetsFlutterBinding` in warning message in `FramesTrackingIntegration` ([#2704](https://github.com/getsentry/sentry-dart/pull/2704))
-- Improve platform memory collection on windows/linux ([#2798](https://github.com/getsentry/sentry-dart/pull/2798))
-  - Fixes an issue where total memory on windows was not read.
-  - Free memory collection was removed on windows/linux, due to performance issues.
   
 ### Deprecations
 

--- a/dart/lib/src/protocol/contexts.dart
+++ b/dart/lib/src/protocol/contexts.dart
@@ -98,6 +98,9 @@ class Contexts extends MapView<String, dynamic> {
   List<SentryRuntime> get runtimes =>
       List.unmodifiable(this[SentryRuntime.listType] ?? []);
 
+  set runtimes(List<SentryRuntime> runtimes) =>
+      this[SentryRuntime.listType] = runtimes;
+
   void addRuntime(SentryRuntime runtime) =>
       this[SentryRuntime.listType].add(runtime);
 

--- a/dart/lib/src/scope.dart
+++ b/dart/lib/src/scope.dart
@@ -317,7 +317,7 @@ class Scope {
           level: level ?? event.level);
     }
 
-    _contexts.clone().forEach((key, value) {
+    _contexts.forEach((key, value) {
       // add the contexts runtime list to the event.contexts.runtimes
       if (key == SentryRuntime.listType &&
           value is List<SentryRuntime> &&

--- a/dart/test/contexts_test.dart
+++ b/dart/test/contexts_test.dart
@@ -134,6 +134,19 @@ void main() {
       expect(clone['theme'], {'value': 'material'});
       expect(clone['version'], {'value': 9});
     });
+
+    test('set runtimes', () {
+      final contexts = Contexts();
+      contexts.runtimes = [
+        const SentryRuntime(name: 'testRT1', version: '1.0'),
+        const SentryRuntime(name: 'testRT2', version: '2.0'),
+      ];
+      expect(contexts.runtimes.length, 2);
+      expect(contexts.runtimes.first.name, 'testRT1');
+      expect(contexts.runtimes.first.version, '1.0');
+      expect(contexts.runtimes.last.name, 'testRT2');
+      expect(contexts.runtimes.last.version, '2.0');
+    });
   });
 
   group('parse contexts', () {

--- a/dart/test/event_processor/enricher/io_enricher_test.dart
+++ b/dart/test/event_processor/enricher/io_enricher_test.dart
@@ -18,9 +18,9 @@ void main() {
     fixture = Fixture();
   });
 
-  test('adds dart runtime', () {
+  test('adds dart runtime', () async {
     final enricher = fixture.getSut();
-    final event = enricher.apply(SentryEvent(), Hint());
+    final event = await enricher.apply(SentryEvent(), Hint());
 
     expect(event?.contexts.runtimes, isNotEmpty);
     final dartRuntime = event?.contexts.runtimes
@@ -31,12 +31,12 @@ void main() {
     expect(Platform.version, contains(dartRuntime.version.toString()));
   });
 
-  test('does add to existing runtimes', () {
+  test('does add to existing runtimes', () async {
     final runtime = SentryRuntime(name: 'foo', version: 'bar');
     var event = SentryEvent(contexts: Contexts(runtimes: [runtime]));
     final enricher = fixture.getSut();
 
-    event = enricher.apply(event, Hint())!;
+    event = (await enricher.apply(event, Hint()))!;
 
     expect(event.contexts.runtimes.contains(runtime), true);
     // second runtime is Dart runtime
@@ -45,10 +45,10 @@ void main() {
 
   group('adds device, os and culture', () {
     for (final hasNativeIntegration in [true, false]) {
-      test('native=$hasNativeIntegration', () {
+      test('native=$hasNativeIntegration', () async {
         final enricher =
             fixture.getSut(hasNativeIntegration: hasNativeIntegration);
-        final event = enricher.apply(SentryEvent(), Hint());
+        final event = await enricher.apply(SentryEvent(), Hint());
 
         expect(event?.contexts.device, isNotNull);
         expect(event?.contexts.operatingSystem, isNotNull);
@@ -57,31 +57,31 @@ void main() {
     }
   });
 
-  test('device has no name if sendDefaultPii = false', () {
+  test('device has no name if sendDefaultPii = false', () async {
     final enricher = fixture.getSut();
-    final event = enricher.apply(SentryEvent(), Hint());
+    final event = await enricher.apply(SentryEvent(), Hint());
 
     expect(event?.contexts.device?.name, isNull);
   });
 
-  test('device has name if sendDefaultPii = true', () {
+  test('device has name if sendDefaultPii = true', () async {
     final enricher = fixture.getSut(includePii: true);
-    final event = enricher.apply(SentryEvent(), Hint());
+    final event = await enricher.apply(SentryEvent(), Hint());
 
     expect(event?.contexts.device?.name, isNotNull);
   });
 
-  test('culture has locale and timezone', () {
+  test('culture has locale and timezone', () async {
     final enricher = fixture.getSut();
-    final event = enricher.apply(SentryEvent(), Hint());
+    final event = await enricher.apply(SentryEvent(), Hint());
 
     expect(event?.contexts.culture?.locale, isNotNull);
     expect(event?.contexts.culture?.timezone, isNotNull);
   });
 
-  test('os has name and version', () {
+  test('os has name and version', () async {
     final enricher = fixture.getSut();
-    final event = enricher.apply(SentryEvent(), Hint());
+    final event = await enricher.apply(SentryEvent(), Hint());
 
     expect(event?.contexts.operatingSystem?.name, isNotNull);
     if (Platform.isLinux) {
@@ -158,9 +158,9 @@ void main() {
     });
   });
 
-  test('adds Dart context with PII', () {
+  test('adds Dart context with PII', () async {
     final enricher = fixture.getSut(includePii: true);
-    final event = enricher.apply(SentryEvent(), Hint());
+    final event = await enricher.apply(SentryEvent(), Hint());
 
     final dartContext = event?.contexts['dart_context'];
     expect(dartContext, isNotNull);
@@ -171,9 +171,9 @@ void main() {
     // package_config and executable_arguments are optional
   });
 
-  test('adds Dart context without PII', () {
+  test('adds Dart context without PII', () async {
     final enricher = fixture.getSut(includePii: false);
-    final event = enricher.apply(SentryEvent(), Hint());
+    final event = await enricher.apply(SentryEvent(), Hint());
 
     final dartContext = event?.contexts['dart_context'];
     expect(dartContext, isNotNull);
@@ -185,7 +185,7 @@ void main() {
     // and Platform is not mockable
   });
 
-  test('does not override event', () {
+  test('does not override event', () async {
     final fakeEvent = SentryEvent(
       contexts: Contexts(
         device: SentryDevice(
@@ -207,7 +207,7 @@ void main() {
       hasNativeIntegration: false,
     );
 
-    final event = enricher.apply(fakeEvent, Hint());
+    final event = await enricher.apply(fakeEvent, Hint());
 
     // contexts.device
     expect(

--- a/dart/test/event_processor/enricher/io_platform_memory_test.dart
+++ b/dart/test/event_processor/enricher/io_platform_memory_test.dart
@@ -15,9 +15,9 @@ void main() {
     fixture = Fixture();
   });
 
-  test('total physical memory', () {
+  test('total physical memory', () async {
     final sut = fixture.getSut();
-    final totalPhysicalMemory = sut.getTotalPhysicalMemory();
+    final totalPhysicalMemory = await sut.getTotalPhysicalMemory();
 
     switch (Platform.operatingSystem) {
       case 'linux':
@@ -30,24 +30,6 @@ void main() {
         break;
       default:
         expect(totalPhysicalMemory, isNull);
-    }
-  });
-
-  test('free physical memory', () {
-    final sut = fixture.getSut();
-    final freePhysicalMemory = sut.getTotalPhysicalMemory();
-
-    switch (Platform.operatingSystem) {
-      case 'linux':
-        expect(freePhysicalMemory, isNotNull);
-        expect(freePhysicalMemory! > 0, true);
-        break;
-      case 'windows':
-        expect(freePhysicalMemory, isNotNull);
-        expect(freePhysicalMemory! > 0, true);
-        break;
-      default:
-        expect(freePhysicalMemory, isNull);
     }
   });
 }

--- a/flutter/lib/src/event_processor/flutter_enricher_event_processor.dart
+++ b/flutter/lib/src/event_processor/flutter_enricher_event_processor.dart
@@ -43,13 +43,13 @@ class FlutterEnricherEventProcessor implements EventProcessor {
         ? null
         : _getDevice(event.contexts.device);
 
-    final contexts = event.contexts.copyWith(
-      device: device,
-      runtimes: _getRuntimes(event.contexts.runtimes),
-      culture: _getCulture(event.contexts.culture),
-      operatingSystem: _getOperatingSystem(event.contexts.operatingSystem),
-      app: _getApp(event.contexts.app),
-    );
+    final contexts = event.contexts;
+    contexts.device = device;
+    contexts.runtimes = _getRuntimes(event.contexts.runtimes);
+    contexts.culture = _getCulture(event.contexts.culture);
+    contexts.operatingSystem =
+        _getOperatingSystem(event.contexts.operatingSystem);
+    contexts.app = _getApp(event.contexts.app);
 
     final app = contexts.app;
     if (app != null) {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

A user reported an issue where his http calls are way slower if wrapped in sentry transactions. Turns out this is because we call external binaries with exec for every transaction to get physical and free memory size. Turns out this has a large overhead. Also the binary used on windows was deprecated and may therefore not be present. So we have the large overhead without the benefit.

This PR introduces the following to mitigate/fix all of the above:

- Disable platform memory collection per default per options.
- If enabled:
  - Cache physical memory indefinitely
  - Cache free memory for one minute
  - On windows, fallback to powershell if wmci is not available.
- Avoid copying of contexts.

Update: free memory has been removed currently on Desktop

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Relates to #2760
Relates to https://github.com/onepub-dev/system_info/issues/12

## :green_heart: How did you test it?

Ran locally in a win 11 vm. Unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
