### PR TITLE
ci: skip flutter test on wasm-beta for now

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -49,6 +49,9 @@ jobs:
             os: ubuntu
           - target: wasm
             os: ubuntu
+        exclude:
+          - target: wasm
+            sdk: beta
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -52,6 +52,7 @@ jobs:
         exclude:
           # Flutter WASM tests don't compile on beta currently.
           # We can re-enable when it is fixed by Flutter.
+          # https://github.com/getsentry/sentry-dart/pull/3003
           - target: wasm
             sdk: beta
 

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -50,6 +50,8 @@ jobs:
           - target: wasm
             os: ubuntu
         exclude:
+          # Flutter WASM tests don't compile on beta currently.
+          # We can re-enable when it is fixed by Flutter.
           - target: wasm
             sdk: beta
 


### PR DESCRIPTION
#skip-changelog

It's currently not able to run the tests. I can repro both in CI and locally

```shell
Run flutter test --platform chrome --wasm --test-randomize-ordering-seed=random --exclude-tags canvasKit
Error: Error when reading '../../.dart_tool/package_config.json': No such file or directory
Error: Couldn't resolve the package 'flutter_test' in 'package:flutter_test/flutter_test.dart'.
Error: Couldn't resolve the package 'sentry_flutter' in 'package:sentry_flutter/sentry_flutter.dart'.
Error: Couldn't resolve the package 'mockito' in 'package:mockito/mockito.dart'.
Error: Couldn't resolve the package 'sentry_flutter' in 'package:sentry_flutter/src/navigation/time_to_full_display_tracker.dart'.
Error: Couldn't resolve the package 'sentry' in 'package:sentry/src/sentry_tracer.dart'.
Error: Couldn't resolve the package 'sentry_flutter' in 'package:sentry_flutter/src/frame_callback_handler.dart'.
Error: Couldn't resolve the package 'sentry_flutter' in 'package:sentry_flutter/src/navigation/time_to_initial_display_tracker.dart'.
Error: Couldn't resolve the package 'flutter' in 'package:flutter/cupertino.dart'.
Error: Couldn't resolve the package 'flutter' in 'package:flutter/material.dart'.
...
```