### PR TITLE
add options to upload more attachments when process android native crash

### DIFF
--- a/flutter/android/src/main/kotlin/io/sentry/flutter/AttachLogcatEventProcess.java
+++ b/flutter/android/src/main/kotlin/io/sentry/flutter/AttachLogcatEventProcess.java
@@ -1,0 +1,59 @@
+package io.sentry.flutter;
+import android.content.Context;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+
+import io.sentry.Attachment;
+import io.sentry.EventProcessor;
+import io.sentry.Hint;
+import io.sentry.SentryEvent;
+
+public class AttachLogcatEventProcess implements EventProcessor {
+    private String getLogcatOutput() {
+        StringBuilder logOutput = new StringBuilder();
+        Process process = null;
+        try {
+            // get most recent 1000 lines of logs and filter warnings.
+            process = Runtime.getRuntime().exec("logcat -d -t 1000 *:W");
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                String line;
+                long maxLogSize = 1024 * 1024 * 2; // 2M
+                while ((line = reader.readLine()) != null) {
+                    if (logOutput.length() + line.length() + 1 > maxLogSize) {
+                        // Stop reading if the log size exceeds a certain limit, add a mark to indicate this.
+                        logOutput.append("Ended due to size limit.").append("\n");
+                        break;
+                    }
+                    logOutput.append(line).append("\n");
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        finally {
+            // destroy process
+            if (process != null) {
+                process.destroy();
+            }
+        }
+        return logOutput.toString();
+    }
+
+    @Override
+    public @Nullable SentryEvent process(@NotNull SentryEvent event, @NotNull Hint hint) {
+        EventProcessor.super.process(event, hint);
+        String logcatOutput = getLogcatOutput();
+        if(!logcatOutput.isEmpty()) {
+            hint.addAttachment(new Attachment(logcatOutput.getBytes(StandardCharsets.UTF_8), "logcat-output.txt", "text/plain"));
+        }
+        return event;
+    }
+}

--- a/flutter/lib/src/native/sentry_native_channel.dart
+++ b/flutter/lib/src/native/sentry_native_channel.dart
@@ -84,6 +84,8 @@ class SentryNativeChannel
       },
       'enableSpotlight': options.spotlight.enabled,
       'spotlightUrl': options.spotlight.url,
+      'attachAndroidLogcat': options.attachAndroidLogcat,
+      'androidAttachmentPaths': options.androidAttachmentPaths,
     });
   }
 

--- a/flutter/lib/src/sentry_flutter_options.dart
+++ b/flutter/lib/src/sentry_flutter_options.dart
@@ -163,6 +163,16 @@ class SentryFlutterOptions extends SentryOptions {
   /// If used on a platform other than Web, this setting will be ignored.
   List<String> denyUrls = [];
 
+  /// (Android only)
+  /// android natvie crash will use this attachment paths when crash happens and upload these attachments via event processor.
+  /// If used on a platform other than Android, it will be ignored.
+  List<String> androidAttachmentPaths = [];
+
+  /// (Android only)
+  /// Indidate that whether the recent android log cat content will be uploaded.
+  /// If used on a platform other than Android, it will be ignored.
+  bool attachAndroidLogcat = false;
+
   /// Enables Out of Memory Tracking for iOS and macCatalyst.
   /// See the following link for more information and possible restrictions:
   /// https://docs.sentry.io/platforms/apple/guides/ios/configuration/out-of-memory/


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
