### PR TITLE
Test wether isolate completes when sentry is closed

### DIFF
--- a/dart/test/sentry_test.dart
+++ b/dart/test/sentry_test.dart
@@ -423,7 +423,6 @@ void main() {
             ..dsn = fakeDsn
             ..tracesSampleRate = 1.0;
         });
-        print(message);
         await Sentry.close();
       }
 

--- a/dart/test/sentry_test.dart
+++ b/dart/test/sentry_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:isolate';
 
 import 'package:sentry/sentry.dart';
 import 'package:sentry/src/dart_exception_type_identifier.dart';
@@ -411,6 +412,37 @@ void main() {
         },
       );
       expect(options.debug, isFalse);
+    });
+
+    test('isolate completes when closing sentry', () async {
+      final onExit = ReceivePort();
+
+      Future<void> _runSentry(String message) async {
+        await Sentry.init((options) {
+          options
+            ..dsn = fakeDsn
+            ..tracesSampleRate = 1.0;
+        });
+        print(message);
+        await Sentry.close();
+      }
+
+      final completer = Completer<void>();
+
+      await Isolate.spawn<String>(
+        _runSentry,
+        'test',
+        onExit: onExit.sendPort,
+      );
+
+      var completed = false;
+      onExit.listen((message) {
+        completed = true;
+        completer.complete();
+      });
+
+      await completer.future;
+      expect(completed, true);
     });
   });
 

--- a/dart/test/sentry_test.dart
+++ b/dart/test/sentry_test.dart
@@ -444,7 +444,7 @@ void main() {
       await completer.future;
       expect(completed, true);
     });
-  });
+  }, testOn: 'vm');
 
   test('should complete when appRunner is not called in runZonedGuarded',
       () async {


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->

Add a test to check if an isolate completes when sentry is closed.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Relates to #2625

It turns out, we need to close sentry to complete an isolate. We should document this behaviour somewhere.

## :green_heart: How did you test it?

Added test.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes
