### PR TITLE
Truncate feedback message  to max 4096 characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Sentry.logger.warn("This is a warning log with attributes.", attributes: {
   - Capture session replay when processing feedback events
   - Record `feedback` client report for dropped feedback events
   - Record `feedback` client report for errors when using `HttpTransport`
+- Truncate feedback message to max 4096 characters ([#2954](https://github.com/getsentry/sentry-dart/pull/2954))
 
 ### Dependencies
 

--- a/dart/lib/src/sentry_client.dart
+++ b/dart/lib/src/sentry_client.dart
@@ -476,6 +476,10 @@ class SentryClient {
     Scope? scope,
     Hint? hint,
   }) {
+    // Cap feedback messages to max 4096 characters
+    if (feedback.message.length > 4096) {
+      feedback.message = feedback.message.substring(0, 4096);
+    }
     final feedbackEvent = SentryEvent(
       type: 'feedback',
       contexts: Contexts(feedback: feedback),

--- a/dart/test/sentry_client_test.dart
+++ b/dart/test/sentry_client_test.dart
@@ -1701,6 +1701,18 @@ void main() {
       expect(envelopeEvent?.contexts.feedback?.toJson(), feedback.toJson());
       expect(envelopeEvent?.level, SentryLevel.info);
     });
+
+    test('should cap feedback messages to max 4096 characters', () async {
+      final client = fixture.getSut();
+      final feedback = fixture.fakeFeedback();
+      feedback.message = 'a' * 4096 + 'b' * 4096;
+      await client.captureFeedback(feedback);
+
+      final capturedEnvelope = (fixture.transport).envelopes.first;
+      final capturedEvent = await eventFromEnvelope(capturedEnvelope);
+
+      expect(capturedEvent.contexts.feedback?.message, 'a' * 4096);
+    });
   });
 
   group('SentryClient captureLog', () {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Truncate feedback message  to max 4096 characters.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Relates to #2892

## :green_heart: How did you test it?

Unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes
