### PR TITLE
enh: refactor `setExtra` and `removeExtra` to use FFI/JNI 

### DIFF
--- a/packages/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/packages/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -61,8 +61,6 @@ class SentryFlutterPlugin :
     when (call.method) {
       "initNativeSdk" -> initNativeSdk(call, result)
       "closeNativeSdk" -> closeNativeSdk(result)
-      "setExtra" -> setExtra(call.argument("key"), call.argument("value"), result)
-      "removeExtra" -> removeExtra(call.argument("key"), result)
       "setTag" -> setTag(call.argument("key"), call.argument("value"), result)
       "removeTag" -> removeTag(call.argument("key"), result)
       "setReplayConfig" -> setReplayConfig(call, result)
@@ -137,33 +135,6 @@ class SentryFlutterPlugin :
     } else {
       options.setReplayController(null)
     }
-  }
-
-  private fun setExtra(
-    key: String?,
-    value: String?,
-    result: Result,
-  ) {
-    if (key == null || value == null) {
-      result.success("")
-      return
-    }
-    Sentry.setExtra(key, value)
-
-    result.success("")
-  }
-
-  private fun removeExtra(
-    key: String?,
-    result: Result,
-  ) {
-    if (key == null) {
-      result.success("")
-      return
-    }
-    Sentry.removeExtra(key)
-
-    result.success("")
   }
 
   private fun setTag(

--- a/packages/flutter/example/integration_test/integration_test.dart
+++ b/packages/flutter/example/integration_test/integration_test.dart
@@ -629,7 +629,8 @@ void main() {
     });
 
     var contexts = await SentryFlutter.native?.loadContexts();
