### PR TITLE
Fix flutter example apk building

### DIFF
--- a/.github/workflows/flutter_test.yml
+++ b/.github/workflows/flutter_test.yml
@@ -69,7 +69,7 @@ jobs:
           disable-animations: true
           script: flutter test integration_test/all.dart --dart-define SENTRY_AUTH_TOKEN_E2E=$SENTRY_AUTH_TOKEN_E2E --verbose && flutter drive --driver=integration_test/test_driver/driver.dart --target=integration_test/sentry_widgets_flutter_binding_test.dart --profile -d emulator-5554
 
-      - name: build apk
+      - name: Build APK
         working-directory: packages/flutter/example/android
         run: flutter build apk --debug --target-platform=android-x64
 

--- a/packages/flutter/example/pubspec.yaml
+++ b/packages/flutter/example/pubspec.yaml
@@ -39,7 +39,7 @@ dependencies:
 dependency_overrides:
   isar_flutter_libs:
     git:
-      url: https://github.com/MrLittleWhite/isar_flutter_libs.git
+      url: https://github.com/Deepjyoti120/isar_flutter_libs.git
 
 dev_dependencies:
   flutter_lints: ^2.0.0

--- a/packages/flutter/example/pubspec_overrides.yaml
+++ b/packages/flutter/example/pubspec_overrides.yaml
@@ -20,4 +20,4 @@ dependency_overrides:
     path: ../../sqflite
   isar_flutter_libs:
     git:
-      url: https://github.com/MrLittleWhite/isar_flutter_libs.git
+      url: https://github.com/Deepjyoti120/isar_flutter_libs.git


### PR DESCRIPTION
#skip-changelog

Currently building release apk fails due to the dependency.

Note: test failures are not because of this change