### PR TITLE
Set `addFeatureFlag` value parameter to dynamic and ignore non-boolean values

### DIFF
--- a/dart/lib/src/sentry.dart
+++ b/dart/lib/src/sentry.dart
@@ -360,7 +360,11 @@ class Sentry {
   /// Gets the current active transaction or span bound to the scope.
   static ISentrySpan? getSpan() => _hub.getSpan();
 
-  static Future<void> addFeatureFlag(String name, bool value) async {
+  static Future<void> addFeatureFlag(String name, dynamic value) async {
+    if (value is! bool) {
+      return;
+    }
+
     final featureFlagsIntegration = currentHub.options.integrations
         .whereType<FeatureFlagsIntegration>()
         .firstOrNull;

--- a/dart/test/sentry_test.dart
+++ b/dart/test/sentry_test.dart
@@ -324,14 +324,15 @@ void main() {
     test('addFeatureFlag should ignore non-boolean values', () async {
       await Sentry.init(
         options: defaultTestOptions(),
-            (options) => options.dsn = fakeDsn,
+        (options) => options.dsn = fakeDsn,
       );
 
       await Sentry.addFeatureFlag('foo1', 'some string');
       await Sentry.addFeatureFlag('foo2', 123);
       await Sentry.addFeatureFlag('foo3', 1.23);
 
-      final featureFlagsContext = Sentry.currentHub.scope.contexts[SentryFeatureFlags.type];
+      final featureFlagsContext =
+          Sentry.currentHub.scope.contexts[SentryFeatureFlags.type];
       expect(featureFlagsContext, isNull);
     });
 

--- a/dart/test/sentry_test.dart
+++ b/dart/test/sentry_test.dart
@@ -321,7 +321,7 @@ void main() {
       );
     });
 
-    test('addFeatureFlag ignores non-boolean values', () async {
+    test('addFeatureFlag should ignore non-boolean values', () async {
       await Sentry.init(
         options: defaultTestOptions(),
             (options) => options.dsn = fakeDsn,

--- a/dart/test/sentry_test.dart
+++ b/dart/test/sentry_test.dart
@@ -301,7 +301,7 @@ void main() {
       );
     }, onPlatform: {'vm': Skip()});
 
-    test('should add feature flagg FeatureFlagsIntegration', () async {
+    test('should add feature flag FeatureFlagsIntegration', () async {
       await Sentry.init(
         options: defaultTestOptions(),
         (options) => options.dsn = fakeDsn,
@@ -319,6 +319,20 @@ void main() {
             .value,
         equals(true),
       );
+    });
+
+    test('addFeatureFlag ignores non-boolean values', () async {
+      await Sentry.init(
+        options: defaultTestOptions(),
+            (options) => options.dsn = fakeDsn,
+      );
+
+      await Sentry.addFeatureFlag('foo1', 'some string');
+      await Sentry.addFeatureFlag('foo2', 123);
+      await Sentry.addFeatureFlag('foo3', 1.23);
+
+      final featureFlagsContext = Sentry.currentHub.scope.contexts[SentryFeatureFlags.type];
+      expect(featureFlagsContext, isNull);
     });
 
     test('should close integrations', () async {


### PR DESCRIPTION
> It must accept a key of type string and a value which is a union of string, boolean, integer, float, and structure

the specs allow for multiple types  even though we only accept booleans currently. 

This will be advantageous in the future when we eventually allow more types.

#skip-changelog