### PR TITLE
deps upgrade Kotlin languageVersion to `1.8`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased 
 
-### Potentially Breaking Change
+### Breaking Change (Tooling)
 
 - Upgrade Kotlin `languageVersion` to `1.8` ([#3032](https://github.com/getsentry/sentry-dart/pull/3032))
   - This allows usage of the Kotlin Android Plugin `2.2.0` which requires a `languageVersion` of `1.8` or higher

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased 
 
+### Potentially Breaking Change
+
+- Upgrade Kotlin `languageVersion` to `1.8` ([#3032](https://github.com/getsentry/sentry-dart/pull/3032))
+  - This allows usage of the Kotlin Android Plugin `2.2.0` which requires a `languageVersion` of `1.8` or higher
+  - If you are experiencing an issue we recommend upgrading to a toolchain compatible with Kotlin `1.8` or higher
+
 ### Features
 
 - SentryFeedbackWidget Improvements ([#2964](https://github.com/getsentry/sentry-dart/pull/2964))
@@ -12,12 +18,6 @@
 // configure your feedback widget
 options.feedback.showBranding = false;
 ```
-
-### Dependencies
-
-- Upgrade Kotlin languageVersion to `1.8` ([#3032](https://github.com/getsentry/sentry-dart/pull/3032))
-  - This allows usage of the Kotlin Android Plugin `2.2.0` which requires a languageVersion of `1.8` or higher
-  - If you are using an older Kotlin/Android toolchain we recommend upgrading to one compatible with Kotlin `1.8` or higher
 
 ## 9.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Unreleased 
+
+### Features
+
+- SentryFeedbackWidget Improvements ([#2964](https://github.com/getsentry/sentry-dart/pull/2964))
+  - Capture a device screenshot for feedback
+  - Customize tests and required fields
+  - Customization moved from the `SentryFeedbackWidget` constructor to `SentryFlutterOptions`:
+```dart
+// configure your feedback widget
+options.feedback.showBranding = false;
+```
+
+### Dependencies
+
+- Upgrade Kotlin languageVersion to `1.8` ([#3032](https://github.com/getsentry/sentry-dart/pull/3032))
+  - This allows usage of the Kotlin Android Plugin `2.2.0` which requires a languageVersion of `1.8` or higher
+  - If you are using an older Kotlin/Android toolchain we recommend upgrading to one compatible with Kotlin `1.8` or higher
+
 ## 9.2.0
 
 ### Features
@@ -7,13 +26,6 @@
 - Add os and device attributes to Flutter logs ([#2978](https://github.com/getsentry/sentry-dart/pull/2978))
 - String templating for structured logs ([#3002](https://github.com/getsentry/sentry-dart/pull/3002))
 - Add user attributes to Dart/Flutter logs ([#3014](https://github.com/getsentry/sentry-dart/pull/3002))
-- SentryFeedbackWidget Improvements ([#2964](https://github.com/getsentry/sentry-dart/pull/2964))
- - Capture a device screenshot for feedback
- - Customize tests and required fields
- - Customization moved from the `SentryFeedbackWidget` constructor to `SentryFlutterOptions`:
-```dart
-options.feedback.showBranding = false;
-```
 
 ### Fixes
 

--- a/flutter/android/build.gradle
+++ b/flutter/android/build.gradle
@@ -55,7 +55,7 @@ android {
     }
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8
-        languageVersion = "1.6"
+        languageVersion = "1.8"
     }
 }
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Fixes  error

```
Task :sentry_flutter:compileDebugKotlin FAILED
e: Language version 1.6 is no longer supported; please, use version 1.8 or greater.
```

which happens when bumping the [kotlin-android](https://plugins.gradle.org/plugin/org.jetbrains.kotlin.android) plugin to `2.2.0`

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3028 

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
