### PR TITLE
Prefix firebase remote config feature flags with `firebase:`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Enhancements
+
+- Prefix firebase remote config feature flags with `firebase:` ([#3258](https://github.com/getsentry/sentry-dart/pull/3258))
+
 ## 9.7.0-beta.5
 
 ### Dependencies

--- a/packages/firebase_remote_config/lib/src/sentry_firebase_remote_config_integration.dart
+++ b/packages/firebase_remote_config/lib/src/sentry_firebase_remote_config_integration.dart
@@ -31,7 +31,7 @@ class SentryFirebaseRemoteConfigIntegration extends Integration<SentryOptions> {
     for (final updatedKey in updatedKeys) {
       final value = _firebaseRemoteConfig.getBoolOrNull(updatedKey);
       if (value != null) {
-        await Sentry.addFeatureFlag(updatedKey, value);
+        await Sentry.addFeatureFlag('firebase:$updatedKey', value);
       }
     }
   }

--- a/packages/firebase_remote_config/test/src/sentry_firebase_remote_config_integration_test.dart
+++ b/packages/firebase_remote_config/test/src/sentry_firebase_remote_config_integration_test.dart
@@ -84,7 +84,7 @@ void main() {
 
     expect(featureFlags, isNotNull);
     expect(featureFlags?.values.length, 1);
-    expect(featureFlags?.values.first.flag, 'test');
+    expect(featureFlags?.values.first.flag, 'firebase:test');
     expect(featureFlags?.values.first.result, isFalse);
   });
 
@@ -105,7 +105,7 @@ void main() {
 
     expect(featureFlags, isNotNull);
     expect(featureFlags?.values.length, 1);
-    expect(featureFlags?.values.first.flag, 'test');
+    expect(featureFlags?.values.first.flag, 'firebase:test');
     expect(featureFlags?.values.first.result, true);
   });
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Prefix firebase remote config feature flags with `firebase:`

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #3086

## :green_heart: How did you test it?

Unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes
