### PR TITLE
ref(dart): Remove unused beforeMetricCallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Internals
+
+- Remove deprecated `beforeMetricCallback` from options ([#3484](https://github.com/getsentry/sentry-dart/pull/3450))
+
 ## 9.11.0-beta.1
 
 ### Features

--- a/packages/dart/lib/src/sentry_options.dart
+++ b/packages/dart/lib/src/sentry_options.dart
@@ -211,10 +211,6 @@ class SentryOptions {
   /// to the scope. When nothing is returned from the function, the breadcrumb is dropped
   BeforeBreadcrumbCallback? beforeBreadcrumb;
 
-  /// This function is called right before a metric is about to be emitted.
-  /// Can return true to emit the metric, or false to drop it.
-  BeforeMetricCallback? beforeMetricCallback;
-
   /// This function is called right before a log is about to be sent.
   /// Can return a modified log or null to drop the log.
   BeforeSendLogCallback? beforeSendLog;
@@ -702,13 +698,6 @@ typedef BeforeBreadcrumbCallback = Breadcrumb? Function(
   Breadcrumb? breadcrumb,
   Hint hint,
 );
-
-/// This function is called right before a metric is about to be emitted.
-/// Can return true to emit the metric, or false to drop it.
-typedef BeforeMetricCallback = bool Function(
-  String key, {
-  Map<String, String>? tags,
-});
 
 /// This function is called right before a log is about to be sent.
 /// Can return a modified log or null to drop the log.


### PR DESCRIPTION
## Summary
- Remove dead code: `BeforeMetricCallback` typedef and `beforeMetricCallback` field from `SentryOptions`
- No usages of this callback exist anywhere in the codebase
- These callbacks are associated with the old metrics feature

## Test plan
- [x] Verified no references to `beforeMetricCallback` or `BeforeMetricCallback` exist in the codebase via grep search
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)