-    final extras = contexts!['extra'];
+
+    final extras = Platform.isIOS ? contexts!['extra'] : contexts!['extras'];
     expect(extras, isNotNull, reason: 'Extras are null');
 
     if (Platform.isIOS) {
@@ -640,11 +641,12 @@ void main() {
       expect(extras['key4'], 12, reason: 'key4 mismatch');
       expect(extras['key5'], 12.3, reason: 'key5 mismatch');
     } else if (Platform.isAndroid) {
+      // Sentry Java's setExtra only allows String values so this is after normalization
       expect(extras['key1'], 'randomValue', reason: 'key1 mismatch');
-      expect(extras['key2'], {'Key': 'Value'}, reason: 'key2 mismatch');
-      expect(extras['key3'], true, reason: 'key3 mismatch');
-      expect(extras['key4'], 12, reason: 'key4 mismatch');
-      expect(extras['key5'], 12.3, reason: 'key5 mismatch');
+      expect(extras['key2'], '{Key: Value}', reason: 'key2 mismatch');
+      expect(extras['key3'], 'true', reason: 'key3 mismatch');
+      expect(extras['key4'], '12', reason: 'key4 mismatch');
+      expect(extras['key5'], '12.3', reason: 'key5 mismatch');
     }
 
     await Sentry.configureScope((scope) async {

--- a/packages/flutter/example/integration_test/integration_test.dart
+++ b/packages/flutter/example/integration_test/integration_test.dart
@@ -1,6 +1,4 @@
-// ignore_for_file: avoid_print
-// ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: unused_local_variable
+// ignore_for_file: avoid_print, invalid_use_of_internal_member, unused_local_variable, deprecated_member_use
 
 import 'dart:async';
 import 'dart:convert';
@@ -130,9 +128,7 @@ void main() {
       await scope.addBreadcrumb(breadcrumb);
       await scope.clearBreadcrumbs();
 
-      // ignore: deprecated_member_use
       await scope.setExtra('extra-key', 'extra-value');
-      // ignore: deprecated_member_use
       await scope.removeExtra('extra-key');
 
       await scope.setTag('tag-key', 'tag-value');

--- a/packages/flutter/ffi-cocoa.yaml
+++ b/packages/flutter/ffi-cocoa.yaml
@@ -40,6 +40,8 @@ objc-interfaces:
         - 'clearBreadcrumbs'
         - 'setContextValue:forKey:'
         - 'removeContextForKey:'
+        - 'setExtraValue:forKey:'
+        - 'removeExtraForKey:'
 preamble: |
   // ignore_for_file: type=lint, unused_element
 

--- a/packages/flutter/ios/sentry_flutter/Sources/sentry_flutter/SentryFlutterPlugin.swift
+++ b/packages/flutter/ios/sentry_flutter/Sources/sentry_flutter/SentryFlutterPlugin.swift
@@ -76,17 +76,6 @@ public class SentryFlutterPlugin: NSObject, FlutterPlugin {
         case "closeNativeSdk":
             closeNativeSdk(call, result: result)
 
-        case "setExtra":
-            let arguments = call.arguments as? [String: Any?]
-            let key = arguments?["key"] as? String
-            let value = arguments?["value"] as? Any
-            setExtra(key: key, value: value, result: result)
-
-        case "removeExtra":
-            let arguments = call.arguments as? [String: Any?]
-            let key = arguments?["key"] as? String
-            removeExtra(key: key, result: result)
-
         case "setTag":
             let arguments = call.arguments as? [String: Any?]
             let key = arguments?["key"] as? String
@@ -253,30 +242,6 @@ public class SentryFlutterPlugin: NSObject, FlutterPlugin {
             return false
         }
         return !name.isEmpty
-    }
-
-    private func setExtra(key: String?, value: Any?, result: @escaping FlutterResult) {
-      guard let key = key else {
-        result("")
-        return
-      }
-      SentrySDK.configureScope { scope in
-        scope.setExtra(value: value, key: key)
-
-        result("")
-      }
-    }
-
-    private func removeExtra(key: String?, result: @escaping FlutterResult) {
-      guard let key = key else {
-        result("")
-        return
-      }
-      SentrySDK.configureScope { scope in
-        scope.removeExtra(key: key)
-
-        result("")
-      }
     }
 
     private func setTag(key: String?, value: String?, result: @escaping FlutterResult) {

--- a/packages/flutter/lib/src/native/cocoa/binding.dart
+++ b/packages/flutter/lib/src/native/cocoa/binding.dart
@@ -1148,6 +1148,9 @@ interface class SentrySerializable extends objc.ObjCProtocolBase
       : this._(other, retain: retain, release: release);
 }
 
+late final _sel_setExtraValue_forKey_ =
+    objc.registerName("setExtraValue:forKey:");
+late final _sel_removeExtraForKey_ = objc.registerName("removeExtraForKey:");
 late final _sel_clearBreadcrumbs = objc.registerName("clearBreadcrumbs");
 final _objc_msgSend_1pl9qdv = objc.msgSendPointer
     .cast<
@@ -1181,6 +1184,19 @@ class SentryScope extends objc.NSObject implements SentrySerializable {
   static bool isInstance(objc.ObjCObjectBase obj) {
     return _objc_msgSend_19nvye5(
         obj.ref.pointer, _sel_isKindOfClass_, _class_SentryScope);
+  }
+
+  /// Set global extra -> these will be sent with every event
+  void setExtraValue(objc.ObjCObjectBase? value,
+      {required objc.NSString forKey}) {
+    _objc_msgSend_pfv6jd(this.ref.pointer, _sel_setExtraValue_forKey_,
+        value?.ref.pointer ?? ffi.nullptr, forKey.ref.pointer);
+  }
+
+  /// Remove the extra for the specified key.
+  void removeExtraForKey(objc.NSString key) {
+    _objc_msgSend_xtuoz7(
+        this.ref.pointer, _sel_removeExtraForKey_, key.ref.pointer);
   }
 
   /// Clears all breadcrumbs in the scope

--- a/packages/flutter/lib/src/native/cocoa/sentry_native_cocoa.dart
+++ b/packages/flutter/lib/src/native/cocoa/sentry_native_cocoa.dart
@@ -256,6 +256,33 @@ class SentryNativeCocoa extends SentryNativeChannel {
           scope.removeContextForKey(key.toNSString());
         }));
       });
+
+  @override
+  void setExtra(String key, dynamic value) => tryCatchSync('setExtra', () {
+        ObjCObjectBase? cValue = switch (value) {
+          Map<String, dynamic> m => _deepConvertMapNonNull(m).toNSDictionary(),
+          bool b => b ? 1.toNSNumber() : 0.toNSNumber(),
+          Object o => toObjCObject(o),
+          _ => null
+        };
+
+        cocoa.SentrySDK.configureScope(
+            cocoa.ObjCBlock_ffiVoid_SentryScope.fromFunction(
+                (cocoa.SentryScope scope) {
+          if (cValue != null) {
+            scope.setExtraValue(cValue, forKey: key.toNSString());
+          }
+        }));
+      });
+
+  @override
+  void removeExtra(String key) => tryCatchSync('removeExtra', () {
+        cocoa.SentrySDK.configureScope(
+            cocoa.ObjCBlock_ffiVoid_SentryScope.fromFunction(
+                (cocoa.SentryScope scope) {
+          scope.removeExtraForKey(key.toNSString());
+        }));
+      });
 }
 
 /// This map conversion is needed so we can use the toNSDictionary extension function

