### PR TITLE
chore(logging): set `meta` dev dep to `^1.16.0`

### DIFF
--- a/packages/logging/pubspec.yaml
+++ b/packages/logging/pubspec.yaml
@@ -20,7 +20,7 @@ platforms:
 dependencies:
   logging: ^1.0.0
   sentry: 9.7.0-beta.1
-  meta: ^1.17.0
+  meta: ^1.16.0
 
 dev_dependencies:
   lints: '>=2.0.0'


### PR DESCRIPTION
1.17.0 conflicts with dependencies of other flutter_test which only supports meta 1.16.0

#skip-changelog