### PR TITLE
refactor(export): add sentry transformer to `sentry_dio` exports

### DIFF
--- a/dio/lib/sentry_dio.dart
+++ b/dio/lib/sentry_dio.dart
@@ -5,3 +5,6 @@ export 'src/sentry_dio_extension.dart';
 // Export the processor in case people want to use it standalone.
 // Normally one doesn't need to use it directly.
 export 'src/dio_event_processor.dart';
+
+// Export the transformer in case people want to use it standalone.
+export 'src/sentry_transformer.dart';


### PR DESCRIPTION
## :scroll: Description

Exports the `SentryTransformer` class from the `sentry_dio` package (`src/sentry_transformer.dart`).

This makes the transformer class available for users to import and utilize directly if needed for custom Dio client transformer configurations.

## :bulb: Motivation and Context

When integrating Sentry with Dio, the `addSentry()` method overwrites Dio's default transformer with Sentry's own wrapper - `SentryTransformer`. However, in some cases, there are performance benefits of Dio's `BackgroundTransformer` (that could be passed to the `SentryTransformer`'s `transformer` parameter), which processes large payloads (>50KB) in separate isolates. But since `SentryTransformer` is not exported, there is no easy way to do it.

## :green_heart: How did you test it?

- Verified that the package (`sentry_dio`) compiles successfully with the added export.
- Manually confirmed in a sample project that `SentryTransformer` can be successfully imported via `import 'package:sentry_dio/sentry_dio.dart';`.
- The need for this change was identified through performance analysis in an application experiencing UI freezes when decoding large (multi-MB) JSON responses after integrating `sentry_dio`.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] Tests are not needed for exports
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps

Consider adding documentation explaining what `addSentry()` does under the hood and how it could be customized.
