### PR TITLE
chore: fix flaky `WidgetsBindingObserver` test

### DIFF
--- a/flutter/test/widgets_binding_observer_test.dart
+++ b/flutter/test/widgets_binding_observer_test.dart
@@ -104,7 +104,7 @@ void main() {
     });
 
     testWidgets(
-        'when app lifecycle tracing enabled is enabled, only inactive and resumed are tracked',
+        'on supported platforms when app lifecycle tracing enabled is enabled, only inactive and resumed are tracked',
         (WidgetTester tester) async {
       flutterTrackingDisabledOptions.platform = MockPlatform(isWeb: false);
       flutterTrackingDisabledOptions.appInBackgroundTracingThreshold =
@@ -128,7 +128,7 @@ void main() {
       await sendLifecycle('resumed');
 
       verify(hub.generateNewTraceId()).called(1);
-    });
+    }, skip: kIsWeb ? 'App lifecycle tracing is not supported on web' : false);
 
     testWidgets('memory pressure breadcrumb', (WidgetTester tester) async {
       final hub = MockHub();

--- a/flutter/test/widgets_binding_observer_test.dart
+++ b/flutter/test/widgets_binding_observer_test.dart
@@ -2,6 +2,7 @@
 
 import 'dart:ui';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
@@ -128,7 +129,7 @@ void main() {
       await sendLifecycle('resumed');
 
       verify(hub.generateNewTraceId()).called(1);
-    }, skip: kIsWeb ? 'App lifecycle tracing is not supported on web' : false);
+    }, skip: kIsWeb);
 
     testWidgets('memory pressure breadcrumb', (WidgetTester tester) async {
       final hub = MockHub();


### PR DESCRIPTION
#skip-changelog

the flaky test should not be running in web environments