### PR TITLE
Set `anrEnabled` to true by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Set `anrEnabled` to true by default ([#2877](https://github.com/getsentry/sentry-dart/pull/2877))
 - Generate new trace on navigation ([#2861](https://github.com/getsentry/sentry-dart/pull/2861))
   - If you have the `SentryNavigatorObserver` installed in your routing, errors and spans will now be linked in a trace properly.
 - Add `FeatureFlagIntegration` ([#2825](https://github.com/getsentry/sentry-dart/pull/2825))

--- a/flutter/android/src/test/kotlin/io/sentry/flutter/SentryFlutterTest.kt
+++ b/flutter/android/src/test/kotlin/io/sentry/flutter/SentryFlutterTest.kt
@@ -47,7 +47,7 @@ class SentryFlutterTest {
     assertEquals(false, fixture.options.isEnableUserInteractionBreadcrumbs)
     assertEquals(9003, fixture.options.maxBreadcrumbs)
     assertEquals(9004, fixture.options.maxCacheItems)
-    assertEquals(false, fixture.options.isAnrEnabled)
+    assertEquals(true, fixture.options.isAnrEnabled)
     assertEquals(true, fixture.options.isSendDefaultPii)
     assertEquals(false, fixture.options.isEnableScopeSync)
     assertEquals("fixture-proguardUuid", fixture.options.proguardUuid)

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -65,10 +65,9 @@ class SentryFlutterOptions extends SentryOptions {
 
   /// Enable or disable ANR (Application Not Responding).
   /// Available only for Android.
-  /// Disabled by default as the stack trace most of the time is hanging on
-  /// the MessageChannel from Flutter, but you can enable it if you have
-  /// Java/Kotlin code as well.
-  bool anrEnabled = false;
+  ///
+  /// Default is `true`.
+  bool anrEnabled = true;
 
   Duration _anrTimeoutInterval = Duration(milliseconds: 5000);
 
@@ -405,8 +404,5 @@ class SentryFlutterOptions extends SentryOptions {
 /// [debounce] indicates if capturing is marked for being debounced.
 ///
 /// Returns `true` if capturing should be performed, otherwise `false`.
-typedef BeforeCaptureCallback = FutureOr<bool> Function(
-  SentryEvent event,
-  Hint hint,
-  bool debounce,
-);
+typedef BeforeCaptureCallback =
+    FutureOr<bool> Function(SentryEvent event, Hint hint, bool debounce);


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
We can now safely set it to true. See referenced issue for more details

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2864 

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
