### PR TITLE
chore(gh): Update GH issue templates for Linear compatibility

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -1,7 +1,6 @@
 name: 🐞 Bug Report
 description: Tell us about something that's not working the way we (probably) intend.
-labels: ["Platform: Dart", "bug"]
-type: Bug
+labels: ["Dart", "Bug"]
 body:
   - type: dropdown
     id: environment

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
@@ -1,7 +1,6 @@
 name: 💡 Feature Request
 description: Tell us about a problem our SDK could solve but doesn't.
-labels: ["Platform: Dart", "enhancement"]
-type: Feature
+labels: ["Dart", "Feature"]
 body:
   - type: textarea
     id: problem

--- a/.github/ISSUE_TEMPLATE/maintainer-blank.yml
+++ b/.github/ISSUE_TEMPLATE/maintainer-blank.yml
@@ -1,6 +1,6 @@
 name: Blank Issue
 description: Blank Issue. Reserved for maintainers.
-labels: ["Platform: Dart"]
+labels: ["Dart"]
 body:
   - type: textarea
     id: description


### PR DESCRIPTION
replaces usage of GH issue type and platform label to Linear-compatible labels

GH issue types will be deprecated internally by August 14

#skip-changelog