### PR TITLE
fix(user-interaction): Add `hasSize` guard when using a renderObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Add `hasSize` guard when using a renderObject in `SentryUserInteractionWidget` ([#2946](https://github.com/getsentry/sentry-dart/pull/2946))
+
 ## 9.0.0-RC.1
 
 ### Fixes

--- a/flutter/lib/src/user_interaction/sentry_user_interaction_widget.dart
+++ b/flutter/lib/src/user_interaction/sentry_user_interaction_widget.dart
@@ -205,13 +205,12 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:meta/meta.dart';
+// ignore: implementation_imports
+import 'package:sentry/src/sentry_tracer.dart';
 
 import '../../sentry_flutter.dart';
 import '../widget_utils.dart';
 import 'user_interaction_info.dart';
-
-// ignore: implementation_imports
-import 'package:sentry/src/sentry_tracer.dart';
 
 const _tapDeltaArea = 20 * 20;
 Element? _clickTrackerElement;
@@ -542,10 +541,14 @@ class _SentryUserInteractionWidgetState
         return;
       }
 
+      // Skip elements that don't have a valid render object or whose
+      // render box hasn't been laid out yet.
       final renderObject = element.renderObject;
-      if (renderObject == null) {
+      if (renderObject == null ||
+          (renderObject is RenderBox && !renderObject.hasSize)) {
         return;
       }
+
       var hitFound = true;
       if (renderObject is RenderPointerListener) {
         final hitResult = BoxHitTestResult();


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2887 

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
