### PR TITLE
feat: Add W3C traceparent header support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add W3C `traceparent` header support ([#3246](https://github.com/getsentry/sentry-dart/pull/3246))
+  - Enable the option `propagateTraceparent` to allow the propagation of the W3C Trace Context HTTP header `traceparent` on outgoing HTTP requests.
+
 ## 9.7.0-beta.4
 
 ### Features

--- a/min_version_test/pubspec.yaml
+++ b/min_version_test/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   sentry_logging:
   dio: any # This gets constrained by `sentry_dio`
   logging: any # This gets constrained by `sentry_logging`
+  package_info_plus: 8.3.1 # version 9 and above requires at least AGP 8.12.1
 
   flutter: any
 dev_dependencies:

--- a/packages/dart/lib/src/sentry_options.dart
+++ b/packages/dart/lib/src/sentry_options.dart
@@ -424,6 +424,13 @@ class SentryOptions {
   /// array, and only attach tracing headers if a match was found.
   final List<String> tracePropagationTargets = ['.*'];
 
+  /// This option is used to enable the propagation of the
+  /// W3C Trace Context HTTP header traceparent on outgoing HTTP requests.
+  /// This is useful when the receiving services only support OTel/W3C propagation
+  ///
+  /// The default is `false`.
+  bool propagateTraceparent = false;
+
   /// The idle time to wait until the transaction will be finished.
   /// The transaction will use the end timestamp of the last finished span as
   /// the endtime for the transaction.

--- a/packages/dart/test/utils/tracing_utils_test.dart
+++ b/packages/dart/test/utils/tracing_utils_test.dart
@@ -292,7 +292,7 @@ void main() {
       expect(parts.length, 4);
       expect(parts[0], '00');
       expect(parts[1], hub.scope.propagationContext.traceId.toString());
-      expect(parts[2], hasLength(16)); // spanId length
+      expect(parts[2], hasLength(16)); // just check length since it's random
       expect(parts[3], '00'); // not sampled for scope context
     });
 

--- a/packages/dart/test/utils/tracing_utils_test.dart
+++ b/packages/dart/test/utils/tracing_utils_test.dart
@@ -269,7 +269,7 @@ void main() {
     });
 
     test(
-        'does not add W3c traceparent header from span when propagateTraceparent is false',
+        'does not add W3C traceparent header from span when propagateTraceparent is false',
         () {
       final headers = <String, dynamic>{};
       final hub = fixture._hub;

--- a/packages/dart/test/utils/tracing_utils_test.dart
+++ b/packages/dart/test/utils/tracing_utils_test.dart
@@ -248,7 +248,11 @@ void main() {
   });
 
   group(addTracingHeadersToHttpHeader, () {
-    final fixture = Fixture();
+    late Fixture fixture;
+
+    setUp(() {
+      fixture = Fixture();
+    });
 
     test(
         'adds W3C traceparent header from span when propagateTraceparent is true',
@@ -269,10 +273,9 @@ void main() {
         () {
       final headers = <String, dynamic>{};
       final hub = fixture._hub;
-      final span = fixture.getSut();
       // propagateTraceparent is false by default
 
-      addTracingHeadersToHttpHeader(headers, hub, span: span);
+      addTracingHeadersToHttpHeader(headers, hub);
 
       expect(headers['traceparent'], isNull);
     });

--- a/packages/dart/test/utils/tracing_utils_test.dart
+++ b/packages/dart/test/utils/tracing_utils_test.dart
@@ -74,6 +74,48 @@ void main() {
     });
   });
 
+  group('W3C traceparent header', () {
+    final fixture = Fixture();
+    final headerName = 'traceparent';
+
+    test('converts SentryTraceHeader to W3C format correctly', () {
+      final sut = fixture.getSut();
+      final sentryHeader = sut.toSentryTrace();
+
+      final w3cHeader = formatAsW3CHeader(sentryHeader);
+
+      expect(w3cHeader,
+          '00-${fixture._context.traceId}-${fixture._context.spanId}-01');
+    });
+
+    test('added when given a span', () {
+      final headers = <String, dynamic>{};
+      final sut = fixture.getSut();
+
+      addW3CHeaderFromSpan(sut, headers);
+
+      expect(headers[headerName],
+          '00-${fixture._context.traceId}-${fixture._context.spanId}-01');
+    });
+
+    test('added when given a scope', () {
+      final headers = <String, dynamic>{};
+      final hub = fixture._hub;
+      final scope = hub.scope;
+
+      addW3CHeaderFromScope(scope, headers);
+
+      final headerValue = headers[headerName] as String;
+      final parts = headerValue.split('-');
+
+      expect(parts.length, 4);
+      expect(parts[0], '00');
+      expect(parts[1], scope.propagationContext.traceId.toString());
+      expect(parts[2], hasLength(16)); // just check length since it's random
+      expect(parts[3], '00');
+    });
+  });
+
   group('$addBaggageHeader', () {
     final fixture = Fixture();
 
@@ -205,8 +247,66 @@ void main() {
     });
   });
 
-  group('$addTracingHeadersToHttpHeader', () {
+  group(addTracingHeadersToHttpHeader, () {
     final fixture = Fixture();
+
+    test(
+        'adds W3C traceparent header from span when propagateTraceparent is true',
+        () {
+      final headers = <String, dynamic>{};
+      final hub = fixture._hub;
+      final span = fixture.getSut();
+      hub.options.propagateTraceparent = true;
+
+      addTracingHeadersToHttpHeader(headers, hub, span: span);
+
+      expect(headers['traceparent'],
+          '00-${fixture._context.traceId}-${fixture._context.spanId}-01');
+    });
+
+    test(
+        'does not add W3c traceparent header from span when propagateTraceparent is false',
+        () {
+      final headers = <String, dynamic>{};
+      final hub = fixture._hub;
+      final span = fixture.getSut();
+      // propagateTraceparent is false by default
+
+      addTracingHeadersToHttpHeader(headers, hub, span: span);
+
+      expect(headers['traceparent'], isNull);
+    });
+
+    test(
+        'adds W3C traceparent header from scope when propagateTraceparent is true',
+        () {
+      final headers = <String, dynamic>{};
+      final hub = fixture._hub;
+      hub.options.propagateTraceparent = true;
+
+      addTracingHeadersToHttpHeader(headers, hub);
+
+      final headerValue = headers['traceparent'] as String;
+      final parts = headerValue.split('-');
+
+      expect(parts.length, 4);
+      expect(parts[0], '00');
+      expect(parts[1], hub.scope.propagationContext.traceId.toString());
+      expect(parts[2], hasLength(16)); // spanId length
+      expect(parts[3], '00'); // not sampled for scope context
+    });
+
+    test(
+        'does not add W3C traceparent header from scope when propagateTraceparent is false',
+        () {
+      final headers = <String, dynamic>{};
+      final hub = fixture._hub;
+      // propagateTraceparent is false by default
+
+      addTracingHeadersToHttpHeader(headers, hub);
+
+      expect(headers['traceparent'], isNull);
+    });
 
     test('adds headers from span when span is provided', () {
       final headers = <String, dynamic>{};


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Adds support for W3C `traceparent` header. Only added if the option `propagateTraceparent` is set to `true`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3218 

## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
