### PR TITLE
Respect ancestor text direction in `SentryScreenshotWidget`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Respect ancestor text direction in `SentryScreenshotWidget` ([#3046](https://github.com/getsentry/sentry-dart/pull/3046))
+
 ## 9.4.0-beta.1
 
 ### Fixes

--- a/flutter/lib/src/screenshot/sentry_screenshot_widget.dart
+++ b/flutter/lib/src/screenshot/sentry_screenshot_widget.dart
@@ -122,17 +122,25 @@ class _SentryScreenshotWidgetState extends State<SentryScreenshotWidget> {
       unregisterCallbacks.forEach(SentryScreenshotWidget._onBuild.remove);
     }
 
+    // Detect the current text direction or fall back to LTR
+    TextDirection textDirection;
+    try {
+      textDirection = Directionality.of(context);
+    } catch (_) {
+      textDirection = TextDirection.ltr;
+    }
+
     return RepaintBoundary(
       child: Directionality(
-        textDirection: TextDirection.ltr,
+        textDirection: textDirection,
         child: Stack(
           children: [
             Container(
               child: widget.child,
             ),
             if (_isScreenshotButtonVisible)
-              Positioned(
-                right: 32,
+              PositionedDirectional(
+                end: 32,
                 bottom: 32,
                 child: ElevatedButton.icon(
                   key: const ValueKey(


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Respect ancestor text direction in `SentryScreenshotWidget`

<img width="770" alt="Bildschirmfoto 2025-07-07 um 14 16 33" src="https://github.com/user-attachments/assets/823aab30-d057-4c66-ab62-09f5d4c312c6" />

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #3044 

## :green_heart: How did you test it?

Tried RTL in sample app.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes
