### PR TITLE
Add crashpad path to Windows

### DIFF
--- a/packages/flutter/lib/src/native/c/sentry_native.dart
+++ b/packages/flutter/lib/src/native/c/sentry_native.dart
@@ -436,15 +436,20 @@ extension on List<dynamic> {
 }
 
 String? _getDefaultCrashpadPath() {
-  if (Platform.isLinux) {
-    final lastSeparator =
-        Platform.resolvedExecutable.lastIndexOf(Platform.pathSeparator);
-    if (lastSeparator >= 0) {
-      final appDir = Platform.resolvedExecutable.substring(0, lastSeparator);
+  final lastSeparator =
+      Platform.resolvedExecutable.lastIndexOf(Platform.pathSeparator);
+  if (lastSeparator >= 0) {
+    final appDir = Platform.resolvedExecutable.substring(0, lastSeparator);
+    if (Platform.isLinux) {
       final candidates = [
         '$appDir${Platform.pathSeparator}crashpad_handler',
         '$appDir${Platform.pathSeparator}bin${Platform.pathSeparator}crashpad_handler',
         '$appDir${Platform.pathSeparator}lib${Platform.pathSeparator}crashpad_handler'
+      ];
+      return candidates.firstWhereOrNull((path) => File(path).existsSync());
+    } else if (Platform.isWindows) {
+      final candidates = [
+        '$appDir${Platform.pathSeparator}crashpad_handler.exe',
       ];
       return candidates.firstWhereOrNull((path) => File(path).existsSync());
     }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

On Windows we don’t get any native crash reporting, which is a real issue since a significant part of our users are on this platform. We receive many crash reports from the native side, but we have no visibility into them. 

> According to the documentation, this isn’t supported on Windows.

@buenaflor : this doc is outdated and needs to be updated

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When testing, we saw that the crashpad handler is packaged with the app, but it seems to have never launched. So I dug into the code and saw it is not launched.

## :green_heart: How did you test it?

No unit test for now, will add in the PR later. I tested with 2 Windows machine and errors was reported to Sentry dashboard.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
