### PR TITLE
chore: update GitHub Actions workflows to use updater v3

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -8,8 +8,6 @@ on:
   push:
     branches:
       - main
-  # Don't merge, testing only
-  pull_request:
 
 permissions:
   contents: write

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -12,9 +12,9 @@ on:
   pull_request:
 
 permissions:
-  contents: write      # To modify files and create commits
-  pull-requests: write # To create and update pull requests
-  actions: write       # To cancel previous workflow runs
+  contents: write
+  pull-requests: write
+  actions: write
 
 jobs:
   android:

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: getsentry/github-workflows/updater@v3
         with:
           path: metrics/flutter.properties
-          name: Flutter SDK (metrics)
+          name: Flutter SDK Metrics
           changelog-entry: false
           ssh-key: ${{ secrets.CI_DEPLOY_KEY }}
 
@@ -69,6 +69,6 @@ jobs:
       - uses: getsentry/github-workflows/updater@v3
         with:
           path: scripts/update-symbol-collector.sh
-          name: Symbol collector CLI
+          name: Symbol Collector CLI
           changelog-entry: false
           ssh-key: ${{ secrets.CI_DEPLOY_KEY }}

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           path: packages/flutter/scripts/update-android.sh
           name: Android SDK
-          api-token: ${{ secrets.CI_DEPLOY_KEY }}
+          ssh-key: ${{ secrets.CI_DEPLOY_KEY }}
 
   cocoa:
     runs-on: macos-latest
@@ -33,7 +33,7 @@ jobs:
         with:
           path: packages/flutter/scripts/update-cocoa.sh
           name: Cocoa SDK
-          api-token: ${{ secrets.CI_DEPLOY_KEY }}
+          ssh-key: ${{ secrets.CI_DEPLOY_KEY }}
 
   js:
     runs-on: ubuntu-latest
@@ -42,7 +42,7 @@ jobs:
         with:
           path: packages/flutter/scripts/update-js.sh
           name: JavaScript SDK
-          api-token: ${{ secrets.CI_DEPLOY_KEY }}
+          ssh-key: ${{ secrets.CI_DEPLOY_KEY }}
 
   native:
     runs-on: ubuntu-latest
@@ -51,7 +51,7 @@ jobs:
         with:
           path: packages/flutter/scripts/update-native.sh
           name: Native SDK
-          api-token: ${{ secrets.CI_DEPLOY_KEY }}
+          ssh-key: ${{ secrets.CI_DEPLOY_KEY }}
 
   metrics-flutter:
     runs-on: ubuntu-latest
@@ -61,7 +61,7 @@ jobs:
           path: metrics/flutter.properties
           name: Flutter SDK (metrics)
           changelog-entry: false
-          api-token: ${{ secrets.CI_DEPLOY_KEY }}
+          ssh-key: ${{ secrets.CI_DEPLOY_KEY }}
 
   symbol-collector:
     runs-on: ubuntu-latest
@@ -71,4 +71,4 @@ jobs:
           path: scripts/update-symbol-collector.sh
           name: Symbol collector CLI
           changelog-entry: false
-          api-token: ${{ secrets.CI_DEPLOY_KEY }}
+          ssh-key: ${{ secrets.CI_DEPLOY_KEY }}

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+  pull_request:
 
 permissions:
   contents: write

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -4,61 +4,69 @@ on:
   # Run every day.
   schedule:
     - cron: "0 3 * * *"
-  # And on on every PR merge so we get the updated dependencies ASAP, and to make sure the changelog doesn't conflict.
+  # And on every PR merge so we get the updated dependencies ASAP, and to make sure the changelog doesn't conflict.
   push:
     branches:
       - main
 
+permissions:
+  contents: write      # To modify files and create commits
+  pull-requests: write # To create and update pull requests
+  actions: write       # To cancel previous workflow runs
+
 jobs:
   android:
