### PR TITLE
chore: temporarily disable Flutter beta channel web integration test

### DIFF
--- a/.github/workflows/flutter_test.yml
+++ b/.github/workflows/flutter_test.yml
@@ -177,7 +177,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: ['stable', 'beta']
+        # Temporarily disable beta because the job run is flaky
+        sdk: ['stable']
     steps:
       - name: checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
The beta channel on web integration test workflow seems to not finish (> 30minutes running) even though all the tests pass so let's disable it for now so we don't block releases

#skip-changelog