### PR TITLE
v9: Remove `other` from `SentryRequest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ await SentryFlutter.init(
 ### API Changes
 
 - Update naming of `LoadImagesListIntegration` to `LoadNativeDebugImagesIntegration` ([#2833](https://github.com/getsentry/sentry-dart/pull/2833))
+- Remove `other` from `SentryRequest` ([#2879](https://github.com/getsentry/sentry-dart/pull/2879))
 
 ### Dependencies
 

--- a/dart/lib/src/http_client/failed_request_client.dart
+++ b/dart/lib/src/http_client/failed_request_client.dart
@@ -1,13 +1,14 @@
 import 'package:http/http.dart';
+
 import '../hint.dart';
-import '../type_check_hint.dart';
-import '../utils/tracing_utils.dart';
-import 'sentry_http_client_error.dart';
-import '../protocol.dart';
 import '../hub.dart';
 import '../hub_adapter.dart';
+import '../protocol.dart';
 import '../throwable_mechanism.dart';
+import '../type_check_hint.dart';
+import '../utils/tracing_utils.dart';
 import 'sentry_http_client.dart';
+import 'sentry_http_client_error.dart';
 
 /// A [http](https://pub.dev/packages/http)-package compatible HTTP client
 /// which records events for failed requests.
@@ -177,11 +178,6 @@ class FailedRequestClient extends BaseClient {
       headers: _hub.options.sendDefaultPii ? request.headers : null,
       uri: request.url,
       data: _hub.options.sendDefaultPii ? _getDataFromRequest(request) : null,
-      // ignore: deprecated_member_use_from_same_package
-      other: {
-        'content_length': request.contentLength.toString(),
-        'duration': requestDuration.toString(),
-      },
     );
 
     final mechanism = Mechanism(

--- a/dart/lib/src/protocol/sentry_request.dart
+++ b/dart/lib/src/protocol/sentry_request.dart
@@ -1,8 +1,8 @@
 import 'package:meta/meta.dart';
-import 'access_aware_map.dart';
 
-import '../utils/iterable_utils.dart';
 import '../utils/http_sanitizer.dart';
+import '../utils/iterable_utils.dart';
+import 'access_aware_map.dart';
 
 /// The Request interface contains information on a HTTP request related to the event.
 /// In client SDKs, this can be an outgoing request, or the request that rendered the current web page.
@@ -58,11 +58,6 @@ class SentryRequest {
   /// This is where information such as CGI/WSGI/Rack keys go that are not HTTP headers.
   Map<String, String> get env => Map.unmodifiable(_env ?? const {});
 
-  Map<String, String>? _other;
-
-  @Deprecated('Will be removed in v8. Use [data] instead')
-  Map<String, String> get other => Map.unmodifiable(_other ?? const {});
-
   /// The fragment of the request URL.
   String? fragment;
 
@@ -86,8 +81,6 @@ class SentryRequest {
     dynamic data,
     Map<String, String>? headers,
     Map<String, String>? env,
-    @Deprecated('Will be removed in v8. Use [data] instead')
-    Map<String, String>? other,
     this.unknown,
   })  : _data = data,
         _headers = headers != null ? Map.from(headers) : null,
@@ -97,8 +90,7 @@ class SentryRequest {
               headers?.entries,
               (MapEntry<String, String> e) => e.key.toLowerCase() == 'cookie',
             )?.value,
-        _env = env != null ? Map.from(env) : null,
-        _other = other != null ? Map.from(other) : null;
+        _env = env != null ? Map.from(env) : null;
 
   factory SentryRequest.fromUri({
     required Uri uri,
@@ -108,8 +100,6 @@ class SentryRequest {
     Map<String, String>? headers,
     Map<String, String>? env,
     String? apiTarget,
-    @Deprecated('Will be removed in v8. Use [data] instead')
-    Map<String, String>? other,
   }) {
     final request = SentryRequest(
       url: uri.toString(),
@@ -121,7 +111,6 @@ class SentryRequest {
       queryString: uri.query,
       fragment: uri.fragment,
       // ignore: deprecated_member_use_from_same_package
-      other: other,
       apiTarget: apiTarget,
     );
     request.sanitize();
@@ -139,8 +128,6 @@ class SentryRequest {
       data: json['data'],
       headers: json.containsKey('headers') ? Map.from(json['headers']) : null,
       env: json.containsKey('env') ? Map.from(json['env']) : null,
-      // ignore: deprecated_member_use_from_same_package
-      other: json.containsKey('other') ? Map.from(json['other']) : null,
       fragment: json['fragment'],
       apiTarget: json['api_target'],
       unknown: json.notAccessed(),
@@ -158,8 +145,6 @@ class SentryRequest {
       if (cookies != null) 'cookies': cookies,
       if (headers.isNotEmpty) 'headers': headers,
       if (env.isNotEmpty) 'env': env,
-      // ignore: deprecated_member_use_from_same_package
-      if (other.isNotEmpty) 'other': other,
       if (fragment != null) 'fragment': fragment,
       if (apiTarget != null) 'api_target': apiTarget,
     };
@@ -177,8 +162,6 @@ class SentryRequest {
     Map<String, String>? env,
     bool removeCookies = false,
     String? apiTarget,
-    @Deprecated('Will be removed in v8. Use [data] instead')
-    Map<String, String>? other,
   }) =>
       SentryRequest(
         url: url ?? this.url,
@@ -190,8 +173,6 @@ class SentryRequest {
         env: env ?? _env,
         fragment: fragment ?? this.fragment,
         apiTarget: apiTarget ?? this.apiTarget,
-        // ignore: deprecated_member_use_from_same_package
-        other: other ?? _other,
         unknown: unknown,
       );
 }

--- a/dart/test/http_client/failed_request_client_test.dart
+++ b/dart/test/http_client/failed_request_client_test.dart
@@ -62,10 +62,6 @@ void main() {
       expect(request?.fragment, 'myFragment');
       expect(request?.cookies, isNull);
       expect(request?.headers, {});
-      // ignore: deprecated_member_use_from_same_package
-      expect(request?.other.keys.contains('duration'), true);
-      // ignore: deprecated_member_use_from_same_package
-      expect(request?.other.keys.contains('content_length'), true);
 
       // Response is not captured in case of exception
       expect(eventCall.contexts.response, isNull);
@@ -174,10 +170,6 @@ void main() {
       expect(request?.fragment, 'myFragment');
       expect(request?.cookies, isNull);
       expect(request?.headers, {});
-      // ignore: deprecated_member_use_from_same_package
-      expect(request?.other.keys.contains('duration'), true);
-      // ignore: deprecated_member_use_from_same_package
-      expect(request?.other.keys.contains('content_length'), true);
 
       final response = eventCall.contexts.response!;
       expect(response.bodySize, 3);

--- a/dart/test/protocol/sentry_request_test.dart
+++ b/dart/test/protocol/sentry_request_test.dart
@@ -26,7 +26,6 @@ void main() {
     'headers': {'header_key': 'header_value'},
     'env': {'env_key': 'env_value'},
     'api_target': 'GraphQL',
-    'other': {'other_key': 'other_value'},
   };
   sentryRequestJson.addAll(testUnknown);
 

--- a/dart/test/protocol/sentry_request_test.dart
+++ b/dart/test/protocol/sentry_request_test.dart
@@ -14,8 +14,6 @@ void main() {
     headers: {'header_key': 'header_value'},
     env: {'env_key': 'env_value'},
     apiTarget: 'GraphQL',
-    // ignore: deprecated_member_use_from_same_package
-    other: {'other_key': 'other_value'},
     unknown: testUnknown,
   );
 

--- a/flutter/lib/src/screenshot/screenshot.dart
+++ b/flutter/lib/src/screenshot/screenshot.dart
@@ -1,7 +1,5 @@
 import 'dart:async';
 import 'dart:developer';
-import 'dart:ui';
-// ignore: unnecessary_import // backcompatibility for Flutter < 3.3
 import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
@@ -18,7 +16,12 @@ class Screenshot {
 
   Screenshot(this._image, this.timestamp, this.flow);
   Screenshot._cloned(
-      this._image, this.timestamp, this.flow, this._rawRgbaData, this._pngData);
+    this._image,
+    this.timestamp,
+    this.flow,
+    this._rawRgbaData,
+    this._pngData,
+  );
 
   int get width => _image.width;
   int get height => _image.height;
@@ -52,7 +55,12 @@ class Screenshot {
   Screenshot clone() {
     assert(!_disposed, 'Cannot clone a disposed screenshot');
     return Screenshot._cloned(
-        _image.clone(), timestamp, flow, _rawRgbaData, _pngData);
+      _image.clone(),
+      timestamp,
+      flow,
+      _rawRgbaData,
+      _pngData,
+    );
   }
 
   void dispose() {

--- a/flutter/lib/src/screenshot/screenshot.dart
+++ b/flutter/lib/src/screenshot/screenshot.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 import 'dart:developer';
-import 'dart:typed_data';
+import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 import 'package:meta/meta.dart';


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Part of v9, this field is not part of the specs anymore and was planned to be removed in v8

Closes https://github.com/getsentry/sentry-dart/issues/1441

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
