### PR TITLE
deps: bump Android from `8.12.0` to `8.13.2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Dependencies
 
 - Bump Android SDK from v8.12.0 to v8.13.2 ([#3024](https://github.com/getsentry/sentry-dart/pull/3024))
-    - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8132)
+  - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8132)
   - [diff](https://github.com/getsentry/sentry-java/compare/8.12.0...8.13.2)
 
 ## 9.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Dependencies
 
-- Bump Android SDK from v8.12.0 to v8.13.2 ([#3024](https://github.com/getsentry/sentry-dart/pull/3024))
+- Bump Android SDK from v8.12.0 to v8.13.2 ([#3042](https://github.com/getsentry/sentry-dart/pull/3042))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8132)
   - [diff](https://github.com/getsentry/sentry-java/compare/8.12.0...8.13.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - Replay JNI usage with `SentryFlutterPlugin` ([#3036](https://github.com/getsentry/sentry-dart/pull/3036), [#3039](https://github.com/getsentry/sentry-dart/pull/3039))
 
+### Dependencies
+
+- Bump Android SDK from v8.12.0 to v8.13.2 ([#3024](https://github.com/getsentry/sentry-dart/pull/3024))
+    - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8132)
+  - [diff](https://github.com/getsentry/sentry-java/compare/8.12.0...8.13.2)
+
 ## 9.3.0
 
 ### Breaking Change (Tooling)

--- a/flutter/android/build.gradle
+++ b/flutter/android/build.gradle
@@ -60,7 +60,7 @@ android {
 }
 
 dependencies {
-    api 'io.sentry:sentry-android:8.12.0'
+    api 'io.sentry:sentry-android:8.13.2'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     // Required -- JUnit 4 framework


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Bump the Android SDK to a stable version

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #3041 

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
