### PR TITLE
Support `firebase_remote_config: >=5.4.3 <7.0.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add `sentry.origin` to logs created by `LoggingIntegration` ([#3153](https://github.com/getsentry/sentry-dart/pull/3153))
 - Tag all spans with thread info on non-web platforms ([#3101](https://github.com/getsentry/sentry-dart/pull/3101), [#3144](https://github.com/getsentry/sentry-dart/pull/3144))
 - feat(feedback): Add option to disable keyboard resize ([#3154](https://github.com/getsentry/sentry-dart/pull/3154))
+- Support `firebase_remote_config: >=5.4.3 <7.0.0` ([#3213](https://github.com/getsentry/sentry-dart/pull/3213))
 
 ### Fixes
 

--- a/packages/firebase_remote_config/pubspec.yaml
+++ b/packages/firebase_remote_config/pubspec.yaml
@@ -20,7 +20,7 @@ platforms:
 dependencies:
   flutter:
     sdk: flutter
-  firebase_remote_config: ^5.4.3
+  firebase_remote_config: '>=5.4.3 <7.0.0'
   sentry: 9.7.0-beta.1
 
 dev_dependencies:


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

The APIs which we use are stable for  `firebase_remote_config` version 6.0.0. So I expanded the supported versions.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Should fix CI checks: https://github.com/getsentry/sentry-dart/runs/49078490561

## :green_heart: How did you test it?

CI
