### PR TITLE
Telemetry Processor (1): Add basic APIs for processing telemetry types e.g log, span

### DIFF
--- a/packages/dart/lib/src/protocol/noop_span.dart
+++ b/packages/dart/lib/src/protocol/noop_span.dart
@@ -44,7 +44,7 @@ class NoOpSpan implements Span {
   Map<String, dynamic> toJson() => {};
 
   @override
-  Span get segmentSpan => NoOpSpan();
+  Span get segmentSpan => this;
 
   @override
   SentryId get traceId => SentryId.empty();

--- a/packages/dart/lib/src/protocol/noop_span.dart
+++ b/packages/dart/lib/src/protocol/noop_span.dart
@@ -1,5 +1,4 @@
 import '../../sentry.dart';
-import '../telemetry_processing/telemetry_item.dart';
 
 class NoOpSpan implements Span {
   const NoOpSpan();

--- a/packages/dart/lib/src/protocol/sentry_log.dart
+++ b/packages/dart/lib/src/protocol/sentry_log.dart
@@ -1,9 +1,8 @@
-import '../telemetry_processing/sentry_encodable.dart';
 import 'sentry_attribute.dart';
 import 'sentry_id.dart';
 import 'sentry_log_level.dart';
 
-class SentryLog implements SentryEncodable {
+class SentryLog {
   DateTime timestamp;
   SentryId traceId;
   SentryLogLevel level;
@@ -22,7 +21,6 @@ class SentryLog implements SentryEncodable {
     this.severityNumber,
   }) : traceId = traceId ?? SentryId.empty();
 
-  @override
   Map<String, dynamic> toJson() {
     return {
       'timestamp': timestamp.toIso8601String(),

--- a/packages/dart/lib/src/protocol/sentry_log.dart
+++ b/packages/dart/lib/src/protocol/sentry_log.dart
@@ -1,8 +1,9 @@
+import '../telemetry_processing/json_encodable.dart';
 import 'sentry_attribute.dart';
 import 'sentry_id.dart';
 import 'sentry_log_level.dart';
 
-class SentryLog {
+class SentryLog implements JsonEncodable {
   DateTime timestamp;
   SentryId traceId;
   SentryLogLevel level;
@@ -21,6 +22,7 @@ class SentryLog {
     this.severityNumber,
   }) : traceId = traceId ?? SentryId.empty();
 
+  @override
   Map<String, dynamic> toJson() {
     return {
       'timestamp': timestamp.toIso8601String(),

--- a/packages/dart/lib/src/protocol/sentry_log.dart
+++ b/packages/dart/lib/src/protocol/sentry_log.dart
@@ -1,9 +1,9 @@
-import '../telemetry_processing/telemetry_item.dart';
+import '../telemetry_processing/sentry_encodable.dart';
 import 'sentry_attribute.dart';
 import 'sentry_id.dart';
 import 'sentry_log_level.dart';
 
-class SentryLog implements TelemetryItem {
+class SentryLog implements SentryEncodable {
   DateTime timestamp;
   SentryId traceId;
   SentryLogLevel level;

--- a/packages/dart/lib/src/protocol/simple_span.dart
+++ b/packages/dart/lib/src/protocol/simple_span.dart
@@ -3,10 +3,10 @@ import '../../sentry.dart';
 class SimpleSpan implements Span {
   final SpanId _spanId;
   final Hub _hub;
-  final DateTime _startTimestamp;
   @override
   final Span? parentSpan;
   final Map<String, SentryAttribute> _attributes = {};
+  late final DateTime _startTimestamp;
   late final Span _segmentSpan;
   late final SentryId _traceId;
 
@@ -21,10 +21,10 @@ class SimpleSpan implements Span {
     Hub? hub,
   })  : _spanId = SpanId.newId(),
         _hub = hub ?? HubAdapter(),
-        _startTimestamp = DateTime.now().toUtc(),
         _name = name {
     _segmentSpan = parentSpan?.segmentSpan ?? this;
     _traceId = parentSpan?.traceId ?? _hub.scope.propagationContext.traceId;
+    _startTimestamp = _hub.options.clock();
   }
 
   @override
@@ -72,7 +72,7 @@ class SimpleSpan implements Span {
     if (_isFinished) {
       return;
     }
-    _endTimestamp = (endTimestamp ?? DateTime.now()).toUtc();
+    _endTimestamp = (endTimestamp ?? _hub.options.clock());
     _isFinished = true;
     _hub.captureSpan(this);
   }

--- a/packages/dart/lib/src/protocol/simple_span.dart
+++ b/packages/dart/lib/src/protocol/simple_span.dart
@@ -24,7 +24,7 @@ class SimpleSpan implements Span {
         _startTimestamp = DateTime.now().toUtc(),
         _name = name {
     _segmentSpan = parentSpan?.segmentSpan ?? this;
-    _traceId = _hub.scope.propagationContext.traceId;
+    _traceId = parentSpan?.traceId ?? _hub.scope.propagationContext.traceId;
   }
 
   @override
@@ -92,7 +92,6 @@ class SimpleSpan implements Span {
           _endTimestamp == null ? null : toUnixSeconds(_endTimestamp!),
       'start_timestamp': toUnixSeconds(_startTimestamp),
       if (parentSpan != null) 'parent_span_id': parentSpan?.spanId.toString(),
-      if (parentSpan == null) 'is_segment': true,
       if (_attributes.isNotEmpty)
         'attributes':
             _attributes.map((key, value) => MapEntry(key, value.toJson())),

--- a/packages/dart/lib/src/protocol/simple_span.dart
+++ b/packages/dart/lib/src/protocol/simple_span.dart
@@ -74,7 +74,7 @@ class SimpleSpan implements Span {
     if (_isFinished) {
       return;
     }
-    _endTimestamp = (endTimestamp ?? _hub.options.clock());
+    _endTimestamp = (endTimestamp?.toUtc() ?? _hub.options.clock());
     _isFinished = true;
     _hub.captureSpan(this);
   }

--- a/packages/dart/lib/src/protocol/simple_span.dart
+++ b/packages/dart/lib/src/protocol/simple_span.dart
@@ -79,7 +79,6 @@ class SimpleSpan implements Span {
     _hub.captureSpan(this);
   }
 
-  @override
   Map<String, dynamic> toJson() {
     double toUnixSeconds(DateTime timestamp) =>
         timestamp.microsecondsSinceEpoch / 1000000;

--- a/packages/dart/lib/src/protocol/simple_span.dart
+++ b/packages/dart/lib/src/protocol/simple_span.dart
@@ -24,7 +24,7 @@ class SimpleSpan implements Span {
         _name = name {
     _segmentSpan = parentSpan?.segmentSpan ?? this;
     _startTimestamp = _hub.options.clock();
-    _traceId = (parentSpan != null && parentSpan!.traceId != SentryId.empty())
+    _traceId = parentSpan != null
         ? parentSpan!.traceId
         : _hub.scope.propagationContext.traceId;
   }
@@ -79,6 +79,7 @@ class SimpleSpan implements Span {
     _hub.captureSpan(this);
   }
 
+  @override
   Map<String, dynamic> toJson() {
     double toUnixSeconds(DateTime timestamp) =>
         timestamp.microsecondsSinceEpoch / 1000000;

--- a/packages/dart/lib/src/protocol/simple_span.dart
+++ b/packages/dart/lib/src/protocol/simple_span.dart
@@ -23,8 +23,10 @@ class SimpleSpan implements Span {
         _hub = hub ?? HubAdapter(),
         _name = name {
     _segmentSpan = parentSpan?.segmentSpan ?? this;
-    _traceId = parentSpan?.traceId ?? _hub.scope.propagationContext.traceId;
     _startTimestamp = _hub.options.clock();
+    _traceId = (parentSpan != null && parentSpan!.traceId != SentryId.empty())
+        ? parentSpan!.traceId
+        : _hub.scope.propagationContext.traceId;
   }
 
   @override

--- a/packages/dart/lib/src/protocol/span.dart
+++ b/packages/dart/lib/src/protocol/span.dart
@@ -1,12 +1,11 @@
 import 'package:meta/meta.dart';
 
 import '../../sentry.dart';
-import '../telemetry_processing/sentry_encodable.dart';
 
 // Span specs: https://develop.sentry.dev/sdk/telemetry/spans/span-api/
 
 /// Represents a basic telemetry span.
-abstract class Span implements SentryEncodable {
+abstract class Span {
   @internal
   const Span();
 
@@ -60,4 +59,7 @@ abstract class Span implements SentryEncodable {
 
   @internal
   bool get isFinished;
+
+  @internal
+  Map<String, dynamic> toJson();
 }

--- a/packages/dart/lib/src/protocol/span.dart
+++ b/packages/dart/lib/src/protocol/span.dart
@@ -1,11 +1,12 @@
 import 'package:meta/meta.dart';
 
 import '../../sentry.dart';
+import '../telemetry_processing/json_encodable.dart';
 
 // Span specs: https://develop.sentry.dev/sdk/telemetry/spans/span-api/
 
 /// Represents a basic telemetry span.
-abstract class Span {
+abstract class Span implements JsonEncodable {
   @internal
   const Span();
 
@@ -61,5 +62,6 @@ abstract class Span {
   bool get isFinished;
 
   @internal
+  @override
   Map<String, dynamic> toJson();
 }

--- a/packages/dart/lib/src/protocol/span.dart
+++ b/packages/dart/lib/src/protocol/span.dart
@@ -1,12 +1,12 @@
 import 'package:meta/meta.dart';
 
 import '../../sentry.dart';
-import '../telemetry_processing/telemetry_item.dart';
+import '../telemetry_processing/sentry_encodable.dart';
 
 // Span specs: https://develop.sentry.dev/sdk/telemetry/spans/span-api/
 
 /// Represents a basic telemetry span.
-abstract class Span implements TelemetryItem {
+abstract class Span implements SentryEncodable {
   @internal
   const Span();
 

--- a/packages/dart/lib/src/sentry_client.dart
+++ b/packages/dart/lib/src/sentry_client.dart
@@ -78,6 +78,7 @@ class SentryClient {
     if (options.enableLogs) {
       options.logBatcher = SentryLogBatcher(options);
     }
+    // TODO(next-pr): wire up telemetry processor and remove log batcher
     return SentryClient._(options);
   }
 

--- a/packages/dart/lib/src/sentry_client.dart
+++ b/packages/dart/lib/src/sentry_client.dart
@@ -30,7 +30,6 @@ import 'type_check_hint.dart';
 import 'utils/isolate_utils.dart';
 import 'utils/regex_utils.dart';
 import 'utils/stacktrace_utils.dart';
-import 'utils.dart';
 import 'sentry_log_batcher.dart';
 import 'version.dart';
 

--- a/packages/dart/lib/src/sentry_client.dart
+++ b/packages/dart/lib/src/sentry_client.dart
@@ -594,6 +594,7 @@ class SentryClient {
   }
 
   FutureOr<void> close() {
+    // TODO(next-pr): replace with telemetry processor
     final flush = _options.logBatcher.flush();
     if (flush is Future<void>) {
       return flush.then((_) => _options.httpClient.close());

--- a/packages/dart/lib/src/sentry_client.dart
+++ b/packages/dart/lib/src/sentry_client.dart
@@ -18,6 +18,8 @@ import 'sentry_exception_factory.dart';
 import 'sentry_options.dart';
 import 'sentry_stack_trace_factory.dart';
 import 'sentry_trace_context_header.dart';
+import 'telemetry_processing/telemetry_buffer.dart';
+import 'telemetry_processing/telemetry_processor.dart';
 import 'transport/client_report_transport.dart';
 import 'transport/data_category.dart';
 import 'transport/http_transport.dart';
@@ -28,6 +30,7 @@ import 'type_check_hint.dart';
 import 'utils/isolate_utils.dart';
 import 'utils/regex_utils.dart';
 import 'utils/stacktrace_utils.dart';
+import 'utils.dart';
 import 'sentry_log_batcher.dart';
 import 'version.dart';
 
@@ -78,7 +81,12 @@ class SentryClient {
     if (options.enableLogs) {
       options.logBatcher = SentryLogBatcher(options);
     }
-    // TODO(next-pr): wire up telemetry processor and remove log batcher
+    options.telemetryProcessor = DefaultTelemetryProcessor(options.log,
+        logBuffer: InMemoryTelemetryBuffer(
+            encoder: (item) => utf8JsonEncoder.convert(item.toJson())),
+        spanBuffer: InMemoryTelemetryBuffer(
+            encoder: (item) => utf8JsonEncoder.convert(item.toJson())));
+    // TODO(next-pr): remove log batcher
     return SentryClient._(options);
   }
 

--- a/packages/dart/lib/src/sentry_client.dart
+++ b/packages/dart/lib/src/sentry_client.dart
@@ -82,10 +82,8 @@ class SentryClient {
       options.logBatcher = SentryLogBatcher(options);
     }
     options.telemetryProcessor = DefaultTelemetryProcessor(options.log,
-        logBuffer: InMemoryTelemetryBuffer(
-            encoder: (item) => utf8JsonEncoder.convert(item.toJson())),
-        spanBuffer: InMemoryTelemetryBuffer(
-            encoder: (item) => utf8JsonEncoder.convert(item.toJson())));
+        logBuffer: InMemoryTelemetryBuffer(),
+        spanBuffer: InMemoryTelemetryBuffer());
     // TODO(next-pr): remove log batcher
     return SentryClient._(options);
   }

--- a/packages/dart/lib/src/sentry_options.dart
+++ b/packages/dart/lib/src/sentry_options.dart
@@ -12,6 +12,7 @@ import 'noop_client.dart';
 import 'platform/platform.dart';
 import 'sentry_exception_factory.dart';
 import 'sentry_stack_trace_factory.dart';
+import 'telemetry_processing/telemetry_processor.dart';
 import 'transport/noop_transport.dart';
 import 'version.dart';
 import 'sentry_log_batcher.dart';
@@ -542,6 +543,9 @@ class SentryOptions {
 
   @internal
   SentryLogBatcher logBatcher = NoopLogBatcher();
+
+  @internal
+  TelemetryProcessor telemetryProcessor = NoOpTelemetryProcessor();
 
   SentryOptions({String? dsn, Platform? platform, RuntimeChecker? checker}) {
     this.dsn = dsn;

--- a/packages/dart/lib/src/telemetry_processing/json_encodable.dart
+++ b/packages/dart/lib/src/telemetry_processing/json_encodable.dart
@@ -1,0 +1,3 @@
+abstract interface class JsonEncodable {
+  Map<String, dynamic> toJson();
+}

--- a/packages/dart/lib/src/telemetry_processing/sentry_encodable.dart
+++ b/packages/dart/lib/src/telemetry_processing/sentry_encodable.dart
@@ -1,8 +1,0 @@
-import 'package:meta/meta.dart';
-
-/// Interface for objects that can be serialized to JSON for Sentry transmission.
-abstract class SentryEncodable {
-  /// Converts this object to a JSON-compatible map.
-  @internal
-  Map<String, dynamic> toJson();
-}

--- a/packages/dart/lib/src/telemetry_processing/sentry_encodable.dart
+++ b/packages/dart/lib/src/telemetry_processing/sentry_encodable.dart
@@ -1,6 +1,8 @@
 import 'package:meta/meta.dart';
 
+/// Interface for objects that can be serialized to JSON for Sentry transmission.
 abstract class SentryEncodable {
+  /// Converts this object to a JSON-compatible map.
   @internal
   Map<String, dynamic> toJson();
 }

--- a/packages/dart/lib/src/telemetry_processing/sentry_encodable.dart
+++ b/packages/dart/lib/src/telemetry_processing/sentry_encodable.dart
@@ -1,6 +1,6 @@
 import 'package:meta/meta.dart';
 
-abstract class TelemetryItem {
+abstract class SentryEncodable {
   @internal
   Map<String, dynamic> toJson();
 }

--- a/packages/dart/lib/src/telemetry_processing/telemetry_buffer.dart
+++ b/packages/dart/lib/src/telemetry_processing/telemetry_buffer.dart
@@ -1,22 +1,24 @@
 import 'dart:async';
 
-import 'telemetry_item.dart';
+import 'sentry_encodable.dart';
 
-abstract class TelemetryBuffer<T extends TelemetryItem> {
+abstract class TelemetryBuffer<T extends SentryEncodable> {
   void add(T item);
   FutureOr<void> flush();
 }
 
-/// Holds both raw item and encoded bytes for size tracking and grouping.
-class EncodedTelemetryItem<T extends TelemetryItem> {
+/// Represents an item that is being hold in a buffer.
+///
+/// Contains both raw item and encoded bytes for size tracking and grouping.
+class BufferedItem<T extends SentryEncodable> {
   final T item;
   final List<int> encoded;
 
-  EncodedTelemetryItem(this.item, this.encoded);
+  BufferedItem(this.item, this.encoded);
 }
 
 /// In-memory buffer with time and size-based flushing.
-class InMemoryTelemetryBuffer<T extends TelemetryItem>
+class InMemoryTelemetryBuffer<T extends SentryEncodable>
     extends TelemetryBuffer<T> {
   @override
   void add(T item) {

--- a/packages/dart/lib/src/telemetry_processing/telemetry_buffer.dart
+++ b/packages/dart/lib/src/telemetry_processing/telemetry_buffer.dart
@@ -13,24 +13,24 @@ abstract class TelemetryBuffer<T> {
 }
 
 /// Pairs an item with its encoded bytes for size tracking and transmission.
-class EncodedItem<T> {
+class BufferedItem<T> {
   final T item;
   final List<int> encoded;
 
-  EncodedItem(this.item, this.encoded);
+  BufferedItem(this.item, this.encoded);
 }
 
-typedef ItemEncoder<T> = List<EncodedItem<T>> Function(T item);
+typedef ItemEncoder<T> = List<int> Function(T item);
 
 /// In-memory buffer with time and size-based flushing.
 class InMemoryTelemetryBuffer<T> extends TelemetryBuffer<T> {
-  final ItemEncoder encoder;
+  final ItemEncoder<T> encoder;
 
   InMemoryTelemetryBuffer({required this.encoder});
 
   @override
   void add(T item) {
-    final encodedItems = encoder(item);
+    final itemToSend = BufferedItem(item, encoder(item));
     // TODO(next-pr)
   }
 

--- a/packages/dart/lib/src/telemetry_processing/telemetry_buffer.dart
+++ b/packages/dart/lib/src/telemetry_processing/telemetry_buffer.dart
@@ -1,12 +1,10 @@
 import 'dart:async';
 
-import 'sentry_encodable.dart';
-
 /// A buffer that batches telemetry items for efficient transmission to Sentry.
 ///
 /// Collects items of type [T] and sends them in batches rather than
 /// individually, reducing network overhead.
-abstract class TelemetryBuffer<T extends SentryEncodable> {
+abstract class TelemetryBuffer<T> {
   /// Adds an item to the buffer.
   void add(T item);
 
@@ -17,7 +15,7 @@ abstract class TelemetryBuffer<T extends SentryEncodable> {
 /// Represents an item that is being hold in a buffer.
 ///
 /// Contains both raw item and encoded bytes for size tracking and grouping.
-class BufferedItem<T extends SentryEncodable> {
+class BufferedItem<T> {
   final T item;
   final List<int> encoded;
 
@@ -25,10 +23,14 @@ class BufferedItem<T extends SentryEncodable> {
 }
 
 /// In-memory buffer with time and size-based flushing.
-class InMemoryTelemetryBuffer<T extends SentryEncodable>
-    extends TelemetryBuffer<T> {
+class InMemoryTelemetryBuffer<T> extends TelemetryBuffer<T> {
+  final Map<String, dynamic> Function(T) serializer;
+
+  InMemoryTelemetryBuffer({required this.serializer});
+
   @override
   void add(T item) {
+    final serializedItem = serializer(item);
     // TODO(next-pr)
   }
 

--- a/packages/dart/lib/src/telemetry_processing/telemetry_buffer.dart
+++ b/packages/dart/lib/src/telemetry_processing/telemetry_buffer.dart
@@ -2,8 +2,15 @@ import 'dart:async';
 
 import 'sentry_encodable.dart';
 
+/// A buffer that batches telemetry items for efficient transmission to Sentry.
+///
+/// Collects items of type [T] and sends them in batches rather than
+/// individually, reducing network overhead.
 abstract class TelemetryBuffer<T extends SentryEncodable> {
+  /// Adds an item to the buffer.
   void add(T item);
+
+  /// Manually sends all buffered items to Sentry and clears the buffer.
   FutureOr<void> flush();
 }
 

--- a/packages/dart/lib/src/telemetry_processing/telemetry_buffer.dart
+++ b/packages/dart/lib/src/telemetry_processing/telemetry_buffer.dart
@@ -12,25 +12,25 @@ abstract class TelemetryBuffer<T> {
   FutureOr<void> flush();
 }
 
-/// Represents an item that is being hold in a buffer.
-///
-/// Contains both raw item and encoded bytes for size tracking and grouping.
-class BufferedItem<T> {
+/// Pairs an item with its encoded bytes for size tracking and transmission.
+class EncodedItem<T> {
   final T item;
   final List<int> encoded;
 
-  BufferedItem(this.item, this.encoded);
+  EncodedItem(this.item, this.encoded);
 }
+
+typedef ItemEncoder<T> = List<EncodedItem<T>> Function(T item);
 
 /// In-memory buffer with time and size-based flushing.
 class InMemoryTelemetryBuffer<T> extends TelemetryBuffer<T> {
-  final Map<String, dynamic> Function(T) serializer;
+  final ItemEncoder encoder;
 
-  InMemoryTelemetryBuffer({required this.serializer});
+  InMemoryTelemetryBuffer({required this.encoder});
 
   @override
   void add(T item) {
-    final serializedItem = serializer(item);
+    final encodedItems = encoder(item);
     // TODO(next-pr)
   }
 

--- a/packages/dart/lib/src/telemetry_processing/telemetry_buffer.dart
+++ b/packages/dart/lib/src/telemetry_processing/telemetry_buffer.dart
@@ -1,5 +1,8 @@
 import 'dart:async';
 
+import '../../sentry.dart';
+import 'json_encodable.dart';
+
 /// A buffer that batches telemetry items for efficient transmission to Sentry.
 ///
 /// Collects items of type [T] and sends them in batches rather than
@@ -20,17 +23,15 @@ class BufferedItem<T> {
   BufferedItem(this.item, this.encoded);
 }
 
-typedef ItemEncoder<T> = List<int> Function(T item);
-
 /// In-memory buffer with time and size-based flushing.
-class InMemoryTelemetryBuffer<T> extends TelemetryBuffer<T> {
-  final ItemEncoder<T> encoder;
-
-  InMemoryTelemetryBuffer({required this.encoder});
+class InMemoryTelemetryBuffer<T extends JsonEncodable>
+    extends TelemetryBuffer<T> {
+  InMemoryTelemetryBuffer();
 
   @override
   void add(T item) {
-    final itemToSend = BufferedItem(item, encoder(item));
+    final encoded = utf8JsonEncoder.convert(item.toJson());
+    final itemToSend = BufferedItem(item, encoded);
     // TODO(next-pr)
   }
 

--- a/packages/dart/lib/src/telemetry_processing/telemetry_buffer.dart
+++ b/packages/dart/lib/src/telemetry_processing/telemetry_buffer.dart
@@ -14,3 +14,17 @@ class EncodedTelemetryItem<T extends TelemetryItem> {
 
   EncodedTelemetryItem(this.item, this.encoded);
 }
+
+/// In-memory buffer with time and size-based flushing.
+class InMemoryTelemetryBuffer<T extends TelemetryItem>
+    extends TelemetryBuffer<T> {
+  @override
+  void add(T item) {
+    // TODO(next-pr)
+  }
+
+  @override
+  FutureOr<void> flush() {
+    // TODO(next-pr)
+  }
+}

--- a/packages/dart/lib/src/telemetry_processing/telemetry_buffer.dart
+++ b/packages/dart/lib/src/telemetry_processing/telemetry_buffer.dart
@@ -31,12 +31,12 @@ class InMemoryTelemetryBuffer<T extends JsonEncodable>
   @override
   void add(T item) {
     final encoded = utf8JsonEncoder.convert(item.toJson());
-    final itemToSend = BufferedItem(item, encoded);
-    // TODO(next-pr)
+    final _ = BufferedItem(item, encoded);
+    // TODO(next-pr): finish this impl
   }
 
   @override
   FutureOr<void> flush() {
-    // TODO(next-pr)
+    // TODO(next-pr): finish this impl
   }
 }

--- a/packages/dart/lib/src/telemetry_processing/telemetry_buffer.dart
+++ b/packages/dart/lib/src/telemetry_processing/telemetry_buffer.dart
@@ -11,8 +11,8 @@ abstract class TelemetryBuffer<T> {
   /// Adds an item to the buffer.
   void add(T item);
 
-  /// Manually sends all buffered items to Sentry and clears the buffer.
-  FutureOr<void> flush();
+  /// When executed immediately sends all buffered items to Sentry and clears the buffer.
+  FutureOr<void> clear();
 }
 
 /// Pairs an item with its encoded bytes for size tracking and transmission.
@@ -36,7 +36,7 @@ class InMemoryTelemetryBuffer<T extends JsonEncodable>
   }
 
   @override
-  FutureOr<void> flush() {
+  FutureOr<void> clear() {
     // TODO(next-pr): finish this impl
   }
 }

--- a/packages/dart/lib/src/telemetry_processing/telemetry_processor.dart
+++ b/packages/dart/lib/src/telemetry_processing/telemetry_processor.dart
@@ -32,7 +32,6 @@ class DefaultTelemetryProcessor implements TelemetryProcessor {
   @visibleForTesting
   TelemetryBuffer<SentryLog>? logBuffer;
 
-  /// Creates a telemetry processor.
   DefaultTelemetryProcessor(
     this._logger, {
     this.spanBuffer,

--- a/packages/dart/lib/src/telemetry_processing/telemetry_processor.dart
+++ b/packages/dart/lib/src/telemetry_processing/telemetry_processor.dart
@@ -6,7 +6,6 @@ import '../../sentry.dart';
 import '../protocol/noop_span.dart';
 import '../protocol/unset_span.dart';
 import 'telemetry_buffer.dart';
-import 'sentry_encodable.dart';
 
 /// Manages buffering and sending of telemetry data to Sentry.
 abstract class TelemetryProcessor {
@@ -45,7 +44,7 @@ class DefaultTelemetryProcessor implements TelemetryProcessor {
   @override
   void addLog(SentryLog log) => _add(log);
 
-  void _add(SentryEncodable item) {
+  void _add(dynamic item) {
     final buffer = switch (item) {
       Span() => spanBuffer,
       SentryLog() => logBuffer,

--- a/packages/dart/lib/src/telemetry_processing/telemetry_processor.dart
+++ b/packages/dart/lib/src/telemetry_processing/telemetry_processor.dart
@@ -9,14 +9,14 @@ import 'telemetry_buffer.dart';
 
 /// Manages buffering and sending of telemetry data to Sentry.
 abstract class TelemetryProcessor {
-  /// Adds a span to the buffer for later transmission.
+  /// Adds a span to the buffer.
   void addSpan(Span span);
 
-  /// Adds a log to the buffer for later transmission.
+  /// Adds a log to the buffer.
   void addLog(SentryLog log);
 
-  /// Flushes all buffers, sending any pending telemetry data.
-  FutureOr<void> flush();
+  /// Clears all buffers which sends any pending telemetry data.
+  FutureOr<void> clear();
 }
 
 /// Manages buffering and sending of telemetry data to Sentry.
@@ -46,8 +46,8 @@ class DefaultTelemetryProcessor implements TelemetryProcessor {
 
   void _add(dynamic item) {
     final buffer = switch (item) {
-      Span() => spanBuffer,
-      SentryLog() => logBuffer,
+      Span _ => spanBuffer,
+      SentryLog _ => logBuffer,
       _ => null,
     };
 
@@ -63,12 +63,12 @@ class DefaultTelemetryProcessor implements TelemetryProcessor {
   }
 
   @override
-  FutureOr<void> flush() {
-    _logger(SentryLevel.debug, 'TelemetryProcessor: Flushing buffers');
+  FutureOr<void> clear() {
+    _logger(SentryLevel.debug, 'TelemetryProcessor: Clearing buffers');
 
     final results = <FutureOr<void>>[
-      spanBuffer?.flush(),
-      logBuffer?.flush(),
+      spanBuffer?.clear(),
+      logBuffer?.clear(),
     ];
 
     final futures = results.whereType<Future<void>>().toList();
@@ -88,5 +88,5 @@ class NoOpTelemetryProcessor implements TelemetryProcessor {
   void addLog(SentryLog log) {}
 
   @override
-  FutureOr<void> flush() {}
+  FutureOr<void> clear() {}
 }

--- a/packages/dart/lib/src/telemetry_processing/telemetry_processor.dart
+++ b/packages/dart/lib/src/telemetry_processing/telemetry_processor.dart
@@ -6,10 +6,6 @@ import '../../sentry.dart';
 import 'telemetry_buffer.dart';
 import 'telemetry_item.dart';
 
-/// Factory function for creating telemetry buffers.
-typedef TelemetryBufferFactory<T extends TelemetryItem> = TelemetryBuffer<T>
-    Function();
-
 /// Manages buffering and sending of telemetry data to Sentry.
 abstract class TelemetryProcessor {
   void addSpan(Span span);

--- a/packages/dart/lib/src/telemetry_processing/telemetry_processor.dart
+++ b/packages/dart/lib/src/telemetry_processing/telemetry_processor.dart
@@ -64,10 +64,6 @@ class DefaultTelemetryProcessor implements TelemetryProcessor {
     buffer.add(item);
   }
 
-  /// Flushes all buffers, sending any pending telemetry data.
-  ///
-  /// Returns a [Future] that completes when all buffers have been flushed.
-  /// Returns immediately if no buffers need flushing.
   @override
   FutureOr<void> flush() {
     _logger(SentryLevel.debug, 'TelemetryProcessor: Flushing buffers');

--- a/packages/dart/lib/src/telemetry_processing/telemetry_processor.dart
+++ b/packages/dart/lib/src/telemetry_processing/telemetry_processor.dart
@@ -34,29 +34,13 @@ class DefaultTelemetryProcessor implements TelemetryProcessor {
 
   void _initBuffers() {
     // TODO(next-pr): add span first flag
-    spanBuffer = createSpanBuffer();
+    spanBuffer = InMemoryTelemetryBuffer();
     _logger(SentryLevel.debug, 'TelemetryProcessor: Span buffer initialized');
 
     if (_options.enableLogs) {
-      logBuffer = createLogBuffer();
+      logBuffer = InMemoryTelemetryBuffer();
       _logger(SentryLevel.debug, 'TelemetryProcessor: Log buffer initialized');
     }
-  }
-
-  /// Creates the span buffer.
-  ///
-  /// Can be overridden in subclasses or tests to provide a custom buffer.
-  @visibleForTesting
-  TelemetryBuffer<Span> createSpanBuffer() {
-    throw UnimplementedError();
-  }
-
-  /// Creates the log buffer.
-  ///
-  /// Can be overridden in subclasses or tests to provide a custom buffer.
-  @visibleForTesting
-  TelemetryBuffer<SentryLog> createLogBuffer() {
-    throw UnimplementedError();
   }
 
   /// Adds a span to the buffer for later transmission.

--- a/packages/dart/lib/src/telemetry_processing/telemetry_processor.dart
+++ b/packages/dart/lib/src/telemetry_processing/telemetry_processor.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import 'package:meta/meta.dart';
 
 import '../../sentry.dart';
+import '../protocol/noop_span.dart';
+import '../protocol/unset_span.dart';
 import 'telemetry_buffer.dart';
 import 'sentry_encodable.dart';
 
@@ -14,9 +16,6 @@ abstract class TelemetryProcessor {
 }
 
 /// Manages buffering and sending of telemetry data to Sentry.
-///
-/// Creates and manages buffers internally based on [SentryOptions] configuration.
-/// Buffers are only created when their respective features are enabled.
 class DefaultTelemetryProcessor implements TelemetryProcessor {
   final SdkLogCallback _logger;
 
@@ -37,14 +36,17 @@ class DefaultTelemetryProcessor implements TelemetryProcessor {
 
   /// Adds a span to the buffer for later transmission.
   ///
-  /// If no span buffer is registered, the span is dropped
+  /// If no span buffer is set, the span is dropped
   /// and a warning is logged.
+  ///
+  /// If span is [NoOpSpan] or [UnsetSpan] it is not added to the buffer.
   @override
-  void addSpan(Span span) => _add(span);
+  void addSpan(Span span) =>
+      (span is NoOpSpan || span is UnsetSpan) ? null : _add(span);
 
   /// Adds a log to the buffer for later transmission.
   ///
-  /// If no log buffer is registered, the log is dropped
+  /// If no log buffer is set, the log is dropped
   /// and a warning is logged.
   @override
   void addLog(SentryLog log) => _add(log);

--- a/packages/dart/lib/src/telemetry_processing/telemetry_processor.dart
+++ b/packages/dart/lib/src/telemetry_processing/telemetry_processor.dart
@@ -21,14 +21,10 @@ class DefaultTelemetryProcessor implements TelemetryProcessor {
   final SdkLogCallback _logger;
 
   /// Buffer for span telemetry data.
-  ///
-  /// Only created if tracing is enabled in options.
   @visibleForTesting
   TelemetryBuffer<Span>? spanBuffer;
 
   /// Buffer for log telemetry data.
-  ///
-  /// Only created if logging is enabled in options.
   @visibleForTesting
   TelemetryBuffer<SentryLog>? logBuffer;
 

--- a/packages/dart/lib/src/telemetry_processing/telemetry_processor.dart
+++ b/packages/dart/lib/src/telemetry_processing/telemetry_processor.dart
@@ -4,7 +4,7 @@ import 'package:meta/meta.dart';
 
 import '../../sentry.dart';
 import 'telemetry_buffer.dart';
-import 'telemetry_item.dart';
+import 'sentry_encodable.dart';
 
 /// Manages buffering and sending of telemetry data to Sentry.
 abstract class TelemetryProcessor {
@@ -49,7 +49,7 @@ class DefaultTelemetryProcessor implements TelemetryProcessor {
   @override
   void addLog(SentryLog log) => _add(log);
 
-  void _add(TelemetryItem item) {
+  void _add(SentryEncodable item) {
     final buffer = switch (item) {
       Span() => spanBuffer,
       SentryLog() => logBuffer,

--- a/packages/dart/lib/src/telemetry_processing/telemetry_processor.dart
+++ b/packages/dart/lib/src/telemetry_processing/telemetry_processor.dart
@@ -78,7 +78,7 @@ class DefaultTelemetryProcessor implements TelemetryProcessor {
     final results = <FutureOr<void>>[
       spanBuffer?.flush(),
       logBuffer?.flush(),
-    ].whereType<FutureOr<void>>().toList();
+    ];
 
     final futures = results.whereType<Future<void>>().toList();
     if (futures.isEmpty) {

--- a/packages/dart/lib/src/telemetry_processing/telemetry_processor.dart
+++ b/packages/dart/lib/src/telemetry_processing/telemetry_processor.dart
@@ -71,7 +71,7 @@ class DefaultTelemetryProcessor implements TelemetryProcessor {
       logBuffer?.clear(),
     ];
 
-    final futures = results.whereType<Future<void>>().toList();
+    final futures = results.whereType<Future>().toList();
     if (futures.isEmpty) {
       return null;
     }

--- a/packages/dart/lib/src/telemetry_processing/telemetry_processor.dart
+++ b/packages/dart/lib/src/telemetry_processing/telemetry_processor.dart
@@ -10,8 +10,13 @@ import 'sentry_encodable.dart';
 
 /// Manages buffering and sending of telemetry data to Sentry.
 abstract class TelemetryProcessor {
+  /// Adds a span to the buffer for later transmission.
   void addSpan(Span span);
+
+  /// Adds a log to the buffer for later transmission.
   void addLog(SentryLog log);
+
+  /// Flushes all buffers, sending any pending telemetry data.
   FutureOr<void> flush();
 }
 
@@ -34,20 +39,10 @@ class DefaultTelemetryProcessor implements TelemetryProcessor {
     this.logBuffer,
   });
 
-  /// Adds a span to the buffer for later transmission.
-  ///
-  /// If no span buffer is set, the span is dropped
-  /// and a warning is logged.
-  ///
-  /// If span is [NoOpSpan] or [UnsetSpan] it is not added to the buffer.
   @override
   void addSpan(Span span) =>
       (span is NoOpSpan || span is UnsetSpan) ? null : _add(span);
 
-  /// Adds a log to the buffer for later transmission.
-  ///
-  /// If no log buffer is set, the log is dropped
-  /// and a warning is logged.
   @override
   void addLog(SentryLog log) => _add(log);
 

--- a/packages/dart/test/mocks/mock_telemetry_buffer.dart
+++ b/packages/dart/test/mocks/mock_telemetry_buffer.dart
@@ -4,7 +4,7 @@ import 'package:sentry/src/telemetry_processing/telemetry_buffer.dart';
 
 class MockTelemetryBuffer<T> extends TelemetryBuffer<T> {
   final List<T> addedItems = [];
-  int flushCallCount = 0;
+  int clearCallCount = 0;
   final bool asyncFlush;
 
   MockTelemetryBuffer({this.asyncFlush = false});
@@ -13,8 +13,8 @@ class MockTelemetryBuffer<T> extends TelemetryBuffer<T> {
   void add(T item) => addedItems.add(item);
 
   @override
-  FutureOr<void> flush() {
-    flushCallCount++;
+  FutureOr<void> clear() {
+    clearCallCount++;
     if (asyncFlush) {
       return Future.value();
     }

--- a/packages/dart/test/mocks/mock_telemetry_buffer.dart
+++ b/packages/dart/test/mocks/mock_telemetry_buffer.dart
@@ -1,0 +1,24 @@
+import 'dart:async';
+
+import 'package:sentry/src/telemetry_processing/telemetry_buffer.dart';
+import 'package:sentry/src/telemetry_processing/telemetry_item.dart';
+
+class MockTelemetryBuffer<T extends TelemetryItem> extends TelemetryBuffer<T> {
+  final List<T> addedItems = [];
+  int flushCallCount = 0;
+  final bool asyncFlush;
+
+  MockTelemetryBuffer({this.asyncFlush = false});
+
+  @override
+  void add(T item) => addedItems.add(item);
+
+  @override
+  FutureOr<void> flush() {
+    flushCallCount++;
+    if (asyncFlush) {
+      return Future.value();
+    }
+    return null;
+  }
+}

--- a/packages/dart/test/mocks/mock_telemetry_buffer.dart
+++ b/packages/dart/test/mocks/mock_telemetry_buffer.dart
@@ -5,9 +5,9 @@ import 'package:sentry/src/telemetry_processing/telemetry_buffer.dart';
 class MockTelemetryBuffer<T> extends TelemetryBuffer<T> {
   final List<T> addedItems = [];
   int clearCallCount = 0;
-  final bool asyncFlush;
+  final bool asyncClear;
 
-  MockTelemetryBuffer({this.asyncFlush = false});
+  MockTelemetryBuffer({this.asyncClear = false});
 
   @override
   void add(T item) => addedItems.add(item);
@@ -15,7 +15,7 @@ class MockTelemetryBuffer<T> extends TelemetryBuffer<T> {
   @override
   FutureOr<void> clear() {
     clearCallCount++;
-    if (asyncFlush) {
+    if (asyncClear) {
       return Future.value();
     }
     return null;

--- a/packages/dart/test/mocks/mock_telemetry_buffer.dart
+++ b/packages/dart/test/mocks/mock_telemetry_buffer.dart
@@ -1,10 +1,8 @@
 import 'dart:async';
 
-import 'package:sentry/src/telemetry_processing/sentry_encodable.dart';
 import 'package:sentry/src/telemetry_processing/telemetry_buffer.dart';
 
-class MockTelemetryBuffer<T extends SentryEncodable>
-    extends TelemetryBuffer<T> {
+class MockTelemetryBuffer<T> extends TelemetryBuffer<T> {
   final List<T> addedItems = [];
   int flushCallCount = 0;
   final bool asyncFlush;

--- a/packages/dart/test/mocks/mock_telemetry_buffer.dart
+++ b/packages/dart/test/mocks/mock_telemetry_buffer.dart
@@ -1,9 +1,10 @@
 import 'dart:async';
 
+import 'package:sentry/src/telemetry_processing/sentry_encodable.dart';
 import 'package:sentry/src/telemetry_processing/telemetry_buffer.dart';
-import 'package:sentry/src/telemetry_processing/telemetry_item.dart';
 
-class MockTelemetryBuffer<T extends TelemetryItem> extends TelemetryBuffer<T> {
+class MockTelemetryBuffer<T extends SentryEncodable>
+    extends TelemetryBuffer<T> {
   final List<T> addedItems = [];
   int flushCallCount = 0;
   final bool asyncFlush;

--- a/packages/dart/test/sentry_client_test.dart
+++ b/packages/dart/test/sentry_client_test.dart
@@ -11,6 +11,7 @@ import 'package:sentry/src/platform/mock_platform.dart';
 import 'package:sentry/src/sentry_item_type.dart';
 import 'package:sentry/src/sentry_stack_trace_factory.dart';
 import 'package:sentry/src/sentry_tracer.dart';
+import 'package:sentry/src/telemetry_processing/telemetry_processor.dart';
 import 'package:sentry/src/transport/client_report_transport.dart';
 import 'package:sentry/src/transport/data_category.dart';
 import 'package:sentry/src/transport/noop_transport.dart';
@@ -1712,6 +1713,23 @@ void main() {
       final capturedEvent = await eventFromEnvelope(capturedEnvelope);
 
       expect(capturedEvent.contexts.feedback?.message, 'a' * 4096);
+    });
+  });
+
+  group('SentryClient telemetryProcessor', () {
+    late Fixture fixture;
+
+    setUp(() {
+      fixture = Fixture();
+    });
+
+    test('sets default telemetry processor when client is initialized', () {
+      expect(fixture.options.telemetryProcessor, isA<NoOpTelemetryProcessor>());
+
+      fixture.getSut();
+
+      expect(
+          fixture.options.telemetryProcessor, isA<DefaultTelemetryProcessor>());
     });
   });
 

--- a/packages/dart/test/span_test.dart
+++ b/packages/dart/test/span_test.dart
@@ -181,8 +181,8 @@ void main() {
         final child = SimpleSpan(name: 'child', parentSpan: root, hub: hub);
         final grandchild =
             SimpleSpan(name: 'grandchild', parentSpan: child, hub: hub);
-        final greatGrandchild =
-            SimpleSpan(name: 'great-grandchild', parentSpan: grandchild, hub: hub);
+        final greatGrandchild = SimpleSpan(
+            name: 'great-grandchild', parentSpan: grandchild, hub: hub);
 
         expect(grandchild.segmentSpan, same(root));
         expect(greatGrandchild.segmentSpan, same(root));
@@ -322,7 +322,8 @@ void main() {
         expect(json['end_timestamp'], isNull);
       });
 
-      test('timestamps are serialized as unix seconds with microsecond precision',
+      test(
+          'timestamps are serialized as unix seconds with microsecond precision',
           () {
         final hub = fixture.getMockHub();
         final span = SimpleSpan(name: 'test-span', parentSpan: null, hub: hub);
@@ -341,7 +342,8 @@ void main() {
 
       test('serializes updated name', () {
         final hub = fixture.getMockHub();
-        final span = SimpleSpan(name: 'original-name', parentSpan: null, hub: hub);
+        final span =
+            SimpleSpan(name: 'original-name', parentSpan: null, hub: hub);
         span.name = 'updated-name';
         span.end();
 

--- a/packages/dart/test/span_test.dart
+++ b/packages/dart/test/span_test.dart
@@ -207,6 +207,25 @@ void main() {
         expect(child.traceId, equals(parent.traceId));
       });
 
+      test(
+          'child span inherits traceId from parent even after propagation context reset',
+          () {
+        final hub = fixture.getHub();
+        final parent = SimpleSpan(name: 'parent', parentSpan: null, hub: hub);
+        final parentTraceId = parent.traceId;
+
+        // Reset the propagation context - this would change the scope's traceId
+        hub.scope.propagationContext.resetTrace();
+        final newPropagationTraceId = hub.scope.propagationContext.traceId;
+
+        // Create child span after reset
+        final child = SimpleSpan(name: 'child', parentSpan: parent, hub: hub);
+
+        // Child should inherit from parent, not from the new propagation context
+        expect(child.traceId, equals(parentTraceId));
+        expect(child.traceId, isNot(equals(newPropagationTraceId)));
+      });
+
       test('traceId is set at construction time', () {
         final hub = fixture.getHub();
         final originalTraceId = hub.scope.propagationContext.traceId;

--- a/packages/dart/test/telemetry_processing/telemetry_processor_test.dart
+++ b/packages/dart/test/telemetry_processing/telemetry_processor_test.dart
@@ -96,10 +96,10 @@ void main() {
           logBuffer: mockLogBuffer,
         );
 
-        await processor.flush();
+        await processor.clear();
 
-        expect(mockSpanBuffer.flushCallCount, 1);
-        expect(mockLogBuffer.flushCallCount, 1);
+        expect(mockSpanBuffer.clearCallCount, 1);
+        expect(mockLogBuffer.clearCallCount, 1);
       });
 
       test('flushes only span buffer when log buffer is null', () async {
@@ -107,9 +107,9 @@ void main() {
         final processor = fixture.getSut(spanBuffer: mockSpanBuffer);
         processor.logBuffer = null;
 
-        await processor.flush();
+        await processor.clear();
 
-        expect(mockSpanBuffer.flushCallCount, 1);
+        expect(mockSpanBuffer.clearCallCount, 1);
       });
 
       test('returns sync (null) when all buffers flush synchronously', () {
@@ -117,7 +117,7 @@ void main() {
         final processor = fixture.getSut(spanBuffer: mockSpanBuffer);
         processor.logBuffer = null;
 
-        final result = processor.flush();
+        final result = processor.clear();
 
         expect(result, isNull);
       });
@@ -128,7 +128,7 @@ void main() {
         final processor = fixture.getSut(spanBuffer: mockSpanBuffer);
         processor.logBuffer = null;
 
-        final result = processor.flush();
+        final result = processor.clear();
 
         expect(result, isA<Future>());
         await result;

--- a/packages/dart/test/telemetry_processing/telemetry_processor_test.dart
+++ b/packages/dart/test/telemetry_processing/telemetry_processor_test.dart
@@ -1,0 +1,136 @@
+import 'dart:async';
+
+import 'package:sentry/sentry.dart';
+import 'package:sentry/src/protocol/simple_span.dart';
+import 'package:sentry/src/telemetry_processing/telemetry_processor.dart';
+import 'package:test/test.dart';
+
+import '../mocks/mock_hub.dart';
+import '../mocks/mock_telemetry_buffer.dart';
+import '../test_utils.dart';
+
+void main() {
+  group('DefaultTelemetryProcessor', () {
+    late Fixture fixture;
+
+    setUp(() {
+      fixture = Fixture();
+    });
+
+    group('initialization', () {
+      test(
+          'registers in-memory span buffer when traceLifeCycle is set to streaming',
+          () {
+        // TODO(next-pr): add test
+      });
+
+      test('registers in-memory log buffer when enableLogs is true', () {
+        // TODO(next-pr): add test
+      });
+
+      test('does NOT register log buffer when enableLogs is false', () {
+        // TODO(next-pr): add test
+      });
+    });
+
+    group('add', () {
+      test('routes telemetry items to correct buffer', () {
+        final processor = fixture.getSut();
+        final mockLogBuffer = MockTelemetryBuffer<SentryLog>();
+        final mockSpanBuffer = MockTelemetryBuffer<Span>();
+        processor.registerBuffer(mockLogBuffer);
+        processor.registerBuffer(mockSpanBuffer);
+
+        final log = fixture.createLog();
+        processor.add(log);
+
+        final span = fixture.createSpan();
+        span.end();
+        processor.add(span);
+
+        expect(mockLogBuffer.addedItems.length, 1);
+        expect(mockLogBuffer.addedItems.first, log);
+        expect(mockSpanBuffer.addedItems.length, 1);
+        expect(mockSpanBuffer.addedItems.first, span);
+      });
+
+      test('does not throw when no buffer registered for type', () {
+        final processor = fixture.getSut();
+        processor.buffers.clear();
+
+        final log = fixture.createLog();
+        processor.add(log);
+
+        // Nothing to assert on - just verifying no exception thrown
+      });
+
+      // Note: Mismatch between buffer generic type and TelemetryType is now
+      // impossible - the type is inferred from the generic parameter T.
+    });
+
+    group('flush', () {
+      test('flushes all registered buffers', () async {
+        final processor = fixture.getSut();
+        final mockSpanBuffer = MockTelemetryBuffer<Span>();
+        final mockLogBuffer = MockTelemetryBuffer<SentryLog>();
+        processor.registerBuffer(mockSpanBuffer);
+        processor.registerBuffer(mockLogBuffer);
+
+        await processor.flush();
+
+        expect(mockSpanBuffer.flushCallCount, 1);
+        expect(mockLogBuffer.flushCallCount, 1);
+      });
+
+      test('returns sync (null) when all buffers flush synchronously', () {
+        final processor = fixture.getSut();
+        final mockBuffer = MockTelemetryBuffer<Span>(asyncFlush: false);
+        processor.registerBuffer(mockBuffer);
+
+        final result = processor.flush();
+
+        expect(result, isNull);
+      });
+
+      test('returns Future when at least one buffer flushes asynchronously',
+          () async {
+        final processor = fixture.getSut();
+        final mockBuffer = MockTelemetryBuffer<Span>(asyncFlush: true);
+        processor.registerBuffer(mockBuffer);
+
+        final result = processor.flush();
+
+        expect(result, isA<Future>());
+        await result;
+      });
+    });
+  });
+}
+
+class Fixture {
+  final hub = MockHub();
+
+  late SentryOptions options;
+
+  Fixture() {
+    options = defaultTestOptions();
+  }
+
+  DefaultTelemetryProcessor getSut({bool enableLogs = false}) {
+    options.enableLogs = enableLogs;
+    return DefaultTelemetryProcessor(options.log);
+  }
+
+  SimpleSpan createSpan({String name = 'test-span'}) {
+    return SimpleSpan(name: name, hub: hub);
+  }
+
+  SentryLog createLog({String body = 'test log'}) {
+    return SentryLog(
+      timestamp: DateTime.now().toUtc(),
+      level: SentryLogLevel.info,
+      body: body,
+      attributes: {},
+    );
+  }
+}

--- a/packages/dart/test/telemetry_processing/telemetry_processor_test.dart
+++ b/packages/dart/test/telemetry_processing/telemetry_processor_test.dart
@@ -17,22 +17,6 @@ void main() {
       fixture = Fixture();
     });
 
-    group('initialization', () {
-      test(
-          'registers in-memory span buffer when traceLifeCycle is set to streaming',
-          () {
-        // TODO(next-pr): add test
-      });
-
-      test('registers in-memory log buffer when enableLogs is true', () {
-        // TODO(next-pr): add test
-      });
-
-      test('does NOT register log buffer when enableLogs is false', () {
-        // TODO(next-pr): add test
-      });
-    });
-
     group('add', () {
       test('routes telemetry items to correct buffer', () {
         final processor = fixture.getSut();

--- a/packages/dart/test/telemetry_processing/telemetry_processor_test.dart
+++ b/packages/dart/test/telemetry_processing/telemetry_processor_test.dart
@@ -113,7 +113,7 @@ void main() {
       });
 
       test('returns sync (null) when all buffers flush synchronously', () {
-        final mockSpanBuffer = MockTelemetryBuffer<Span>(asyncFlush: false);
+        final mockSpanBuffer = MockTelemetryBuffer<Span>(asyncClear: false);
         final processor = fixture.getSut(spanBuffer: mockSpanBuffer);
         processor.logBuffer = null;
 
@@ -124,7 +124,7 @@ void main() {
 
       test('returns Future when at least one buffer flushes asynchronously',
           () async {
-        final mockSpanBuffer = MockTelemetryBuffer<Span>(asyncFlush: true);
+        final mockSpanBuffer = MockTelemetryBuffer<Span>(asyncClear: true);
         final processor = fixture.getSut(spanBuffer: mockSpanBuffer);
         processor.logBuffer = null;
 

--- a/packages/dart/test/telemetry_processing/telemetry_processor_test.dart
+++ b/packages/dart/test/telemetry_processing/telemetry_processor_test.dart
@@ -142,7 +142,7 @@ class Fixture {
 
   DefaultTelemetryProcessor getSut({bool enableLogs = false}) {
     options.enableLogs = enableLogs;
-    return _TestTelemetryProcessor(options, options.log);
+    return DefaultTelemetryProcessor(options, options.log);
   }
 
   SimpleSpan createSpan({String name = 'test-span'}) {
@@ -157,17 +157,4 @@ class Fixture {
       attributes: {},
     );
   }
-}
-
-/// Test subclass that overrides buffer creation to avoid UnimplementedError.
-/// TODO(next-pr): can be removed when we have the default in-memory buffers
-class _TestTelemetryProcessor extends DefaultTelemetryProcessor {
-  _TestTelemetryProcessor(super.options, super.logger);
-
-  @override
-  TelemetryBuffer<Span> createSpanBuffer() => MockTelemetryBuffer<Span>();
-
-  @override
-  TelemetryBuffer<SentryLog> createLogBuffer() =>
-      MockTelemetryBuffer<SentryLog>();
 }

--- a/packages/dart/test/telemetry_processing/telemetry_processor_test.dart
+++ b/packages/dart/test/telemetry_processing/telemetry_processor_test.dart
@@ -143,10 +143,9 @@ class Fixture {
   }) {
     options.enableLogs = enableLogs;
     return DefaultTelemetryProcessor(
-      options,
       options.log,
-      spanBufferFactory: spanBuffer != null ? () => spanBuffer : null,
-      logBufferFactory: logBuffer != null ? () => logBuffer : null,
+      spanBuffer: spanBuffer,
+      logBuffer: logBuffer,
     );
   }
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Add basic APIs for processing telemetry types e.g log, span

#skip-changelog

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Part of #3333 

## :green_heart: How did you test it?
Unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
