### PR TITLE
Fix flaky `SentryFeedbackWidget` test

### DIFF
--- a/flutter/test/feedback/sentry_feedback_widget_test.dart
+++ b/flutter/test/feedback/sentry_feedback_widget_test.dart
@@ -272,6 +272,11 @@ void main() {
       await tester.tap(find.text('fixture-submitButtonLabel'));
       await tester.pumpAndSettle();
 
+      // Wait for validation errors to fully render - sometimes multiple errors
+      // don't all appear at exactly the same time causing flaky test failures
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.pumpAndSettle();
+
       expect(find.text('fixture-validationErrorLabel'), findsAny);
     });
   });

--- a/flutter/test/feedback/sentry_feedback_widget_test.dart
+++ b/flutter/test/feedback/sentry_feedback_widget_test.dart
@@ -272,11 +272,6 @@ void main() {
       await tester.tap(find.text('fixture-submitButtonLabel'));
       await tester.pumpAndSettle();
 
-      // Wait for validation errors to fully render - sometimes multiple errors
-      // don't all appear at exactly the same time causing flaky test failures
-      await tester.pump(const Duration(milliseconds: 100));
-      await tester.pumpAndSettle();
-
       expect(find.text('fixture-validationErrorLabel'), findsAny);
     });
   });
@@ -574,7 +569,6 @@ void main() {
 
     setUp(() {
       fixture = Fixture();
-      SentryFeedbackWidget.clearPreservedData();
     });
 
     testWidgets('preserves form data when taking screenshot', (tester) async {
@@ -774,6 +768,9 @@ class Fixture {
       hint: anyNamed('hint'),
       withScope: anyNamed('withScope'),
     )).thenAnswer((_) async => SentryId.empty());
+
+    SentryFeedbackWidget.pendingAssociatedEventId = null;
+    SentryFeedbackWidget.clearPreservedData();
   }
 
   Future<void> pumpFeedbackWidget(


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
