### PR TITLE
fix: debug images not loaded for split debug info only builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Debug meta not loaded for split debug info only builds ([#3104](https://github.com/getsentry/sentry-dart/pull/3104))
+
 ### Dependencies
 
 - Bump Android SDK from v8.13.2 to v8.17.0 ([#2977](https://github.com/getsentry/sentry-dart/pull/2977))

--- a/dart/lib/src/load_dart_debug_images_integration.dart
+++ b/dart/lib/src/load_dart_debug_images_integration.dart
@@ -19,7 +19,8 @@ class LoadDartDebugImagesIntegration extends Integration<SentryOptions> {
   @override
   void call(Hub hub, SentryOptions options) {
     if (options.enableDartSymbolication &&
-        options.runtimeChecker.isAppObfuscated() &&
+        (options.runtimeChecker.isAppObfuscated() ||
+            options.runtimeChecker.isSplitDebugInfoBuild()) &&
         !options.platform.isWeb) {
       options.addEventProcessor(
           LoadDartDebugImagesIntegrationEventProcessor(options));

--- a/dart/lib/src/runtime_checker.dart
+++ b/dart/lib/src/runtime_checker.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'utils/stacktrace_utils.dart';
+
 /// Helper to check in which environment the library is running.
 /// The environment checks (release/debug/profile) are mutually exclusive.
 class RuntimeChecker {
@@ -29,6 +31,11 @@ class RuntimeChecker {
     // Note: Flutter Web production builds will always be minified / "obfuscated".
     final typeName = runtimeType.toString();
     return !typeName.contains('RuntimeChecker');
+  }
+
+  bool isSplitDebugInfoBuild() {
+    final str = StackTrace.current.toString();
+    return buildIdRegex.hasMatch(str) || absRegex.hasMatch(str);
   }
 
   final bool isRootZone;

--- a/dart/lib/src/runtime_checker.dart
+++ b/dart/lib/src/runtime_checker.dart
@@ -33,6 +33,7 @@ class RuntimeChecker {
     return !typeName.contains('RuntimeChecker');
   }
 
+  /// Check if the current build has been built with --split-debug-info
   bool isSplitDebugInfoBuild() {
     final str = StackTrace.current.toString();
     return buildIdRegex.hasMatch(str) || absRegex.hasMatch(str);

--- a/dart/lib/src/sentry_stack_trace_factory.dart
+++ b/dart/lib/src/sentry_stack_trace_factory.dart
@@ -4,14 +4,13 @@ import 'package:stack_trace/stack_trace.dart';
 import 'origin.dart';
 import 'protocol.dart';
 import 'sentry_options.dart';
+import 'utils/stacktrace_utils.dart';
 
 /// converts [StackTrace] to [SentryStackFrame]s
 class SentryStackTraceFactory {
   final SentryOptions _options;
 
-  static final _absRegex = RegExp(r'^\s*#[0-9]+ +abs +([A-Fa-f0-9]+)');
   static final _frameRegex = RegExp(r'^\s*#', multiLine: true);
-  static final _buildIdRegex = RegExp(r"build_id[:=] *'([A-Fa-f0-9]+)'");
   static final _baseAddrRegex = RegExp(r'isolate_dso_base[:=] *([A-Fa-f0-9]+)');
   static final SentryStackFrame _asynchronousGapFrameJson =
       SentryStackFrame(absPath: '<asynchronous suspension>');
@@ -91,7 +90,7 @@ class SentryStackTraceFactory {
       final chain = Chain.parse(
           startOffset == 0 ? stackTrace : stackTrace.substring(startOffset));
       final info = _StackInfo(chain.traces);
-      info.buildId = _buildIdRegex.firstMatch(stackTrace)?.group(1);
+      info.buildId = buildIdRegex.firstMatch(stackTrace)?.group(1);
       info.baseAddr = _baseAddrRegex.firstMatch(stackTrace)?.group(1);
       if (info.baseAddr != null) {
         info.baseAddr = '0x${info.baseAddr}';
@@ -111,7 +110,7 @@ class SentryStackTraceFactory {
       //     #00 abs 000000723d6346d7 _kDartIsolateSnapshotInstructions+0x1e26d7
 
       // we are only interested on the #01, 02... items which contains the 'abs' addresses.
-      final match = _absRegex.firstMatch(member);
+      final match = absRegex.firstMatch(member);
       if (match != null) {
         return SentryStackFrame(
           instructionAddr: '0x${match.group(1)!}',

--- a/dart/lib/src/utils/stacktrace_utils.dart
+++ b/dart/lib/src/utils/stacktrace_utils.dart
@@ -8,3 +8,11 @@ import 'package:meta/meta.dart';
 // https://github.com/getsentry/sentry/blob/master/src/sentry/utils/sdk_crashes/README.rst
 @internal
 StackTrace getCurrentStackTrace() => StackTrace.current;
+
+/// Regex that matches an “abs …” stack-frame line emitted by split-debug-info builds.
+@internal
+final absRegex = RegExp(r'^\s*#[0-9]+ +abs +([A-Fa-f0-9]+)');
+
+/// Regex that matches the header of a stacktrace emitted by split-debug-info builds.
+@internal
+final buildIdRegex = RegExp(r"build_id[:=] *'([A-Fa-f0-9]+)'");

--- a/dart/test/load_dart_debug_images_integration_test.dart
+++ b/dart/test/load_dart_debug_images_integration_test.dart
@@ -193,9 +193,32 @@ isolate_dso_base: 10000000
     });
   }
 
-  test('does not add itself to sdk.integrations if app is not obfuscated', () {
+  test('does add itself to sdk.integrations if split debug info is true', () {
     final fixture = Fixture()
-      ..options.runtimeChecker = MockRuntimeChecker(isObfuscated: false);
+      ..options.runtimeChecker = MockRuntimeChecker(isSplitDebugInfo: true);
+    fixture.callIntegration();
+    expect(
+      fixture.options.sdk.integrations
+          .contains(LoadDartDebugImagesIntegration.integrationName),
+      isTrue,
+    );
+  });
+
+  test('does add itself to sdk.integrations if obfuscation is true', () {
+    final fixture = Fixture()
+      ..options.runtimeChecker = MockRuntimeChecker(isObfuscated: true);
+    fixture.callIntegration();
+    expect(
+      fixture.options.sdk.integrations
+          .contains(LoadDartDebugImagesIntegration.integrationName),
+      isTrue,
+    );
+  });
+
+  test(
+      'does not add itself to sdk.integrations if app obfuscation and split debug info is false',
+      () {
+    final fixture = Fixture()..options.runtimeChecker = MockRuntimeChecker();
     fixture.callIntegration();
     expect(
       fixture.options.sdk.integrations
@@ -204,9 +227,24 @@ isolate_dso_base: 10000000
     );
   });
 
-  test('does not add event processor to options if app is not obfuscated', () {
+  test('does add event processor to options if split debug info is true', () {
     final fixture = Fixture()
-      ..options.runtimeChecker = MockRuntimeChecker(isObfuscated: false);
+      ..options.runtimeChecker = MockRuntimeChecker(isSplitDebugInfo: true);
+    fixture.callIntegration();
+    expect(fixture.options.eventProcessors.length, 1);
+  });
+
+  test('does add event processor to options if obfuscation is true', () {
+    final fixture = Fixture()
+      ..options.runtimeChecker = MockRuntimeChecker(isObfuscated: true);
+    fixture.callIntegration();
+    expect(fixture.options.eventProcessors.length, 1);
+  });
+
+  test(
+      'does not add event processor to options if app obfuscation and split debug info is false',
+      () {
+    final fixture = Fixture()..options.runtimeChecker = MockRuntimeChecker();
     fixture.callIntegration();
     expect(fixture.options.eventProcessors.length, 0);
   });
@@ -239,7 +277,8 @@ isolate_dso_base: 40000000
 
 class Fixture {
   final options = defaultTestOptions()
-    ..runtimeChecker = MockRuntimeChecker(isObfuscated: true);
+    ..runtimeChecker =
+        MockRuntimeChecker(isObfuscated: true, isSplitDebugInfo: true);
   late final factory = SentryStackTraceFactory(options);
 
   void callIntegration() {

--- a/dart/test/mocks/mock_runtime_checker.dart
+++ b/dart/test/mocks/mock_runtime_checker.dart
@@ -8,6 +8,7 @@ class MockRuntimeChecker extends RuntimeChecker with NoSuchMethodProvider {
     this.isProfile = false,
     this.isRelease = false,
     this.isObfuscated = false,
+    this.isSplitDebugInfo = false,
     bool isRootZone = true,
   }) : super(isRootZone: isRootZone);
 
@@ -15,6 +16,7 @@ class MockRuntimeChecker extends RuntimeChecker with NoSuchMethodProvider {
   final bool isProfile;
   final bool isRelease;
   final bool isObfuscated;
+  final bool isSplitDebugInfo;
 
   @override
   bool isDebugMode() => isDebug;
@@ -27,4 +29,7 @@ class MockRuntimeChecker extends RuntimeChecker with NoSuchMethodProvider {
 
   @override
   bool isAppObfuscated() => isObfuscated;
+
+  @override
+  bool isSplitDebugInfoBuild() => isSplitDebugInfo;
 }

--- a/flutter/lib/src/integrations/native_load_debug_images_integration.dart
+++ b/flutter/lib/src/integrations/native_load_debug_images_integration.dart
@@ -23,7 +23,8 @@ class LoadNativeDebugImagesIntegration
   @override
   void call(Hub hub, SentryFlutterOptions options) {
     // ignore: invalid_use_of_internal_member
-    if (options.runtimeChecker.isAppObfuscated()) {
+    if (options.runtimeChecker.isAppObfuscated() ||
+        options.runtimeChecker.isSplitDebugInfoBuild()) {
       options.addEventProcessor(
         _LoadNativeDebugImagesIntegrationEventProcessor(options, _native),
       );

--- a/flutter/test/integrations/load_native_debug_images_integration_test.dart
+++ b/flutter/test/integrations/load_native_debug_images_integration_test.dart
@@ -107,7 +107,33 @@ void main() {
     });
   });
 
-  test('does not add itself to sdk.integrations if app is not obfuscated',
+  test('does add itself to sdk.integrations if app split debug info is true',
+      () async {
+    final fixture =
+        IntegrationTestFixture(LoadNativeDebugImagesIntegration.new);
+    fixture.options.runtimeChecker = MockRuntimeChecker(isSplitDebugInfo: true);
+    await fixture.registerIntegration();
+    expect(
+      fixture.options.sdk.integrations
+          .contains(LoadNativeDebugImagesIntegration.integrationName),
+      isTrue,
+    );
+  });
+
+  test('does add itself to sdk.integrations if obfuscation is true', () async {
+    final fixture =
+        IntegrationTestFixture(LoadNativeDebugImagesIntegration.new);
+    fixture.options.runtimeChecker = MockRuntimeChecker(isObfuscated: true);
+    await fixture.registerIntegration();
+    expect(
+      fixture.options.sdk.integrations
+          .contains(LoadNativeDebugImagesIntegration.integrationName),
+      isTrue,
+    );
+  });
+
+  test(
+      'does not add itself to sdk.integrations if app obfuscation and split debug info is false',
       () async {
     final fixture =
         IntegrationTestFixture(LoadNativeDebugImagesIntegration.new);
@@ -120,7 +146,25 @@ void main() {
     );
   });
 
-  test('does not add event processor to options if app is not obfuscated',
+  test('does add event processor to options if split debug info is true',
+      () async {
+    final fixture =
+        IntegrationTestFixture(LoadNativeDebugImagesIntegration.new);
+    fixture.options.runtimeChecker = MockRuntimeChecker(isSplitDebugInfo: true);
+    await fixture.registerIntegration();
+    expect(fixture.options.eventProcessors.length, 1);
+  });
+
+  test('does add event processor to options if obfuscation is true', () async {
+    final fixture =
+        IntegrationTestFixture(LoadNativeDebugImagesIntegration.new);
+    fixture.options.runtimeChecker = MockRuntimeChecker(isObfuscated: true);
+    await fixture.registerIntegration();
+    expect(fixture.options.eventProcessors.length, 1);
+  });
+
+  test(
+      'does not add event processor to options if app obfuscation and split debug info is false',
       () async {
     final fixture =
         IntegrationTestFixture(LoadNativeDebugImagesIntegration.new);

--- a/flutter/test/mocks.dart
+++ b/flutter/test/mocks.dart
@@ -80,11 +80,13 @@ class MockRuntimeChecker with NoSuchMethodProvider implements RuntimeChecker {
   MockRuntimeChecker({
     this.buildMode = MockRuntimeCheckerBuildMode.debug,
     this.isObfuscated = false,
+    this.isSplitDebugInfo = false,
     this.isRoot = true,
   });
 
   final MockRuntimeCheckerBuildMode buildMode;
   final bool isObfuscated;
+  final bool isSplitDebugInfo;
   final bool isRoot;
 
   @override
@@ -98,6 +100,9 @@ class MockRuntimeChecker with NoSuchMethodProvider implements RuntimeChecker {
 
   @override
   bool isAppObfuscated() => isObfuscated;
+
+  @override
+  bool isSplitDebugInfoBuild() => isSplitDebugInfo;
 
   @override
   bool get isRootZone => isRoot;


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It's also possible that builds are not obfuscated but still built with `--split-debug-info`, in those cases we do not include the debug image integration which is wrong and ends up in symbolication issues

## :green_heart: How did you test it?
Manual testing, unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
