### PR TITLE
fix: onError should be `handled: false` by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Errors caught by `OnErrorIntegration` should be unhandled by default ([#2901](https://github.com/getsentry/sentry-dart/pull/2901))
+  - This will not affect grouping
+  - This might affect crash-free rate
+
 ## 9.0.0-beta.1
 
 ### Features

--- a/flutter/lib/src/integrations/on_error_integration.dart
+++ b/flutter/lib/src/integrations/on_error_integration.dart
@@ -40,6 +40,19 @@ class OnErrorIntegration implements Integration<SentryFlutterOptions> {
 
     _integrationOnError = (Object exception, StackTrace stackTrace) {
       final handled = _defaultOnError?.call(exception, stackTrace) ?? false;
+      // If the original `onError` callback returned `true` the framework
+      // treats the exception as already handled and suppresses the default
+      // error printing. To make sure these exceptions are still visible
+      // to developers (and to Sentry), we log them explicitly here.
+      if (handled) {
+        options.logger(
+          SentryLevel.error,
+          'Uncaught Platform Error',
+          logger: 'sentry.platformError',
+          exception: exception,
+          stackTrace: stackTrace,
+        );
+      }
 
       // As per docs, the app might crash on some platforms
       // after this is called.

--- a/flutter/lib/src/integrations/on_error_integration.dart
+++ b/flutter/lib/src/integrations/on_error_integration.dart
@@ -41,14 +41,6 @@ class OnErrorIntegration implements Integration<SentryFlutterOptions> {
     _defaultOnError = wrapper.onError;
 
     _integrationOnError = (Object exception, StackTrace stackTrace) {
-      _options!.logger(
-        SentryLevel.error,
-        "Uncaught Platform Error",
-        logger: 'sentry.platformError',
-        exception: exception,
-        stackTrace: stackTrace,
-      );
-
       final handled = _defaultOnError?.call(exception, stackTrace) ?? false;
 
       // As per docs, the app might crash on some platforms

--- a/flutter/lib/src/integrations/on_error_integration.dart
+++ b/flutter/lib/src/integrations/on_error_integration.dart
@@ -49,7 +49,7 @@ class OnErrorIntegration implements Integration<SentryFlutterOptions> {
         stackTrace: stackTrace,
       );
 
-      final handled = _defaultOnError?.call(exception, stackTrace) ?? true;
+      final handled = _defaultOnError?.call(exception, stackTrace) ?? false;
 
       // As per docs, the app might crash on some platforms
       // after this is called.

--- a/flutter/lib/src/integrations/on_error_integration.dart
+++ b/flutter/lib/src/integrations/on_error_integration.dart
@@ -23,11 +23,9 @@ class OnErrorIntegration implements Integration<SentryFlutterOptions> {
   ErrorCallback? _defaultOnError;
   ErrorCallback? _integrationOnError;
   PlatformDispatcherWrapper? dispatchWrapper;
-  SentryFlutterOptions? _options;
 
   @override
   void call(Hub hub, SentryFlutterOptions options) {
-    _options = options;
     final binding = options.bindingUtils.instance;
 
     if (binding == null) {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2898 

Note:
 - I checked and this does not affect grouping
 - This will however affect crash free rate but we're still including this in a new major so we have to call this out properly

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
