### PR TITLE
chore: fix flaky replay integration test

### DIFF
--- a/packages/flutter/example/integration_test/replay_test.dart
+++ b/packages/flutter/example/integration_test/replay_test.dart
@@ -26,12 +26,12 @@ void main() {
 
     test('session replay is captured', () async {
       // TODO add when the beforeSend callback is implemented for replays.
-    });
+    }, skip: true);
 
     test('replay is captured on errors', () async {
       // TODO we may need an HTTP server for this because Android sends replays
       // in a separate envelope.
-    });
+    }, skip: true);
   },
       skip: Platform.isAndroid
           ? false


### PR DESCRIPTION
#skip-changelog

We have two tests that don’t execute any code. As a result, `SentryFlutter.init` and `SentryFlutter.close` may be called immediately one after the other. In this situation, `close` can run before the `AndroidReplayWorker` isolate has been spawned, leaving the isolate running indefinitely and preventing the test from completing.

This often leads to flaky tests.