### PR TITLE
fix(jni): update proguard rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### Unreleased
+
+### Fixes
+
+- Replay JNI usage with `SentryFlutterPlugin` ([#3036](https://github.com/getsentry/sentry-dart/pull/3036))
+
 ## 9.3.0
 
 ### Breaking Change (Tooling)

--- a/flutter/android/proguard-rules.pro
+++ b/flutter/android/proguard-rules.pro
@@ -1,5 +1,4 @@
 -keep class io.sentry.flutter.** { *; }
--keepclassmembers class io.sentry.flutter.** { *; }
 
 # Keep replay integration classes used by JNI
 -keep class io.sentry.android.replay.** { *; }

--- a/flutter/android/proguard-rules.pro
+++ b/flutter/android/proguard-rules.pro
@@ -1,4 +1,12 @@
 -keep class io.sentry.flutter.** { *; }
+-keepclassmembers class io.sentry.flutter.** { *; }
+
+# Keep replay integration classes used by JNI
+-keep class io.sentry.android.replay.** { *; }
+
+# Keep bitmap classes used by JNI
+-keep class android.graphics.Bitmap { *; }
+-keep class android.graphics.Bitmap$Config { *; }
 
 # To ensure that stack traces is unambiguous
 # https://developer.android.com/studio/build/shrink-code#decode-stack-trace

--- a/flutter/lib/src/native/java/android_replay_recorder.dart
+++ b/flutter/lib/src/native/java/android_replay_recorder.dart
@@ -140,7 +140,7 @@ class _AndroidNativeReplayWorker {
     // Android Bitmap creation is a bit costly so we reuse it between captures.
     native.Bitmap? bitmap;
 
-    final _nativeReplay = native.SentryFlutterPlugin$Companion(null)
+    final _nativeReplay = native.SentryFlutterPlugin.Companion
         .privateSentryGetReplayIntegration()!;
 
     receivePort.listen((message) {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Running the app in release means the native java symbols names are obfuscated so we need to add additional rules for keeping them in their original names for JNI to work properly

Closes #3030 

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
