### PR TITLE
Fix feature flag model keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix feature flag model keys ([#2943](https://github.com/getsentry/sentry-dart/pull/2943))
+
 ## 9.0.0-RC
 
 ### Various fixes & improvements

--- a/dart/lib/src/feature_flags_integration.dart
+++ b/dart/lib/src/feature_flags_integration.dart
@@ -16,7 +16,7 @@ class FeatureFlagsIntegration extends Integration<SentryOptions> {
     options.sdk.addIntegration('FeatureFlagsIntegration');
   }
 
-  FutureOr<void> addFeatureFlag(String name, bool value) async {
+  FutureOr<void> addFeatureFlag(String flag, bool result) async {
     final flags =
         _hub?.scope.contexts[SentryFeatureFlags.type] as SentryFeatureFlags? ??
             SentryFeatureFlags(values: []);
@@ -26,11 +26,11 @@ class FeatureFlagsIntegration extends Integration<SentryOptions> {
       values.removeAt(0);
     }
 
-    final index = values.indexWhere((element) => element.name == name);
+    final index = values.indexWhere((element) => element.flag == flag);
     if (index != -1) {
-      values[index] = SentryFeatureFlag(name: name, value: value);
+      values[index] = SentryFeatureFlag(flag: flag, result: result);
     } else {
-      values.add(SentryFeatureFlag(name: name, value: value));
+      values.add(SentryFeatureFlag(flag: flag, result: result));
     }
 
     flags.values = values;

--- a/dart/lib/src/protocol/sentry_feature_flag.dart
+++ b/dart/lib/src/protocol/sentry_feature_flag.dart
@@ -3,15 +3,15 @@ import 'package:meta/meta.dart';
 import 'access_aware_map.dart';
 
 class SentryFeatureFlag {
-  final String name;
-  final bool value;
+  final String flag;
+  final bool result;
 
   @internal
   final Map<String, dynamic>? unknown;
 
   SentryFeatureFlag({
-    required this.name,
-    required this.value,
+    required this.flag,
+    required this.result,
     this.unknown,
   });
 
@@ -19,8 +19,8 @@ class SentryFeatureFlag {
     final json = AccessAwareMap(data);
 
     return SentryFeatureFlag(
-      name: json['name'],
-      value: json['value'],
+      flag: json['flag'],
+      result: json['result'],
       unknown: json.notAccessed(),
     );
   }
@@ -28,20 +28,20 @@ class SentryFeatureFlag {
   Map<String, dynamic> toJson() {
     return {
       ...?unknown,
-      'name': name,
-      'value': value,
+      'flag': flag,
+      'result': result,
     };
   }
 
   @Deprecated('Assign values directly to the instance.')
   SentryFeatureFlag copyWith({
-    String? name,
-    bool? value,
+    String? flag,
+    bool? result,
     Map<String, dynamic>? unknown,
   }) {
     return SentryFeatureFlag(
-      name: name ?? this.name,
-      value: value ?? this.value,
+      flag: flag ?? this.flag,
+      result: result ?? this.result,
       unknown: unknown ?? this.unknown,
     );
   }

--- a/dart/lib/src/sentry.dart
+++ b/dart/lib/src/sentry.dart
@@ -365,8 +365,8 @@ class Sentry {
   /// Returns `null` if performance is disabled in the options.
   static ISentrySpan? getSpan() => _hub.getSpan();
 
-  static Future<void> addFeatureFlag(String name, dynamic value) async {
-    if (value is! bool) {
+  static Future<void> addFeatureFlag(String flag, dynamic result) async {
+    if (result is! bool) {
       return;
     }
 
@@ -382,7 +382,7 @@ class Sentry {
       return;
     }
 
-    await featureFlagsIntegration.addFeatureFlag(name, value);
+    await featureFlagsIntegration.addFeatureFlag(flag, result);
   }
 
   @internal

--- a/dart/test/contexts_test.dart
+++ b/dart/test/contexts_test.dart
@@ -49,8 +49,8 @@ void main() {
 
     final flags = SentryFeatureFlags(
       values: [
-        SentryFeatureFlag(name: 'feature_flag_1', value: true),
-        SentryFeatureFlag(name: 'feature_flag_2', value: false),
+        SentryFeatureFlag(flag: 'feature_flag_1', result: true),
+        SentryFeatureFlag(flag: 'feature_flag_2', result: false),
       ],
     );
 
@@ -104,8 +104,8 @@ void main() {
       'version': {'value': 9},
       'flags': {
         'values': [
-          {'name': 'feature_flag_1', 'value': true},
-          {'name': 'feature_flag_2', 'value': false},
+          {'flag': 'feature_flag_1', 'result': true},
+          {'flag': 'feature_flag_2', 'result': false},
         ]
       },
     };
@@ -204,8 +204,8 @@ void main() {
       final contexts = Contexts();
       contexts.flags = SentryFeatureFlags(
         values: [
-          SentryFeatureFlag(name: 'feature_flag_1', value: true),
-          SentryFeatureFlag(name: 'feature_flag_2', value: false),
+          SentryFeatureFlag(flag: 'feature_flag_1', result: true),
+          SentryFeatureFlag(flag: 'feature_flag_2', result: false),
         ],
       );
       expect(contexts.flags!.toJson(), flags.toJson());
@@ -323,8 +323,8 @@ const jsonContexts = '''
    "gpu": {"name": "Radeon", "version": "1"},
    "flags": {
       "values": [
-        {"name": "feature_flag_1", "value": true},
-        {"name": "feature_flag_2", "value": false}
+        {"flag": "feature_flag_1", "result": true},
+        {"flag": "feature_flag_2", "result": false}
       ]
    }
 }

--- a/dart/test/feature_flags_integration_test.dart
+++ b/dart/test/feature_flags_integration_test.dart
@@ -32,10 +32,11 @@ void main() {
 
     expect(fixture.hub.scope.contexts[SentryFeatureFlags.type], isNotNull);
     expect(
-        fixture.hub.scope.contexts[SentryFeatureFlags.type]?.values.first.name,
+        fixture.hub.scope.contexts[SentryFeatureFlags.type]?.values.first.flag,
         equals('foo'));
     expect(
-        fixture.hub.scope.contexts[SentryFeatureFlags.type]?.values.first.value,
+        fixture
+            .hub.scope.contexts[SentryFeatureFlags.type]?.values.first.result,
         equals(true));
   });
 
@@ -49,10 +50,11 @@ void main() {
 
     expect(fixture.hub.scope.contexts[SentryFeatureFlags.type], isNotNull);
     expect(
-        fixture.hub.scope.contexts[SentryFeatureFlags.type]?.values.first.name,
+        fixture.hub.scope.contexts[SentryFeatureFlags.type]?.values.first.flag,
         equals('foo'));
     expect(
-        fixture.hub.scope.contexts[SentryFeatureFlags.type]?.values.first.value,
+        fixture
+            .hub.scope.contexts[SentryFeatureFlags.type]?.values.first.result,
         equals(false));
   });
 
@@ -69,17 +71,18 @@ void main() {
         equals(100));
 
     expect(
-        fixture.hub.scope.contexts[SentryFeatureFlags.type]?.values.first.name,
+        fixture.hub.scope.contexts[SentryFeatureFlags.type]?.values.first.flag,
         equals('foo_0'));
     expect(
-        fixture.hub.scope.contexts[SentryFeatureFlags.type]?.values.first.value,
+        fixture
+            .hub.scope.contexts[SentryFeatureFlags.type]?.values.first.result,
         equals(true));
 
     expect(
-        fixture.hub.scope.contexts[SentryFeatureFlags.type]?.values.last.name,
+        fixture.hub.scope.contexts[SentryFeatureFlags.type]?.values.last.flag,
         equals('foo_99'));
     expect(
-        fixture.hub.scope.contexts[SentryFeatureFlags.type]?.values.last.value,
+        fixture.hub.scope.contexts[SentryFeatureFlags.type]?.values.last.result,
         equals(false));
 
     await sut.addFeatureFlag('foo_100', true);
@@ -88,17 +91,18 @@ void main() {
         equals(100));
 
     expect(
-        fixture.hub.scope.contexts[SentryFeatureFlags.type]?.values.first.name,
+        fixture.hub.scope.contexts[SentryFeatureFlags.type]?.values.first.flag,
         equals('foo_1'));
     expect(
-        fixture.hub.scope.contexts[SentryFeatureFlags.type]?.values.first.value,
+        fixture
+            .hub.scope.contexts[SentryFeatureFlags.type]?.values.first.result,
         equals(false));
 
     expect(
-        fixture.hub.scope.contexts[SentryFeatureFlags.type]?.values.last.name,
+        fixture.hub.scope.contexts[SentryFeatureFlags.type]?.values.last.flag,
         equals('foo_100'));
     expect(
-        fixture.hub.scope.contexts[SentryFeatureFlags.type]?.values.last.value,
+        fixture.hub.scope.contexts[SentryFeatureFlags.type]?.values.last.result,
         equals(true));
   });
 }

--- a/dart/test/protocol/contexts_test.dart
+++ b/dart/test/protocol/contexts_test.dart
@@ -38,6 +38,9 @@ void main() {
     culture: SentryCulture(locale: 'foo-bar'),
     trace: _trace,
     feedback: _feedback,
+    flags: SentryFeatureFlags(values: [
+      SentryFeatureFlag(flag: 'name', result: true),
+    ]),
   );
 
   final _contextsJson = <String, dynamic>{
@@ -63,7 +66,12 @@ void main() {
       'replay_id': 'fixture-replayId',
       'url': 'https://fixture-url.com',
       'associated_event_id': '8a32c0f9be1d34a5efb2c4a10d80de9a',
-    }
+    },
+    'flags': {
+      'values': [
+        {'flag': 'name', 'result': true}
+      ],
+    },
   };
 
   final _contextsMutlipleRuntimes = Contexts(

--- a/dart/test/protocol/sentry_feature_flag_tests.dart
+++ b/dart/test/protocol/sentry_feature_flag_tests.dart
@@ -6,14 +6,14 @@ import '../mocks.dart';
 
 void main() {
   final featureFlag = SentryFeatureFlag(
-    name: 'feature_flag_1',
-    value: true,
+    flag: 'feature_flag_1',
+    result: true,
     unknown: testUnknown,
   );
   final featureFlagJson = <String, dynamic>{
     ...testUnknown,
-    'name': 'feature_flag_1',
-    'value': true,
+    'flag': 'feature_flag_1',
+    'result': true,
   };
 
   group('json', () {

--- a/dart/test/protocol/sentry_feature_flags_tests.dart
+++ b/dart/test/protocol/sentry_feature_flags_tests.dart
@@ -7,8 +7,8 @@ import '../mocks.dart';
 void main() {
   final featureFlags = SentryFeatureFlags(
     values: [
-      SentryFeatureFlag(name: 'feature_flag_1', value: true),
-      SentryFeatureFlag(name: 'feature_flag_2', value: false),
+      SentryFeatureFlag(flag: 'feature_flag_1', result: true),
+      SentryFeatureFlag(flag: 'feature_flag_2', result: false),
     ],
     unknown: testUnknown,
   );

--- a/dart/test/scope_test.dart
+++ b/dart/test/scope_test.dart
@@ -440,7 +440,7 @@ void main() {
       await scope.setContexts(
           SentryFeatureFlags.type,
           SentryFeatureFlags(
-            values: [SentryFeatureFlag(name: 'foo', value: true)],
+            values: [SentryFeatureFlag(flag: 'foo', result: true)],
           ));
       await scope.setUser(scopeUser);
 
@@ -456,10 +456,10 @@ void main() {
       expect(
           updatedEvent?.extra, {'e-infos': 'abc', 'company-name': 'Dart Inc'});
       expect(updatedEvent?.contexts['theme'], {'value': 'material'});
-      expect(updatedEvent?.contexts[SentryFeatureFlags.type]?.values.first.name,
+      expect(updatedEvent?.contexts[SentryFeatureFlags.type]?.values.first.flag,
           'foo');
       expect(
-          updatedEvent?.contexts[SentryFeatureFlags.type]?.values.first.value,
+          updatedEvent?.contexts[SentryFeatureFlags.type]?.values.first.result,
           true);
     });
 

--- a/dart/test/sentry_test.dart
+++ b/dart/test/sentry_test.dart
@@ -313,12 +313,12 @@ void main() {
 
       expect(
         Sentry.currentHub.scope.contexts[SentryFeatureFlags.type]?.values.first
-            .name,
+            .flag,
         equals('foo'),
       );
       expect(
         Sentry.currentHub.scope.contexts[SentryFeatureFlags.type]?.values.first
-            .value,
+            .result,
         equals(true),
       );
     });

--- a/firebase_remote_config/test/src/sentry_firebase_remote_config_integration_test.dart
+++ b/firebase_remote_config/test/src/sentry_firebase_remote_config_integration_test.dart
@@ -69,8 +69,8 @@ void main() {
 
     expect(featureFlags, isNotNull);
     expect(featureFlags?.values.length, 1);
-    expect(featureFlags?.values.first.name, 'test');
-    expect(featureFlags?.values.first.value, true);
+    expect(featureFlags?.values.first.flag, 'test');
+    expect(featureFlags?.values.first.result, true);
   });
 
   test('stream canceld on close', () async {

--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -520,6 +520,13 @@ class MainScaffold extends StatelessWidget {
                   'Demonstrates the logging integration. log.info() will create an info event send it to Sentry.',
               buttonTitle: 'Logging',
             ),
+            TooltipButton(
+              onPressed: () {
+                Sentry.addFeatureFlag('feature-one', true);
+              },
+              text: 'Demonstrates the feature flags.',
+              buttonTitle: 'Add "feature-one" flag',
+            ),
             if (UniversalPlatform.isIOS || UniversalPlatform.isMacOS)
               const CocoaExample(),
             if (UniversalPlatform.isAndroid) const AndroidExample(),


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Uses the correct keys as described in: https://develop.sentry.dev/sdk/data-model/event-payloads/contexts/#feature-flag-context

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Feature flags were not visible on sentry.io

## :green_heart: How did you test it?

Unit tests. Tested with sample app.

https://sentry-sdks.sentry.io/issues/4349777516/events/latest/?project=5428562&query=is%3Aunresolved%20issue.category%3A%5Berror%2Coutage%5D&referrer=latest-event&stream_index=0

<img width="1840" alt="Bildschirmfoto 2025-05-14 um 14 54 57" src="https://github.com/user-attachments/assets/c1bb10fb-c129-428e-a841-d787879145da" />

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
