### PR TITLE
fix(sqflite): recursion in `openDatabase` when using `SentrySqfliteDatabaseFactory`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Recursion in `openDatabase` when using `SentrySqfliteDatabaseFactory` ([#3231](https://github.com/getsentry/sentry-dart/pull/3231))
+
 ## 9.7.0-beta.2
 
 ### Features

--- a/packages/sqflite/lib/src/sentry_sqflite_database_factory.dart
+++ b/packages/sqflite/lib/src/sentry_sqflite_database_factory.dart
@@ -1,7 +1,6 @@
 import 'package:meta/meta.dart';
 import 'package:sentry/sentry.dart';
-import 'package:sqflite/sqflite.dart';
-import 'package:sqflite/sqflite.dart' as sqflite show databaseFactory;
+import 'package:sqflite/sqflite.dart' as sqflite;
 // ignore: implementation_imports
 import 'package:sqflite_common/src/factory_mixin.dart';
 // ignore: implementation_imports
@@ -34,22 +33,22 @@ class SentrySqfliteDatabaseFactory with SqfliteDatabaseFactoryMixin {
   /// final database = await openDatabase('path/to/db');
   /// ```
   SentrySqfliteDatabaseFactory({
-    DatabaseFactory? databaseFactory,
+    sqflite.DatabaseFactory? databaseFactory,
     @internal Hub? hub,
   })  : _databaseFactory = databaseFactory ?? sqflite.databaseFactory,
         _hub = hub ?? HubAdapter();
 
   final Hub _hub;
-  final DatabaseFactory _databaseFactory;
+  final sqflite.DatabaseFactory _databaseFactory;
 
   @override
   Future<T> invokeMethod<T>(String method, [Object? arguments]) =>
       impl.invokeMethod(method, arguments);
 
   @override
-  Future<Database> openDatabase(
+  Future<sqflite.Database> openDatabase(
     String path, {
-    OpenDatabaseOptions? options,
+    sqflite.OpenDatabaseOptions? options,
   }) async {
     final databaseFactory = _databaseFactory;
 
@@ -58,7 +57,7 @@ class SentrySqfliteDatabaseFactory with SqfliteDatabaseFactoryMixin {
       return databaseFactory.openDatabase(path, options: options);
     }
 
-    return Future<Database>(() async {
+    return Future<sqflite.Database>(() async {
       final currentSpan = _hub.getSpan();
       final description = 'Open DB: $path';
       final span = currentSpan?.startChild(

--- a/packages/sqflite/lib/src/sentry_sqflite_database_factory.dart
+++ b/packages/sqflite/lib/src/sentry_sqflite_database_factory.dart
@@ -1,6 +1,7 @@
 import 'package:meta/meta.dart';
 import 'package:sentry/sentry.dart';
 import 'package:sqflite/sqflite.dart';
+import 'package:sqflite/sqflite.dart' as sqflite show databaseFactory;
 // ignore: implementation_imports
 import 'package:sqflite_common/src/factory_mixin.dart';
 // ignore: implementation_imports
@@ -35,11 +36,11 @@ class SentrySqfliteDatabaseFactory with SqfliteDatabaseFactoryMixin {
   SentrySqfliteDatabaseFactory({
     DatabaseFactory? databaseFactory,
     @internal Hub? hub,
-  })  : _databaseFactory = databaseFactory,
+  })  : _databaseFactory = databaseFactory ?? sqflite.databaseFactory,
         _hub = hub ?? HubAdapter();
 
   final Hub _hub;
-  final DatabaseFactory? _databaseFactory;
+  final DatabaseFactory _databaseFactory;
 
   @override
   Future<T> invokeMethod<T>(String method, [Object? arguments]) =>
@@ -50,7 +51,7 @@ class SentrySqfliteDatabaseFactory with SqfliteDatabaseFactoryMixin {
     String path, {
     OpenDatabaseOptions? options,
   }) async {
-    final databaseFactory = _databaseFactory ?? this;
+    final databaseFactory = _databaseFactory;
 
     // ignore: invalid_use_of_internal_member
     if (!_hub.options.isTracingEnabled()) {

--- a/packages/sqflite/test/sentry_sqflite_database_factory_dart_test.dart
+++ b/packages/sqflite/test/sentry_sqflite_database_factory_dart_test.dart
@@ -88,6 +88,32 @@ void main() {
     });
   });
 
+  group('openDatabase without delegate', () {
+    late Fixture fixture;
+
+    setUp(() {
+      fixture = Fixture();
+
+      when(fixture.hub.options).thenReturn(fixture.options);
+      when(fixture.hub.scope).thenReturn(fixture.scope);
+      when(fixture.hub.getSpan()).thenReturn(fixture.tracer);
+
+      // using ffi for testing on vm
+      sqfliteFfiInit();
+      databaseFactory = databaseFactoryFfi;
+    });
+
+    test('does not recurse when calling instance openDatabase', () async {
+      final wrapper = SentrySqfliteDatabaseFactory(hub: fixture.hub);
+
+      final db = await wrapper.openDatabase(inMemoryDatabasePath);
+
+      expect(db is SentryDatabase, true);
+
+      await db.close();
+    });
+  });
+
   tearDown(() {
     databaseFactory = sqfliteDatabaseFactoryDefault;
   });


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Fixes a recursion happening when calling `openDatabase` on a `SentrySqfliteDatabaseFactory` instance where no database factory has been passed

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #3229 

## :green_heart: How did you test it?
Unit tests

Also ran the test without the fix which fails as expected

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
