### PR TITLE
Fix: Use iPhone 16 & iOS 18

### DIFF
--- a/.github/workflows/flutter_test.yml
+++ b/.github/workflows/flutter_test.yml
@@ -134,7 +134,7 @@ jobs:
         run: |
           case "${{ matrix.target }}" in
             ios)
-            device=$(xcrun simctl create sentryPhone com.apple.CoreSimulator.SimDeviceType.iPhone-14 com.apple.CoreSimulator.SimRuntime.iOS-17-0)
+            device=$(xcrun simctl create sentryPhone com.apple.CoreSimulator.SimDeviceType.iPhone-16 com.apple.CoreSimulator.SimRuntime.iOS-18-0)
             xcrun simctl boot ${device}
             echo "platform=iOS Simulator,id=${device}" >> "$GITHUB_OUTPUT"
             ;;


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->

MacOS 15 Runners don't have older simulator anymore: Fix: Use iPhone 15 & iOS 18:

https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md#installed-simulators

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

CI failing