### PR TITLE
Structured Logs: Don’t add template when there are no `'sentry.message.parameter.x’` attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixes
 
 - Implement prefill logic in `SentryFeedbackWidget` for `useSentryUser` parameter to populate fields with current user data ([#3180](https://github.com/getsentry/sentry-dart/pull/3180))
+- Structured Logs: Don’t add template when there are no 'sentry.message.parameter.x’ attributes ([#3219](https://github.com/getsentry/sentry-dart/pull/3219))
 
 ### Enhancements
 

--- a/packages/dart/lib/src/sentry_logger_formatter.dart
+++ b/packages/dart/lib/src/sentry_logger_formatter.dart
@@ -106,9 +106,20 @@ class SentryLoggerFormatter {
     Map<String, SentryLogAttribute>? attributes,
     FutureOr<void> Function(String, Map<String, SentryLogAttribute>) callback,
   ) {
-    final templateString = SentryTemplateString(templateBody, arguments);
-    final formattedBody = templateString.format();
-    final templateAttributes = _getAllAttributes(templateBody, arguments);
+    String formattedBody;
+    Map<String, SentryLogAttribute> templateAttributes;
+
+    if (arguments.isEmpty) {
+      // No arguments means no template processing needed
+      formattedBody = templateBody;
+      templateAttributes = <String, SentryLogAttribute>{};
+    } else {
+      // Process template with arguments
+      final templateString = SentryTemplateString(templateBody, arguments);
+      formattedBody = templateString.format();
+      templateAttributes = _getAllAttributes(templateBody, arguments);
+    }
+
     if (attributes != null) {
       templateAttributes.addAll(attributes);
     }

--- a/packages/dart/test/sentry_logger_formatter_test.dart
+++ b/packages/dart/test/sentry_logger_formatter_test.dart
@@ -248,6 +248,128 @@ void main() {
       verifyTemplateWithMultipleArguments(message, attributes);
     });
   });
+
+  group('template with no arguments', () {
+    test('for trace', () {
+      final logger = MockLogger();
+      final sut = fixture.getSut(logger);
+
+      sut.trace(
+        "Hello, World!",
+        [],
+        attributes: {'foo': SentryLogAttribute.string('bar')},
+      );
+
+      expect(logger.traceCalls.length, 1);
+      final message = logger.traceCalls[0].message;
+      final attributes = logger.traceCalls[0].attributes!;
+
+      expect(message, 'Hello, World!');
+      expect(attributes['sentry.message.template'], isNull);
+      expect(attributes['sentry.message.parameter.0'], isNull);
+      verifyPassedAttributes(attributes);
+    });
+
+    test('for debug', () {
+      final logger = MockLogger();
+      final sut = fixture.getSut(logger);
+
+      sut.debug(
+        "Hello, World!",
+        [],
+        attributes: {'foo': SentryLogAttribute.string('bar')},
+      );
+
+      expect(logger.debugCalls.length, 1);
+      final message = logger.debugCalls[0].message;
+      final attributes = logger.debugCalls[0].attributes!;
+
+      expect(message, 'Hello, World!');
+      expect(attributes['sentry.message.template'], isNull);
+      expect(attributes['sentry.message.parameter.0'], isNull);
+      verifyPassedAttributes(attributes);
+    });
+
+    test('for info', () {
+      final logger = MockLogger();
+      final sut = fixture.getSut(logger);
+
+      sut.info(
+        "Hello, World!",
+        [],
+        attributes: {'foo': SentryLogAttribute.string('bar')},
+      );
+
+      expect(logger.infoCalls.length, 1);
+      final message = logger.infoCalls[0].message;
+      final attributes = logger.infoCalls[0].attributes!;
+
+      expect(message, 'Hello, World!');
+      expect(attributes['sentry.message.template'], isNull);
+      expect(attributes['sentry.message.parameter.0'], isNull);
+      verifyPassedAttributes(attributes);
+    });
+
+    test('for warn', () {
+      final logger = MockLogger();
+      final sut = fixture.getSut(logger);
+
+      sut.warn(
+        "Hello, World!",
+        [],
+        attributes: {'foo': SentryLogAttribute.string('bar')},
+      );
+
+      expect(logger.warnCalls.length, 1);
+      final message = logger.warnCalls[0].message;
+      final attributes = logger.warnCalls[0].attributes!;
+
+      expect(message, 'Hello, World!');
+      expect(attributes['sentry.message.template'], isNull);
+      expect(attributes['sentry.message.parameter.0'], isNull);
+      verifyPassedAttributes(attributes);
+    });
+
+    test('for error', () {
+      final logger = MockLogger();
+      final sut = fixture.getSut(logger);
+
+      sut.error(
+        "Hello, World!",
+        [],
+        attributes: {'foo': SentryLogAttribute.string('bar')},
+      );
+
+      expect(logger.errorCalls.length, 1);
+      final message = logger.errorCalls[0].message;
+      final attributes = logger.errorCalls[0].attributes!;
+
+      expect(message, 'Hello, World!');
+      expect(attributes['sentry.message.template'], isNull);
+      expect(attributes['sentry.message.parameter.0'], isNull);
+      verifyPassedAttributes(attributes);
+    });
+
+    test('for fatal', () {
+      final logger = MockLogger();
+      final sut = fixture.getSut(logger);
+
+      sut.fatal(
+        "Hello, World!",
+        [],
+        attributes: {'foo': SentryLogAttribute.string('bar')},
+      );
+
+      expect(logger.fatalCalls.length, 1);
+      final message = logger.fatalCalls[0].message;
+      final attributes = logger.fatalCalls[0].attributes!;
+
+      expect(message, 'Hello, World!');
+      expect(attributes['sentry.message.template'], isNull);
+      expect(attributes['sentry.message.parameter.0'], isNull);
+      verifyPassedAttributes(attributes);
+    });
+  });
 }
 
 class Fixture {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Structured Logs: Don’t add template when there are no `'sentry.message.parameter.x’` attributes

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Relates to https://github.com/getsentry/sentry-docs/pull/14759

Fixes https://github.com/getsentry/sentry-dart/issues/3217

## :green_heart: How did you test it?

Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes
