### PR TITLE
fix: prevent false replay config restarts from `ScreenshotWidgetStatus` equality issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- False replay config restarts because of `ScreenshotWidgetStatus` equality issues ([#3114](https://github.com/getsentry/sentry-dart/pull/3114))
+
 ## 9.6.0-beta.1
 
 ### Fixes

--- a/flutter/lib/src/replay/integration.dart
+++ b/flutter/lib/src/replay/integration.dart
@@ -33,20 +33,20 @@ class ReplayIntegration extends Integration<SentryFlutterOptions> {
       }
 
       SentryScreenshotWidget.onBuild((status, prevStatus) {
-        if (status != prevStatus) {
-          // Skip config update if the difference is negligible (e.g., due to floating-point precision)
-          // e.g a size.height of 200.00001 and 200.001 could be treated as equals
-          if (prevStatus != null && status.almostEquals(prevStatus)) {
-            return true;
-          }
-          _native.setReplayConfig(ReplayConfig(
-              windowWidth: status.size?.width ?? 0.0,
-              windowHeight: status.size?.height ?? 0.0,
-              width: replayOptions.quality.resolutionScalingFactor *
-                  (status.size?.width ?? 0.0),
-              height: replayOptions.quality.resolutionScalingFactor *
-                  (status.size?.height ?? 0.0)));
+        // Skip config update if the difference is negligible (e.g., due to floating-point precision)
+        // e.g a size.height of 200.00001 and 200.001 could be treated as equals
+        if (prevStatus != null && status.matches(prevStatus)) {
+          return true;
         }
+
+        _native.setReplayConfig(ReplayConfig(
+            windowWidth: status.size?.width ?? 0.0,
+            windowHeight: status.size?.height ?? 0.0,
+            width: replayOptions.quality.resolutionScalingFactor *
+                (status.size?.width ?? 0.0),
+            height: replayOptions.quality.resolutionScalingFactor *
+                (status.size?.height ?? 0.0)));
+
         return true;
       });
     }

--- a/flutter/lib/src/replay/integration.dart
+++ b/flutter/lib/src/replay/integration.dart
@@ -34,6 +34,11 @@ class ReplayIntegration extends Integration<SentryFlutterOptions> {
 
       SentryScreenshotWidget.onBuild((status, prevStatus) {
         if (status != prevStatus) {
+          // Skip config update if the difference is negligible (e.g., due to floating-point precision)
+          // e.g a size.height of 200.00001 and 200.001 could be treated as equals
+          if (prevStatus != null && status.almostEquals(prevStatus)) {
+            return true;
+          }
           _native.setReplayConfig(ReplayConfig(
               windowWidth: status.size?.width ?? 0.0,
               windowHeight: status.size?.height ?? 0.0,

--- a/flutter/lib/src/screenshot/sentry_screenshot_widget.dart
+++ b/flutter/lib/src/screenshot/sentry_screenshot_widget.dart
@@ -198,25 +198,41 @@ class SentryScreenshotWidgetStatus {
 
     if (orientation != other.orientation) return false;
 
-    if (pixelRatio != other.pixelRatio) {
-      if (pixelRatio == null || other.pixelRatio == null) return false;
-      if ((pixelRatio! - other.pixelRatio!).abs() > _pixelRatioTolerance) {
-        return false;
-      }
+    if (!_almostEqual(pixelRatio, other.pixelRatio, _pixelRatioTolerance)) {
+      return false;
     }
 
-    if (size != other.size) {
-      if (size == null || other.size == null) return false;
-      final widthDiff = (size!.width - other.size!.width).abs();
-      final heightDiff = (size!.height - other.size!.height).abs();
-      if (widthDiff > _sizeTolerance || heightDiff > _sizeTolerance) {
-        return false;
-      }
+    if (!_sizeAlmostEqual(size, other.size, _sizeTolerance)) {
+      return false;
     }
 
     return true;
   }
 
   @override
-  int get hashCode => Object.hash(size, pixelRatio, orientation);
+  int get hashCode {
+    final prHash = _quantize(pixelRatio, _pixelRatioTolerance);
+    final wHash = _quantize(size?.width, _sizeTolerance);
+    final hHash = _quantize(size?.height, _sizeTolerance);
+
+    return Object.hash(orientation, prHash, wHash, hHash);
+  }
+
+  static bool _almostEqual(double? a, double? b, double tol) {
+    if (a == b) return true;
+    if (a == null || b == null) return false;
+    return (a - b).abs() <= tol;
+  }
+
+  static bool _sizeAlmostEqual(Size? a, Size? b, double tol) {
+    if (a == b) return true;
+    if (a == null || b == null) return false;
+    return (a.width - b.width).abs() <= tol &&
+        (a.height - b.height).abs() <= tol;
+  }
+
+  static int _quantize(double? value, double tol) {
+    if (value == null) return 0;
+    return (value / tol).round();
+  }
 }

--- a/flutter/lib/src/screenshot/sentry_screenshot_widget.dart
+++ b/flutter/lib/src/screenshot/sentry_screenshot_widget.dart
@@ -198,7 +198,8 @@ class SentryScreenshotWidgetStatus {
 
     if (orientation != other.orientation) return false;
 
-    if (!_almostEqual(pixelRatio, other.pixelRatio, _pixelRatioTolerance)) {
+    if (!_pixelRatioAlmostEqual(
+        pixelRatio, other.pixelRatio, _pixelRatioTolerance)) {
       return false;
     }
 
@@ -218,7 +219,7 @@ class SentryScreenshotWidgetStatus {
     return Object.hash(orientation, prHash, wHash, hHash);
   }
 
-  static bool _almostEqual(double? a, double? b, double tol) {
+  static bool _pixelRatioAlmostEqual(double? a, double? b, double tol) {
     if (a == b) return true;
     if (a == null || b == null) return false;
     return (a - b).abs() <= tol;

--- a/flutter/lib/src/screenshot/sentry_screenshot_widget.dart
+++ b/flutter/lib/src/screenshot/sentry_screenshot_widget.dart
@@ -193,11 +193,10 @@ class SentryScreenshotWidgetStatus {
     required this.orientation,
   });
 
-  bool almostEquals(SentryScreenshotWidgetStatus other) {
+  bool matches(SentryScreenshotWidgetStatus other) {
     if (identical(this, other)) return true;
     if (orientation != other.orientation) return false;
 
-    // Nulls must match exactly
     if (pixelRatio == null || other.pixelRatio == null) {
       if (pixelRatio != other.pixelRatio) return false;
     } else if ((pixelRatio! - other.pixelRatio!).abs() > _pixelRatioTolerance) {
@@ -217,16 +216,4 @@ class SentryScreenshotWidgetStatus {
 
     return true;
   }
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) return true;
-    if (other is! SentryScreenshotWidgetStatus) return false;
-    return size == other.size &&
-        pixelRatio == other.pixelRatio &&
-        orientation == other.orientation;
-  }
-
-  @override
-  int get hashCode => Object.hash(size, pixelRatio, orientation);
 }

--- a/flutter/lib/src/screenshot/sentry_screenshot_widget.dart
+++ b/flutter/lib/src/screenshot/sentry_screenshot_widget.dart
@@ -182,6 +182,9 @@ class SentryScreenshotWidgetStatus {
   final double? pixelRatio;
   final Orientation? orientation;
 
+  static const double _pixelRatioTolerance = 1e-6;
+  static const double _sizeTolerance = 0.05;
+
   const SentryScreenshotWidgetStatus({
     required this.size,
     required this.pixelRatio,
@@ -193,28 +196,22 @@ class SentryScreenshotWidgetStatus {
     if (identical(this, other)) return true;
     if (other is! SentryScreenshotWidgetStatus) return false;
 
-    // First, try exact equality (the original method) - this is faster and handles most cases
-    if (orientation == other.orientation &&
-        pixelRatio == other.pixelRatio &&
-        size == other.size) {
-      return true;
-    }
-
-    // If exact equality fails, use tolerance-based comparison as additional safeguard
-    // This prevents false reconfiguration when values differ by tiny amounts
-    // due to floating-point precision issues
     if (orientation != other.orientation) return false;
+
     if (pixelRatio != other.pixelRatio) {
       if (pixelRatio == null || other.pixelRatio == null) return false;
-      const double tolerance = 1e-6;
-      if ((pixelRatio! - other.pixelRatio!).abs() > tolerance) return false;
+      if ((pixelRatio! - other.pixelRatio!).abs() > _pixelRatioTolerance) {
+        return false;
+      }
     }
+
     if (size != other.size) {
       if (size == null || other.size == null) return false;
-      const double tolerance = 0.05;
       final widthDiff = (size!.width - other.size!.width).abs();
       final heightDiff = (size!.height - other.size!.height).abs();
-      if (widthDiff >= tolerance || heightDiff >= tolerance) return false;
+      if (widthDiff > _sizeTolerance || heightDiff > _sizeTolerance) {
+        return false;
+      }
     }
 
     return true;

--- a/flutter/lib/src/screenshot/sentry_screenshot_widget.dart
+++ b/flutter/lib/src/screenshot/sentry_screenshot_widget.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
 import '../../sentry_flutter.dart';

--- a/flutter/lib/src/screenshot/sentry_screenshot_widget.dart
+++ b/flutter/lib/src/screenshot/sentry_screenshot_widget.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
 import '../../sentry_flutter.dart';
@@ -198,42 +200,31 @@ class SentryScreenshotWidgetStatus {
 
     if (orientation != other.orientation) return false;
 
-    if (!_pixelRatioAlmostEqual(
-        pixelRatio, other.pixelRatio, _pixelRatioTolerance)) {
-      return false;
-    }
+    final pr1 = pixelRatio?.roundToResolution(_pixelRatioTolerance);
+    final pr2 = other.pixelRatio?.roundToResolution(_pixelRatioTolerance);
+    if (pr1 != pr2) return false;
 
-    if (!_sizeAlmostEqual(size, other.size, _sizeTolerance)) {
-      return false;
-    }
+    final w1 = size?.width.roundToResolution(_sizeTolerance);
+    final h1 = size?.height.roundToResolution(_sizeTolerance);
+    final w2 = other.size?.width.roundToResolution(_sizeTolerance);
+    final h2 = other.size?.height.roundToResolution(_sizeTolerance);
+    if (w1 != w2 || h1 != h2) return false;
 
     return true;
   }
 
   @override
   int get hashCode {
-    final prHash = _quantize(pixelRatio, _pixelRatioTolerance);
-    final wHash = _quantize(size?.width, _sizeTolerance);
-    final hHash = _quantize(size?.height, _sizeTolerance);
-
-    return Object.hash(orientation, prHash, wHash, hHash);
+    final pr = pixelRatio?.roundToResolution(_pixelRatioTolerance);
+    final w = size?.width.roundToResolution(_sizeTolerance);
+    final h = size?.height.roundToResolution(_sizeTolerance);
+    return Object.hash(orientation, pr, w, h);
   }
+}
 
-  static bool _pixelRatioAlmostEqual(double? a, double? b, double tol) {
-    if (a == b) return true;
-    if (a == null || b == null) return false;
-    return (a - b).abs() <= tol;
-  }
-
-  static bool _sizeAlmostEqual(Size? a, Size? b, double tol) {
-    if (a == b) return true;
-    if (a == null || b == null) return false;
-    return (a.width - b.width).abs() <= tol &&
-        (a.height - b.height).abs() <= tol;
-  }
-
-  static int _quantize(double? value, double tol) {
-    if (value == null) return 0;
-    return (value / tol).round();
+extension _RoundToTolerance on double {
+  /// Rounds this value to the nearest multiple of [resolution].
+  double roundToResolution(double resolution) {
+    return (this / resolution).round() * resolution;
   }
 }

--- a/flutter/lib/src/screenshot/sentry_screenshot_widget.dart
+++ b/flutter/lib/src/screenshot/sentry_screenshot_widget.dart
@@ -107,7 +107,7 @@ class _SentryScreenshotWidgetState extends State<SentryScreenshotWidget> {
     final status = SentryScreenshotWidgetStatus(
       size: mq.size,
       pixelRatio: mq.devicePixelRatio,
-      orientantion: mq.orientation,
+      orientation: mq.orientation,
     );
     final prevStatus = SentryScreenshotWidget._status;
     SentryScreenshotWidget._status = status;
@@ -180,11 +180,23 @@ class _SentryScreenshotWidgetState extends State<SentryScreenshotWidget> {
 class SentryScreenshotWidgetStatus {
   final Size? size;
   final double? pixelRatio;
-  final Orientation? orientantion;
+  final Orientation? orientation;
 
   const SentryScreenshotWidgetStatus({
     required this.size,
     required this.pixelRatio,
-    required this.orientantion,
+    required this.orientation,
   });
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other is! SentryScreenshotWidgetStatus) return false;
+    return size == other.size &&
+        pixelRatio == other.pixelRatio &&
+        orientation == other.orientation;
+  }
+
+  @override
+  int get hashCode => Object.hash(size, pixelRatio, orientation);
 }

--- a/flutter/lib/src/screenshot/sentry_screenshot_widget.dart
+++ b/flutter/lib/src/screenshot/sentry_screenshot_widget.dart
@@ -193,38 +193,40 @@ class SentryScreenshotWidgetStatus {
     required this.orientation,
   });
 
-  @override
-  bool operator ==(Object other) {
+  bool almostEquals(SentryScreenshotWidgetStatus other) {
     if (identical(this, other)) return true;
-    if (other is! SentryScreenshotWidgetStatus) return false;
-
     if (orientation != other.orientation) return false;
 
-    final pr1 = pixelRatio?.roundToResolution(_pixelRatioTolerance);
-    final pr2 = other.pixelRatio?.roundToResolution(_pixelRatioTolerance);
-    if (pr1 != pr2) return false;
+    // Nulls must match exactly
+    if (pixelRatio == null || other.pixelRatio == null) {
+      if (pixelRatio != other.pixelRatio) return false;
+    } else if ((pixelRatio! - other.pixelRatio!).abs() > _pixelRatioTolerance) {
+      return false;
+    }
 
-    final w1 = size?.width.roundToResolution(_sizeTolerance);
-    final h1 = size?.height.roundToResolution(_sizeTolerance);
-    final w2 = other.size?.width.roundToResolution(_sizeTolerance);
-    final h2 = other.size?.height.roundToResolution(_sizeTolerance);
-    if (w1 != w2 || h1 != h2) return false;
+    if (size == null || other.size == null) {
+      if (size != other.size) return false;
+    } else {
+      if ((size!.width - other.size!.width).abs() > _sizeTolerance) {
+        return false;
+      }
+      if ((size!.height - other.size!.height).abs() > _sizeTolerance) {
+        return false;
+      }
+    }
 
     return true;
   }
 
   @override
-  int get hashCode {
-    final pr = pixelRatio?.roundToResolution(_pixelRatioTolerance);
-    final w = size?.width.roundToResolution(_sizeTolerance);
-    final h = size?.height.roundToResolution(_sizeTolerance);
-    return Object.hash(orientation, pr, w, h);
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other is! SentryScreenshotWidgetStatus) return false;
+    return size == other.size &&
+        pixelRatio == other.pixelRatio &&
+        orientation == other.orientation;
   }
-}
 
-extension _RoundToTolerance on double {
-  /// Rounds this value to the nearest multiple of [resolution].
-  double roundToResolution(double resolution) {
-    return (this / resolution).round() * resolution;
-  }
+  @override
+  int get hashCode => Object.hash(size, pixelRatio, orientation);
 }

--- a/flutter/lib/src/screenshot/sentry_screenshot_widget.dart
+++ b/flutter/lib/src/screenshot/sentry_screenshot_widget.dart
@@ -192,9 +192,32 @@ class SentryScreenshotWidgetStatus {
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
     if (other is! SentryScreenshotWidgetStatus) return false;
-    return size == other.size &&
+
+    // First, try exact equality (the original method) - this is faster and handles most cases
+    if (orientation == other.orientation &&
         pixelRatio == other.pixelRatio &&
-        orientation == other.orientation;
+        size == other.size) {
+      return true;
+    }
+
+    // If exact equality fails, use tolerance-based comparison as additional safeguard
+    // This prevents false reconfiguration when values differ by tiny amounts
+    // due to floating-point precision issues
+    if (orientation != other.orientation) return false;
+    if (pixelRatio != other.pixelRatio) {
+      if (pixelRatio == null || other.pixelRatio == null) return false;
+      const double tolerance = 1e-6;
+      if ((pixelRatio! - other.pixelRatio!).abs() > tolerance) return false;
+    }
+    if (size != other.size) {
+      if (size == null || other.size == null) return false;
+      const double tolerance = 0.05;
+      final widthDiff = (size!.width - other.size!.width).abs();
+      final heightDiff = (size!.height - other.size!.height).abs();
+      if (widthDiff >= tolerance || heightDiff >= tolerance) return false;
+    }
+
+    return true;
   }
 
   @override

--- a/flutter/test/replay/replay_integration_test.dart
+++ b/flutter/test/replay/replay_integration_test.dart
@@ -120,13 +120,11 @@ void main() {
     await pumpTestElement(tester);
     await tester.pumpAndSettle(Duration(seconds: 1));
 
-    verify(native.setReplayConfig(any)).called(1);
-
     tester.view.physicalSize = Size(10, 20);
     await pumpTestElement(tester);
     await tester.pumpAndSettle(Duration(seconds: 1));
 
-    verifyNever(native.setReplayConfig(any));
+    verify(native.setReplayConfig(any)).called(1);
   });
 
   testWidgets('Does call setReplayConfig again when widget size changed',

--- a/flutter/test/replay/replay_integration_test.dart
+++ b/flutter/test/replay/replay_integration_test.dart
@@ -3,7 +3,8 @@
 @TestOn('vm')
 library;
 
-import 'package:flutter/material.dart';
+import 'dart:ui';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';

--- a/flutter/test/replay/replay_integration_test.dart
+++ b/flutter/test/replay/replay_integration_test.dart
@@ -32,8 +32,6 @@ void main() {
 
   tearDown(() {
     SentryScreenshotWidget.reset();
-    // Reset the view to default physical size for clean test state
-    // This ensures each test starts with the default 800x600 size
     final binding = TestWidgetsFlutterBinding.ensureInitialized();
     for (final view in binding.platformDispatcher.views) {
       view.resetPhysicalSize();

--- a/flutter/test/replay/replay_integration_test.dart
+++ b/flutter/test/replay/replay_integration_test.dart
@@ -32,6 +32,12 @@ void main() {
 
   tearDown(() {
     SentryScreenshotWidget.reset();
+    // Reset the view to default physical size for clean test state
+    // This ensures each test starts with the default 800x600 size
+    final binding = TestWidgetsFlutterBinding.ensureInitialized();
+    for (final view in binding.platformDispatcher.views) {
+      view.resetPhysicalSize();
+    }
   });
 
   for (var supportsReplay in [true, false]) {

--- a/flutter/test/screenshot/sentry_screenshot_widget_test.dart
+++ b/flutter/test/screenshot/sentry_screenshot_widget_test.dart
@@ -124,6 +124,182 @@ void main() {
       expect(find.text('Send Bug Report'), findsOne);
     });
   });
+
+  group('SentryScreenshotWidgetStatus', () {
+    group('equality operator', () {
+      test('returns true for identical instances', () {
+        final status = SentryScreenshotWidgetStatus(
+          size: const Size(100, 200),
+          pixelRatio: 2.0,
+          orientation: Orientation.portrait,
+        );
+        
+        expect(status == status, isTrue);
+      });
+
+      test('returns true for instances with same values', () {
+        final status1 = SentryScreenshotWidgetStatus(
+          size: const Size(100, 200),
+          pixelRatio: 2.0,
+          orientation: Orientation.portrait,
+        );
+        final status2 = SentryScreenshotWidgetStatus(
+          size: const Size(100, 200),
+          pixelRatio: 2.0,
+          orientation: Orientation.portrait,
+        );
+        
+        expect(status1 == status2, isTrue);
+      });
+
+      test('returns false for instances with different size', () {
+        final status1 = SentryScreenshotWidgetStatus(
+          size: const Size(100, 200),
+          pixelRatio: 2.0,
+          orientation: Orientation.portrait,
+        );
+        final status2 = SentryScreenshotWidgetStatus(
+          size: const Size(200, 300),
+          pixelRatio: 2.0,
+          orientation: Orientation.portrait,
+        );
+        
+        expect(status1 == status2, isFalse);
+      });
+
+      test('returns false for instances with different pixelRatio', () {
+        final status1 = SentryScreenshotWidgetStatus(
+          size: const Size(100, 200),
+          pixelRatio: 2.0,
+          orientation: Orientation.portrait,
+        );
+        final status2 = SentryScreenshotWidgetStatus(
+          size: const Size(100, 200),
+          pixelRatio: 3.0,
+          orientation: Orientation.portrait,
+        );
+        
+        expect(status1 == status2, isFalse);
+      });
+
+      test('returns false for instances with different orientation', () {
+        final status1 = SentryScreenshotWidgetStatus(
+          size: const Size(100, 200),
+          pixelRatio: 2.0,
+          orientation: Orientation.portrait,
+        );
+        final status2 = SentryScreenshotWidgetStatus(
+          size: const Size(100, 200),
+          pixelRatio: 2.0,
+          orientation: Orientation.landscape,
+        );
+        
+        expect(status1 == status2, isFalse);
+      });
+
+      test('returns false for null values comparison', () {
+        final status1 = SentryScreenshotWidgetStatus(
+          size: const Size(100, 200),
+          pixelRatio: 2.0,
+          orientation: Orientation.portrait,
+        );
+        final status2 = SentryScreenshotWidgetStatus(
+          size: null,
+          pixelRatio: null,
+          orientation: null,
+        );
+        
+        expect(status1 == status2, isFalse);
+      });
+
+      test('returns true for instances with all null values', () {
+        final status1 = SentryScreenshotWidgetStatus(
+          size: null,
+          pixelRatio: null,
+          orientation: null,
+        );
+        final status2 = SentryScreenshotWidgetStatus(
+          size: null,
+          pixelRatio: null,
+          orientation: null,
+        );
+        
+        expect(status1 == status2, isTrue);
+      });
+
+      test('returns false when compared to different type', () {
+        final status = SentryScreenshotWidgetStatus(
+          size: const Size(100, 200),
+          pixelRatio: 2.0,
+          orientation: Orientation.portrait,
+        );
+        
+        expect(status == 'not a status', isFalse);
+        expect(status == 42, isFalse);
+        expect(status == null, isFalse);
+      });
+    });
+
+    group('hashCode', () {
+      test('returns same hashCode for equal instances', () {
+        final status1 = SentryScreenshotWidgetStatus(
+          size: const Size(100, 200),
+          pixelRatio: 2.0,
+          orientation: Orientation.portrait,
+        );
+        final status2 = SentryScreenshotWidgetStatus(
+          size: const Size(100, 200),
+          pixelRatio: 2.0,
+          orientation: Orientation.portrait,
+        );
+        
+        expect(status1.hashCode, equals(status2.hashCode));
+      });
+
+      test('returns different hashCode for different instances', () {
+        final status1 = SentryScreenshotWidgetStatus(
+          size: const Size(100, 200),
+          pixelRatio: 2.0,
+          orientation: Orientation.portrait,
+        );
+        final status2 = SentryScreenshotWidgetStatus(
+          size: const Size(200, 300),
+          pixelRatio: 3.0,
+          orientation: Orientation.landscape,
+        );
+        
+        expect(status1.hashCode, isNot(equals(status2.hashCode)));
+      });
+
+      test('hashCode is consistent across multiple calls', () {
+        final status = SentryScreenshotWidgetStatus(
+          size: const Size(100, 200),
+          pixelRatio: 2.0,
+          orientation: Orientation.portrait,
+        );
+        
+        final hashCode1 = status.hashCode;
+        final hashCode2 = status.hashCode;
+        
+        expect(hashCode1, equals(hashCode2));
+      });
+
+      test('handles null values in hashCode calculation', () {
+        final status1 = SentryScreenshotWidgetStatus(
+          size: null,
+          pixelRatio: null,
+          orientation: null,
+        );
+        final status2 = SentryScreenshotWidgetStatus(
+          size: null,
+          pixelRatio: null,
+          orientation: null,
+        );
+        
+        expect(status1.hashCode, equals(status2.hashCode));
+      });
+    });
+  });
 }
 
 @GenerateMocks([Callbacks])

--- a/flutter/test/screenshot/sentry_screenshot_widget_test.dart
+++ b/flutter/test/screenshot/sentry_screenshot_widget_test.dart
@@ -126,6 +126,105 @@ void main() {
   });
 
   group('SentryScreenshotWidgetStatus', () {
+    group('almostEquals', () {
+      test('returns true for instances with very close pixelRatio values', () {
+        final status1 = SentryScreenshotWidgetStatus(
+          size: const Size(100, 200),
+          pixelRatio: 2.0,
+          orientation: Orientation.portrait,
+        );
+        final status2 = SentryScreenshotWidgetStatus(
+          size: const Size(100, 200),
+          pixelRatio: 2.0000001, // Very close to 2.0
+          orientation: Orientation.portrait,
+        );
+
+        expect(status1.almostEquals(status2), isTrue);
+      });
+
+      test('returns true for instances with very close size dimensions', () {
+        final status1 = SentryScreenshotWidgetStatus(
+          size: const Size(100.0, 200.0),
+          pixelRatio: 2.0,
+          orientation: Orientation.portrait,
+        );
+        final status2 = SentryScreenshotWidgetStatus(
+          size: const Size(100.005, 200.005),
+          // Very close dimensions (within 0.01 tolerance)
+          pixelRatio: 2.0,
+          orientation: Orientation.portrait,
+        );
+
+        expect(status1.almostEquals(status2), isTrue);
+      });
+
+      test(
+          'returns false for instances with significantly different pixelRatio',
+          () {
+        final status1 = SentryScreenshotWidgetStatus(
+          size: const Size(100, 200),
+          pixelRatio: 2.0,
+          orientation: Orientation.portrait,
+        );
+        final status2 = SentryScreenshotWidgetStatus(
+          size: const Size(100, 200),
+          pixelRatio: 2.1, // Significantly different
+          orientation: Orientation.portrait,
+        );
+
+        expect(status1.almostEquals(status2), isFalse);
+      });
+
+      test(
+          'returns false for instances with significantly different size dimensions',
+          () {
+        final status1 = SentryScreenshotWidgetStatus(
+          size: const Size(100.0, 200.0),
+          pixelRatio: 2.0,
+          orientation: Orientation.portrait,
+        );
+        final status2 = SentryScreenshotWidgetStatus(
+          size: const Size(100.1, 200.0), // Significantly different width
+          pixelRatio: 2.0,
+          orientation: Orientation.portrait,
+        );
+
+        expect(status1.almostEquals(status2), isFalse);
+      });
+
+      test(
+          'returns true for instances with significantly different size dimensions',
+          () {
+        final status1 = SentryScreenshotWidgetStatus(
+          size: const Size(100.0, 200.0),
+          pixelRatio: 2.0,
+          orientation: Orientation.portrait,
+        );
+        final status2 = SentryScreenshotWidgetStatus(
+          size: const Size(100.01, 200.0), // Significantly different width
+          pixelRatio: 2.0,
+          orientation: Orientation.portrait,
+        );
+
+        expect(status1.almostEquals(status2), isTrue);
+      });
+
+      test('returns true if values are within tolerance', () {
+        final status1 = SentryScreenshotWidgetStatus(
+          size: const Size(100.0, 200.0),
+          pixelRatio: 2.0,
+          orientation: Orientation.portrait,
+        );
+        final status2 = SentryScreenshotWidgetStatus(
+          size: const Size(100.005, 200.005),
+          pixelRatio: 2.0000001,
+          orientation: Orientation.portrait,
+        );
+
+        expect(status1.almostEquals(status2), isTrue);
+      });
+    });
+
     group('equality operator', () {
       test('returns true for identical instances', () {
         final status = SentryScreenshotWidgetStatus(
@@ -227,88 +326,6 @@ void main() {
         expect(status1 == status2, isTrue);
       });
 
-      test('returns true for instances with very close pixelRatio values', () {
-        final status1 = SentryScreenshotWidgetStatus(
-          size: const Size(100, 200),
-          pixelRatio: 2.0,
-          orientation: Orientation.portrait,
-        );
-        final status2 = SentryScreenshotWidgetStatus(
-          size: const Size(100, 200),
-          pixelRatio: 2.0000001, // Very close to 2.0
-          orientation: Orientation.portrait,
-        );
-
-        expect(status1 == status2, isTrue);
-      });
-
-      test('returns true for instances with very close size dimensions', () {
-        final status1 = SentryScreenshotWidgetStatus(
-          size: const Size(100.0, 200.0),
-          pixelRatio: 2.0,
-          orientation: Orientation.portrait,
-        );
-        final status2 = SentryScreenshotWidgetStatus(
-          size: const Size(100.005, 200.005),
-          // Very close dimensions (within 0.01 tolerance)
-          pixelRatio: 2.0,
-          orientation: Orientation.portrait,
-        );
-
-        expect(status1 == status2, isTrue);
-      });
-
-      test(
-          'returns false for instances with significantly different pixelRatio',
-          () {
-        final status1 = SentryScreenshotWidgetStatus(
-          size: const Size(100, 200),
-          pixelRatio: 2.0,
-          orientation: Orientation.portrait,
-        );
-        final status2 = SentryScreenshotWidgetStatus(
-          size: const Size(100, 200),
-          pixelRatio: 2.1, // Significantly different
-          orientation: Orientation.portrait,
-        );
-
-        expect(status1 == status2, isFalse);
-      });
-
-      test(
-          'returns false for instances with significantly different size dimensions',
-          () {
-        final status1 = SentryScreenshotWidgetStatus(
-          size: const Size(100.0, 200.0),
-          pixelRatio: 2.0,
-          orientation: Orientation.portrait,
-        );
-        final status2 = SentryScreenshotWidgetStatus(
-          size: const Size(100.1, 200.0), // Significantly different width
-          pixelRatio: 2.0,
-          orientation: Orientation.portrait,
-        );
-
-        expect(status1 == status2, isFalse);
-      });
-
-      test(
-          'returns true for instances with significantly different size dimensions',
-          () {
-        final status1 = SentryScreenshotWidgetStatus(
-          size: const Size(100.0, 200.0),
-          pixelRatio: 2.0,
-          orientation: Orientation.portrait,
-        );
-        final status2 = SentryScreenshotWidgetStatus(
-          size: const Size(100.01, 200.0), // Significantly different width
-          pixelRatio: 2.0,
-          orientation: Orientation.portrait,
-        );
-
-        expect(status1 == status2, isTrue);
-      });
-
       test('returns true for exact equality', () {
         final status1 = SentryScreenshotWidgetStatus(
           size: const Size(100.0, 200.0),
@@ -321,26 +338,6 @@ void main() {
           orientation: Orientation.portrait,
         );
 
-        expect(status1 == status2, isTrue);
-      });
-
-      test(
-          'layered equality check tolerance fallback when exact equality fails',
-          () {
-        final status1 = SentryScreenshotWidgetStatus(
-          size: const Size(100.0, 200.0),
-          pixelRatio: 2.0,
-          orientation: Orientation.portrait,
-        );
-        final status2 = SentryScreenshotWidgetStatus(
-          size: const Size(100.005, 200.005),
-          // Very close but not exact (within 0.01 tolerance)
-          pixelRatio: 2.0000001,
-          // Very close but not exact (within 1e-6 tolerance)
-          orientation: Orientation.portrait,
-        );
-
-        // This should fail exact equality but pass tolerance check
         expect(status1 == status2, isTrue);
       });
     });

--- a/flutter/test/screenshot/sentry_screenshot_widget_test.dart
+++ b/flutter/test/screenshot/sentry_screenshot_widget_test.dart
@@ -226,6 +226,106 @@ void main() {
 
         expect(status1 == status2, isTrue);
       });
+
+      test(
+          'returns true for instances below the tolerance for different pixelRatio',
+          () {
+        final status1 = SentryScreenshotWidgetStatus(
+          size: const Size(100, 200),
+          pixelRatio: 2.0,
+          orientation: Orientation.portrait,
+        );
+        final status2 = SentryScreenshotWidgetStatus(
+          size: const Size(100, 200),
+          pixelRatio: 2.0000001, // Very close to 2.0
+          orientation: Orientation.portrait,
+        );
+
+        expect(status1 == status2, isTrue);
+      });
+
+      test(
+          'returns false for instances over the tolerance for different pixelRatio',
+          () {
+        final status1 = SentryScreenshotWidgetStatus(
+          size: const Size(100, 200),
+          pixelRatio: 2.0,
+          orientation: Orientation.portrait,
+        );
+        final status2 = SentryScreenshotWidgetStatus(
+          size: const Size(100, 200),
+          pixelRatio: 2.1, // Significantly different
+          orientation: Orientation.portrait,
+        );
+
+        expect(status1 == status2, isFalse);
+      });
+
+      test(
+          'returns false for instances over the tolerance for different size dimensions',
+          () {
+        final status1 = SentryScreenshotWidgetStatus(
+          size: const Size(100.0, 200.0),
+          pixelRatio: 2.0,
+          orientation: Orientation.portrait,
+        );
+        final status2 = SentryScreenshotWidgetStatus(
+          size: const Size(100.1, 200.0), // Significantly different width
+          pixelRatio: 2.0,
+          orientation: Orientation.portrait,
+        );
+
+        expect(status1 == status2, isFalse);
+      });
+
+      test(
+          'returns true for instances below the tolerance for different size dimensions',
+          () {
+        final status1 = SentryScreenshotWidgetStatus(
+          size: const Size(100.0, 200.0),
+          pixelRatio: 2.0,
+          orientation: Orientation.portrait,
+        );
+        final status2 = SentryScreenshotWidgetStatus(
+          size: const Size(100.01, 200.0),
+          pixelRatio: 2.0,
+          orientation: Orientation.portrait,
+        );
+
+        expect(status1 == status2, isTrue);
+      });
+
+      test('returns true for exact equality', () {
+        final status1 = SentryScreenshotWidgetStatus(
+          size: const Size(100.0, 200.0),
+          pixelRatio: 2.0,
+          orientation: Orientation.portrait,
+        );
+        final status2 = SentryScreenshotWidgetStatus(
+          size: const Size(100.0, 200.0), // Exactly the same
+          pixelRatio: 2.0,
+          orientation: Orientation.portrait,
+        );
+
+        expect(status1 == status2, isTrue);
+      });
+
+      test(
+          'returns true when checking successful tolerance fallback when exact equality fails',
+          () {
+        final status1 = SentryScreenshotWidgetStatus(
+          size: const Size(100.0, 200.0),
+          pixelRatio: 2.0,
+          orientation: Orientation.portrait,
+        );
+        final status2 = SentryScreenshotWidgetStatus(
+          size: const Size(100.005, 200.005),
+          pixelRatio: 2.0000001,
+          orientation: Orientation.portrait,
+        );
+
+        expect(status1 == status2, isTrue);
+      });
     });
 
     group('hashCode', () {

--- a/flutter/test/screenshot/sentry_screenshot_widget_test.dart
+++ b/flutter/test/screenshot/sentry_screenshot_widget_test.dart
@@ -227,9 +227,7 @@ void main() {
         expect(status1 == status2, isTrue);
       });
 
-      test(
-          'returns true for instances below the tolerance for different pixelRatio',
-          () {
+      test('returns true for instances with very close pixelRatio values', () {
         final status1 = SentryScreenshotWidgetStatus(
           size: const Size(100, 200),
           pixelRatio: 2.0,
@@ -244,8 +242,24 @@ void main() {
         expect(status1 == status2, isTrue);
       });
 
+      test('returns true for instances with very close size dimensions', () {
+        final status1 = SentryScreenshotWidgetStatus(
+          size: const Size(100.0, 200.0),
+          pixelRatio: 2.0,
+          orientation: Orientation.portrait,
+        );
+        final status2 = SentryScreenshotWidgetStatus(
+          size: const Size(100.005, 200.005),
+          // Very close dimensions (within 0.01 tolerance)
+          pixelRatio: 2.0,
+          orientation: Orientation.portrait,
+        );
+
+        expect(status1 == status2, isTrue);
+      });
+
       test(
-          'returns false for instances over the tolerance for different pixelRatio',
+          'returns false for instances with significantly different pixelRatio',
           () {
         final status1 = SentryScreenshotWidgetStatus(
           size: const Size(100, 200),
@@ -262,7 +276,7 @@ void main() {
       });
 
       test(
-          'returns false for instances over the tolerance for different size dimensions',
+          'returns false for instances with significantly different size dimensions',
           () {
         final status1 = SentryScreenshotWidgetStatus(
           size: const Size(100.0, 200.0),
@@ -279,7 +293,7 @@ void main() {
       });
 
       test(
-          'returns true for instances below the tolerance for different size dimensions',
+          'returns true for instances with significantly different size dimensions',
           () {
         final status1 = SentryScreenshotWidgetStatus(
           size: const Size(100.0, 200.0),
@@ -287,7 +301,7 @@ void main() {
           orientation: Orientation.portrait,
         );
         final status2 = SentryScreenshotWidgetStatus(
-          size: const Size(100.01, 200.0),
+          size: const Size(100.01, 200.0), // Significantly different width
           pixelRatio: 2.0,
           orientation: Orientation.portrait,
         );
@@ -311,7 +325,7 @@ void main() {
       });
 
       test(
-          'returns true when checking successful tolerance fallback when exact equality fails',
+          'layered equality check tolerance fallback when exact equality fails',
           () {
         final status1 = SentryScreenshotWidgetStatus(
           size: const Size(100.0, 200.0),
@@ -320,10 +334,13 @@ void main() {
         );
         final status2 = SentryScreenshotWidgetStatus(
           size: const Size(100.005, 200.005),
+          // Very close but not exact (within 0.01 tolerance)
           pixelRatio: 2.0000001,
+          // Very close but not exact (within 1e-6 tolerance)
           orientation: Orientation.portrait,
         );
 
+        // This should fail exact equality but pass tolerance check
         expect(status1 == status2, isTrue);
       });
     });
@@ -385,6 +402,56 @@ void main() {
         );
 
         expect(status1.hashCode, equals(status2.hashCode));
+      });
+
+      test(
+          'returns different hashCode for pixelRatio difference just over tolerance',
+          () {
+        final status1 = SentryScreenshotWidgetStatus(
+          size: const Size(100.0, 200.0),
+          pixelRatio: 2.0,
+          orientation: Orientation.portrait,
+        );
+        final status2 = SentryScreenshotWidgetStatus(
+          size: const Size(100.0, 200.0),
+          pixelRatio: 2.000001,
+          orientation: Orientation.portrait,
+        );
+
+        expect(status1.hashCode, isNot(equals(status2.hashCode)));
+      });
+
+      test('returns different hashCode for size difference just over tolerance',
+          () {
+        final status1 = SentryScreenshotWidgetStatus(
+          size: const Size(100.0, 200.0),
+          pixelRatio: 2.0,
+          orientation: Orientation.portrait,
+        );
+        final status2 = SentryScreenshotWidgetStatus(
+          size: const Size(100.1, 200.0),
+          pixelRatio: 2.0,
+          orientation: Orientation.portrait,
+        );
+
+        expect(status1.hashCode, isNot(equals(status2.hashCode)));
+      });
+
+      test(
+          'returns different hashCode for same size/pixelRatio but different orientation',
+          () {
+        final status1 = SentryScreenshotWidgetStatus(
+          size: const Size(100.0, 200.0),
+          pixelRatio: 2.0,
+          orientation: Orientation.portrait,
+        );
+        final status2 = SentryScreenshotWidgetStatus(
+          size: const Size(100.0, 200.0),
+          pixelRatio: 2.0,
+          orientation: Orientation.landscape,
+        );
+
+        expect(status1.hashCode, isNot(equals(status2.hashCode)));
       });
     });
   });

--- a/flutter/test/screenshot/sentry_screenshot_widget_test.dart
+++ b/flutter/test/screenshot/sentry_screenshot_widget_test.dart
@@ -126,7 +126,7 @@ void main() {
   });
 
   group('SentryScreenshotWidgetStatus', () {
-    group('almostEquals', () {
+    group('matches', () {
       test('returns true for instances with very close pixelRatio values', () {
         final status1 = SentryScreenshotWidgetStatus(
           size: const Size(100, 200),
@@ -139,7 +139,7 @@ void main() {
           orientation: Orientation.portrait,
         );
 
-        expect(status1.almostEquals(status2), isTrue);
+        expect(status1.matches(status2), isTrue);
       });
 
       test('returns true for instances with very close size dimensions', () {
@@ -155,7 +155,7 @@ void main() {
           orientation: Orientation.portrait,
         );
 
-        expect(status1.almostEquals(status2), isTrue);
+        expect(status1.matches(status2), isTrue);
       });
 
       test(
@@ -172,7 +172,7 @@ void main() {
           orientation: Orientation.portrait,
         );
 
-        expect(status1.almostEquals(status2), isFalse);
+        expect(status1.matches(status2), isFalse);
       });
 
       test(
@@ -189,7 +189,7 @@ void main() {
           orientation: Orientation.portrait,
         );
 
-        expect(status1.almostEquals(status2), isFalse);
+        expect(status1.matches(status2), isFalse);
       });
 
       test(
@@ -206,7 +206,7 @@ void main() {
           orientation: Orientation.portrait,
         );
 
-        expect(status1.almostEquals(status2), isTrue);
+        expect(status1.matches(status2), isTrue);
       });
 
       test('returns true if values are within tolerance', () {
@@ -221,234 +221,7 @@ void main() {
           orientation: Orientation.portrait,
         );
 
-        expect(status1.almostEquals(status2), isTrue);
-      });
-    });
-
-    group('equality operator', () {
-      test('returns true for identical instances', () {
-        final status = SentryScreenshotWidgetStatus(
-          size: const Size(100, 200),
-          pixelRatio: 2.0,
-          orientation: Orientation.portrait,
-        );
-
-        expect(status == status, isTrue);
-      });
-
-      test('returns true for instances with same values', () {
-        final status1 = SentryScreenshotWidgetStatus(
-          size: const Size(100, 200),
-          pixelRatio: 2.0,
-          orientation: Orientation.portrait,
-        );
-        final status2 = SentryScreenshotWidgetStatus(
-          size: const Size(100, 200),
-          pixelRatio: 2.0,
-          orientation: Orientation.portrait,
-        );
-
-        expect(status1 == status2, isTrue);
-      });
-
-      test('returns false for instances with different size', () {
-        final status1 = SentryScreenshotWidgetStatus(
-          size: const Size(100, 200),
-          pixelRatio: 2.0,
-          orientation: Orientation.portrait,
-        );
-        final status2 = SentryScreenshotWidgetStatus(
-          size: const Size(200, 300),
-          pixelRatio: 2.0,
-          orientation: Orientation.portrait,
-        );
-
-        expect(status1 == status2, isFalse);
-      });
-
-      test('returns false for instances with different pixelRatio', () {
-        final status1 = SentryScreenshotWidgetStatus(
-          size: const Size(100, 200),
-          pixelRatio: 2.0,
-          orientation: Orientation.portrait,
-        );
-        final status2 = SentryScreenshotWidgetStatus(
-          size: const Size(100, 200),
-          pixelRatio: 3.0,
-          orientation: Orientation.portrait,
-        );
-
-        expect(status1 == status2, isFalse);
-      });
-
-      test('returns false for instances with different orientation', () {
-        final status1 = SentryScreenshotWidgetStatus(
-          size: const Size(100, 200),
-          pixelRatio: 2.0,
-          orientation: Orientation.portrait,
-        );
-        final status2 = SentryScreenshotWidgetStatus(
-          size: const Size(100, 200),
-          pixelRatio: 2.0,
-          orientation: Orientation.landscape,
-        );
-
-        expect(status1 == status2, isFalse);
-      });
-
-      test('returns false for null values comparison', () {
-        final status1 = SentryScreenshotWidgetStatus(
-          size: const Size(100, 200),
-          pixelRatio: 2.0,
-          orientation: Orientation.portrait,
-        );
-        final status2 = SentryScreenshotWidgetStatus(
-          size: null,
-          pixelRatio: null,
-          orientation: null,
-        );
-
-        expect(status1 == status2, isFalse);
-      });
-
-      test('returns true for instances with all null values', () {
-        final status1 = SentryScreenshotWidgetStatus(
-          size: null,
-          pixelRatio: null,
-          orientation: null,
-        );
-        final status2 = SentryScreenshotWidgetStatus(
-          size: null,
-          pixelRatio: null,
-          orientation: null,
-        );
-
-        expect(status1 == status2, isTrue);
-      });
-
-      test('returns true for exact equality', () {
-        final status1 = SentryScreenshotWidgetStatus(
-          size: const Size(100.0, 200.0),
-          pixelRatio: 2.0,
-          orientation: Orientation.portrait,
-        );
-        final status2 = SentryScreenshotWidgetStatus(
-          size: const Size(100.0, 200.0), // Exactly the same
-          pixelRatio: 2.0,
-          orientation: Orientation.portrait,
-        );
-
-        expect(status1 == status2, isTrue);
-      });
-    });
-
-    group('hashCode', () {
-      test('returns same hashCode for equal instances', () {
-        final status1 = SentryScreenshotWidgetStatus(
-          size: const Size(100, 200),
-          pixelRatio: 2.0,
-          orientation: Orientation.portrait,
-        );
-        final status2 = SentryScreenshotWidgetStatus(
-          size: const Size(100, 200),
-          pixelRatio: 2.0,
-          orientation: Orientation.portrait,
-        );
-
-        expect(status1.hashCode, equals(status2.hashCode));
-      });
-
-      test('returns different hashCode for different instances', () {
-        final status1 = SentryScreenshotWidgetStatus(
-          size: const Size(100, 200),
-          pixelRatio: 2.0,
-          orientation: Orientation.portrait,
-        );
-        final status2 = SentryScreenshotWidgetStatus(
-          size: const Size(200, 300),
-          pixelRatio: 3.0,
-          orientation: Orientation.landscape,
-        );
-
-        expect(status1.hashCode, isNot(equals(status2.hashCode)));
-      });
-
-      test('hashCode is consistent across multiple calls', () {
-        final status = SentryScreenshotWidgetStatus(
-          size: const Size(100, 200),
-          pixelRatio: 2.0,
-          orientation: Orientation.portrait,
-        );
-
-        final hashCode1 = status.hashCode;
-        final hashCode2 = status.hashCode;
-
-        expect(hashCode1, equals(hashCode2));
-      });
-
-      test('handles null values in hashCode calculation', () {
-        final status1 = SentryScreenshotWidgetStatus(
-          size: null,
-          pixelRatio: null,
-          orientation: null,
-        );
-        final status2 = SentryScreenshotWidgetStatus(
-          size: null,
-          pixelRatio: null,
-          orientation: null,
-        );
-
-        expect(status1.hashCode, equals(status2.hashCode));
-      });
-
-      test(
-          'returns different hashCode for pixelRatio difference just over tolerance',
-          () {
-        final status1 = SentryScreenshotWidgetStatus(
-          size: const Size(100.0, 200.0),
-          pixelRatio: 2.0,
-          orientation: Orientation.portrait,
-        );
-        final status2 = SentryScreenshotWidgetStatus(
-          size: const Size(100.0, 200.0),
-          pixelRatio: 2.000001,
-          orientation: Orientation.portrait,
-        );
-
-        expect(status1.hashCode, isNot(equals(status2.hashCode)));
-      });
-
-      test('returns different hashCode for size difference just over tolerance',
-          () {
-        final status1 = SentryScreenshotWidgetStatus(
-          size: const Size(100.0, 200.0),
-          pixelRatio: 2.0,
-          orientation: Orientation.portrait,
-        );
-        final status2 = SentryScreenshotWidgetStatus(
-          size: const Size(100.1, 200.0),
-          pixelRatio: 2.0,
-          orientation: Orientation.portrait,
-        );
-
-        expect(status1.hashCode, isNot(equals(status2.hashCode)));
-      });
-
-      test(
-          'returns different hashCode for same size/pixelRatio but different orientation',
-          () {
-        final status1 = SentryScreenshotWidgetStatus(
-          size: const Size(100.0, 200.0),
-          pixelRatio: 2.0,
-          orientation: Orientation.portrait,
-        );
-        final status2 = SentryScreenshotWidgetStatus(
-          size: const Size(100.0, 200.0),
-          pixelRatio: 2.0,
-          orientation: Orientation.landscape,
-        );
-
-        expect(status1.hashCode, isNot(equals(status2.hashCode)));
+        expect(status1.matches(status2), isTrue);
       });
     });
   });

--- a/flutter/test/screenshot/sentry_screenshot_widget_test.dart
+++ b/flutter/test/screenshot/sentry_screenshot_widget_test.dart
@@ -133,7 +133,7 @@ void main() {
           pixelRatio: 2.0,
           orientation: Orientation.portrait,
         );
-        
+
         expect(status == status, isTrue);
       });
 
@@ -148,7 +148,7 @@ void main() {
           pixelRatio: 2.0,
           orientation: Orientation.portrait,
         );
-        
+
         expect(status1 == status2, isTrue);
       });
 
@@ -163,7 +163,7 @@ void main() {
           pixelRatio: 2.0,
           orientation: Orientation.portrait,
         );
-        
+
         expect(status1 == status2, isFalse);
       });
 
@@ -178,7 +178,7 @@ void main() {
           pixelRatio: 3.0,
           orientation: Orientation.portrait,
         );
-        
+
         expect(status1 == status2, isFalse);
       });
 
@@ -193,7 +193,7 @@ void main() {
           pixelRatio: 2.0,
           orientation: Orientation.landscape,
         );
-        
+
         expect(status1 == status2, isFalse);
       });
 
@@ -208,7 +208,7 @@ void main() {
           pixelRatio: null,
           orientation: null,
         );
-        
+
         expect(status1 == status2, isFalse);
       });
 
@@ -223,20 +223,8 @@ void main() {
           pixelRatio: null,
           orientation: null,
         );
-        
-        expect(status1 == status2, isTrue);
-      });
 
-      test('returns false when compared to different type', () {
-        final status = SentryScreenshotWidgetStatus(
-          size: const Size(100, 200),
-          pixelRatio: 2.0,
-          orientation: Orientation.portrait,
-        );
-        
-        expect(status == 'not a status', isFalse);
-        expect(status == 42, isFalse);
-        expect(status == null, isFalse);
+        expect(status1 == status2, isTrue);
       });
     });
 
@@ -252,7 +240,7 @@ void main() {
           pixelRatio: 2.0,
           orientation: Orientation.portrait,
         );
-        
+
         expect(status1.hashCode, equals(status2.hashCode));
       });
 
@@ -267,7 +255,7 @@ void main() {
           pixelRatio: 3.0,
           orientation: Orientation.landscape,
         );
-        
+
         expect(status1.hashCode, isNot(equals(status2.hashCode)));
       });
 
@@ -277,10 +265,10 @@ void main() {
           pixelRatio: 2.0,
           orientation: Orientation.portrait,
         );
-        
+
         final hashCode1 = status.hashCode;
         final hashCode2 = status.hashCode;
-        
+
         expect(hashCode1, equals(hashCode2));
       });
 
@@ -295,7 +283,7 @@ void main() {
           pixelRatio: null,
           orientation: null,
         );
-        
+
         expect(status1.hashCode, equals(status2.hashCode));
       });
     });


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

This basically checks if the current device configuration e.g orientation, size changed and if so update the config, however this check fails currently meaning it treats every onBuild trigger as a new config.

-> Fixed `ScreenshotWidgetStatus` equality implementation to prevent false replay configuration restarts and worker spawning on rebuilds.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The `ScreenshotWidgetStatus` class lacked equality comparison, causing the replay configuration to be incorrectly identified as changed on every rebuild.

Improves https://github.com/getsentry/sentry-dart/issues/3110

## :green_heart: How did you test it?
Manual tests, unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
