### PR TITLE
feat(logs): add origin to logs created by `LoggingIntegration`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Add `sentry.origin` to logs created by `LoggingIntegration` ([#3153](https://github.com/getsentry/sentry-dart/pull/3153))
 - Tag all spans with thread info on non-web platforms ([#3101](https://github.com/getsentry/sentry-dart/pull/3101), [#3144](https://github.com/getsentry/sentry-dart/pull/3144))
 
 ## 9.7.0-beta.1

--- a/packages/logging/lib/src/logging_integration.dart
+++ b/packages/logging/lib/src/logging_integration.dart
@@ -51,6 +51,7 @@ class LoggingIntegration implements Integration<SentryOptions> {
   late SentryOptions _options;
 
   @internal
+  // ignore: public_member_api_docs
   static const origin = 'auto.log.logging';
 
   @override

--- a/packages/logging/lib/src/logging_integration.dart
+++ b/packages/logging/lib/src/logging_integration.dart
@@ -102,7 +102,7 @@ class LoggingIntegration implements Integration<SentryOptions> {
         'loggerName': SentryLogAttribute.string(record.loggerName),
         'sequenceNumber': SentryLogAttribute.int(record.sequenceNumber),
         'time': SentryLogAttribute.int(record.time.millisecondsSinceEpoch),
-        'origin': SentryLogAttribute.string(origin),
+        'sentry.origin': SentryLogAttribute.string(origin),
       };
 
       // Map log levels based on value ranges

--- a/packages/logging/lib/src/logging_integration.dart
+++ b/packages/logging/lib/src/logging_integration.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:meta/meta.dart';
 import 'package:logging/logging.dart';
 import 'package:sentry/sentry.dart';
 
@@ -48,6 +49,9 @@ class LoggingIntegration implements Integration<SentryOptions> {
   late StreamSubscription<LogRecord> _subscription;
   late Hub _hub;
   late SentryOptions _options;
+
+  @internal
+  static const origin = 'auto.log.logging';
 
   @override
   void call(Hub hub, SentryOptions options) {
@@ -98,6 +102,7 @@ class LoggingIntegration implements Integration<SentryOptions> {
         'loggerName': SentryLogAttribute.string(record.loggerName),
         'sequenceNumber': SentryLogAttribute.int(record.sequenceNumber),
         'time': SentryLogAttribute.int(record.time.millisecondsSinceEpoch),
+        'origin': SentryLogAttribute.string(origin),
       };
 
       // Map log levels based on value ranges

--- a/packages/logging/pubspec.yaml
+++ b/packages/logging/pubspec.yaml
@@ -27,4 +27,3 @@ dev_dependencies:
   test: ^1.21.1
   yaml: ^3.1.0 # needed for version match (code and pubspec)
   coverage: ^1.3.0
-  meta: ^1.3.0

--- a/packages/logging/pubspec.yaml
+++ b/packages/logging/pubspec.yaml
@@ -20,6 +20,7 @@ platforms:
 dependencies:
   logging: ^1.0.0
   sentry: 9.7.0-beta.1
+  meta: ^1.17.0
 
 dev_dependencies:
   lints: '>=2.0.0'

--- a/packages/logging/test/logging_integration_test.dart
+++ b/packages/logging/test/logging_integration_test.dart
@@ -330,6 +330,7 @@ void main() {
       expect(basicAttributes['loggerName']?.value, 'TestLogger');
       expect(basicAttributes['sequenceNumber']?.value, isA<int>());
       expect(basicAttributes['time']?.value, isA<int>());
+      expect(basicAttributes['origin']?.value, LoggingIntegration.origin);
       expect(basicAttributes.containsKey('error'), false);
       expect(basicAttributes.containsKey('stackTrace'), false);
 

--- a/packages/logging/test/logging_integration_test.dart
+++ b/packages/logging/test/logging_integration_test.dart
@@ -330,7 +330,8 @@ void main() {
       expect(basicAttributes['loggerName']?.value, 'TestLogger');
       expect(basicAttributes['sequenceNumber']?.value, isA<int>());
       expect(basicAttributes['time']?.value, isA<int>());
-      expect(basicAttributes['sentry.origin']?.value, LoggingIntegration.origin);
+      expect(
+          basicAttributes['sentry.origin']?.value, LoggingIntegration.origin);
       expect(basicAttributes.containsKey('error'), false);
       expect(basicAttributes.containsKey('stackTrace'), false);
 

--- a/packages/logging/test/logging_integration_test.dart
+++ b/packages/logging/test/logging_integration_test.dart
@@ -330,7 +330,7 @@ void main() {
       expect(basicAttributes['loggerName']?.value, 'TestLogger');
       expect(basicAttributes['sequenceNumber']?.value, isA<int>());
       expect(basicAttributes['time']?.value, isA<int>());
-      expect(basicAttributes['origin']?.value, LoggingIntegration.origin);
+      expect(basicAttributes['sentry.origin']?.value, LoggingIntegration.origin);
       expect(basicAttributes.containsKey('error'), false);
       expect(basicAttributes.containsKey('stackTrace'), false);
 

--- a/packages/logging/test/logging_integration_test.dart
+++ b/packages/logging/test/logging_integration_test.dart
@@ -331,7 +331,9 @@ void main() {
       expect(basicAttributes['sequenceNumber']?.value, isA<int>());
       expect(basicAttributes['time']?.value, isA<int>());
       expect(
-          basicAttributes['sentry.origin']?.value, LoggingIntegration.origin);
+        basicAttributes['sentry.origin']?.value,
+        LoggingIntegration.origin,
+      );
       expect(basicAttributes.containsKey('error'), false);
       expect(basicAttributes.containsKey('stackTrace'), false);
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Added needed origin: https://develop.sentry.dev/sdk/telemetry/logs/#sdk-integration-attributes

## :green_heart: How did you test it?
Unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