--- a/packages/flutter/lib/src/native/sentry_native_channel.dart
+++ b/packages/flutter/lib/src/native/sentry_native_channel.dart
@@ -12,7 +12,6 @@ import 'native_app_start.dart';
 import 'sentry_native_binding.dart';
 import 'sentry_native_invoker.dart';
 import 'sentry_safe_method_channel.dart';
-import 'utils/data_normalizer.dart';
 
 /// Provide typed methods to access native layer via MethodChannel.
 @internal

--- a/packages/flutter/lib/src/native/sentry_native_channel.dart
+++ b/packages/flutter/lib/src/native/sentry_native_channel.dart
@@ -148,14 +148,14 @@ class SentryNativeChannel
   }
 
   @override
-  FutureOr<void> setExtra(String key, dynamic value) => channel.invokeMethod(
-        'setExtra',
-        {'key': key, 'value': normalize(value)},
-      );
+  FutureOr<void> setExtra(String key, dynamic value) {
+    assert(false, "setExtra should not be used through method channels.");
+  }
 
   @override
-  FutureOr<void> removeExtra(String key) =>
-      channel.invokeMethod('removeExtra', {'key': key});
+  FutureOr<void> removeExtra(String key) {
+    assert(false, "removeExtra should not be used through method channels.");
+  }
 
   @override
   Future<void> setTag(String key, String value) =>

--- a/packages/flutter/lib/src/native/sentry_native_channel.dart
+++ b/packages/flutter/lib/src/native/sentry_native_channel.dart
@@ -148,13 +148,13 @@ class SentryNativeChannel
   }
 
   @override
-  Future<void> setExtra(String key, dynamic value) => channel.invokeMethod(
+  FutureOr<void> setExtra(String key, dynamic value) => channel.invokeMethod(
         'setExtra',
         {'key': key, 'value': normalize(value)},
       );
 
   @override
-  Future<void> removeExtra(String key) =>
+  FutureOr<void> removeExtra(String key) =>
       channel.invokeMethod('removeExtra', {'key': key});
 
   @override

--- a/packages/flutter/test/sentry_native_channel_test.dart
+++ b/packages/flutter/test/sentry_native_channel_test.dart
@@ -119,26 +119,29 @@ void main() {
         verifyZeroInteractions(channel);
       });
 
-      test('setExtra', () async {
+      test('setExtra', () {
         final value = {'object': Object()};
-        final normalizedValue = normalize(value);
-        when(channel.invokeMethod(
-                'setExtra', {'key': 'fixture-key', 'value': normalizedValue}))
-            .thenAnswer((_) => Future.value());
+        final matcher = _nativeUnavailableMatcher(
+          mockPlatform,
+          includeLookupSymbol: true,
+          includeFailedToLoadClassException: true,
+        );
 
-        await sut.setExtra('fixture-key', value);
+        expect(() => sut.setExtra('fixture-key', value), matcher);
 
-        verify(channel.invokeMethod(
-            'setExtra', {'key': 'fixture-key', 'value': normalizedValue}));
+        verifyZeroInteractions(channel);
       });
 
-      test('removeExtra', () async {
-        when(channel.invokeMethod('removeExtra', {'key': 'fixture-key'}))
-            .thenAnswer((_) => Future.value());
+      test('removeExtra', () {
+        final matcher = _nativeUnavailableMatcher(
+          mockPlatform,
+          includeLookupSymbol: true,
+          includeFailedToLoadClassException: true,
+        );
 
-        await sut.removeExtra('fixture-key');
+        expect(() => sut.removeExtra('fixture-key'), matcher);
 
-        verify(channel.invokeMethod('removeExtra', {'key': 'fixture-key'}));
+        verifyZeroInteractions(channel);
       });
 
       test('setTag', () async {

--- a/packages/flutter/test/sentry_native_channel_test.dart
+++ b/packages/flutter/test/sentry_native_channel_test.dart
@@ -11,7 +11,6 @@ import 'package:sentry/src/platform/mock_platform.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:sentry_flutter/src/native/factory.dart';
 import 'package:sentry_flutter/src/native/sentry_native_binding.dart';
-import 'package:sentry_flutter/src/native/utils/data_normalizer.dart';
 import 'package:sentry_flutter/src/replay/replay_config.dart';
 
 import 'mocks.dart';


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Part of moving away from method channel

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Partly completes #3204

## :green_heart: How did you test it?
Manual, integration test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
