### PR TITLE
[DRAFT] feat(span-first): Span Buffer

### DIFF
--- a/packages/dart/lib/src/hub.dart
+++ b/packages/dart/lib/src/hub.dart
@@ -628,7 +628,11 @@ class Hub {
 
     scope.removeActiveSpan(span);
 
-    // TODO(next-pr): run this span through span specific pipeline and then forward to span buffer
+    final item = _peek();
+    item.client.captureSpan(span, scope: scope);
+
+    // TODO(next-pr): client reports
+    // TODO(next-pr): run this span through span specific pipeline
   }
 
   @internal

--- a/packages/dart/lib/src/protocol/noop_span.dart
+++ b/packages/dart/lib/src/protocol/noop_span.dart
@@ -22,6 +22,15 @@ class NoOpSpan implements Span {
   Span? get parentSpan => null;
 
   @override
+  Span get segmentSpan => this;
+
+  @override
+  SentryId get traceId => SentryId.empty();
+
+  @override
+  String get segmentKey => '';
+
+  @override
   DateTime? get endTimestamp => null;
 
   @override

--- a/packages/dart/lib/src/protocol/sentry_log.dart
+++ b/packages/dart/lib/src/protocol/sentry_log.dart
@@ -1,8 +1,9 @@
+import '../telemetry_buffer/telemetry_buffer.dart';
 import 'sentry_attribute.dart';
 import 'sentry_id.dart';
 import 'sentry_log_level.dart';
 
-class SentryLog {
+class SentryLog implements TelemetryPayload {
   DateTime timestamp;
   SentryId traceId;
   SentryLogLevel level;
@@ -21,6 +22,7 @@ class SentryLog {
     this.severityNumber,
   }) : traceId = traceId ?? SentryId.empty();
 
+  @override
   Map<String, dynamic> toJson() {
     return {
       'timestamp': timestamp.toIso8601String(),

--- a/packages/dart/lib/src/protocol/simple_span.dart
+++ b/packages/dart/lib/src/protocol/simple_span.dart
@@ -7,11 +7,13 @@ class SimpleSpan implements Span {
   final Span? parentSpan;
   final Map<String, SentryAttribute> _attributes = {};
   final DateTime _startTimestamp;
+  late final SentryId _traceId;
 
   String _name;
   SpanV2Status _status = SpanV2Status.ok;
   DateTime? _endTimestamp;
   bool _isFinished = false;
+  String? _segmentKey;
 
   SimpleSpan({
     required String name,
@@ -20,7 +22,15 @@ class SimpleSpan implements Span {
   })  : _spanId = SpanId.newId(),
         _startTimestamp = DateTime.now().toUtc(),
         _hub = hub ?? HubAdapter(),
-        _name = name;
+        _name = name {
+    _traceId = parentSpan?.traceId ?? _hub.scope.propagationContext.traceId;
+  }
+
+  @override
+  Span get segmentSpan => parentSpan?.segmentSpan ?? this;
+
+  @override
+  SentryId get traceId => _traceId;
 
   @override
   SpanId get spanId => _spanId;
@@ -45,6 +55,9 @@ class SimpleSpan implements Span {
 
   @override
   bool get isFinished => _isFinished;
+
+  @override
+  String get segmentKey => _segmentKey ??= '$traceId-${segmentSpan.spanId}';
 
   @override
   void setAttribute(String key, SentryAttribute value) {

--- a/packages/dart/lib/src/protocol/span.dart
+++ b/packages/dart/lib/src/protocol/span.dart
@@ -1,11 +1,12 @@
 import 'package:meta/meta.dart';
 
 import '../../sentry.dart';
+import '../telemetry_buffer/telemetry_buffer.dart';
 
 // Span specs: https://develop.sentry.dev/sdk/telemetry/spans/span-api/
 
 /// Represents a basic telemetry span.
-abstract class Span {
+abstract class Span implements TelemetryPayload {
   @internal
   const Span();
 
@@ -54,6 +55,7 @@ abstract class Span {
   @internal
   bool get isFinished;
 
+  @override
   @internal
   Map<String, dynamic> toJson();
 }

--- a/packages/dart/lib/src/protocol/span.dart
+++ b/packages/dart/lib/src/protocol/span.dart
@@ -53,6 +53,15 @@ abstract class Span implements TelemetryPayload {
   void setAttributes(Map<String, SentryAttribute> attributes);
 
   @internal
+  String get segmentKey;
+
+  @internal
+  SentryId get traceId;
+
+  @internal
+  Span get segmentSpan;
+
+  @internal
   bool get isFinished;
 
   @override

--- a/packages/dart/lib/src/protocol/unset_span.dart
+++ b/packages/dart/lib/src/protocol/unset_span.dart
@@ -63,4 +63,16 @@ class UnsetSpan extends Span {
   Map<String, dynamic> toJson() {
     throw UnimplementedError('$UnsetSpan apis should not be used');
   }
+
+  @override
+  String get segmentKey =>
+      throw UnimplementedError('$UnsetSpan apis should not be used');
+
+  @override
+  Span get segmentSpan =>
+      throw UnimplementedError('$UnsetSpan apis should not be used');
+
+  @override
+  SentryId get traceId =>
+      throw UnimplementedError('$UnsetSpan apis should not be used');
 }

--- a/packages/dart/lib/src/sentry_client.dart
+++ b/packages/dart/lib/src/sentry_client.dart
@@ -30,7 +30,6 @@ import 'type_check_hint.dart';
 import 'utils/isolate_utils.dart';
 import 'utils/regex_utils.dart';
 import 'utils/stacktrace_utils.dart';
-import 'sentry_log_batcher.dart';
 import 'version.dart';
 
 /// Default value for [SentryUser.ipAddress]. It gets set when an event does not have
@@ -78,17 +77,9 @@ class SentryClient {
       options.transport = SpotlightHttpTransport(options, options.transport);
     }
     if (options.enableLogs) {
-      options.logBuffer = InMemoryTelemetryBuffer(options,
-          toEnvelope: (telemetryData) =>
-              SentryEnvelope.fromLogsData(telemetryData, options.sdk));
+      options.logBuffer = InMemoryTelemetryBuffer.forLogs(options);
     }
-    options.spanBuffer = InMemoryTelemetryBuffer(options,
-        toEnvelope: (telemetryData) => SentryEnvelope.fromSpansData(
-            telemetryData, options.sdk,
-            dsn: options.dsn,
-            traceContext: SentryTraceContextHeader(
-                Sentry.currentHub.scope.propagationContext.traceId,
-                options.parsedDsn.publicKey)));
+    options.spanBuffer = InMemoryTelemetryBuffer.forSpans(options);
     return SentryClient._(options);
   }
 

--- a/packages/dart/lib/src/sentry_client.dart
+++ b/packages/dart/lib/src/sentry_client.dart
@@ -79,6 +79,7 @@ class SentryClient {
     if (options.enableLogs) {
       options.logBuffer = InMemoryTelemetryBuffer.forLogs(options);
     }
+    // TODO(next-pr): only add span buffer when the traceLifecycle flag is true
     options.spanBuffer = InMemoryTelemetryBuffer.forSpans(options);
     return SentryClient._(options);
   }

--- a/packages/dart/lib/src/sentry_options.dart
+++ b/packages/dart/lib/src/sentry_options.dart
@@ -12,6 +12,8 @@ import 'noop_client.dart';
 import 'platform/platform.dart';
 import 'sentry_exception_factory.dart';
 import 'sentry_stack_trace_factory.dart';
+import 'telemetry_buffer/noop_telemetry_buffer.dart';
+import 'telemetry_buffer/telemetry_buffer.dart';
 import 'transport/noop_transport.dart';
 import 'version.dart';
 import 'sentry_log_batcher.dart';
@@ -541,7 +543,10 @@ class SentryOptions {
   late final SentryLogger logger = SentryLogger(clock);
 
   @internal
-  SentryLogBatcher logBatcher = NoopLogBatcher();
+  TelemetryBuffer<SentryLog> logBuffer = NoOpTelemetryBuffer();
+
+  @internal
+  TelemetryBuffer<Span> spanBuffer = NoOpTelemetryBuffer();
 
   SentryOptions({String? dsn, Platform? platform, RuntimeChecker? checker}) {
     this.dsn = dsn;

--- a/packages/dart/lib/src/telemetry_buffer/buffer_flusher.dart
+++ b/packages/dart/lib/src/telemetry_buffer/buffer_flusher.dart
@@ -1,0 +1,106 @@
+import 'dart:async';
+import 'dart:io';
+
+import '../../sentry.dart';
+
+/// A buffered item containing both the raw item and its encoded bytes.
+/// This allows accurate size tracking while preserving access to raw data
+/// for grouping/inspection by flushers.
+class BufferedItem<T> {
+  final T item;
+  final List<int> encoded;
+
+  BufferedItem(this.item, this.encoded);
+}
+
+/// Flusher for processing buffered telemetry items.
+/// Responsible for grouping, envelope creation, and sending.
+abstract class BufferFlusher<T> {
+  FutureOr<void> flush(List<BufferedItem<T>> items);
+}
+
+/// Flusher for logs: no grouping, single envelope.
+class LogBufferFlusher implements BufferFlusher<SentryLog> {
+  final SentryOptions _options;
+
+  LogBufferFlusher(this._options);
+
+  @override
+  FutureOr<void> flush(List<BufferedItem<SentryLog>> items) {
+    if (items.isEmpty) return null;
+
+    final encoded = items.map((i) => i.encoded).toList();
+    final envelope = SentryEnvelope.fromLogsData(encoded, _options.sdk);
+    return _options.transport.send(envelope).then((_) => null);
+  }
+}
+
+/// Flusher for spans: groups by segment, one envelope per group with trace context.
+class SpanBufferFlusher implements BufferFlusher<Span> {
+  final SentryOptions _options;
+
+  SpanBufferFlusher(this._options);
+
+  @override
+  FutureOr<void> flush(List<BufferedItem<Span>> items) async {
+    if (items.isEmpty) return;
+
+    final groups = _groupBySegment(items);
+
+    for (final entry in groups.entries) {
+      try {
+        final encoded = entry.value.map((i) => i.encoded).toList();
+        final traceContext = _createTraceContext(entry.value.first.item);
+        final envelope = SentryEnvelope.fromSpansData(
+          encoded,
+          _options.sdk,
+          dsn: _options.dsn,
+          traceContext: traceContext,
+        );
+        await _options.transport.send(envelope);
+      } catch (error) {
+        _options.log(
+          SentryLevel.error,
+          'SpanBufferFlusher: Failed to send span group ${entry.key}: $error',
+        );
+      }
+    }
+  }
+
+  /// Groups buffered spans by their segment (traceId + segmentSpanId).
+  Map<String, List<BufferedItem<Span>>> _groupBySegment(
+    List<BufferedItem<Span>> items,
+  ) {
+    final groups = <String, List<BufferedItem<Span>>>{};
+    for (final buffered in items) {
+      final key = _segmentKey(buffered.item);
+      groups.putIfAbsent(key, () => []).add(buffered);
+    }
+    return groups;
+  }
+
+  /// Returns a unique key for the segment this span belongs to.
+  String _segmentKey(Span span) {
+    final segment = span.parentSpan ?? span;
+    final json = segment.toJson();
+    final traceId = json['trace_id'];
+    return traceId == null ? '_' : '$traceId-${segment.spanId}';
+  }
+
+  /// Creates a trace context header from the segment span.
+  SentryTraceContextHeader? _createTraceContext(Span span) {
+    final segment = span.parentSpan ?? span;
+    final json = segment.toJson();
+    final traceId = json['trace_id'];
+    final publicKey = _options.parsedDsn.publicKey;
+
+    if (traceId == null) return null;
+
+    return SentryTraceContextHeader(
+      SentryId.fromId(traceId),
+      publicKey,
+      release: _options.release,
+      environment: _options.environment,
+    );
+  }
+}

--- a/packages/dart/lib/src/telemetry_buffer/in_memory_telemetry_buffer.dart
+++ b/packages/dart/lib/src/telemetry_buffer/in_memory_telemetry_buffer.dart
@@ -1,41 +1,76 @@
 import 'dart:async';
 
 import '../../sentry.dart';
+import 'buffer_flusher.dart';
 import 'telemetry_buffer.dart';
 
+/// In-memory buffer for telemetry items with time and size-based flushing.
+///
+/// This buffer is generic and delegates all domain-specific logic
+/// (grouping, envelope creation, sending) to a [BufferFlusher].
 class InMemoryTelemetryBuffer<T extends TelemetryPayload>
     extends TelemetryBuffer<T> {
-  final SentryEnvelope Function(List<List<int>>) toEnvelope;
   final SentryOptions _options;
+  final BufferFlusher<T> _flusher;
   final Duration _flushTimeout;
   final int _maxBufferSizeBytes;
-  Timer? _flushTimer;
-  // Store encoded telemetry data instead of raw telemetry to avoid re-serialization
-  final List<List<int>> _encodedTelemetry = [];
-  int _encodedTelemetrySize = 0;
 
-  InMemoryTelemetryBuffer(
-    this._options, {
-    required this.toEnvelope,
+  Timer? _flushTimer;
+  final List<BufferedItem<T>> _items = [];
+  int _bufferSize = 0;
+
+  InMemoryTelemetryBuffer._(
+    this._options,
+    this._flusher, {
     Duration? flushTimeout,
     int? maxBufferSizeBytes,
-  })  : _flushTimeout = flushTimeout ?? Duration(seconds: 5),
+  })  : _flushTimeout = flushTimeout ?? const Duration(seconds: 5),
         _maxBufferSizeBytes = maxBufferSizeBytes ??
             1024 * 1024; // 1MB default per Mobile Buffer spec
 
-  /// Adds a telemetry to the buffer.
-  @override
-  void add(T telemetry) {
-    try {
-      final encodedTelemetry = utf8JsonEncoder.convert(telemetry.toJson());
+  /// Creates a buffer for logs.
+  ///
+  /// Optionally provide a custom [flusher] for testing.
+  static InMemoryTelemetryBuffer<SentryLog> forLogs(
+    SentryOptions options, {
+    BufferFlusher<SentryLog>? flusher,
+    Duration? flushTimeout,
+    int? maxBufferSizeBytes,
+  }) =>
+      InMemoryTelemetryBuffer._(
+        options,
+        flusher ?? LogBufferFlusher(options),
+        flushTimeout: flushTimeout,
+        maxBufferSizeBytes: maxBufferSizeBytes,
+      );
 
-      _encodedTelemetry.add(encodedTelemetry);
-      _encodedTelemetrySize += encodedTelemetry.length;
+  /// Creates a buffer for spans.
+  ///
+  /// Optionally provide a custom [flusher] for testing.
+  static InMemoryTelemetryBuffer<Span> forSpans(
+    SentryOptions options, {
+    BufferFlusher<Span>? flusher,
+    Duration? flushTimeout,
+    int? maxBufferSizeBytes,
+  }) =>
+      InMemoryTelemetryBuffer._(
+        options,
+        flusher ?? SpanBufferFlusher(options),
+        flushTimeout: flushTimeout,
+        maxBufferSizeBytes: maxBufferSizeBytes,
+      );
+
+  /// Adds a telemetry item to the buffer.
+  @override
+  void add(T item) {
+    try {
+      final encoded = utf8JsonEncoder.convert(item.toJson());
+      _items.add(BufferedItem(item, encoded));
+      _bufferSize += encoded.length;
 
       // Flush if size threshold is reached
-      if (_encodedTelemetrySize >= _maxBufferSizeBytes) {
-        // Buffer size exceeded, flush immediately
-        _performFlushTelemetry();
+      if (_bufferSize >= _maxBufferSizeBytes) {
+        _performFlush();
       } else if (_flushTimer == null) {
         // Start timeout only when first item is added
         _startTimer();
@@ -44,50 +79,51 @@ class InMemoryTelemetryBuffer<T extends TelemetryPayload>
     } catch (error) {
       _options.log(
         SentryLevel.error,
-        '$InMemoryTelemetryBuffer for $T: Failed to encode log with error $error',
+        '$InMemoryTelemetryBuffer<$T>: Failed to encode item: $error',
       );
     }
   }
 
   /// Flushes the buffer immediately, sending all buffered telemetry.
   @override
-  FutureOr<void> flush() => _performFlushTelemetry();
+  FutureOr<void> flush() => _performFlush();
 
   void _startTimer() {
     _flushTimer = Timer(_flushTimeout, () {
       _options.log(
         SentryLevel.debug,
-        '$InMemoryTelemetryBuffer for $T: Timer fired, flushing $T data.',
+        '$InMemoryTelemetryBuffer<$T>: Timer fired, flushing.',
       );
-      _performFlushTelemetry();
+      _performFlush();
     });
   }
 
-  FutureOr<void> _performFlushTelemetry() {
+  FutureOr<void> _performFlush() {
     // Reset timer state first
     _flushTimer?.cancel();
     _flushTimer = null;
 
-    // Reset buffer on function exit
-    final telemetryToSend = List<List<int>>.from(_encodedTelemetry);
-    _encodedTelemetry.clear();
-    _encodedTelemetrySize = 0;
+    // Capture and clear buffer
+    final itemsToSend = List<BufferedItem<T>>.from(_items);
+    _items.clear();
+    _bufferSize = 0;
 
-    if (telemetryToSend.isEmpty) {
+    if (itemsToSend.isEmpty) {
       _options.log(
         SentryLevel.debug,
-        '$InMemoryTelemetryBuffer for $T: No data to flush.',
+        '$InMemoryTelemetryBuffer<$T>: No data to flush.',
       );
-    } else {
-      try {
-        final envelope = toEnvelope(telemetryToSend);
-        return _options.transport.send(envelope).then((_) => null);
-      } catch (error) {
-        _options.log(
-          SentryLevel.error,
-          '$InMemoryTelemetryBuffer for $T: Failed to create envelope for batched data with error $error',
-        );
-      }
+      return null;
+    }
+
+    try {
+      return _flusher.flush(itemsToSend);
+    } catch (error) {
+      _options.log(
+        SentryLevel.error,
+        '$InMemoryTelemetryBuffer<$T>: Failed to flush items: $error',
+      );
+      return null;
     }
   }
 }

--- a/packages/dart/lib/src/telemetry_buffer/in_memory_telemetry_buffer.dart
+++ b/packages/dart/lib/src/telemetry_buffer/in_memory_telemetry_buffer.dart
@@ -79,7 +79,7 @@ class InMemoryTelemetryBuffer<T extends TelemetryPayload>
     } catch (error) {
       _options.log(
         SentryLevel.error,
-        '$InMemoryTelemetryBuffer<$T>: Failed to encode item: $error',
+        '$InMemoryTelemetryBuffer for $T: Failed to encode item: $error',
       );
     }
   }
@@ -92,7 +92,7 @@ class InMemoryTelemetryBuffer<T extends TelemetryPayload>
     _flushTimer = Timer(_flushTimeout, () {
       _options.log(
         SentryLevel.debug,
-        '$InMemoryTelemetryBuffer<$T>: Timer fired, flushing.',
+        '$InMemoryTelemetryBuffer for $T: Timer fired, flushing.',
       );
       _performFlush();
     });
@@ -111,7 +111,7 @@ class InMemoryTelemetryBuffer<T extends TelemetryPayload>
     if (itemsToSend.isEmpty) {
       _options.log(
         SentryLevel.debug,
-        '$InMemoryTelemetryBuffer<$T>: No data to flush.',
+        '$InMemoryTelemetryBuffer for $T: No data to flush.',
       );
       return null;
     }
@@ -121,7 +121,7 @@ class InMemoryTelemetryBuffer<T extends TelemetryPayload>
     } catch (error) {
       _options.log(
         SentryLevel.error,
-        '$InMemoryTelemetryBuffer<$T>: Failed to flush items: $error',
+        '$InMemoryTelemetryBuffer for $T: Failed to flush items: $error',
       );
       return null;
     }

--- a/packages/dart/lib/src/telemetry_buffer/in_memory_telemetry_buffer.dart
+++ b/packages/dart/lib/src/telemetry_buffer/in_memory_telemetry_buffer.dart
@@ -1,0 +1,87 @@
+class InMemoryTelemetryBuffer<T extends TelemetryPayload> extends TelemetryBuffer<T> {
+  final SentryEnvelope Function(List<List<int>>) toEnvelope;
+  final SentryOptions _options;
+  final Duration _flushTimeout;
+  final int _maxBufferSizeBytes;
+  Timer? _flushTimer;
+  // Store encoded telemetry data instead of raw telemetry to avoid re-serialization
+  final List<List<int>> _encodedTelemetry = [];
+  int _encodedTelemetrySize = 0;
+
+  InMemoryTelemetryBuffer(
+      this._options, {
+        required this.toEnvelope,
+        Duration? flushTimeout,
+        int? maxBufferSizeBytes,
+      })  : _flushTimeout = flushTimeout ?? Duration(seconds: 5),
+        _maxBufferSizeBytes = maxBufferSizeBytes ??
+            1024 * 1024; // 1MB default per Mobile Buffer spec
+
+  /// Adds a telemetry to the buffer.
+  @override
+  void add(T telemetry) {
+    try {
+      final encodedTelemetry = utf8JsonEncoder.convert(telemetry.toJson());
+
+      _encodedTelemetry.add(encodedTelemetry);
+      _encodedTelemetrySize += encodedTelemetry.length;
+
+      // Flush if size threshold is reached
+      if (_encodedTelemetrySize >= _maxBufferSizeBytes) {
+        // Buffer size exceeded, flush immediately
+        _performFlushLogs();
+      } else if (_flushTimer == null) {
+        // Start timeout only when first item is added
+        _startTimer();
+      }
+      // Note: We don't restart the timer on subsequent additions per spec
+    } catch (error) {
+      _options.log(
+        SentryLevel.error,
+        '$InMemoryTelemetryBuffer for $T: Failed to encode log with error $error',
+      );
+    }
+  }
+
+  /// Flushes the buffer immediately, sending all buffered telemetry.
+  @override
+  FutureOr<void> flush() => _performFlushLogs();
+
+  void _startTimer() {
+    _flushTimer = Timer(_flushTimeout, () {
+      _options.log(
+        SentryLevel.debug,
+        '$InMemoryTelemetryBuffer for $T: Timer fired, calling performCaptureLogs().',
+      );
+      _performFlushLogs();
+    });
+  }
+
+  FutureOr<void> _performFlushLogs() {
+    // Reset timer state first
+    _flushTimer?.cancel();
+    _flushTimer = null;
+
+    // Reset buffer on function exit
+    final telemetryToSend = List<List<int>>.from(_encodedTelemetry);
+    _encodedTelemetry.clear();
+    _encodedTelemetrySize = 0;
+
+    if (telemetryToSend.isEmpty) {
+      _options.log(
+        SentryLevel.debug,
+        '$InMemoryTelemetryBuffer for $T: No logs to flush.',
+      );
+    } else {
+      try {
+        final envelope = toEnvelope(telemetryToSend);
+        return _options.transport.send(envelope).then((_) => null);
+      } catch (error) {
+        _options.log(
+          SentryLevel.error,
+          '$InMemoryTelemetryBuffer for $T: Failed to create envelope for batched logs with error $error',
+        );
+      }
+    }
+  }
+}

--- a/packages/dart/lib/src/telemetry_buffer/noop_telemetry_buffer.dart
+++ b/packages/dart/lib/src/telemetry_buffer/noop_telemetry_buffer.dart
@@ -1,0 +1,7 @@
+class NoOpTelemetryBuffer<T extends TelemetryPayload> extends TelemetryBuffer<T> {
+  @override
+  void add(T item) {}
+
+  @override
+  FutureOr<void> flush() {}
+}

--- a/packages/dart/lib/src/telemetry_buffer/noop_telemetry_buffer.dart
+++ b/packages/dart/lib/src/telemetry_buffer/noop_telemetry_buffer.dart
@@ -1,4 +1,9 @@
-class NoOpTelemetryBuffer<T extends TelemetryPayload> extends TelemetryBuffer<T> {
+import 'dart:async';
+
+import 'telemetry_buffer.dart';
+
+class NoOpTelemetryBuffer<T extends TelemetryPayload>
+    extends TelemetryBuffer<T> {
   @override
   void add(T item) {}
 

--- a/packages/dart/lib/src/telemetry_buffer/telemetry_buffer.dart
+++ b/packages/dart/lib/src/telemetry_buffer/telemetry_buffer.dart
@@ -6,7 +6,7 @@ abstract class TelemetryPayload {
   Map<String, dynamic> toJson();
 }
 
-abstract class TelemetryBuffer<T extends Telemetry> {
+abstract class TelemetryBuffer<T extends TelemetryPayload> {
   void add(T item);
   FutureOr<void> flush();
 }

--- a/packages/dart/lib/src/telemetry_buffer/telemetry_buffer.dart
+++ b/packages/dart/lib/src/telemetry_buffer/telemetry_buffer.dart
@@ -1,11 +1,11 @@
 import 'dart:async';
 
-import '../sentry.dart';
-
+/// Represents a telemetry item that can be serialized to JSON.
 abstract class TelemetryPayload {
   Map<String, dynamic> toJson();
 }
 
+/// Abstract buffer interface for telemetry items.
 abstract class TelemetryBuffer<T extends TelemetryPayload> {
   void add(T item);
   FutureOr<void> flush();

--- a/packages/dart/lib/src/telemetry_buffer/telemetry_buffer.dart
+++ b/packages/dart/lib/src/telemetry_buffer/telemetry_buffer.dart
@@ -1,0 +1,12 @@
+import 'dart:async';
+
+import '../sentry.dart';
+
+abstract class TelemetryPayload {
+  Map<String, dynamic> toJson();
+}
+
+abstract class TelemetryBuffer<T extends Telemetry> {
+  void add(T item);
+  FutureOr<void> flush();
+}

--- a/packages/flutter/lib/src/widgets_binding_observer.dart
+++ b/packages/flutter/lib/src/widgets_binding_observer.dart
@@ -94,7 +94,7 @@ class SentryWidgetsBindingObserver with WidgetsBindingObserver {
     if (!_isNavigatorObserverCreated() && !_options.platform.isWeb) {
       if (state == AppLifecycleState.inactive) {
         _appInBackgroundStopwatch.start();
-        _options.logBatcher.flush();
+        _options.logBuffer.flush();
       } else if (_appInBackgroundStopwatch.isRunning &&
           state == AppLifecycleState.resumed) {
         _appInBackgroundStopwatch.stop();


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
This PR is still WIP

Note that the proposed architecture is not yet final - the full spec is still WIP and this is only a minimal part of it.

This current impl does not include:
- rate limiting before adding to buffer

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### New Telemetry Buffer Architecture

Note that this only illustrates mainly the default `InMemoryTelemetryBuffer` but it is later swappable when we will eventually reuse iOS and Android (crash-safe) native buffers 

(graphics made by Cursor :D)

```
┌─────────────────────────────────────────────────────────────────────────────┐
│                           TELEMETRY BUFFER ARCHITECTURE                      │
└─────────────────────────────────────────────────────────────────────────────┘

                              ┌──────────────────┐
                              │  TelemetryPayload │  (interface)
                              │  ───────────────  │
                              │  + toJson()       │
                              └────────┬─────────┘
                                       │ implements
              ┌────────────────────────┼────────────────────────┐
              │                        │                        │
              ▼                        ▼                        ▼
       ┌────────────┐          ┌─────────────┐          ┌─────────────┐
       │  SentryLog │          │    Span     │          │   Metrics   │
       └────────────┘          └─────────────┘          │  (future)   │
              │                        │                └─────────────┘
              │                        │                        │
              │ add()                  │ add()                  │ add()
              ▼                        ▼                        ▼
┌─────────────────────────────────────────────────────────────────────────────┐
│                          TelemetryBuffer<T>                                  │
│  ─────────────────────────────────────────────────────────────────────────  │
│  Abstract interface for buffering telemetry items.                           │
│                                                                              │
│  + add(T item)      → Adds an item to the buffer                             │
│  + flush()          → Flushes all buffered items                             │
│                                                                              │
│  Implementations:                                                            │
│  • InMemoryTelemetryBuffer  → Time/size-based flushing with BufferFlusher   │
│  • NoOpTelemetryBuffer      → Does nothing (disabled state)                  │
│                                                                              │
└─────────────────────────────────────────────────────────────────────────────┘
                                       │
                                       │ extends
                                       ▼
┌─────────────────────────────────────────────────────────────────────────────┐
│                        InMemoryTelemetryBuffer<T>                            │
│  ─────────────────────────────────────────────────────────────────────────  │
│                                                                              │
│   ┌─────────────────────────────────────────────────────────────────────┐   │
│   │  Storage: List<BufferedItem<T>>                                      │   │
│   │  ┌──────────────┐ ┌──────────────┐ ┌──────────────┐                 │   │
│   │  │ item: T      │ │ item: T      │ │ item: T      │  ...            │   │
│   │  │ encoded: []  │ │ encoded: []  │ │ encoded: []  │                 │   │
│   │  └──────────────┘ └──────────────┘ └──────────────┘                 │   │
│   └─────────────────────────────────────────────────────────────────────┘   │
│                                                                              │
│   Triggers flush when:                                                       │
│   • Timer fires (5s default)                                                 │
│   • Size threshold reached (1MB default)                                     │
│   • Manual flush() called                                                    │
│                                                                              │
│   Factory methods:                                                           │
│   • forLogs(options, {flusher?})  → InMemoryTelemetryBuffer<SentryLog>      │
│   • forSpans(options, {flusher?}) → InMemoryTelemetryBuffer<Span>           │
│   • forMetrics(options, {flusher?}) → (future)                              │
│                                                                              │
└──────────────────────────────────┬──────────────────────────────────────────┘
                                   │
                                   │ flush triggers
                                   │ _flusher.flush(items)
                                   ▼
                        ┌─────────────────────┐
                        │   BufferFlusher<T>   │  (abstract)
                        │   ────────────────   │
                        │   + flush(items)     │
                        └──────────┬──────────┘
                                   │ implements
              ┌────────────────────┼────────────────────────┐
              │                    │                        │
              ▼                    ▼                        ▼
   ┌──────────────────┐  ┌───────────────────┐  ┌───────────────────┐
   │  LogBufferFlusher │  │ SpanBufferFlusher │  │MetricsBufferFlusher│
   │  ────────────────  │  │ ───────────────── │  │    (future)        │
   │                    │  │                   │  └───────────────────┘
   │  • No grouping     │  │  • Group by key:  │
   │  • Single envelope │  │    "${traceId}-   │
   │                    │  │     ${segmentId}" │
   │                    │  │                   │
   │                    │  │  • One envelope   │
   │                    │  │    per group with │
   │                    │  │    trace context  │
   └─────────┬──────────┘  └─────────┬─────────┘
             │                       │
             │                       │ for each group
             ▼                       ▼
   ┌──────────────────────────────────────────────────────────────────────────┐
   │                              Transport                                    │
   │  ────────────────────────────────────────────────────────────────────    │
   │                                                                           │
   │  ┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐       │
   │  │ Logs Envelope   │    │ Spans Envelope  │    │ Spans Envelope  │ ...   │
   │  │ (all logs)      │    │ (trace A spans) │    │ (trace B spans) │       │
   │  └─────────────────┘    └─────────────────┘    └─────────────────┘       │
   │                                                                           │
   └──────────────────────────────────────────────────────────────────────────┘
                                   │
                                   ▼
                            ┌─────────────┐
                            │   Sentry    │
                            └─────────────┘
```

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
