### PR TITLE
Remove `SentryTimingsCallback` and use Flutter's `TimingsCallback` instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `ScreenshotIntegration` not being added for web ([#3055](https://github.com/getsentry/sentry-dart/pull/3055))
 
+### Enhancements
+
+- Remove `SentryTimingsCallback` and use Flutter's `TimingsCallback` instead ([#3054](https://github.com/getsentry/sentry-dart/pull/3054))
+
 ## 9.4.0
 
 ### Fixes
@@ -28,10 +32,6 @@
 ### Fixes
 
 - Respect ancestor text direction in `SentryScreenshotWidget` ([#3046](https://github.com/getsentry/sentry-dart/pull/3046))
-
-### Enhancements
-
-- Remove `SentryTimingsCallback` and use Flutter's `TimingsCallback` instead ([#3054](https://github.com/getsentry/sentry-dart/pull/3054))
 
 ## 9.4.0-beta.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 
 - Respect ancestor text direction in `SentryScreenshotWidget` ([#3046](https://github.com/getsentry/sentry-dart/pull/3046))
 
+### Enhancements
+
+- Remove `SentryTimingsCallback` and use Flutter's `TimingsCallback` instead ([#3054](https://github.com/getsentry/sentry-dart/pull/3054))
+
 ## 9.4.0-beta.1
 
 ### Fixes

--- a/flutter/lib/src/frame_callback_handler.dart
+++ b/flutter/lib/src/frame_callback_handler.dart
@@ -1,13 +1,10 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/scheduler.dart';
 
-/// Use instead of TimingsCallback as it is not available in the Flutter min version
-typedef SentryTimingsCallback = void Function(List<FrameTiming> timings);
-
 abstract class FrameCallbackHandler {
   void addPostFrameCallback(FrameCallback callback);
-  void removeTimingsCallback(SentryTimingsCallback callback);
-  void addTimingsCallback(SentryTimingsCallback callback);
+  void removeTimingsCallback(TimingsCallback callback);
+  void addTimingsCallback(TimingsCallback callback);
 }
 
 class DefaultFrameCallbackHandler implements FrameCallbackHandler {
@@ -20,14 +17,14 @@ class DefaultFrameCallbackHandler implements FrameCallbackHandler {
   }
 
   @override
-  void addTimingsCallback(SentryTimingsCallback callback) {
+  void addTimingsCallback(TimingsCallback callback) {
     try {
       WidgetsBinding.instance.addTimingsCallback(callback);
     } catch (_) {}
   }
 
   @override
-  void removeTimingsCallback(SentryTimingsCallback callback) {
+  void removeTimingsCallback(TimingsCallback callback) {
     try {
       WidgetsBinding.instance.removeTimingsCallback(callback);
     } catch (_) {}


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
We have since bumped our Flutter version so we can safely use it now

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
