### PR TITLE
fix potential segfault: dont use `Companion` in JNI calls and improve JNI ref releasing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Dont use `Companion` in JNI calls ([#3354](https://github.com/getsentry/sentry-dart/pull/3354))
+- Dont use `Companion` in JNI calls and properly release JNI refs ([#3354](https://github.com/getsentry/sentry-dart/pull/3354))
   - This potentially fixes segfault crashes related to JNI
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fixes
+
+- Dont use `Companion` in JNI calls ([#3354](https://github.com/getsentry/sentry-dart/pull/3354))
+  - This potentially fixes segfault crashes related to JNI
+
 ### Enhancements
 
 - Flush logs if client/hub/sdk is closed ([#3335](https://github.com/getsentry/sentry-dart/pull/3335)

--- a/packages/flutter/lib/src/native/java/android_replay_recorder.dart
+++ b/packages/flutter/lib/src/native/java/android_replay_recorder.dart
@@ -99,8 +99,8 @@ class _AndroidReplayHandler extends WorkerHandler {
   late final native.ReplayIntegration _nativeReplay;
 
   _AndroidReplayHandler(this._config) {
-    _nativeReplay = native.SentryFlutterPlugin.Companion
-        .privateSentryGetReplayIntegration()!;
+    _nativeReplay =
+        native.SentryFlutterPlugin.privateSentryGetReplayIntegration()!;
   }
 
   @override

--- a/packages/flutter/lib/src/native/java/sentry_native_java.dart
+++ b/packages/flutter/lib/src/native/java/sentry_native_java.dart
@@ -390,37 +390,37 @@ class SentryNativeJava extends SentryNativeChannel {
       });
 }
 
-JObject? _dartToJObject(Object? value) {
-  if (value == null) return null;
-  if (value is String) return value.toJString();
-  if (value is bool) return value.toJBoolean();
-  if (value is int) return value.toJLong();
-  if (value is double) return value.toJDouble();
-  if (value is List) return _dartToJList(value);
-  if (value is Map<String, dynamic>) return _dartToJMap(value);
-  return null;
-}
+JObject? _dartToJObject(Object? value) => switch (value) {
+      null => null,
+      String s => s.toJString(),
+      bool b => b.toJBoolean(),
+      int i => i.toJLong(),
+      double d => d.toJDouble(),
+      List<dynamic> l => _dartToJList(l),
+      Map<String, dynamic> m => _dartToJMap(m),
+      _ => null
+    };
 
 JList<JObject?> _dartToJList(List<dynamic> values) {
-  final jlist = JList.array(JObject.nullableType);
+  final jList = JList.array(JObject.nullableType);
   for (final v in values) {
     final j = _dartToJObject(v);
-    jlist.add(j);
+    jList.add(j);
     j?.release();
   }
-  return jlist;
+  return jList;
 }
 
 JMap<JString, JObject?> _dartToJMap(Map<String, dynamic> json) {
-  final jmap = JMap.hash(JString.type, JObject.nullableType);
+  final jMap = JMap.hash(JString.type, JObject.nullableType);
   for (final entry in json.entries) {
     final jk = entry.key.toJString();
     final jv = _dartToJObject(entry.value);
-    jmap[jk] = jv;
+    jMap[jk] = jv;
     jk.release();
     jv?.release();
   }
-  return jmap;
+  return jMap;
 }
 
 const _videoBlockSize = 16;

--- a/packages/flutter/lib/src/native/java/sentry_native_java.dart
+++ b/packages/flutter/lib/src/native/java/sentry_native_java.dart
@@ -304,8 +304,8 @@ class SentryNativeJava extends SentryNativeChannel {
   SentryId captureReplay() {
     final id = tryCatchSync<SentryId>('captureReplay', () {
       return using((arena) {
-        _nativeReplay ??= native.SentryFlutterPlugin.Companion
-            .privateSentryGetReplayIntegration();
+        _nativeReplay ??=
+            native.SentryFlutterPlugin.privateSentryGetReplayIntegration();
         // The passed parameter is `isTerminating`
         _nativeReplay?.captureReplay(false.toJBoolean()..releasedBy(arena));
 
@@ -378,8 +378,8 @@ class SentryNativeJava extends SentryNativeChannel {
           0, // bitRate is currently not used
         );
 
-        _nativeReplay ??= native.SentryFlutterPlugin.Companion
-            .privateSentryGetReplayIntegration();
+        _nativeReplay ??=
+            native.SentryFlutterPlugin.privateSentryGetReplayIntegration();
         _nativeReplay?.onConfigurationChanged(replayConfig);
 
         replayConfig.release();

--- a/packages/flutter/lib/src/native/java/sentry_native_java.dart
+++ b/packages/flutter/lib/src/native/java/sentry_native_java.dart
@@ -74,8 +74,8 @@ class SentryNativeJava extends SentryNativeChannel {
 
       // NOTE: when instructionAddressSet is empty, loadDebugImagesAsBytes will return
       // all debug images as fallback.
-      imagesUtf8JsonBytes = native.SentryFlutterPlugin.Companion
-          .loadDebugImagesAsBytes(instructionAddressSet);
+      imagesUtf8JsonBytes = native.SentryFlutterPlugin.loadDebugImagesAsBytes(
+          instructionAddressSet);
       if (imagesUtf8JsonBytes == null) return null;
 
       final byteRange =
@@ -112,8 +112,7 @@ class SentryNativeJava extends SentryNativeChannel {
       // is significantly faster because contexts can be large and contain many nested
       // objects. Local benchmarks show this method is ~4x faster than the alternative
       // approach of converting JNI objects to Dart objects one by one.
-      contextsUtf8JsonBytes =
-          native.SentryFlutterPlugin.Companion.loadContextsAsBytes();
+      contextsUtf8JsonBytes = native.SentryFlutterPlugin.loadContextsAsBytes();
       if (contextsUtf8JsonBytes == null) return null;
 
       final byteRange =
@@ -136,8 +135,7 @@ class SentryNativeJava extends SentryNativeChannel {
 
   @override
   int? displayRefreshRate() => tryCatchSync('displayRefreshRate', () {
-        return native.SentryFlutterPlugin.Companion
-            .getDisplayRefreshRate()
+        return native.SentryFlutterPlugin.getDisplayRefreshRate()
             ?.intValue(releaseOriginal: true);
       });
 
@@ -150,7 +148,7 @@ class SentryNativeJava extends SentryNativeChannel {
         return null;
       }
       appStartUtf8JsonBytes =
-          native.SentryFlutterPlugin.Companion.fetchNativeAppStartAsBytes();
+          native.SentryFlutterPlugin.fetchNativeAppStartAsBytes();
       if (appStartUtf8JsonBytes == null) return null;
 
       final byteRange =
@@ -166,7 +164,7 @@ class SentryNativeJava extends SentryNativeChannel {
 
   @override
   void nativeCrash() {
-    native.SentryFlutterPlugin.Companion.crash();
+    native.SentryFlutterPlugin.crash();
   }
 
   @override

--- a/packages/flutter/lib/src/native/java/sentry_native_java_init.dart
+++ b/packages/flutter/lib/src/native/java/sentry_native_java_init.dart
@@ -46,8 +46,7 @@ void initSentryAndroid({
           );
 
           replayCallbacks.use((cb) {
-            native.SentryFlutterPlugin.Companion
-                .setupReplay(androidOptions, cb);
+            native.SentryFlutterPlugin.setupReplay(androidOptions, cb);
           });
         },
       ),
@@ -151,8 +150,8 @@ native.ReplayRecorderCallbacks? createReplayRecorderCallbacks({
             SentryId.fromId(replayIdString.toDartString(releaseOriginal: true));
 
         owner._replayId = replayId;
-        owner._nativeReplay = native.SentryFlutterPlugin.Companion
-            .privateSentryGetReplayIntegration();
+        owner._nativeReplay =
+            native.SentryFlutterPlugin.privateSentryGetReplayIntegration();
         owner._replayRecorder = AndroidReplayRecorder.factory(options);
         await owner._replayRecorder!.start();
         hub.configureScope((s) {

--- a/packages/flutter/lib/src/native/java/sentry_native_java_init.dart
+++ b/packages/flutter/lib/src/native/java/sentry_native_java_init.dart
@@ -125,7 +125,9 @@ native.SentryOptions$BeforeSendReplayCallback createBeforeSendReplayCallback(
               return shouldRemove;
             });
 
-            payload?.addAll(_dartToJMap(options.privacy.toJson()));
+            final jMap = _dartToJMap(options.privacy.toJson());
+            payload?.addAll(jMap);
+            jMap.release();
           }
         });
         return sentryReplayEvent;

--- a/packages/flutter/lib/src/native/java/sentry_native_java_init.dart
+++ b/packages/flutter/lib/src/native/java/sentry_native_java_init.dart
@@ -125,7 +125,7 @@ native.SentryOptions$BeforeSendReplayCallback createBeforeSendReplayCallback(
               return shouldRemove;
             });
 
-            payload?.addAll(_dartToJMap(options.privacy.toJson(), arena));
+            payload?.addAll(_dartToJMap(options.privacy.toJson()));
           }
         });
         return sentryReplayEvent;


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
### Switch JNI/Dart calls from `native.SentryFlutterPlugin.Companion.xyz()` to `native.SentryFlutterPlugin.xyz()` 

No object lifetime hazards: Static calls use only a jclass and `CallStatic…Method`. Companion calls use a Companion object and `Call…Method`, which can crash if the object ref is stale, not global, or used across threads.`globalEnv_CallStaticObjectMethod` vs `globalEnv_CallObjectMethod`

Fixes https://github.com/getsentry/sentry-dart/issues/3353

### Properly set up releasing of JNI Refs

Each `toJString()` (and other `toJxyz()`) creates a JNI local reference. `releasedBy(arena)` defers deletion until the arena ends, so building big maps/lists holds hundreds/thousands of locals at once. That can overflow the per-thread local reference table and crash around `globalEnv_NewString/AddGlobalRef.` 

Fixes  https://github.com/getsentry/sentry-dart/issues/3348

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Potentially fixes https://github.com/getsentry/sentry-dart/issues/3348 and https://github.com/getsentry/sentry-dart/issues/3353

## :green_heart: How did you test it?
Unfortunately I could not repro the crashes referenced in the issue. 

But the existing integration tests should still work with this change

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