-    uses: getsentry/github-workflows/.github/workflows/updater.yml@v2
-    with:
-      path: packages/flutter/scripts/update-android.sh
-      name: Android SDK
-    secrets:
-      api-token: ${{ secrets.CI_DEPLOY_KEY }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: getsentry/github-workflows/updater@v3
+        with:
+          path: packages/flutter/scripts/update-android.sh
+          name: Android SDK
+          api-token: ${{ secrets.CI_DEPLOY_KEY }}
 
   cocoa:
-    uses: getsentry/github-workflows/.github/workflows/updater.yml@v2
-    with:
-      path: packages/flutter/scripts/update-cocoa.sh
-      name: Cocoa SDK
-      runs-on: macos-latest
-    secrets:
-      api-token: ${{ secrets.CI_DEPLOY_KEY }}
+    runs-on: macos-latest
+    steps:
+      - uses: getsentry/github-workflows/updater@v3
+        with:
+          path: packages/flutter/scripts/update-cocoa.sh
+          name: Cocoa SDK
+          api-token: ${{ secrets.CI_DEPLOY_KEY }}
 
   js:
-    uses: getsentry/github-workflows/.github/workflows/updater.yml@v2
-    with:
-      path: packages/flutter/scripts/update-js.sh
-      name: JavaScript SDK
-    secrets:
-      api-token: ${{ secrets.CI_DEPLOY_KEY }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: getsentry/github-workflows/updater@v3
+        with:
+          path: packages/flutter/scripts/update-js.sh
+          name: JavaScript SDK
+          api-token: ${{ secrets.CI_DEPLOY_KEY }}
 
   native:
-    uses: getsentry/github-workflows/.github/workflows/updater.yml@v2
-    with:
-      path: packages/flutter/scripts/update-native.sh
-      name: Native SDK
-    secrets:
-      api-token: ${{ secrets.CI_DEPLOY_KEY }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: getsentry/github-workflows/updater@v3
+        with:
+          path: packages/flutter/scripts/update-native.sh
+          name: Native SDK
+          api-token: ${{ secrets.CI_DEPLOY_KEY }}
 
   metrics-flutter:
-    uses: getsentry/github-workflows/.github/workflows/updater.yml@v2
-    with:
-      path: metrics/flutter.properties
-      name: Flutter SDK (metrics)
-      changelog-entry: false
-      pr-strategy: update
-    secrets:
-      api-token: ${{ secrets.CI_DEPLOY_KEY }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: getsentry/github-workflows/updater@v3
+        with:
+          path: metrics/flutter.properties
+          name: Flutter SDK (metrics)
+          changelog-entry: false
+          api-token: ${{ secrets.CI_DEPLOY_KEY }}
 
   symbol-collector:
-    uses: getsentry/github-workflows/.github/workflows/updater.yml@v2
-    with:
-      path: scripts/update-symbol-collector.sh
-      name: Symbol collector CLI
-      changelog-entry: false
-      pr-strategy: update
-    secrets:
-      api-token: ${{ secrets.CI_DEPLOY_KEY }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: getsentry/github-workflows/updater@v3
+        with:
+          path: scripts/update-symbol-collector.sh
+          name: Symbol collector CLI
+          changelog-entry: false
+          api-token: ${{ secrets.CI_DEPLOY_KEY }}

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -8,6 +8,8 @@ on:
   push:
     branches:
       - main
+  # Don't merge, testing only
+  pull_request:
 
 permissions:
   contents: write      # To modify files and create commits

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
 
 permissions:
   contents: write

--- a/packages/flutter/scripts/generate-cocoa-bindings.sh
+++ b/packages/flutter/scripts/generate-cocoa-bindings.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 if [[ -n ${CI:+x} ]]; then
     echo "Running in CI so we need to set up Flutter SDK first"
     curl -Lv https://storage.googleapis.com/flutter_infra_release/releases/stable/macos/flutter_macos_3.27.3-stable.zip --output /tmp/flutter.zip
-    rm -rf /tmp/flutter
     unzip -q /tmp/flutter.zip -d /tmp
     export PATH=":/tmp/flutter/bin:$PATH"
     which flutter

--- a/packages/flutter/scripts/generate-cocoa-bindings.sh
+++ b/packages/flutter/scripts/generate-cocoa-bindings.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 if [[ -n ${CI:+x} ]]; then
     echo "Running in CI so we need to set up Flutter SDK first"
     curl -Lv https://storage.googleapis.com/flutter_infra_release/releases/stable/macos/flutter_macos_3.27.3-stable.zip --output /tmp/flutter.zip
+    rm -rf /tmp/flutter
     unzip -q /tmp/flutter.zip -d /tmp
     export PATH=":/tmp/flutter/bin:$PATH"
     which flutter


### PR DESCRIPTION
Refactor the update-deps.yml workflow to utilize the latest version of the updater action, improving the structure and permissions for dependency updates across Android, Cocoa, JavaScript, Native, and Symbol Collector jobs.

Tested the impl by enabling it in pull request

#skip-changelog
