### PR TITLE
fix(app-start): Fixes cold/warm start spans not attaching if TTFD takes more than 3 seconds to report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Fixes cold/warm start spans not attaching if TTFD takes more than 3 seconds to report ([#3404](https://github.com/getsentry/sentry-dart/pull/3404))
+- Cold/warm start spans not attaching if TTFD takes more than 3 seconds to report ([#3404](https://github.com/getsentry/sentry-dart/pull/3404))
 
 ## 9.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fixes cold/warm start spans not attaching if TTFD takes more than 3 seconds to report ([#3404](https://github.com/getsentry/sentry-dart/pull/3404))
+
 ## 9.9.0
 
 ### Features

--- a/packages/flutter/lib/src/integrations/native_app_start_handler.dart
+++ b/packages/flutter/lib/src/integrations/native_app_start_handler.dart
@@ -63,8 +63,8 @@ class NativeAppStartHandler {
     // TODO(buenaflor): eventually we can move this to the onFinish callback
     SentryMeasurement? measurement = appStartInfo.toMeasurement();
     sentryTracer.measurements[measurement.name] = appStartInfo.toMeasurement();
-    await _attachAppStartSpans(appStartInfo, sentryTracer);
 
+    await _attachAppStartSpans(appStartInfo, sentryTracer);
     await options.timeToDisplayTracker.track(
       rootScreenTransaction,
       ttidEndTimestamp: appStartInfo.end,

--- a/packages/flutter/lib/src/integrations/native_app_start_handler.dart
+++ b/packages/flutter/lib/src/integrations/native_app_start_handler.dart
@@ -63,12 +63,12 @@ class NativeAppStartHandler {
     // TODO(buenaflor): eventually we can move this to the onFinish callback
     SentryMeasurement? measurement = appStartInfo.toMeasurement();
     sentryTracer.measurements[measurement.name] = appStartInfo.toMeasurement();
+    await _attachAppStartSpans(appStartInfo, sentryTracer);
 
     await options.timeToDisplayTracker.track(
       rootScreenTransaction,
       ttidEndTimestamp: appStartInfo.end,
     );
-    await _attachAppStartSpans(appStartInfo, sentryTracer);
   }
 
   _AppStartInfo? _infoNativeAppStart(


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Fixes cold/warm start spans not attaching if TTFD takes more than 3 seconds to report

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #3402 

## :green_heart: How did you test it?
Unit test, manually

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
