### PR TITLE
[v9]: Update naming of `LoadImagesListIntegration`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### API Changes
+
+- Update naming of `LoadImagesListIntegration` to `LoadNativeDebugImagesIntegration` ([#2833](https://github.com/getsentry/sentry-dart/pull/2833))
+
 ### Dependencies
 
 - Bump Android SDK from v8.2.0 to v8.6.0 ([#2819](https://github.com/getsentry/sentry-dart/pull/2819), [#2831](https://github.com/getsentry/sentry-dart/pull/2831))

--- a/dart/lib/src/load_dart_debug_images_integration.dart
+++ b/dart/lib/src/load_dart_debug_images_integration.dart
@@ -14,11 +14,13 @@ import 'protocol/sentry_stack_trace.dart';
 import 'sentry_options.dart';
 
 class LoadDartDebugImagesIntegration extends Integration<SentryOptions> {
+  static const integrationName = 'LoadDartDebugImagesIntegration';
+
   @override
   void call(Hub hub, SentryOptions options) {
     if (options.enableDartSymbolication) {
       options.addEventProcessor(LoadImageIntegrationEventProcessor(options));
-      options.sdk.addIntegration('LoadDartDebugImagesIntegration');
+      options.sdk.addIntegration(integrationName);
     }
   }
 }

--- a/dart/lib/src/load_dart_debug_images_integration.dart
+++ b/dart/lib/src/load_dart_debug_images_integration.dart
@@ -18,7 +18,7 @@ class LoadDartDebugImagesIntegration extends Integration<SentryOptions> {
   void call(Hub hub, SentryOptions options) {
     if (options.enableDartSymbolication) {
       options.addEventProcessor(LoadImageIntegrationEventProcessor(options));
-      options.sdk.addIntegration('LoadDartImagesIntegration');
+      options.sdk.addIntegration('LoadDartDebugImagesIntegration');
     }
   }
 }

--- a/dart/lib/src/load_dart_debug_images_integration.dart
+++ b/dart/lib/src/load_dart_debug_images_integration.dart
@@ -1,4 +1,5 @@
 import 'dart:typed_data';
+
 import 'package:meta/meta.dart';
 
 import 'event_processor.dart';
@@ -17,7 +18,7 @@ class LoadDartDebugImagesIntegration extends Integration<SentryOptions> {
   void call(Hub hub, SentryOptions options) {
     if (options.enableDartSymbolication) {
       options.addEventProcessor(LoadImageIntegrationEventProcessor(options));
-      options.sdk.addIntegration('loadDartImageIntegration');
+      options.sdk.addIntegration('LoadDartImagesIntegration');
     }
   }
 }

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -386,7 +386,7 @@ class SentryOptions {
         _ignoredExceptionsForType.contains(exception.runtimeType);
   }
 
-  /// Enables Dart symbolication for stack traces in Flutter.
+  /// Enables Dart symbolication for stack traces in Flutter for Android and Cocoa.
   ///
   /// If true, the SDK will attempt to symbolicate Dart stack traces when
   /// [Sentry.init] is used instead of `SentryFlutter.init`. This is useful

--- a/dart/test/load_dart_debug_images_integration_test.dart
+++ b/dart/test/load_dart_debug_images_integration_test.dart
@@ -30,7 +30,8 @@ void main() {
 
       test('adds itself to sdk.integrations', () {
         expect(
-          fixture.options.sdk.integrations.contains('loadDartImageIntegration'),
+          fixture.options.sdk.integrations
+              .contains(LoadDartDebugImagesIntegration.integrationName),
           true,
         );
       });

--- a/flutter/lib/src/integrations/integrations.dart
+++ b/flutter/lib/src/integrations/integrations.dart
@@ -1,7 +1,7 @@
 export 'debug_print_integration.dart';
 export 'flutter_error_integration.dart';
 export 'load_contexts_integration.dart';
-export 'load_image_list_integration.dart';
+export 'load_native_debug_images_integration.dart';
 export 'load_release_integration.dart';
 export 'native_app_start_integration.dart';
 export 'on_error_integration.dart';

--- a/flutter/lib/src/integrations/load_native_debug_images_integration.dart
+++ b/flutter/lib/src/integrations/load_native_debug_images_integration.dart
@@ -7,12 +7,12 @@ import 'package:sentry/src/load_dart_debug_images_integration.dart';
 import '../native/sentry_native_binding.dart';
 import '../sentry_flutter_options.dart';
 
-/// Loads the native debug image list for stack trace symbolication.
-class LoadImageListIntegration extends Integration<SentryFlutterOptions> {
-  /// TODO: rename to LoadNativeDebugImagesIntegration in the next major version
+/// Loads the native debug image list from the native SDKs on Android and Cocoa for stack trace symbolication.
+class LoadNativeDebugImagesIntegration
+    extends Integration<SentryFlutterOptions> {
   final SentryNativeBinding _native;
 
-  LoadImageListIntegration(this._native);
+  LoadNativeDebugImagesIntegration(this._native);
 
   @override
   void call(Hub hub, SentryFlutterOptions options) {
@@ -20,7 +20,7 @@ class LoadImageListIntegration extends Integration<SentryFlutterOptions> {
       _LoadImageListIntegrationEventProcessor(options, _native),
     );
 
-    options.sdk.addIntegration('loadImageListIntegration');
+    options.sdk.addIntegration('LoadNativeDebugImagesIntegration');
   }
 }
 

--- a/flutter/lib/src/integrations/load_native_debug_images_integration.dart
+++ b/flutter/lib/src/integrations/load_native_debug_images_integration.dart
@@ -7,7 +7,7 @@ import 'package:sentry/src/load_dart_debug_images_integration.dart';
 import '../native/sentry_native_binding.dart';
 import '../sentry_flutter_options.dart';
 
-/// Loads the native debug image list from the native SDKs on Android and Cocoa for stack trace symbolication.
+/// Loads the native debug image list from the native SDKs for stack trace symbolication.
 class LoadNativeDebugImagesIntegration
     extends Integration<SentryFlutterOptions> {
   final SentryNativeBinding _native;

--- a/flutter/lib/src/integrations/load_native_debug_images_integration.dart
+++ b/flutter/lib/src/integrations/load_native_debug_images_integration.dart
@@ -11,6 +11,7 @@ import '../sentry_flutter_options.dart';
 class LoadNativeDebugImagesIntegration
     extends Integration<SentryFlutterOptions> {
   final SentryNativeBinding _native;
+  static const integrationName = 'LoadNativeDebugImagesIntegration';
 
   LoadNativeDebugImagesIntegration(this._native);
 
@@ -19,7 +20,7 @@ class LoadNativeDebugImagesIntegration
     options.addEventProcessor(
       _LoadImageListIntegrationEventProcessor(options, _native),
     );
-    options.sdk.addIntegration('LoadNativeDebugImagesIntegration');
+    options.sdk.addIntegration(integrationName);
   }
 }
 

--- a/flutter/lib/src/integrations/load_native_debug_images_integration.dart
+++ b/flutter/lib/src/integrations/load_native_debug_images_integration.dart
@@ -19,7 +19,6 @@ class LoadNativeDebugImagesIntegration
     options.addEventProcessor(
       _LoadImageListIntegrationEventProcessor(options, _native),
     );
-
     options.sdk.addIntegration('LoadNativeDebugImagesIntegration');
   }
 }

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -185,7 +185,7 @@ mixin SentryFlutter {
         if (native.supportsLoadContexts) {
           integrations.add(LoadContextsIntegration(native));
         }
-        integrations.add(LoadImageListIntegration(native));
+        integrations.add(LoadNativeDebugImagesIntegration(native));
         integrations.add(FramesTrackingIntegration(native));
         integrations.add(
           NativeAppStartIntegration(

--- a/flutter/test/integrations/load_native_debug_images_integration_test.dart
+++ b/flutter/test/integrations/load_native_debug_images_integration_test.dart
@@ -31,10 +31,10 @@ void main() {
       await fixture.registerIntegration();
     });
 
-    test('$LoadNativeDebugImagesIntegration adds itself to sdk.integrations',
-        () async {
+    test('adds itself to sdk.integrations', () async {
       expect(
-        fixture.options.sdk.integrations.contains('loadImageListIntegration'),
+        fixture.options.sdk.integrations
+            .contains(LoadNativeDebugImagesIntegration.integrationName),
         true,
       );
     });

--- a/flutter/test/integrations/load_native_debug_images_integration_test.dart
+++ b/flutter/test/integrations/load_native_debug_images_integration_test.dart
@@ -4,12 +4,12 @@ library;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
-import 'package:sentry_flutter/src/integrations/load_image_list_integration.dart';
+import 'package:sentry_flutter/src/integrations/load_native_debug_images_integration.dart';
 
 import 'fixture.dart';
 
 void main() {
-  group(LoadImageListIntegration, () {
+  group(LoadNativeDebugImagesIntegration, () {
     final imageList = [
       DebugImage.fromJson({
         'code_file': '/apex/com.android.art/javalib/arm64/boot.oat',
@@ -22,16 +22,17 @@ void main() {
       })
     ];
 
-    late IntegrationTestFixture<LoadImageListIntegration> fixture;
+    late IntegrationTestFixture<LoadNativeDebugImagesIntegration> fixture;
 
     setUp(() async {
-      fixture = IntegrationTestFixture(LoadImageListIntegration.new);
+      fixture = IntegrationTestFixture(LoadNativeDebugImagesIntegration.new);
       when(fixture.binding.loadDebugImages(any))
           .thenAnswer((_) async => imageList.toList());
       await fixture.registerIntegration();
     });
 
-    test('$LoadImageListIntegration adds itself to sdk.integrations', () async {
+    test('$LoadNativeDebugImagesIntegration adds itself to sdk.integrations',
+        () async {
       expect(
         fixture.options.sdk.integrations.contains('loadImageListIntegration'),
         true,

--- a/flutter/test/sentry_flutter_test.dart
+++ b/flutter/test/sentry_flutter_test.dart
@@ -44,13 +44,13 @@ final nonWebIntegrations = [
 
 // These should be added to Android
 final androidIntegrations = [
-  LoadImageListIntegration,
+  LoadNativeDebugImagesIntegration,
   LoadContextsIntegration,
 ];
 
 // These should be added to iOS and macOS
 final iOsAndMacOsIntegrations = [
-  LoadImageListIntegration,
+  LoadNativeDebugImagesIntegration,
   LoadContextsIntegration,
 ];
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Renames `LoadImagesListIntegration` ->  `LoadNativeDebugImagesIntegration`

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
v9 issue

Closes https://github.com/getsentry/sentry-dart/issues/2834

## :green_heart: How did you test it?
Existing tests
