### PR TITLE
v9: Set log level to `warning` by default 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Behavioral changes
+
+- Set log level to `warning` by default when `debug = true` ([#2836](https://github.com/getsentry/sentry-dart/pull/2836))
+
 ### Dependencies
 
 - Bump Android SDK from v8.2.0 to v8.6.0 ([#2819](https://github.com/getsentry/sentry-dart/pull/2819), [#2831](https://github.com/getsentry/sentry-dart/pull/2831))

--- a/dart/lib/src/diagnostic_logger.dart
+++ b/dart/lib/src/diagnostic_logger.dart
@@ -2,8 +2,9 @@ import 'protocol.dart';
 import 'sentry_options.dart';
 
 class DiagnosticLogger {
-  final SentryLogger _logger;
   final SentryOptions _options;
+  final SentryLogger _logger;
+  SentryLogger get logger => _logger;
 
   DiagnosticLogger(this._logger, this._options);
 

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -131,8 +131,12 @@ class SentryOptions {
   SentryLogger get logger => _logger;
 
   set logger(SentryLogger logger) {
-    _logger = DiagnosticLogger(logger, this).log;
+    diagnosticLogger = DiagnosticLogger(logger, this);
+    _logger = diagnosticLogger!.log;
   }
+
+  @visibleForTesting
+  DiagnosticLogger? diagnosticLogger;
 
   final List<EventProcessor> _eventProcessors = [];
 
@@ -155,10 +159,12 @@ class SentryOptions {
 
   set debug(bool newValue) {
     _debug = newValue;
-    if (_debug == true && logger == noOpLogger) {
+    if (_debug == true &&
+        (logger == noOpLogger || diagnosticLogger?.logger == noOpLogger)) {
       logger = _debugLogger;
     }
-    if (_debug == false && logger == _debugLogger) {
+    if (_debug == false &&
+        (logger == _debugLogger || diagnosticLogger?.logger == _debugLogger)) {
       logger = noOpLogger;
     }
   }

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -161,10 +161,10 @@ class SentryOptions {
     _debug = newValue;
     if (_debug == true &&
         (logger == noOpLogger || diagnosticLogger?.logger == noOpLogger)) {
-      logger = _debugLogger;
+      logger = debugLogger;
     }
     if (_debug == false &&
-        (logger == _debugLogger || diagnosticLogger?.logger == _debugLogger)) {
+        (logger == debugLogger || diagnosticLogger?.logger == debugLogger)) {
       logger = noOpLogger;
     }
   }
@@ -597,7 +597,8 @@ class SentryOptions {
   late SentryStackTraceFactory stackTraceFactory =
       SentryStackTraceFactory(this);
 
-  void _debugLogger(
+  @visibleForTesting
+  void debugLogger(
     SentryLevel level,
     String message, {
     String? logger,

--- a/dart/lib/src/sentry_options.dart
+++ b/dart/lib/src/sentry_options.dart
@@ -21,8 +21,8 @@ import 'version.dart';
 
 /// Sentry SDK options
 class SentryOptions {
-  /// Default Log level if not specified Default is DEBUG
-  static final SentryLevel _defaultDiagnosticLevel = SentryLevel.debug;
+  /// Default Log level if not specified Default is WARNING
+  static final SentryLevel _defaultDiagnosticLevel = SentryLevel.warning;
 
   String? _dsn;
   Dsn? _parsedDsn;
@@ -156,10 +156,10 @@ class SentryOptions {
   set debug(bool newValue) {
     _debug = newValue;
     if (_debug == true && logger == noOpLogger) {
-      _logger = _debugLogger;
+      logger = _debugLogger;
     }
     if (_debug == false && logger == _debugLogger) {
-      _logger = noOpLogger;
+      logger = noOpLogger;
     }
   }
 

--- a/dart/test/diagnostic_logger_test.dart
+++ b/dart/test/diagnostic_logger_test.dart
@@ -11,37 +11,39 @@ void main() {
     fixture = Fixture();
   });
 
-  test('$DiagnosticLogger do not log if debug is disabled', () {
-    fixture.options.debug = false;
+  group(DiagnosticLogger, () {
+    test('does not log if debug is disabled', () {
+      fixture.options.debug = false;
 
-    fixture.getSut().log(SentryLevel.error, 'foobar');
+      fixture.getSut().log(SentryLevel.error, 'foobar');
 
-    expect(fixture.loggedMessage, isNull);
-  });
+      expect(fixture.loggedMessage, isNull);
+    });
 
-  test('$DiagnosticLogger log if debug is enabled', () {
-    fixture.options.debug = true;
+    test('logs if debug is enabled', () {
+      fixture.options.debug = true;
 
-    fixture.getSut().log(SentryLevel.error, 'foobar');
+      fixture.getSut().log(SentryLevel.error, 'foobar');
 
-    expect(fixture.loggedMessage, 'foobar');
-  });
+      expect(fixture.loggedMessage, 'foobar');
+    });
 
-  test('$DiagnosticLogger do not log if level is too low', () {
-    fixture.options.debug = true;
-    fixture.options.diagnosticLevel = SentryLevel.error;
+    test('does not log if level is too low', () {
+      fixture.options.debug = true;
+      fixture.options.diagnosticLevel = SentryLevel.error;
 
-    fixture.getSut().log(SentryLevel.warning, 'foobar');
+      fixture.getSut().log(SentryLevel.warning, 'foobar');
 
-    expect(fixture.loggedMessage, isNull);
-  });
+      expect(fixture.loggedMessage, isNull);
+    });
 
-  test('$DiagnosticLogger always log fatal', () {
-    fixture.options.debug = false;
+    test('always logs fatal', () {
+      fixture.options.debug = false;
 
-    fixture.getSut().log(SentryLevel.fatal, 'foobar');
+      fixture.getSut().log(SentryLevel.fatal, 'foobar');
 
-    expect(fixture.loggedMessage, 'foobar');
+      expect(fixture.loggedMessage, 'foobar');
+    });
   });
 }
 

--- a/dart/test/sentry_options_test.dart
+++ b/dart/test/sentry_options_test.dart
@@ -41,6 +41,26 @@ void main() {
     expect(options.logger, isNot(noOpLogger));
   });
 
+  test('setting debug correctly sets logger', () {
+    final options = defaultTestOptions();
+    expect(options.logger, noOpLogger);
+    expect(options.diagnosticLogger, isNull);
+    options.debug = true;
+    expect(options.logger, isNot(options.debugLogger));
+    expect(options.diagnosticLogger!.logger, options.debugLogger);
+    expect(options.logger, options.diagnosticLogger!.log);
+
+    options.debug = false;
+    expect(options.logger, isNot(noOpLogger));
+    expect(options.diagnosticLogger!.logger, noOpLogger);
+    expect(options.logger, options.diagnosticLogger!.log);
+
+    options.debug = true;
+    expect(options.logger, isNot(options.debugLogger));
+    expect(options.diagnosticLogger!.logger, options.debugLogger);
+    expect(options.logger, options.diagnosticLogger!.log);
+  });
+
   test('tracesSampler is null by default', () {
     final options = defaultTestOptions();
 

--- a/dart/test/sentry_options_test.dart
+++ b/dart/test/sentry_options_test.dart
@@ -125,6 +125,12 @@ void main() {
     expect(options.enableDartSymbolication, true);
   });
 
+  test('diagnosticLevel is warning by default', () {
+    final options = defaultTestOptions();
+
+    expect(options.diagnosticLevel, SentryLevel.warning);
+  });
+
   test('parsedDsn is correctly parsed and cached', () {
     final options = defaultTestOptions();
 

--- a/dart/test/sentry_test.dart
+++ b/dart/test/sentry_test.dart
@@ -489,15 +489,18 @@ void main() {
       (options) {
         options.dsn = fakeDsn;
         options.debug = true;
-        expect(options.logger, isNot(noOpLogger));
+        expect(options.diagnosticLogger?.logger, isNot(noOpLogger));
 
         options.debug = false;
-        expect(options.logger, noOpLogger);
+        expect(options.diagnosticLogger?.logger, noOpLogger);
+
+        options.debug = true;
+        expect(options.diagnosticLogger?.logger, isNot(noOpLogger));
       },
       options: sentryOptions,
     );
 
-    expect(sentryOptions.logger, noOpLogger);
+    expect(sentryOptions.diagnosticLogger?.logger, isNot(noOpLogger));
   });
 
   group('Sentry init optionsConfiguration', () {

--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -79,6 +79,7 @@ Future<void> setupSentry(
       // We can enable Sentry debug logging during development. This is likely
       // going to log too much for your app, but can be useful when figuring out
       // configuration issues, e.g. finding out why your events are not uploaded.
+      options.diagnosticLevel = SentryLevel.debug;
       options.debug = kDebugMode;
       options.spotlight = Spotlight(enabled: true);
       options.enableTimeToFullDisplayTracing = true;

--- a/flutter/lib/src/screenshot/recorder.dart
+++ b/flutter/lib/src/screenshot/recorder.dart
@@ -2,10 +2,10 @@ import 'dart:async';
 import 'dart:developer';
 import 'dart:ui';
 
+import 'package:flutter/cupertino.dart' as cupertino;
+import 'package:flutter/material.dart' as material;
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart' as widgets;
-import 'package:flutter/material.dart' as material;
-import 'package:flutter/cupertino.dart' as cupertino;
 import 'package:meta/meta.dart';
 
 import '../../sentry_flutter.dart';

--- a/flutter/test/integrations/init_native_sdk_test.dart
+++ b/flutter/test/integrations/init_native_sdk_test.dart
@@ -50,7 +50,7 @@ void main() {
           {'name': 'pub:sentry_flutter', 'version': sdkVersion}
         ]
       },
-      'diagnosticLevel': 'debug',
+      'diagnosticLevel': 'warning',
       'maxBreadcrumbs': 100,
       'anrEnabled': false,
       'anrTimeoutIntervalMillis': 5000,


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Update logging min level

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/getsentry/sentry-dart/issues/2816

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
