### PR TITLE
fix: SPM should use `exact` instead of `from` when defining the sentry-cocoa package

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -123,9 +123,6 @@ jobs:
         with:
           channel: main
 
-      - name: Use Xcode 16.4
-        run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-
       - run: flutter config --enable-swift-package-manager
 
       - name: Run on iOS

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -123,6 +123,9 @@ jobs:
         with:
           channel: main
 
+      - name: Use Xcode 16.4
+        run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+
       - run: flutter config --enable-swift-package-manager
 
       - name: Run on iOS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- SPM should use `exact` instead of `from` when defining the sentry-cocoa package ([#3065](https://github.com/getsentry/sentry-dart/pull/3065))
 - Respect ancestor text direction in `SentryScreenshotWidget` ([#3046](https://github.com/getsentry/sentry-dart/pull/3046))
 - Add additional crashpad path candidate ([#3016](https://github.com/getsentry/sentry-dart/pull/3016))
 - Replay JNI usage with `SentryFlutterPlugin` ([#3036](https://github.com/getsentry/sentry-dart/pull/3036), [#3039](https://github.com/getsentry/sentry-dart/pull/3039))

--- a/flutter/ios/sentry_flutter/Package.swift
+++ b/flutter/ios/sentry_flutter/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .library(name: "sentry-flutter", targets: ["sentry_flutter", "sentry_flutter_objc"])
     ],
     dependencies: [
-      .package(url: "https://github.com/getsentry/sentry-cocoa", from: "8.52.1")
+      .package(url: "https://github.com/getsentry/sentry-cocoa", exact: "8.52.1")
     ],
     targets: [
         .target(


### PR DESCRIPTION
`from` could install any cocoa version that is not the next major. we should use `exact` instead