### PR TITLE
Ensure consistent sampleRand per trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   - Search for feature flags that are prefixed with `flutter:*`
   - This works on Flutter builds that include [this PR](https://github.com/flutter/flutter/pull/171545)
 
+### Fixes
+
+- Ensure consistent sampling per trace ([#3079](https://github.com/getsentry/sentry-dart/pull/3079))
+
 ### Dependencies
 
 - Bump Native SDK from v0.9.0 to v0.9.1 ([#3018](https://github.com/getsentry/sentry-dart/pull/3018))

--- a/dart/lib/src/hub.dart
+++ b/dart/lib/src/hub.dart
@@ -506,14 +506,14 @@ class Hub {
         transactionContext.samplingDecision = samplingDecision;
 
         // Store the generated/used sampleRand on the propagation context so
-        // that subsequent spans/transactions of the same trace reuse it.
+        // that subsequent transactions in the same trace reuse it.
         if (samplingDecision.sampleRand != null) {
           propagationContext.sampleRand = samplingDecision.sampleRand;
         }
       }
 
       transactionContext.origin ??= SentryTraceOrigins.manual;
-      transactionContext.traceId = scope.propagationContext.traceId;
+      transactionContext.traceId = propagationContext.traceId;
 
       SentryProfiler? profiler;
       if (_profilerFactory != null &&
@@ -544,7 +544,7 @@ class Hub {
   @internal
   void generateNewTrace() {
     scope.propagationContext.traceId = SentryId.newId();
-    // Reset sampleRand so that a new one is generated for the new trace.
+    // Reset sampleRand so that a new one is generated for the new trace when a new transaction is started
     scope.propagationContext.sampleRand = null;
   }
 

--- a/dart/lib/src/hub.dart
+++ b/dart/lib/src/hub.dart
@@ -542,7 +542,7 @@ class Hub {
   }
 
   @internal
-  void generateNewTraceId() {
+  void generateNewTrace() {
     scope.propagationContext.traceId = SentryId.newId();
     // Reset sampleRand so that a new one is generated for the new trace.
     scope.propagationContext.sampleRand = null;

--- a/dart/lib/src/hub.dart
+++ b/dart/lib/src/hub.dart
@@ -492,8 +492,8 @@ class Hub {
 
       // if transactionContext has no sampling decision yet, run the traces sampler
       var samplingDecision = transactionContext.samplingDecision;
+      final propagationContext = scope.propagationContext;
       if (samplingDecision == null) {
-        final propagationContext = scope.propagationContext;
         final samplingContext = SentrySamplingContext(
             transactionContext, customSamplingContext ?? {});
 
@@ -504,14 +504,11 @@ class Hub {
 
         // Persist the sampling decision within the transaction context
         transactionContext.samplingDecision = samplingDecision;
-
-        // Store the generated/used sampleRand on the propagation context so
-        // that subsequent transactions in the same trace reuse it.
-        if (samplingDecision.sampleRand != null) {
-          propagationContext.sampleRand = samplingDecision.sampleRand;
-        }
       }
 
+      // Store the generated/used sampleRand on the propagation context so
+      // that subsequent transactions in the same trace reuse it.
+      propagationContext.sampleRand ??= samplingDecision.sampleRand;
       transactionContext.origin ??= SentryTraceOrigins.manual;
       transactionContext.traceId = propagationContext.traceId;
 

--- a/dart/lib/src/hub_adapter.dart
+++ b/dart/lib/src/hub_adapter.dart
@@ -162,7 +162,7 @@ class HubAdapter implements Hub {
       );
 
   @override
-  void generateNewTraceId() => Sentry.currentHub.generateNewTraceId();
+  void generateNewTrace() => Sentry.currentHub.generateNewTrace();
 
   @override
   void setSpanContext(

--- a/dart/lib/src/noop_hub.dart
+++ b/dart/lib/src/noop_hub.dart
@@ -126,7 +126,7 @@ class NoOpHub implements Hub {
       NoOpSentrySpan();
 
   @override
-  void generateNewTraceId() {}
+  void generateNewTrace() {}
 
   @override
   ISentrySpan? getSpan() => null;

--- a/dart/lib/src/propagation_context.dart
+++ b/dart/lib/src/propagation_context.dart
@@ -14,7 +14,7 @@ class PropagationContext {
   ///
   /// This value must be generated **once per trace** and reused across all
   /// child spans and transactions that belong to the same trace. It is reset
-  /// whenever a new trace is started (i.e. when [traceId] changes).
+  /// whenever a new trace is started.
   double? sampleRand;
 
   /// Baggage header to attach to http headers.

--- a/dart/lib/src/propagation_context.dart
+++ b/dart/lib/src/propagation_context.dart
@@ -10,6 +10,13 @@ class PropagationContext {
   /// The dynamic sampling context.
   SentryBaggage? baggage;
 
+  /// Random number generated for sampling decisions.
+  ///
+  /// This value must be generated **once per trace** and reused across all
+  /// child spans and transactions that belong to the same trace. It is reset
+  /// whenever a new trace is started (i.e. when [traceId] changes).
+  double? sampleRand;
+
   /// Baggage header to attach to http headers.
   SentryBaggageHeader? toBaggageHeader() =>
       baggage != null ? SentryBaggageHeader.fromBaggage(baggage!) : null;

--- a/dart/lib/src/sentry_traces_sampler.dart
+++ b/dart/lib/src/sentry_traces_sampler.dart
@@ -19,7 +19,10 @@ class SentryTracesSampler {
     }
   }
 
-  SentryTracesSamplingDecision sample(SentrySamplingContext samplingContext) {
+  SentryTracesSamplingDecision sample(
+    SentrySamplingContext samplingContext, {
+    double? sampleRand,
+  }) {
     final samplingDecision =
         samplingContext.transactionContext.samplingDecision;
     if (samplingDecision != null) {
@@ -31,7 +34,7 @@ class SentryTracesSampler {
       try {
         final sampleRate = tracesSampler(samplingContext);
         if (sampleRate != null) {
-          return _makeSampleDecision(sampleRate);
+          return _makeSampleDecision(sampleRate, sampleRand: sampleRand);
         }
       } catch (exception, stackTrace) {
         _options.log(
@@ -54,7 +57,7 @@ class SentryTracesSampler {
 
     double? optionsRate = _options.tracesSampleRate;
     if (optionsRate != null) {
-      return _makeSampleDecision(optionsRate);
+      return _makeSampleDecision(optionsRate, sampleRand: sampleRand);
     }
 
     return SentryTracesSamplingDecision(false);
@@ -68,11 +71,14 @@ class SentryTracesSampler {
     return _isSampled(optionsRate);
   }
 
-  SentryTracesSamplingDecision _makeSampleDecision(double sampleRate) {
-    final sampleRand = _random.nextDouble();
-    final sampled = _isSampled(sampleRate, sampleRand: sampleRand);
+  SentryTracesSamplingDecision _makeSampleDecision(
+    double sampleRate, {
+    double? sampleRand,
+  }) {
+    final _rand = sampleRand ?? _random.nextDouble();
+    final sampled = _isSampled(sampleRate, sampleRand: _rand);
     return SentryTracesSamplingDecision(sampled,
-        sampleRate: sampleRate, sampleRand: sampleRand);
+        sampleRate: sampleRate, sampleRand: _rand);
   }
 
   bool _isSampled(double sampleRate, {double? sampleRand}) {

--- a/dart/lib/src/sentry_traces_sampler.dart
+++ b/dart/lib/src/sentry_traces_sampler.dart
@@ -20,9 +20,9 @@ class SentryTracesSampler {
   }
 
   SentryTracesSamplingDecision sample(
-    SentrySamplingContext samplingContext, {
-    double? sampleRand,
-  }) {
+    SentrySamplingContext samplingContext,
+    double sampleRand,
+  ) {
     final samplingDecision =
         samplingContext.transactionContext.samplingDecision;
     if (samplingDecision != null) {

--- a/dart/lib/src/sentry_traces_sampler.dart
+++ b/dart/lib/src/sentry_traces_sampler.dart
@@ -34,7 +34,7 @@ class SentryTracesSampler {
       try {
         final sampleRate = tracesSampler(samplingContext);
         if (sampleRate != null) {
-          return _makeSampleDecision(sampleRate, sampleRand: sampleRand);
+          return _makeSampleDecision(sampleRate, sampleRand);
         }
       } catch (exception, stackTrace) {
         _options.log(
@@ -57,7 +57,7 @@ class SentryTracesSampler {
 
     double? optionsRate = _options.tracesSampleRate;
     if (optionsRate != null) {
-      return _makeSampleDecision(optionsRate, sampleRand: sampleRand);
+      return _makeSampleDecision(optionsRate, sampleRand);
     }
 
     return SentryTracesSamplingDecision(false);
@@ -72,13 +72,12 @@ class SentryTracesSampler {
   }
 
   SentryTracesSamplingDecision _makeSampleDecision(
-    double sampleRate, {
-    double? sampleRand,
-  }) {
-    final _rand = sampleRand ?? _random.nextDouble();
-    final sampled = _isSampled(sampleRate, sampleRand: _rand);
+    double sampleRate,
+    double sampleRand,
+  ) {
+    final sampled = _isSampled(sampleRate, sampleRand: sampleRand);
     return SentryTracesSamplingDecision(sampled,
-        sampleRate: sampleRate, sampleRand: _rand);
+        sampleRate: sampleRate, sampleRand: sampleRand);
   }
 
   bool _isSampled(double sampleRate, {double? sampleRand}) {

--- a/dart/test/hub_test.dart
+++ b/dart/test/hub_test.dart
@@ -581,10 +581,10 @@ void main() {
       });
     });
 
-    test('generateNewTraceId creates new trace id in propagation context', () {
+    test('generateNewTrace creates new trace id in propagation context', () {
       final oldTraceId = hub.scope.propagationContext.traceId;
 
-      hub.generateNewTraceId();
+      hub.generateNewTrace();
 
       final newTraceId = hub.scope.propagationContext.traceId;
       expect(oldTraceId, isNot(newTraceId));

--- a/dart/test/hub_test.dart
+++ b/dart/test/hub_test.dart
@@ -589,6 +589,15 @@ void main() {
       final newTraceId = hub.scope.propagationContext.traceId;
       expect(oldTraceId, isNot(newTraceId));
     });
+
+    test('generateNewTrace resets sampleRand in propagation context', () {
+      hub.scope.propagationContext.sampleRand = 1.0;
+
+      hub.generateNewTrace();
+
+      final newSampleRand = hub.scope.propagationContext.sampleRand;
+      expect(newSampleRand, isNull);
+    });
   });
 
   group('Hub scope callback', () {

--- a/dart/test/sample_rand_propagation_test.dart
+++ b/dart/test/sample_rand_propagation_test.dart
@@ -31,7 +31,7 @@ void main() {
       expect(rand1, isNotNull);
 
       // Start a new trace
-      hub.generateNewTraceId();
+      hub.generateNewTrace();
 
       final tx2 = hub.startTransaction('tx2', 'op') as SentryTracer;
       final rand2 = tx2.samplingDecision?.sampleRand;

--- a/dart/test/sample_rand_propagation_test.dart
+++ b/dart/test/sample_rand_propagation_test.dart
@@ -5,8 +5,8 @@ import 'package:test/test.dart';
 import 'test_utils.dart';
 
 void main() {
-  group('sampleRand propagation', () {
-    test('sampleRand is reused for transactions within the same trace', () {
+  group('sampleRand', () {
+    test('is reused for transactions within the same trace', () {
       final options = defaultTestOptions()..tracesSampleRate = 1.0;
       final hub = Hub(options);
 
@@ -22,7 +22,7 @@ void main() {
       expect(rand2, equals(rand1));
     });
 
-    test('new trace gets new sampleRand', () {
+    test('is generated within a transaction in a new trace', () {
       final options = defaultTestOptions()..tracesSampleRate = 1.0;
       final hub = Hub(options);
 

--- a/dart/test/sample_rand_propagation_test.dart
+++ b/dart/test/sample_rand_propagation_test.dart
@@ -1,0 +1,43 @@
+import 'package:sentry/sentry.dart';
+import 'package:sentry/src/sentry_tracer.dart';
+import 'package:test/test.dart';
+
+import 'test_utils.dart';
+
+void main() {
+  group('sampleRand propagation', () {
+    test('sampleRand is reused for transactions within the same trace', () {
+      final options = defaultTestOptions()..tracesSampleRate = 1.0;
+      final hub = Hub(options);
+
+      final tx1 = hub.startTransaction('tx1', 'op') as SentryTracer;
+      final rand1 = tx1.samplingDecision?.sampleRand;
+
+      // Sanity check
+      expect(rand1, isNotNull);
+
+      final tx2 = hub.startTransaction('tx2', 'op') as SentryTracer;
+      final rand2 = tx2.samplingDecision?.sampleRand;
+
+      expect(rand2, equals(rand1));
+    });
+
+    test('new trace gets new sampleRand', () {
+      final options = defaultTestOptions()..tracesSampleRate = 1.0;
+      final hub = Hub(options);
+
+      final tx1 = hub.startTransaction('tx1', 'op') as SentryTracer;
+      final rand1 = tx1.samplingDecision?.sampleRand;
+      expect(rand1, isNotNull);
+
+      // Start a new trace
+      hub.generateNewTraceId();
+
+      final tx2 = hub.startTransaction('tx2', 'op') as SentryTracer;
+      final rand2 = tx2.samplingDecision?.sampleRand;
+
+      expect(rand2, isNotNull);
+      expect(rand2, isNot(equals(rand1)));
+    });
+  });
+}

--- a/dart/test/sentry_traces_sampler_test.dart
+++ b/dart/test/sentry_traces_sampler_test.dart
@@ -6,6 +6,7 @@ import 'test_utils.dart';
 
 void main() {
   late Fixture fixture;
+  const _sampleRand = 1.0;
 
   setUp(() {
     fixture = Fixture();
@@ -21,7 +22,7 @@ void main() {
     );
     final context = SentrySamplingContext(trContext, {});
 
-    expect(sut.sample(context).sampled, true);
+    expect(sut.sample(context, _sampleRand).sampled, true);
   });
 
   test('options has sampler', () {
@@ -40,7 +41,7 @@ void main() {
     );
     final context = SentrySamplingContext(trContext, {});
 
-    expect(sut.sample(context).sampled, true);
+    expect(sut.sample(context, _sampleRand).sampled, true);
   });
 
   test('transactionContext has parentSampled', () {
@@ -53,7 +54,7 @@ void main() {
     );
     final context = SentrySamplingContext(trContext, {});
 
-    expect(sut.sample(context).sampled, true);
+    expect(sut.sample(context, _sampleRand).sampled, true);
   });
 
   test('options has rate 1.0', () {
@@ -65,7 +66,7 @@ void main() {
     );
     final context = SentrySamplingContext(trContext, {});
 
-    expect(sut.sample(context).sampled, true);
+    expect(sut.sample(context, _sampleRand).sampled, true);
   });
 
   test('options has rate 0.0', () {
@@ -77,7 +78,7 @@ void main() {
     );
     final context = SentrySamplingContext(trContext, {});
 
-    expect(sut.sample(context).sampled, false);
+    expect(sut.sample(context, _sampleRand).sampled, false);
   });
 
   test('does not sample if tracesSampleRate and tracesSampleRate are null', () {
@@ -88,7 +89,7 @@ void main() {
       'op',
     );
     final context = SentrySamplingContext(trContext, {});
-    final samplingDecision = sut.sample(context);
+    final samplingDecision = sut.sample(context, _sampleRand);
 
     expect(samplingDecision.sampleRate, isNull);
     expect(samplingDecision.sampleRand, isNull);
@@ -111,7 +112,7 @@ void main() {
       'op',
     );
     final context = SentrySamplingContext(trContext, {});
-    sut.sample(context);
+    sut.sample(context, _sampleRand);
 
     expect(fixture.loggedException, exception);
     expect(fixture.loggedLevel, SentryLevel.error);

--- a/drift/test/mocks/mocks.mocks.dart
+++ b/drift/test/mocks/mocks.mocks.dart
@@ -429,9 +429,9 @@ class MockHub extends _i1.Mock implements _i2.Hub {
       ) as _i2.ISentrySpan);
 
   @override
-  void generateNewTraceId() => super.noSuchMethod(
+  void generateNewTrace() => super.noSuchMethod(
         Invocation.method(
-          #generateNewTraceId,
+          #generateNewTrace,
           [],
         ),
         returnValueForMissingStub: null,

--- a/firebase_remote_config/test/mocks/mocks.mocks.dart
+++ b/firebase_remote_config/test/mocks/mocks.mocks.dart
@@ -481,9 +481,9 @@ class MockHub extends _i1.Mock implements _i2.Hub {
       ) as _i2.ISentrySpan);
 
   @override
-  void generateNewTraceId() => super.noSuchMethod(
+  void generateNewTrace() => super.noSuchMethod(
         Invocation.method(
-          #generateNewTraceId,
+          #generateNewTrace,
           [],
         ),
         returnValueForMissingStub: null,

--- a/flutter/lib/src/navigation/sentry_navigator_observer.dart
+++ b/flutter/lib/src/navigation/sentry_navigator_observer.dart
@@ -143,7 +143,7 @@ class SentryNavigatorObserver extends RouteObserver<PageRoute<dynamic>> {
       return;
     }
 
-    _hub.generateNewTraceId();
+    _hub.generateNewTrace();
     _setCurrentRouteName(route);
     _setCurrentRouteNameAsTransaction(route);
 
@@ -174,7 +174,7 @@ class SentryNavigatorObserver extends RouteObserver<PageRoute<dynamic>> {
       return;
     }
 
-    _hub.generateNewTraceId();
+    _hub.generateNewTrace();
     _setCurrentRouteName(newRoute);
     _setCurrentRouteNameAsTransaction(newRoute);
 
@@ -196,7 +196,7 @@ class SentryNavigatorObserver extends RouteObserver<PageRoute<dynamic>> {
       return;
     }
 
-    _hub.generateNewTraceId();
+    _hub.generateNewTrace();
     _setCurrentRouteName(previousRoute);
     _setCurrentRouteNameAsTransaction(previousRoute);
 

--- a/flutter/lib/src/widgets_binding_observer.dart
+++ b/flutter/lib/src/widgets_binding_observer.dart
@@ -100,7 +100,7 @@ class SentryWidgetsBindingObserver with WidgetsBindingObserver {
         _appInBackgroundStopwatch.stop();
         if (_appInBackgroundStopwatch.elapsed.inSeconds >
             _options.appInBackgroundTracingThreshold.inSeconds) {
-          _hub.generateNewTraceId();
+          _hub.generateNewTrace();
         }
         _appInBackgroundStopwatch.reset();
       }

--- a/flutter/test/mocks.mocks.dart
+++ b/flutter/test/mocks.mocks.dart
@@ -4266,9 +4266,9 @@ class MockHub extends _i1.Mock implements _i2.Hub {
       ) as _i2.ISentrySpan);
 
   @override
-  void generateNewTraceId() => super.noSuchMethod(
+  void generateNewTrace() => super.noSuchMethod(
         Invocation.method(
-          #generateNewTraceId,
+          #generateNewTrace,
           [],
         ),
         returnValueForMissingStub: null,

--- a/flutter/test/navigation/sentry_navigator_observer_test.dart
+++ b/flutter/test/navigation/sentry_navigator_observer_test.dart
@@ -1101,7 +1101,7 @@ class Fixture {
     List<String>? ignoreRoutes,
   }) {
     if (hub is MockHub) {
-      when(hub.generateNewTraceId()).thenAnswer((_) => {});
+      when(hub.generateNewTrace()).thenAnswer((_) => {});
     }
     final options = hub.options;
     if (options is SentryFlutterOptions) {

--- a/flutter/test/navigation/sentry_navigator_observer_traces_test.dart
+++ b/flutter/test/navigation/sentry_navigator_observer_traces_test.dart
@@ -55,7 +55,7 @@ void main() {
     /// Prepares mocks, we don't care about what they exactly do.
     /// We only test the order of execution in this group.
     void _prepareMocks() {
-      when(fixture.mockHub.generateNewTraceId()).thenAnswer((_) => {});
+      when(fixture.mockHub.generateNewTrace()).thenAnswer((_) => {});
       when(fixture.mockHub.configureScope(any))
           .thenAnswer((_) => Future.value());
       when(fixture.mockHub.startTransactionWithContext(
@@ -79,7 +79,7 @@ void main() {
       final sut = fixture.getSut(hub: fixture.mockHub);
       sut.didPush(toRoute, fromRoute);
       verifyInOrder([
-        fixture.mockHub.generateNewTraceId(),
+        fixture.mockHub.generateNewTrace(),
         fixture.mockHub.startTransactionWithContext(
           any,
           bindToScope: anyNamed('bindToScope'),

--- a/flutter/test/widgets_binding_observer_test.dart
+++ b/flutter/test/widgets_binding_observer_test.dart
@@ -59,7 +59,7 @@ void main() {
       await sendLifecycle('inactive');
       await sendLifecycle('resumed');
 
-      verifyNever(hub.generateNewTraceId());
+      verifyNever(hub.generateNewTrace());
     });
 
     testWidgets('app lifecycle does not generate new trace if platform is web',
@@ -79,7 +79,7 @@ void main() {
       await sendLifecycle('inactive');
       await sendLifecycle('resumed');
 
-      verifyNever(hub.generateNewTraceId());
+      verifyNever(hub.generateNewTrace());
     });
 
     testWidgets(
@@ -89,7 +89,7 @@ void main() {
       flutterTrackingDisabledOptions.appInBackgroundTracingThreshold =
           Duration(seconds: -1);
       final hub = MockHub();
-      when(hub.generateNewTraceId()).thenAnswer((_) {});
+      when(hub.generateNewTrace()).thenAnswer((_) {});
       final observer = SentryWidgetsBindingObserver(
         hub: hub,
         options: flutterTrackingDisabledOptions,
@@ -101,7 +101,7 @@ void main() {
       await sendLifecycle('inactive');
       await sendLifecycle('resumed');
 
-      verify(hub.generateNewTraceId()).called(1);
+      verify(hub.generateNewTrace()).called(1);
     });
 
     testWidgets(
@@ -111,7 +111,7 @@ void main() {
       flutterTrackingDisabledOptions.appInBackgroundTracingThreshold =
           Duration(seconds: -1);
       final hub = MockHub();
-      when(hub.generateNewTraceId()).thenAnswer((_) {});
+      when(hub.generateNewTrace()).thenAnswer((_) {});
       final observer = SentryWidgetsBindingObserver(
         hub: hub,
         options: flutterTrackingDisabledOptions,
@@ -123,12 +123,12 @@ void main() {
       await sendLifecycle('detached');
       await sendLifecycle('resumed');
 
-      verifyNever(hub.generateNewTraceId());
+      verifyNever(hub.generateNewTrace());
 
       await sendLifecycle('inactive');
       await sendLifecycle('resumed');
 
-      verify(hub.generateNewTraceId()).called(1);
+      verify(hub.generateNewTrace()).called(1);
     }, skip: kIsWeb);
 
     testWidgets('memory pressure breadcrumb', (WidgetTester tester) async {

--- a/isar/test/mocks/mocks.mocks.dart
+++ b/isar/test/mocks/mocks.mocks.dart
@@ -472,9 +472,9 @@ class MockHub extends _i1.Mock implements _i2.Hub {
       ) as _i2.ISentrySpan);
 
   @override
-  void generateNewTraceId() => super.noSuchMethod(
+  void generateNewTrace() => super.noSuchMethod(
         Invocation.method(
-          #generateNewTraceId,
+          #generateNewTrace,
           [],
         ),
         returnValueForMissingStub: null,

--- a/sqflite/test/mocks/mocks.mocks.dart
+++ b/sqflite/test/mocks/mocks.mocks.dart
@@ -1783,9 +1783,9 @@ class MockHub extends _i1.Mock implements _i2.Hub {
       ) as _i2.ISentrySpan);
 
   @override
-  void generateNewTraceId() => super.noSuchMethod(
+  void generateNewTrace() => super.noSuchMethod(
         Invocation.method(
-          #generateNewTraceId,
+          #generateNewTrace,
           [],
         ),
         returnValueForMissingStub: null,


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
We want to ensure that spans within a trace are consistently sampled otherwise we might end up with traces that have missing transactions

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #3052 

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
