### PR TITLE
Add `DioException` response data to error breadcrumb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Tag all spans with thread info on non-web platforms ([#3101](https://github.com/getsentry/sentry-dart/pull/3101), [#3144](https://github.com/getsentry/sentry-dart/pull/3144))
 - feat(feedback): Add option to disable keyboard resize ([#3154](https://github.com/getsentry/sentry-dart/pull/3154))
 
+### Enhancements
+
+- Add `DioException` response data to error breadcrumb ([#3164](https://github.com/getsentry/sentry-dart/pull/3164))
+
 ## 9.7.0-beta.1
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Enhancements
 
 - Add `DioException` response data to error breadcrumb ([#3164](https://github.com/getsentry/sentry-dart/pull/3164))
+  - Bumped `dio` min verion to `5.2.0`
 
 ## 9.7.0-beta.1
 

--- a/packages/dio/pubspec.yaml
+++ b/packages/dio/pubspec.yaml
@@ -18,7 +18,7 @@ platforms:
   web:
 
 dependencies:
-  dio: ^5.0.0
+  dio: ^5.2.0
   sentry: 9.7.0-beta.1
 
 dev_dependencies:

--- a/packages/dio/test/breadcrumb_client_adapter_test.dart
+++ b/packages/dio/test/breadcrumb_client_adapter_test.dart
@@ -157,7 +157,7 @@ void main() {
           statusCode: 404,
           statusMessage: 'Not Found',
           headers: {
-            'content-length': ['123']
+            'content-length': ['123'],
           },
         ),
       );
@@ -235,9 +235,9 @@ class DioExceptionWithResponseAdapter implements HttpClientAdapter {
   Future<ResponseBody> fetch(
     RequestOptions options,
     Stream<Uint8List>? requestStream,
-    Future? cancelFuture,
+    Future<dynamic>? cancelFuture,
   ) async {
-    final response = Response(
+    final response = Response<dynamic>(
       requestOptions: options,
       statusCode: statusCode,
       statusMessage: statusMessage,


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Add `DioException` response data to error breadcrumb

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #3023

## :green_heart: How did you test it?

Tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
