### PR TITLE
ci: fix native binding generation

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
 
 jobs:
   android:

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+  pull_request:
 
 jobs:
   android:

--- a/packages/flutter/scripts/generate-native-bindings.ps1
+++ b/packages/flutter/scripts/generate-native-bindings.ps1
@@ -1,4 +1,21 @@
 # This is a PowerShell script instead of a bash script because it needs to run on Windows during local development.
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+# If running in CI, set up Flutter SDK first (keep version in sync with other scripts).
+if ($env:CI)
+{
+    Write-Host "Running in CI so we need to set up Flutter SDK first"
+    $flutterZip = Join-Path $env:TEMP "flutter.zip"
+    $flutterDir = Join-Path $env:TEMP "flutter"
+    Invoke-WebRequest -Uri "https://storage.googleapis.com/flutter_infra_release/releases/stable/windows/flutter_windows_3.27.3-stable.zip" -OutFile $flutterZip
+    if (Test-Path $flutterDir) { Remove-Item -Recurse -Force $flutterDir }
+    Expand-Archive -Path $flutterZip -DestinationPath $env:TEMP -Force
+    $env:PATH = "$flutterDir\bin;$env:PATH"
+    Get-Command flutter | Out-Host
+    flutter --version
+}
 Push-Location "$PSScriptRoot/../"
 try
 {


### PR DESCRIPTION
#skip-changelog

previously we never set up Flutter so the binding generation just failed silently

see the created PR which now has proper binding generation: https://github.com/getsentry/sentry-dart/pull/3223