### PR TITLE
fix(jni): ensure that the `ScopesAdapter` instance is released after use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Cold/warm start spans not attaching if TTFD takes more than 3 seconds to report ([#3404](https://github.com/getsentry/sentry-dart/pull/3404))
+- Ensure that the JNI `ScopesAdapter` instance is released after use ([#3411](https://github.com/getsentry/sentry-dart/pull/3411))
 
 ## 9.9.0
 

--- a/packages/flutter/lib/src/native/java/sentry_native_java.dart
+++ b/packages/flutter/lib/src/native/java/sentry_native_java.dart
@@ -189,9 +189,11 @@ class SentryNativeJava extends SentryNativeChannel {
   void addBreadcrumb(Breadcrumb breadcrumb) =>
       tryCatchSync('addBreadcrumb', () {
         using((arena) {
-          final nativeOptions = native.ScopesAdapter.getInstance()?.getOptions()
+          final scopesAdapter = native.ScopesAdapter.getInstance()
             ?..releasedBy(arena);
-          if (nativeOptions == null) return;
+          if (scopesAdapter == null) return;
+          final nativeOptions = scopesAdapter.getOptions()..releasedBy(arena);
+
           final jMap = dartToJMap(breadcrumb.toJson());
           final nativeBreadcrumb =
               native.Breadcrumb.fromMap(jMap, nativeOptions)
@@ -214,10 +216,10 @@ class SentryNativeJava extends SentryNativeChannel {
           if (user == null) {
             native.Sentry.setUser(null);
           } else {
-            final nativeOptions = native.ScopesAdapter.getInstance()
-                ?.getOptions()
+            final scopesAdapter = native.ScopesAdapter.getInstance()
               ?..releasedBy(arena);
-            if (nativeOptions == null) return;
+            if (scopesAdapter == null) return;
+            final nativeOptions = scopesAdapter.getOptions()..releasedBy(arena);
 
             final jMap = dartToJMap(user.toJson());
             final nativeUser = native.User.fromMap(jMap, nativeOptions)


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Currently it's not being released and may end up causing a crash due to stale references.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #3410 

## :green_heart: How did you test it?
Hard to test since it relies on GC.

I have been verifying nothing is crashing by stress testing with thousands of added breadcrumbs in a tight loop.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
