### PR TITLE
Dont execute app start integration if tracing is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 
 - Fix context to native sync for sentry context types ([#3012](https://github.com/getsentry/sentry-dart/pull/3012))
 
+### Enhancements
+
+- Dont execute app start integration if tracing is disabled ([#3026](https://github.com/getsentry/sentry-dart/pull/3026))
+
+
 ## 9.1.0
 
 ### Features

--- a/flutter/lib/src/integrations/native_app_start_integration.dart
+++ b/flutter/lib/src/integrations/native_app_start_integration.dart
@@ -24,7 +24,7 @@ class NativeAppStartIntegration extends Integration<SentryFlutterOptions> {
   void call(Hub hub, SentryFlutterOptions options) async {
     if (!options.isTracingEnabled()) {
       options.log(SentryLevel.info,
-          '$integrationName integration is disabled. Tracing is not enabled.');
+          'Skipping $integrationName integration because tracing is disabled.');
       return;
     }
 

--- a/flutter/lib/src/integrations/native_app_start_integration.dart
+++ b/flutter/lib/src/integrations/native_app_start_integration.dart
@@ -1,5 +1,7 @@
 import 'dart:ui';
 
+import 'package:meta/meta.dart';
+
 import '../../sentry_flutter.dart';
 import '../frame_callback_handler.dart';
 import 'native_app_start_handler.dart';
@@ -10,6 +12,9 @@ class NativeAppStartIntegration extends Integration<SentryFlutterOptions> {
   NativeAppStartIntegration(
       this._frameCallbackHandler, this._nativeAppStartHandler);
 
+  @internal
+  static const integrationName = 'nativeAppStartIntegration';
+
   final FrameCallbackHandler _frameCallbackHandler;
   final NativeAppStartHandler _nativeAppStartHandler;
 
@@ -17,6 +22,12 @@ class NativeAppStartIntegration extends Integration<SentryFlutterOptions> {
 
   @override
   void call(Hub hub, SentryFlutterOptions options) async {
+    if (!options.isTracingEnabled()) {
+      options.log(SentryLevel.info,
+          '$integrationName is disabled. Tracing is not enabled.');
+      return;
+    }
+
     // Create context early so we have an id to refernce for reporting full display
     final context = SentryTransactionContext(
       'root /',
@@ -59,6 +70,6 @@ class NativeAppStartIntegration extends Integration<SentryFlutterOptions> {
     }
 
     _frameCallbackHandler.addTimingsCallback(timingsCallback);
-    options.sdk.addIntegration('nativeAppStartIntegration');
+    options.sdk.addIntegration(integrationName);
   }
 }

--- a/flutter/lib/src/integrations/native_app_start_integration.dart
+++ b/flutter/lib/src/integrations/native_app_start_integration.dart
@@ -13,7 +13,7 @@ class NativeAppStartIntegration extends Integration<SentryFlutterOptions> {
       this._frameCallbackHandler, this._nativeAppStartHandler);
 
   @internal
-  static const integrationName = 'nativeAppStartIntegration';
+  static const integrationName = 'NativeAppStart';
 
   final FrameCallbackHandler _frameCallbackHandler;
   final NativeAppStartHandler _nativeAppStartHandler;
@@ -24,7 +24,7 @@ class NativeAppStartIntegration extends Integration<SentryFlutterOptions> {
   void call(Hub hub, SentryFlutterOptions options) async {
     if (!options.isTracingEnabled()) {
       options.log(SentryLevel.info,
-          '$integrationName is disabled. Tracing is not enabled.');
+          '$integrationName integration is disabled. Tracing is not enabled.');
       return;
     }
 

--- a/flutter/test/integrations/native_app_start_integration_test.dart
+++ b/flutter/test/integrations/native_app_start_integration_test.dart
@@ -20,6 +20,7 @@ void main() {
 
   setUp(() {
     fixture = Fixture();
+    fixture.options.tracesSampleRate = 1.0;
   });
 
   final _fakeFrameTiming = FrameTiming(
@@ -31,13 +32,21 @@ void main() {
       rasterFinishWallTime: 10);
 
   group('$NativeAppStartIntegration', () {
+    test('does not add integration if tracing is disabled', () {
+      fixture.options.tracesSampleRate = null;
+      fixture.options.tracesSampler = null;
+
+      fixture.callIntegration();
+
+      expect(fixture.options.sdk.integrations,
+          isNot(contains(NativeAppStartIntegration.integrationName)));
+    });
+
     test('adds integration', () async {
       fixture.callIntegration();
 
-      expect(
-          fixture.options.sdk.integrations
-              .contains('nativeAppStartIntegration'),
-          true);
+      expect(fixture.options.sdk.integrations,
+          contains(NativeAppStartIntegration.integrationName));
     });
 
     test('adds timingsCallback', () async {


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Small enhancement


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
