### PR TITLE
ci: running Android native unit tests does not require an emulator

### DIFF
--- a/.github/workflows/flutter_test.yml
+++ b/.github/workflows/flutter_test.yml
@@ -82,18 +82,9 @@ jobs:
           disable-animations: true
           script: flutter drive --driver=integration_test/test_driver/driver.dart --target=integration_test/sentry_widgets_flutter_binding_test.dart --profile -d emulator-5554
 
-      - name: launch android emulator & run android native test
-        uses: reactivecircus/android-emulator-runner@1dcd0090116d15e7c562f8db72807de5e036a4ed #pin@v2.34.0
-        with:
-          working-directory: packages/flutter/example/android
-          api-level: 31
-          profile: Nexus 6
-          arch: x86_64
-          force-avd-creation: false
-          avd-name: avd-x86_64-31
-          emulator-options: -no-snapshot-save -no-window -accel on -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: true
-          script: ./gradlew testDebugUnitTest
+      - name: Run Android native unit tests
+        working-directory: packages/flutter/example/android
+        run: ./gradlew testDebugUnitTest
 
       - name: build apk
         working-directory: packages/flutter/example/android


### PR DESCRIPTION
#skip-changelog

since it's a unit test we dont actually need an emulator

this fixes flakiness