### PR TITLE
fix: `ScreenshotIntegration` not being added for web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- `ScreenshotIntegration` not being added for web ([#3055](https://github.com/getsentry/sentry-dart/pull/3055))
+
 ## 9.4.0
 
 ### Fixes

--- a/flutter/lib/src/event_processor/screenshot_event_processor.dart
+++ b/flutter/lib/src/event_processor/screenshot_event_processor.dart
@@ -49,7 +49,7 @@ class ScreenshotEventProcessor implements EventProcessor {
     }
 
     final renderer = _options.rendererWrapper.renderer;
-    if (isScreenshotSupported(_options)) {
+    if (_options.isScreenshotSupported) {
       _options.log(
         SentryLevel.debug,
         'Screenshot: not supported in this environment with renderer $renderer',

--- a/flutter/lib/src/event_processor/screenshot_event_processor.dart
+++ b/flutter/lib/src/event_processor/screenshot_event_processor.dart
@@ -3,7 +3,6 @@ import 'dart:typed_data';
 
 import 'package:meta/meta.dart';
 import '../../sentry_flutter.dart';
-import '../renderer/renderer.dart';
 import '../screenshot/recorder.dart';
 import '../screenshot/recorder_config.dart';
 
@@ -49,7 +48,7 @@ class ScreenshotEventProcessor implements EventProcessor {
     }
 
     final renderer = _options.rendererWrapper.renderer;
-    if (_options.isScreenshotSupported) {
+    if (!_options.isScreenshotSupported) {
       _options.log(
         SentryLevel.debug,
         'Screenshot: not supported in this environment with renderer $renderer',

--- a/flutter/lib/src/renderer/renderer.dart
+++ b/flutter/lib/src/renderer/renderer.dart
@@ -6,9 +6,7 @@ import 'unknown_renderer.dart'
 
 @internal
 class RendererWrapper {
-  FlutterRenderer? getRenderer() {
-    return implementation.getRenderer();
-  }
+  late final FlutterRenderer? renderer = implementation.getRenderer();
 }
 
 enum FlutterRenderer {
@@ -18,10 +16,13 @@ enum FlutterRenderer {
   /// https://docs.flutter.dev/perf/impeller
   impeller,
 
-  /// https://docs.flutter.dev/platform-integration/web/renderers
+  /// https://docs.flutter.dev/platform-integration/web/renderers#canvaskit
   canvasKit,
 
-  /// https://docs.flutter.dev/platform-integration/web/renderers
+  /// https://docs.flutter.dev/platform-integration/web/renderers#skwasm
+  skwasm,
+
+  /// HTML is still there but considered legacy
   html,
   unknown,
 }

--- a/flutter/lib/src/renderer/web_renderer.dart
+++ b/flutter/lib/src/renderer/web_renderer.dart
@@ -1,18 +1,9 @@
-import 'dart:js_interop';
+import 'package:flutter/foundation.dart';
 
 import 'renderer.dart';
 
 FlutterRenderer? getRenderer() {
-  return isCanvasKitRenderer ? FlutterRenderer.canvasKit : FlutterRenderer.html;
+  if (isCanvasKit) return FlutterRenderer.canvasKit;
+  if (isSkwasm) return FlutterRenderer.skwasm;
+  return FlutterRenderer.html;
 }
-
-bool get isCanvasKitRenderer {
-  return _windowFlutterCanvasKit != null;
-}
-
-// These values are set by the engine. They are used to determine if the
-// application is using canvaskit or skwasm.
-//
-// See https://github.com/flutter/flutter/blob/414d9238720a3cde85475f49ce0ba313f95046f7/packages/flutter/lib/src/foundation/_capabilities_web.dart#L10
-@JS('window.flutterCanvasKit')
-external JSAny? get _windowFlutterCanvasKit;

--- a/flutter/lib/src/screenshot/screenshot_support.dart
+++ b/flutter/lib/src/screenshot/screenshot_support.dart
@@ -1,0 +1,19 @@
+import '../../sentry_flutter.dart';
+import '../renderer/renderer.dart';
+
+/// Returns `true` if capturing screenshots are allowed in the current environment.
+///
+/// - On mobile / desktop we allow them unconditionally.
+/// - On Web we allow them only when the renderer is CanvasKit or Skwasm.
+bool isScreenshotSupported(SentryFlutterOptions options) {
+  if (!options.platform.isWeb) {
+    return true;
+  }
+
+  const supportedWebRenderers = {
+    FlutterRenderer.canvasKit,
+    FlutterRenderer.skwasm,
+  };
+
+  return supportedWebRenderers.contains(options.rendererWrapper.renderer);
+}

--- a/flutter/lib/src/screenshot/screenshot_support.dart
+++ b/flutter/lib/src/screenshot/screenshot_support.dart
@@ -1,19 +1,19 @@
 import '../../sentry_flutter.dart';
 import '../renderer/renderer.dart';
 
-/// Returns `true` if capturing screenshots are allowed in the current environment.
-///
-/// - On mobile / desktop we allow them unconditionally.
-/// - On Web we allow them only when the renderer is CanvasKit or Skwasm.
-bool isScreenshotSupported(SentryFlutterOptions options) {
-  if (!options.platform.isWeb) {
-    return true;
+extension ScreenshotSupport on SentryFlutterOptions {
+  /// Returns `true` if capturing screenshots are allowed in the current environment.
+  ///
+  /// - On mobile / desktop we allow them unconditionally.
+  /// - On Web we allow them only when the renderer is CanvasKit or Skwasm.
+  bool get isScreenshotSupported {
+    // Mobile / desktop → always OK.
+    if (!platform.isWeb) return true;
+
+    const supportedWebRenderers = {
+      FlutterRenderer.canvasKit,
+      FlutterRenderer.skwasm,
+    };
+    return supportedWebRenderers.contains(rendererWrapper.renderer);
   }
-
-  const supportedWebRenderers = {
-    FlutterRenderer.canvasKit,
-    FlutterRenderer.skwasm,
-  };
-
-  return supportedWebRenderers.contains(options.rendererWrapper.renderer);
 }

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -27,7 +27,6 @@ import 'native/factory.dart';
 import 'native/native_scope_observer.dart';
 import 'native/sentry_native_binding.dart';
 import 'profiling.dart';
-import 'renderer/renderer.dart';
 import 'replay/integration.dart';
 import 'screenshot/screenshot_support.dart';
 import 'utils/platform_dispatcher_wrapper.dart';

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -29,6 +29,7 @@ import 'native/sentry_native_binding.dart';
 import 'profiling.dart';
 import 'renderer/renderer.dart';
 import 'replay/integration.dart';
+import 'screenshot/screenshot_support.dart';
 import 'utils/platform_dispatcher_wrapper.dart';
 import 'version.dart';
 import 'view_hierarchy/view_hierarchy_integration.dart';
@@ -205,8 +206,7 @@ mixin SentryFlutter {
       options.enableDartSymbolication = false;
     }
 
-    final renderer = options.rendererWrapper.getRenderer();
-    if (!platform.isWeb || renderer == FlutterRenderer.canvasKit) {
+    if (isScreenshotSupported(options)) {
       integrations.add(ScreenshotIntegration());
     }
 

--- a/flutter/lib/src/sentry_flutter.dart
+++ b/flutter/lib/src/sentry_flutter.dart
@@ -206,7 +206,7 @@ mixin SentryFlutter {
       options.enableDartSymbolication = false;
     }
 
-    if (isScreenshotSupported(options)) {
+    if (options.isScreenshotSupported) {
       integrations.add(ScreenshotIntegration());
     }
 

--- a/flutter/test/event_processor/screenshot_event_processor_test.dart
+++ b/flutter/test/event_processor/screenshot_event_processor_test.dart
@@ -75,6 +75,12 @@ void main() {
         added: true, isWeb: true);
   });
 
+  testWidgets('adds screenshot attachment with skwasm renderer',
+      (tester) async {
+    await _addScreenshotAttachment(tester, FlutterRenderer.skwasm,
+        added: true, isWeb: true);
+  });
+
   testWidgets('does not add screenshot attachment with html renderer',
       (tester) async {
     await _addScreenshotAttachment(tester, FlutterRenderer.html,

--- a/flutter/test/mocks.dart
+++ b/flutter/test/mocks.dart
@@ -124,9 +124,7 @@ class MockRendererWrapper implements RendererWrapper {
   final FlutterRenderer? _renderer;
 
   @override
-  FlutterRenderer? getRenderer() {
-    return _renderer;
-  }
+  FlutterRenderer? get renderer => _renderer;
 }
 
 class TestBindingWrapper implements BindingWrapper {

--- a/flutter/test/screenshot/screenshot_support_test.dart
+++ b/flutter/test/screenshot/screenshot_support_test.dart
@@ -23,7 +23,7 @@ void main() {
       expect(options.isScreenshotSupported, isTrue);
     });
 
-    test('returns true for web CanvasKit renderer', () {
+    test('returns true for web canvasKit renderer', () {
       final options = _buildOptions(
         isWeb: true,
         renderer: FlutterRenderer.canvasKit,
@@ -31,7 +31,7 @@ void main() {
       expect(options.isScreenshotSupported, isTrue);
     });
 
-    test('returns true for web Skwasm renderer', () {
+    test('returns true for web skwasm renderer', () {
       final options = _buildOptions(
         isWeb: true,
         renderer: FlutterRenderer.skwasm,

--- a/flutter/test/screenshot/screenshot_support_test.dart
+++ b/flutter/test/screenshot/screenshot_support_test.dart
@@ -20,7 +20,7 @@ void main() {
 
     test('returns true for non-web platforms', () {
       final options = _buildOptions(isWeb: false);
-      expect(isScreenshotSupported(options), isTrue);
+      expect(options.isScreenshotSupported, isTrue);
     });
 
     test('returns true for web CanvasKit renderer', () {
@@ -28,7 +28,7 @@ void main() {
         isWeb: true,
         renderer: FlutterRenderer.canvasKit,
       );
-      expect(isScreenshotSupported(options), isTrue);
+      expect(options.isScreenshotSupported, isTrue);
     });
 
     test('returns true for web Skwasm renderer', () {
@@ -36,7 +36,7 @@ void main() {
         isWeb: true,
         renderer: FlutterRenderer.skwasm,
       );
-      expect(isScreenshotSupported(options), isTrue);
+      expect(options.isScreenshotSupported, isTrue);
     });
 
     test('returns false for web html renderer', () {
@@ -44,7 +44,7 @@ void main() {
         isWeb: true,
         renderer: FlutterRenderer.html,
       );
-      expect(isScreenshotSupported(options), isFalse);
+      expect(options.isScreenshotSupported, isFalse);
     });
 
     test('returns false for web unknown renderer', () {
@@ -52,7 +52,7 @@ void main() {
         isWeb: true,
         renderer: FlutterRenderer.unknown,
       );
-      expect(isScreenshotSupported(options), isFalse);
+      expect(options.isScreenshotSupported, isFalse);
     });
   });
 }

--- a/flutter/test/screenshot/screenshot_support_test.dart
+++ b/flutter/test/screenshot/screenshot_support_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sentry/src/platform/mock_platform.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+import 'package:sentry_flutter/src/renderer/renderer.dart';
+import 'package:sentry_flutter/src/screenshot/screenshot_support.dart';
+
+import '../mocks.dart';
+
+void main() {
+  group('isScreenshotSupported', () {
+    SentryFlutterOptions _buildOptions({
+      required bool isWeb,
+      FlutterRenderer? renderer,
+    }) {
+      final options = defaultTestOptions();
+      options.platform = MockPlatform(isWeb: isWeb);
+      options.rendererWrapper = MockRendererWrapper(renderer);
+      return options;
+    }
+
+    test('returns true for non-web platforms', () {
+      final options = _buildOptions(isWeb: false);
+      expect(isScreenshotSupported(options), isTrue);
+    });
+
+    test('returns true for web CanvasKit renderer', () {
+      final options = _buildOptions(
+        isWeb: true,
+        renderer: FlutterRenderer.canvasKit,
+      );
+      expect(isScreenshotSupported(options), isTrue);
+    });
+
+    test('returns true for web Skwasm renderer', () {
+      final options = _buildOptions(
+        isWeb: true,
+        renderer: FlutterRenderer.skwasm,
+      );
+      expect(isScreenshotSupported(options), isTrue);
+    });
+
+    test('returns false for web html renderer', () {
+      final options = _buildOptions(
+        isWeb: true,
+        renderer: FlutterRenderer.html,
+      );
+      expect(isScreenshotSupported(options), isFalse);
+    });
+
+    test('returns false for web unknown renderer', () {
+      final options = _buildOptions(
+        isWeb: true,
+        renderer: FlutterRenderer.unknown,
+      );
+      expect(isScreenshotSupported(options), isFalse);
+    });
+  });
+}

--- a/flutter/test/sentry_flutter_test.dart
+++ b/flutter/test/sentry_flutter_test.dart
@@ -564,13 +564,40 @@ void main() {
       await Sentry.close();
     }, testOn: 'vm');
 
-    test('installed with canvasKit renderer', () async {
+    test('installed on web with canvasKit renderer', () async {
       List<Integration> integrations = [];
 
       final sentryFlutterOptions =
           defaultTestOptions(checker: MockRuntimeChecker())
-            ..platform = MockPlatform.iOS()
+            ..platform = MockPlatform.iOS(isWeb: true)
             ..rendererWrapper = MockRendererWrapper(FlutterRenderer.canvasKit)
+            ..release = ''
+            ..dist = '';
+
+      await SentryFlutter.init(
+        (options) async {
+          integrations = options.integrations;
+        },
+        appRunner: appRunner,
+        options: sentryFlutterOptions,
+      );
+
+      expect(
+          integrations
+              .map((e) => e.runtimeType)
+              .contains(ScreenshotIntegration),
+          true);
+
+      await Sentry.close();
+    }, testOn: 'browser');
+
+    test('installed on web with skwasm renderer', () async {
+      List<Integration> integrations = [];
+
+      final sentryFlutterOptions =
+          defaultTestOptions(checker: MockRuntimeChecker())
+            ..platform = MockPlatform.iOS(isWeb: true)
+            ..rendererWrapper = MockRendererWrapper(FlutterRenderer.skwasm)
             ..release = ''
             ..dist = '';
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
`ScreenshotIntegration` was not added on web even though it's supported (for canvasKit and Skwasm)

## :green_heart: How did you test it?
Unit tests, manual tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
