### PR TITLE
feat(feedback): Add option to disable keyboard resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add `sentry.origin` to logs created by `LoggingIntegration` ([#3153](https://github.com/getsentry/sentry-dart/pull/3153))
 - Tag all spans with thread info on non-web platforms ([#3101](https://github.com/getsentry/sentry-dart/pull/3101), [#3144](https://github.com/getsentry/sentry-dart/pull/3144))
+- feat(feedback): Add option to disable keyboard resize ([#3154](https://github.com/getsentry/sentry-dart/pull/3154))
 
 ## 9.7.0-beta.1
 

--- a/packages/flutter/lib/src/feedback/sentry_feedback_options.dart
+++ b/packages/flutter/lib/src/feedback/sentry_feedback_options.dart
@@ -25,6 +25,9 @@ class SentryFeedbackOptions {
   /// Displays the capture screenshot button on the feedback form
   var showCaptureScreenshot = true;
 
+  /// Determines whether the feedback view should resize to avoid the keyboard.
+  var resizeToAvoidBottomInset = true;
+
   // Form Labels Configuration
 
   /// The title of the feedback form.

--- a/packages/flutter/lib/src/feedback/sentry_feedback_widget.dart
+++ b/packages/flutter/lib/src/feedback/sentry_feedback_widget.dart
@@ -117,6 +117,7 @@ class _SentryFeedbackWidgetState extends State<SentryFeedbackWidget> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      resizeToAvoidBottomInset: widget.options.resizeToAvoidBottomInset,
       appBar: AppBar(
         title: Text(widget.options.title),
         actions: [


### PR DESCRIPTION
## :scroll: Description
This PR adds a `resizeToAvoidBottomInset` option to `SentryFeedbackOptions` to allow developers to control whether the view resizes when the on-screen keyboard appears.

This change is non-breaking as the option defaults to true (the current behavior).

## :bulb: Motivation and Context
The current default behavior for the feedback widget is to resize the view when a text field is focused. This pushes the bottom action buttons ("Send" and "Cancel") up above the keyboard, which can be visually disruptive.

This change introduces an option to disable this resizing, allowing the keyboard to overlay the UI instead.

<details>
<summary>Click to see UI comparison</summary>

| Before | After |
| --- | --- |
| ![old](https://github.com/user-attachments/assets/9ff5e684-f454-4ffc-9952-12a4fe6b4dc9) | ![new](https://github.com/user-attachments/assets/364796d6-880f-4839-b103-b1793ad472c3) |

</details>

## :green_heart: How did you test it?
1. Manually tested the change in the example app on Android.
2. Verified that setting `resizeToAvoidBottomInset` to false in the Sentry options resulted in the keyboard overlaying the UI.
3. Verified that the default behavior (`true`) remained unchanged.
4. Ran the full existing test suite via `flutter test` to check for any regressions.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
Ready for review.