### PR TITLE
fix(ci): failing package-analysis

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -12,7 +12,7 @@ on:
         description: Minumum percentage of Dart Package Analyzer score that must be achieved.
         required: false
         type: number
-        default: 100
+        default: 160
 
 jobs:
   analyze:
@@ -74,8 +74,8 @@ jobs:
       - name: Check scores
         env:
           TOTAL: ${{ steps.analysis.outputs.total }}
-          TOTAL_MAX: 150
-          PANA_THRESHOLD: 100
+          TOTAL_MAX: ${{ steps.analysis.outputs.total_max }}
+          PANA_THRESHOLD: ${{ inputs.panaThreshold }}
         run: |
           PERCENTAGE=$(( $TOTAL * 100 / $TOTAL_MAX ))
           if (( $PERCENTAGE < $PANA_THRESHOLD ))

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -80,8 +80,8 @@ jobs:
       - name: Check scores
         env:
           TOTAL: ${{ steps.analysis.outputs.total }}
-          TOTAL_MAX: ${{ steps.analysis.outputs.total_max }}
-          PANA_THRESHOLD: ${{ inputs.panaThreshold }}
+          TOTAL_MAX: 70
+          PANA_THRESHOLD: 70
         run: |
           PERCENTAGE=$(( $TOTAL * 100 / $TOTAL_MAX ))
           if (( $PERCENTAGE < $PANA_THRESHOLD ))

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -65,7 +65,13 @@ jobs:
         if: ${{ inputs.package != 'packages/dart' }}
         working-directory: ${{ inputs.package }}
         run: |
-          sed -i.bak 's|sentry:.*|sentry:\n    path: /github/workspace/packages/dart|g' pubspec.yaml
+          # Get current commit hash
+          COMMIT_HASH=$(git rev-parse HEAD)
+
+          # Only modify if package depends on sentry
+          if grep -q "^  sentry:" pubspec.yaml; then
+            sed -i.bak "s|^  sentry:.*|  sentry:\n    git:\n      url: https://github.com/getsentry/sentry-dart.git\n      ref: $COMMIT_HASH\n      path: packages/dart|g" pubspec.yaml
+          fi
       - uses: axel-op/dart-package-analyzer@56afb7e6737bd2b7cee05382ae7f0e8111138080 # pin@v3
         id: analysis
         with:

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -12,7 +12,7 @@ on:
         description: Minumum percentage of Dart Package Analyzer score that must be achieved.
         required: false
         type: number
-        default: 160
+        default: 90
 
 jobs:
   analyze:

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -62,7 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Apply dependency override
-        if: ${{ inputs.package == 'flutter' }}
+        if: ${{ inputs.package != 'packages/dart' }}
         working-directory: ${{ inputs.package }}
         run: |
           sed -i.bak 's|sentry:.*|sentry:\n    path: /github/workspace/packages/dart|g' pubspec.yaml

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -77,14 +77,10 @@ jobs:
           TOTAL_MAX: ${{ steps.analysis.outputs.total_max }}
           PANA_THRESHOLD: ${{ inputs.panaThreshold }}
         run: |
-          MISSING_POINTS=$(( $TOTAL_MAX - $TOTAL ))
-          if (( $MISSING_POINTS > $PANA_THRESHOLD ))
-          then
-            PERCENTAGE=$(( $TOTAL * 100 / $TOTAL_MAX ))
-            echo "Pana score: $PERCENTAGE% ($TOTAL/$TOTAL_MAX points, $MISSING_POINTS points missing)"
-            echo "Score too low ($PERCENTAGE % is less than the expected $PANA_THRESHOLD %)!"
+          MISSING_POINTS=$(( TOTAL_MAX - TOTAL ))
+          if (( MISSING_POINTS > PANA_THRESHOLD )); then
+            echo "Pana score check failed: ${TOTAL}/${TOTAL_MAX} points (missing ${MISSING_POINTS}; allowed missing <= ${PANA_THRESHOLD})."
             exit 1
           else
-            echo "Pana score: $PERCENTAGE% ($TOTAL/$TOTAL_MAX points, $MISSING_POINTS points missing)"
-            echo "Score is good ($PERCENTAGE % is greater than the expected $PANA_THRESHOLD %)!"
+            echo "Pana score check passed: ${TOTAL}/${TOTAL_MAX} points (missing ${MISSING_POINTS}; allowed missing <= ${PANA_THRESHOLD})."
           fi

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -77,10 +77,9 @@ jobs:
           TOTAL_MAX: ${{ steps.analysis.outputs.total_max }}
           PANA_THRESHOLD: ${{ inputs.panaThreshold }}
         run: |
