### PR TITLE
docs(sentry-dio): improve `addSentry` method documentation

### DIFF
--- a/dio/lib/src/sentry_dio_extension.dart
+++ b/dio/lib/src/sentry_dio_extension.dart
@@ -14,11 +14,11 @@ import 'version.dart';
 extension SentryDioExtension on Dio {
   /// Adds support for automatic spans for http requests,
   /// as well as request and response transformations.
-  /// This must be the last initialization step of the [Dio] setup. Sentry will use 
-  /// your configuration, so update it first, and call `addSentry()` as the last step.
-  /// Since Sentry does not override any user configuration, it then uses whatever 
-  /// transformer, adapter, etc., you configured [Dio] to use.
-  /// 
+  /// This must be the last initialization step of the [Dio] setup. Sentry will
+  /// use your configuration, so update it first, and call `addSentry()` as the
+  /// last step. Since Sentry does not override any user configuration, it then
+  /// uses whatever transformer, adapter, etc., you configured [Dio] to use.
+  ///
   /// ```dart
   /// final dio = Dio();
   /// dio.transformer = YourCustomTransformer();

--- a/dio/lib/src/sentry_dio_extension.dart
+++ b/dio/lib/src/sentry_dio_extension.dart
@@ -14,8 +14,17 @@ import 'version.dart';
 extension SentryDioExtension on Dio {
   /// Adds support for automatic spans for http requests,
   /// as well as request and response transformations.
-  /// This must be the last initialization step of the [Dio] setup, otherwise
-  /// your configuration of Dio might overwrite the Sentry configuration.
+  /// This must be the last initialization step of the [Dio] setup. Sentry will use 
+  /// your configuration, so update it first, and call `addSentry()` as the last step.
+  /// Since Sentry does not override any user configuration, it then uses whatever 
+  /// transformer, adapter, etc., you configured [Dio] to use.
+  /// 
+  /// ```dart
+  /// final dio = Dio();
+  /// dio.transformer = YourCustomTransformer();
+  /// dio.httpClientAdapter = YourCustomHttpClientAdapter();
+  /// dio.addSentry();
+  /// ```
   ///
   /// You can also configure specific HTTP response codes to be considered
   /// as a failed request. In the following example, the status codes 404 and 500


### PR DESCRIPTION
## :scroll: Description

Improves the `addSentry()` method documentation in the `sentry_dio` package with clearer usage examples and explanation.

The updated docs now clearly explain that Sentry should be added as the last step in Dio configuration, ensuring that it uses the user's custom configuration rather than overriding it. Kudos to @ueman.

## :bulb: Motivation and Context

When integrating Sentry with Dio, users need to understand the correct order of operations. Previously, the documentation didn't fully clarify that `addSentry()` should be called last after any custom transformer or adapter configuration. This led to confusion when users wanted to use custom Dio components alongside Sentry.

This documentation improvement addresses the "Next steps" item from the [previous PR](https://github.com/getsentry/sentry-dart/pull/2911#issuecomment-2853756421) that exported `SentryTransformer`, by explaining how `addSentry()` works with custom configurations.

## :green_heart: How did you test it?

- Verified that the documentation is technically accurate with respect to how `addSentry()` functions.
- Ensured the documentation provides clear guidance on integration order.

## :pencil: Checklist
- [x] I reviewed submitted code
- [x] Tests are not needed for documentation changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs (that's what this PR is about)
- [x] All tests passing
- [x] No breaking changes

#skip-changelog