### PR TITLE
Apply proguard rules to debug builds as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## Unreleased
 
+### Fixes
+
+- Apply proguard rules to debug builds as well ([#3339](https://github.com/getsentry/sentry-dart/pull/3339))
+
 ### Enhancements
 
 - Refactor `captureReplay` and `setReplayConfig` to use FFI/JNI ([#3318](https://github.com/getsentry/sentry-dart/pull/3318))
+- 
 
 ## 9.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
 ### Enhancements
 
 - Refactor `captureReplay` and `setReplayConfig` to use FFI/JNI ([#3318](https://github.com/getsentry/sentry-dart/pull/3318))
-- 
 
 ## 9.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Apply proguard rules to debug builds as well ([#3339](https://github.com/getsentry/sentry-dart/pull/3339))
+- Added `consumerProguardFiles 'proguard-rules.pro'` to the debug build configuration to ensure ProGuard rules are consistently applied across both release and debug variants. ([#3339](https://github.com/getsentry/sentry-dart/pull/3339))
 
 ### Enhancements
 

--- a/packages/flutter/android/build.gradle
+++ b/packages/flutter/android/build.gradle
@@ -47,6 +47,9 @@ android {
         release {
             consumerProguardFiles 'proguard-rules.pro'
         }
+        debug {
+            consumerProguardFiles 'proguard-rules.pro'
+        }
     }
 
     compileOptions {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Similar to how Sentry Android does it: https://github.com/getsentry/sentry-java/blob/main/sentry-android-core/build.gradle.kts#L32C1-L35C4

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/getsentry/sentry-dart/issues/3338

## :green_heart: How did you test it?
Manually

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
