### PR TITLE
Update proguard rules to keep `io.sentry.**`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Replay JNI usage with `SentryFlutterPlugin` ([#3036](https://github.com/getsentry/sentry-dart/pull/3036))
+- Replay JNI usage with `SentryFlutterPlugin` ([#3036](https://github.com/getsentry/sentry-dart/pull/3036), [#3039](https://github.com/getsentry/sentry-dart/pull/3039))
 
 ## 9.3.0
 

--- a/flutter/android/proguard-rules.pro
+++ b/flutter/android/proguard-rules.pro
@@ -1,7 +1,5 @@
 -keep class io.sentry.flutter.** { *; }
-
-# Keep replay integration classes used by JNI
--keep class io.sentry.android.replay.** { *; }
+-keep class io.sentry.** { *; }
 
 # Keep bitmap classes used by JNI
 -keep class android.graphics.Bitmap { *; }

--- a/flutter/android/proguard-rules.pro
+++ b/flutter/android/proguard-rules.pro
@@ -1,4 +1,3 @@
--keep class io.sentry.flutter.** { *; }
 -keep class io.sentry.** { *; }
 
 # Keep bitmap classes used by JNI


### PR DESCRIPTION
Update rules to keep all `io.sentry` classes instead of only `io.sentry.android.replay`

Tested the change locally