-          MISSING_POINTS=$(( TOTAL_MAX - TOTAL ))
-          if (( MISSING_POINTS > PANA_THRESHOLD )); then
-            echo "Pana score check failed: ${TOTAL}/${TOTAL_MAX} points (missing ${MISSING_POINTS}; allowed missing <= ${PANA_THRESHOLD})."
+          if (( TOTAL < PANA_THRESHOLD )); then
+            echo "Pana score check failed: ${TOTAL}/${TOTAL_MAX} points (minimum required: ${PANA_THRESHOLD})."
             exit 1
           else
-            echo "Pana score check passed: ${TOTAL}/${TOTAL_MAX} points (missing ${MISSING_POINTS}; allowed missing <= ${PANA_THRESHOLD})."
+            echo "Pana score check passed: ${TOTAL}/${TOTAL_MAX} points (minimum required: ${PANA_THRESHOLD})."
           fi

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -9,10 +9,10 @@ on:
         type: string
         default: dart
       panaThreshold:
-        description: Minumum percentage of Dart Package Analyzer score that must be achieved.
+        description: Minimum number of points that must be achieved.
         required: false
         type: number
-        default: 90
+        default: 140
 
 jobs:
   analyze:
@@ -77,9 +77,14 @@ jobs:
           TOTAL_MAX: ${{ steps.analysis.outputs.total_max }}
           PANA_THRESHOLD: ${{ inputs.panaThreshold }}
         run: |
-          PERCENTAGE=$(( $TOTAL * 100 / $TOTAL_MAX ))
-          if (( $PERCENTAGE < $PANA_THRESHOLD ))
+          MISSING_POINTS=$(( $TOTAL_MAX - $TOTAL ))
+          if (( $MISSING_POINTS > $PANA_THRESHOLD ))
           then
+            PERCENTAGE=$(( $TOTAL * 100 / $TOTAL_MAX ))
+            echo "Pana score: $PERCENTAGE% ($TOTAL/$TOTAL_MAX points, $MISSING_POINTS points missing)"
             echo "Score too low ($PERCENTAGE % is less than the expected $PANA_THRESHOLD %)!"
             exit 1
+          else
+            echo "Pana score: $PERCENTAGE% ($TOTAL/$TOTAL_MAX points, $MISSING_POINTS points missing)"
+            echo "Score is good ($PERCENTAGE % is greater than the expected $PANA_THRESHOLD %)!"
           fi

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -65,13 +65,7 @@ jobs:
         if: ${{ inputs.package != 'packages/dart' }}
         working-directory: ${{ inputs.package }}
         run: |
-          # Get current commit hash
-          COMMIT_HASH=$(git rev-parse HEAD)
-
-          # Only modify if package depends on sentry
-          if grep -q "^  sentry:" pubspec.yaml; then
-            sed -i.bak "s|^  sentry:.*|  sentry:\n    git:\n      url: https://github.com/getsentry/sentry-dart.git\n      ref: $COMMIT_HASH\n      path: packages/dart|g" pubspec.yaml
-          fi
+          sed -i.bak 's|sentry:.*|sentry:\n    path: /github/workspace/packages/dart|g' pubspec.yaml
       - uses: axel-op/dart-package-analyzer@56afb7e6737bd2b7cee05382ae7f0e8111138080 # pin@v3
         id: analysis
         with:
@@ -80,8 +74,8 @@ jobs:
       - name: Check scores
         env:
           TOTAL: ${{ steps.analysis.outputs.total }}
-          TOTAL_MAX: 70
-          PANA_THRESHOLD: 70
+          TOTAL_MAX: 150
+          PANA_THRESHOLD: 100
         run: |
           PERCENTAGE=$(( $TOTAL * 100 / $TOTAL_MAX ))
           if (( $PERCENTAGE < $PANA_THRESHOLD ))

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -61,4 +61,3 @@ jobs:
     uses: ./.github/workflows/analyze.yml
     with:
       package: packages/dart
-      panaThreshold: 87

--- a/.github/workflows/file.yml
+++ b/.github/workflows/file.yml
@@ -50,4 +50,3 @@ jobs:
     uses: ./.github/workflows/analyze.yml
     with:
       package: packages/file
-      panaThreshold: 90

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -143,7 +143,6 @@ jobs:
     with:
       package: packages/flutter
       sdk: flutter
-      panaThreshold: 87
 
   pod-lint:
     runs-on: macos-15

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -50,4 +50,3 @@ jobs:
     uses: ./.github/workflows/analyze.yml
     with:
       package: packages/hive
-      panaThreshold: 90

--- a/packages/dart/lib/src/utils/_io_get_sentry_operating_system.dart
+++ b/packages/dart/lib/src/utils/_io_get_sentry_operating_system.dart
@@ -1,5 +1,4 @@
 import '../protocol/sentry_operating_system.dart';
-import 'dart:convert';
 import 'dart:io';
 import 'package:meta/meta.dart';
 
