### PR TITLE
chore: fix flaky startup time metrics test

### DIFF
--- a/metrics/metrics-android.yml
+++ b/metrics/metrics-android.yml
@@ -8,7 +8,7 @@ apps:
 
 startupTimeTest:
   runs: 50
-  diffMin: 0
+  diffMin: -25 # For the flaky case where the app with Sentry is slightly faster than plain.
   diffMax: 150
 
 binarySizeTest:

--- a/metrics/metrics-ios.yml
+++ b/metrics/metrics-ios.yml
@@ -6,7 +6,7 @@ apps:
 
 startupTimeTest:
   runs: 50
-  diffMin: -10 # For the flaky test case where the app with sentry is faster than the app without sentry.
+  diffMin: -25 # For the flaky test case where the app with sentry is faster than the app without sentry.
   diffMax: 150
 
 binarySizeTest:

--- a/packages/flutter/example/integration_test/replay_test.dart
+++ b/packages/flutter/example/integration_test/replay_test.dart
@@ -26,12 +26,12 @@ void main() {
 
     test('session replay is captured', () async {
       // TODO add when the beforeSend callback is implemented for replays.
-    }, skip: true);
+    });
 
     test('replay is captured on errors', () async {
       // TODO we may need an HTTP server for this because Android sends replays
       // in a separate envelope.
-    }, skip: true);
+    });
   },
       skip: Platform.isAndroid
           ? false

--- a/packages/flutter/example/integration_test/replay_test.dart
+++ b/packages/flutter/example/integration_test/replay_test.dart
@@ -26,12 +26,12 @@ void main() {
 
     test('session replay is captured', () async {
       // TODO add when the beforeSend callback is implemented for replays.
-    });
+    }, skip: true);
 
     test('replay is captured on errors', () async {
       // TODO we may need an HTTP server for this because Android sends replays
       // in a separate envelope.
-    });
+    }, skip: true);
   },
       skip: Platform.isAndroid
           ? false


### PR DESCRIPTION
#skip-changelog

In some cases the startup time of an app with Sentry is slightly faster than the plain app (could happen due to a variety of reasons, in the future we might wanna use something more like the concept of TTFD to report the end time

We don't want to fail in those cases so let's raise the `diffMin` as a negative value