### PR TITLE
ci(testflight): Update to Xcode 26.2

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: subosito/flutter-action@fd55f4c5af5b953cc57a2be44cb082c8f6635e8e # pin@v2.21.0
-      - run: xcodes select 16.4
+      - run: xcodes select 26.2
       - uses: ruby/setup-ruby@4c24fa5ec04b2e79eb40571b1cee2a0d2b705771 # pin@v1.278.0
         with:
           ruby-version: '2.7.5'


### PR DESCRIPTION
## Summary
- Updates Xcode version from 16.4 to 26 in the Testflight CI workflow

## Test plan
- [ ] Verify CI passes with the new Xcode version

Fixes: https://github.com/getsentry/sentry-dart/issues/3480

🤖 Generated with [Claude Code](https://claude.com/claude-code)