@@ -8,19 +7,6 @@ SentryOperatingSystem getSentryOperatingSystem({
   String? name,
   String? rawDescription,
 }) {
-  // #region agent log
-  _debugLog({
-    'location': '_io_get_sentry_operating_system.dart:11',
-    'message': 'getSentryOperatingSystem entry',
-    'data': {
-      'inputName': name,
-      'inputRawDescription': rawDescription,
-      'platformName': Platform.operatingSystem,
-      'platformVersion': Platform.operatingSystemVersion,
-    },
-    'hypothesisId': 'H1',
-  });
-  // #endregion
   name ??= Platform.operatingSystem;
   rawDescription ??= Platform.operatingSystemVersion;
   RegExpMatch? match;
@@ -46,46 +32,13 @@ SentryOperatingSystem getSentryOperatingSystem({
       match = _windowsOsRegexp.firstMatch(rawDescription);
       break;
   }
-  // #region agent log
-  _debugLog({
-    'location': '_io_get_sentry_operating_system.dart:44',
-    'message': 'parsed operating system',
-    'data': {
-      'normalizedName': name,
-      'rawDescription': rawDescription,
-      'matchFound': match != null,
-      'matchValue': match?.group(0),
-      'version': match?.namedGroupOrNull('version'),
-      'build': match?.namedGroupOrNull('build'),
-      'kernelVersion': match?.namedGroupOrNull('kernelVersion'),
-    },
-    'hypothesisId': 'H1',
-  });
-  // #endregion
-  final version = match?.namedGroupOrNull('version');
-  final build = match?.namedGroupOrNull('build');
-  final kernelVersion = match?.namedGroupOrNull('kernelVersion');
-  // #region agent log
-  _debugLog({
-    'location': '_io_get_sentry_operating_system.dart:61',
-    'message': 'operating system result',
-    'data': {
-      'name': name,
-      'rawDescription': rawDescription,
-      'version': version,
-      'build': build,
-      'kernelVersion': kernelVersion,
-    },
-    'hypothesisId': 'H4',
-  });
-  // #endregion
 
   return SentryOperatingSystem(
     name: name,
     rawDescription: rawDescription,
-    version: version,
-    build: build,
-    kernelVersion: kernelVersion,
+    version: match?.namedGroupOrNull('version'),
+    build: match?.namedGroupOrNull('build'),
+    kernelVersion: match?.namedGroupOrNull('kernelVersion'),
   );
 }
 
@@ -116,22 +69,4 @@ extension on RegExpMatch {
       return null;
     }
   }
-}
-
-void _debugLog(Map<String, Object?> payload) {
-  try {
-    final entry = <String, Object?>{
-      'id': 'log_${DateTime.now().millisecondsSinceEpoch}',
-      'timestamp': DateTime.now().millisecondsSinceEpoch,
-      'sessionId': 'debug-session',
-      'runId': 'pre-fix',
-      'hypothesisId': payload['hypothesisId'],
-      'location': payload['location'],
-      'message': payload['message'],
-      'data': payload['data'],
-    };
-    File('/Users/giancarlobuenaflor/Desktop/sentry-projects/dart-new6/.cursor/debug.log')
-        .writeAsStringSync('${jsonEncode(entry)}\n',
-            mode: FileMode.append, flush: true);
-  } catch (_) {}
 }

--- a/packages/file/analysis_options.yaml
+++ b/packages/file/analysis_options.yaml
@@ -8,6 +8,8 @@ analyzer:
     missing_required_param: error
     # treat missing returns as a warning (not a hint)
     missing_return: error
+    # ignore sentry/path on pubspec as we change it on deployment
+    invalid_dependency: ignore
   language:
     strict-casts: true
     strict-inference: true

--- a/packages/file/analysis_options.yaml
+++ b/packages/file/analysis_options.yaml
@@ -8,7 +8,6 @@ analyzer:
     missing_required_param: error
     # treat missing returns as a warning (not a hint)
     missing_return: error
-    # ignore sentry/path on pubspec as we change it on deployment
     invalid_dependency: ignore
   language:
     strict-casts: true

--- a/packages/link/analysis_options.yaml
+++ b/packages/link/analysis_options.yaml
@@ -11,3 +11,6 @@ analyzer:
     strict-casts: true
     strict-inference: true
     strict-raw-types: true
+  errors:
+    # ignore sentry/path on pubspec as we change it on deployment
+    invalid_dependency: ignore

--- a/packages/link/analysis_options.yaml
+++ b/packages/link/analysis_options.yaml
@@ -12,5 +12,4 @@ analyzer:
     strict-inference: true
     strict-raw-types: true
   errors:
-    # ignore sentry/path on pubspec as we change it on deployment
     invalid_dependency: ignore


### PR DESCRIPTION
issues:
- the run script that's supposed to swap the sentry dart path did not trigger; happened when we moved the packages from root to `/packages`
- invalid dependency was not ignored for all analysis rules
- the run script should execute for all targets that are not sentry-dart, not only for flutter

#skip-changelog