### PR TITLE
chore: add `isNotNull` assert for debug images integration test

### DIFF
--- a/packages/flutter/example/integration_test/integration_test.dart
+++ b/packages/flutter/example/integration_test/integration_test.dart
@@ -161,6 +161,7 @@ void main() {
     // By default it should load all debug images
     final allDebugImages = await SentryFlutter.native
         ?.loadDebugImages(SentryStackTrace(frames: const []));
+    expect(allDebugImages, isNotNull);
     // Typically loading all images results in a larger numbers
     expect(allDebugImages!.length > 100, isTrue);
 


### PR DESCRIPTION
#skip-changelog

~Note: this will expect to fail currently with Sentry Android `8.20.0`~

CI should be green