### PR TITLE
feat(flutter): Add captureNativeFailedRequests option for iOS/macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
     - `Sentry.metrics.gauge(...)`
     - `Sentry.metrics.count(...)`
     - `Sentry.metrics.distribution(...)`
+- Add `captureNativeFailedRequests` option for iOS/macOS ([#3472](https://github.com/getsentry/sentry-dart/pull/3472))
+  - This option allows controlling native HTTP error capturing independently from `captureFailedRequests`.
+  - When `null` (the default), it falls back to `captureFailedRequests` for backwards compatibility.
+  - Set to `false` to disable native failed request capturing while keeping Dart-side capturing enabled.
 
 ### Enhancements
 

--- a/packages/dart/lib/src/sentry_options.dart
+++ b/packages/dart/lib/src/sentry_options.dart
@@ -333,9 +333,20 @@ class SentryOptions {
   /// - In an browser environment this can be requests which fail because of CORS.
   /// - In an mobile or desktop application this can be requests which failed
   ///   because the connection was interrupted.
-  /// Use with [SentryHttpClient] or `sentry_dio` integration for this to work,
-  /// or iOS native where it sets the value to `enableCaptureFailedRequests`.
+  /// Use with [SentryHttpClient] or `sentry_dio` integration for this to work
+  ///
+  /// If you wish to disable capturing native failed requests on iOS/macOS, use [captureNativeFailedRequests] instead.
+  // TODO(major-v10): do not sync this with native options, instead use captureNativeFailedRequests instead to sync.
   bool captureFailedRequests = true;
+
+  /// Whether failed HTTP requests are captured by the native iOS/macOS SDK.
+  ///
+  /// This allows controlling native-side HTTP error capturing independently
+  /// from [captureFailedRequests], which controls Dart-side capturing.
+  ///
+  /// When `null` (the default), falls back to [captureFailedRequests].
+  // TODO(major-v10): it's currently nullable for backwards compatibility, make non-nullable by default.
+  bool? captureNativeFailedRequests;
 
   /// Whether to records requests as breadcrumbs. This is on by default.
   /// It only has an effect when the SentryHttpClient or dio integration is in

--- a/packages/flutter/lib/src/native/sentry_native_channel.dart
+++ b/packages/flutter/lib/src/native/sentry_native_channel.dart
@@ -66,7 +66,8 @@ class SentryNativeChannel
       'proguardUuid': options.proguardUuid,
       'maxAttachmentSize': options.maxAttachmentSize,
       'recordHttpBreadcrumbs': options.recordHttpBreadcrumbs,
-      'captureFailedRequests': options.captureFailedRequests,
+      'captureFailedRequests':
+          options.captureNativeFailedRequests ?? options.captureFailedRequests,
       'enableAppHangTracking': options.enableAppHangTracking,
       'connectionTimeoutMillis': options.connectionTimeout.inMilliseconds,
       'readTimeoutMillis': options.readTimeout.inMilliseconds,


### PR DESCRIPTION
## :scroll: Description

Add a new `captureNativeFailedRequests` option to control native HTTP failed request capturing independently from `captureFailedRequests`.

This separation allows users to:
- Keep Dart-side failed request capturing enabled while disabling native
- Or vice versa, based on their needs

For backwards compatibility, `captureNativeFailedRequests` defaults to `null`, which falls back to the value of `captureFailedRequests`. This ensures existing users who set `captureFailedRequests = false` will still have native capturing disabled as expected.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3321 

## :green_heart: How did you test it?
Unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
