### PR TITLE
Clean up `getSpan()` log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 - Improve performance of frames tracking ([#2854](https://github.com/getsentry/sentry-dart/pull/2854))
+- Clean up `getSpan()` log ([#2865](https://github.com/getsentry/sentry-dart/pull/2865))
 
 ### Fixes
 

--- a/dart/lib/src/hub.dart
+++ b/dart/lib/src/hub.dart
@@ -544,12 +544,7 @@ class Hub {
         SentryLevel.warning,
         "Instance is disabled and this 'getSpan' call is a no-op.",
       );
-    } else if (!_options.isTracingEnabled()) {
-      _options.logger(
-        SentryLevel.info,
-        "Tracing is disabled and this 'getSpan' returns null.",
-      );
-    } else {
+    } else if (_options.isTracingEnabled()) {
       final item = _peek();
 
       span = item.scope.span;

--- a/dart/lib/src/sentry.dart
+++ b/dart/lib/src/sentry.dart
@@ -364,6 +364,7 @@ class Sentry {
       );
 
   /// Gets the current active transaction or span bound to the scope.
+  /// Returns null if performance is disable in the options.
   static ISentrySpan? getSpan() => _hub.getSpan();
 
   @internal

--- a/dart/lib/src/sentry.dart
+++ b/dart/lib/src/sentry.dart
@@ -364,7 +364,7 @@ class Sentry {
       );
 
   /// Gets the current active transaction or span bound to the scope.
-  /// Returns null if performance is disabled in the options.
+  /// Returns `null` if performance is disabled in the options.
   static ISentrySpan? getSpan() => _hub.getSpan();
 
   @internal

--- a/dart/lib/src/sentry.dart
+++ b/dart/lib/src/sentry.dart
@@ -364,7 +364,7 @@ class Sentry {
       );
 
   /// Gets the current active transaction or span bound to the scope.
-  /// Returns null if performance is disable in the options.
+  /// Returns null if performance is disabled in the options.
   static ISentrySpan? getSpan() => _hub.getSpan();
 
   @internal


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Lots of our integrations use `getSpan` and if someone uses multiple integations with performance turned off, this would spam their consoles.

Instead we should opt to document the behaviour in the function docs.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Small step towards #2859 

Closes #2855 

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
