### PR TITLE
feat(span-first): Add streaming instrumentation span implementation and tests

### DIFF
--- a/packages/_sentry_testing/README.md
+++ b/packages/_sentry_testing/README.md
@@ -1,0 +1,23 @@
+# _sentry_testing
+
+Internal testing utilities for the Sentry Dart/Flutter SDK monorepo.
+
+> ⚠️ **Internal Use Only**
+> This package is for use within the Sentry SDK development only.
+> It is not published and should not be used in external projects.
+
+## Usage
+
+Add to your integration package's `dev_dependencies`:
+
+```yaml
+dev_dependencies:
+  _sentry_testing:
+    path: ../_sentry_testing
+```
+
+Import in tests:
+
+```dart
+import 'package:_sentry_testing/_sentry_testing.dart';
+```

--- a/packages/_sentry_testing/README.md
+++ b/packages/_sentry_testing/README.md
@@ -1,6 +1,6 @@
 # _sentry_testing
 
-Internal testing utilities for the Sentry Dart/Flutter SDK monorepo.
+Internal testing utilities for the Sentry Dart/Flutter SDK monorepo that can be shared among packages.
 
 > ⚠️ **Internal Use Only**
 > This package is for use within the Sentry SDK development only.
@@ -8,7 +8,7 @@ Internal testing utilities for the Sentry Dart/Flutter SDK monorepo.
 
 ## Usage
 
-Add to your integration package's `dev_dependencies`:
+Add to the integration package's `dev_dependencies`:
 
 ```yaml
 dev_dependencies:

--- a/packages/_sentry_testing/lib/_sentry_testing.dart
+++ b/packages/_sentry_testing/lib/_sentry_testing.dart
@@ -1,0 +1,7 @@
+/// Internal testing utilities for Sentry Dart/Flutter SDK.
+///
+/// This library is for internal use only and should not be used outside
+/// the Sentry SDK monorepo.
+library _sentry_testing;
+
+export 'src/fake_telemetry_processor.dart';

--- a/packages/_sentry_testing/lib/src/fake_telemetry_processor.dart
+++ b/packages/_sentry_testing/lib/src/fake_telemetry_processor.dart
@@ -4,7 +4,7 @@ import 'package:collection/collection.dart';
 import 'package:sentry/sentry.dart';
 import 'package:sentry/src/telemetry/processing/processor.dart';
 
-/// Fake telemetry processor that captures spans for test assertions.
+/// Fake telemetry processor that captures telemetry data for test assertions.
 ///
 /// Usage:
 /// ```dart

--- a/packages/_sentry_testing/lib/src/fake_telemetry_processor.dart
+++ b/packages/_sentry_testing/lib/src/fake_telemetry_processor.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: invalid_use_of_internal_member
+
 import 'dart:async';
 
 import 'package:collection/collection.dart';
@@ -39,7 +41,9 @@ class FakeTelemetryProcessor implements TelemetryProcessor {
 
   RecordingSentrySpanV2? findSpanByOperation(String operation) {
     return capturedSpans.firstWhereOrNull(
-      (span) => span.attributes['sentry.op']?.value == operation,
+      (span) =>
+          span.attributes[SemanticAttributesConstants.sentryOp]?.value ==
+          operation,
     );
   }
 

--- a/packages/_sentry_testing/lib/src/fake_telemetry_processor.dart
+++ b/packages/_sentry_testing/lib/src/fake_telemetry_processor.dart
@@ -1,0 +1,54 @@
+import 'dart:async';
+
+import 'package:collection/collection.dart';
+import 'package:sentry/sentry.dart';
+import 'package:sentry/src/telemetry/processing/processor.dart';
+
+/// Fake telemetry processor that captures spans for test assertions.
+///
+/// Usage:
+/// ```dart
+/// final processor = FakeTelemetryProcessor();
+/// final options = SentryOptions()
+///   ..telemetryProcessor = processor;
+/// ```
+class FakeTelemetryProcessor implements TelemetryProcessor {
+  final List<RecordingSentrySpanV2> capturedSpans = [];
+
+  @override
+  void addSpan(RecordingSentrySpanV2 span) {
+    capturedSpans.add(span);
+  }
+
+  @override
+  void addLog(SentryLog log) {}
+
+  @override
+  void addMetric(SentryMetric metric) {}
+
+  @override
+  FutureOr<void> flush() {}
+
+  void clear() {
+    capturedSpans.clear();
+  }
+
+  List<RecordingSentrySpanV2> getChildSpans() {
+    return capturedSpans.where((s) => s.parentSpan != null).toList();
+  }
+
+  RecordingSentrySpanV2? findSpanByOperation(String operation) {
+    return capturedSpans.firstWhereOrNull(
+      (span) => span.attributes['sentry.op']?.value == operation,
+    );
+  }
+
+  List<RecordingSentrySpanV2> findChildrenOf(RecordingSentrySpanV2 parent) {
+    return capturedSpans.where((s) => s.parentSpan == parent).toList();
+  }
+
+  Future<void> waitForProcessing() async {
+    // Small delay to ensure async telemetry callbacks complete.
+    await Future.delayed(Duration(milliseconds: 10));
+  }
+}

--- a/packages/_sentry_testing/pubspec.yaml
+++ b/packages/_sentry_testing/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   sentry:
     path: ../dart
   meta: ^1.11.0
-  collection: ^1.18.0  # For firstWhereOrNull
+  collection: ^1.18.0
 
 dev_dependencies:
   test: ^1.24.0

--- a/packages/_sentry_testing/pubspec.yaml
+++ b/packages/_sentry_testing/pubspec.yaml
@@ -1,0 +1,16 @@
+name: _sentry_testing
+version: 0.1.0
+description: Testing utilities for Sentry Dart/Flutter SDK (internal use only)
+publish_to: none
+
+environment:
+  sdk: '>=3.5.0 <4.0.0'
+
+dependencies:
+  sentry:
+    path: ../dart
+  meta: ^1.11.0
+  collection: ^1.18.0  # For firstWhereOrNull
+
+dev_dependencies:
+  test: ^1.24.0

--- a/packages/dart/lib/src/constants.dart
+++ b/packages/dart/lib/src/constants.dart
@@ -85,10 +85,12 @@ abstract class SemanticAttributesConstants {
   /// The replay ID.
   static const sentryReplayId = 'sentry.replay_id';
 
+  /// The operation name of a span.
+  static const sentryOp = 'sentry.op';
+
   /// Whether the replay is buffering (onErrorSampleRate).
   static const sentryInternalReplayIsBuffering =
       'sentry._internal.replay_is_buffering';
-
 
   /// The user ID (gated by `sendDefaultPii`).
   static const userId = 'user.id';
@@ -116,4 +118,31 @@ abstract class SemanticAttributesConstants {
 
   /// The device family (e.g., "iOS", "Android").
   static const deviceFamily = 'device.family';
+
+  /// The HTTP request method (e.g., "GET", "POST").
+  static const httpRequestMethod = 'http.request.method';
+
+  /// The URL of an HTTP request.
+  // TODO: this needs to be updated to use the new url attributes e.g url.full, etc...
+  static const url = 'url';
+
+  /// The HTTP query string (e.g., "foo=bar").
+  static const httpQuery = 'http.query';
+
+  /// The HTTP fragment (e.g., "section").
+  static const httpFragment = 'http.fragment';
+
+  /// The HTTP response status code.
+  static const httpResponseStatusCode = 'http.response.status_code';
+
+  /// The HTTP response content length.
+  static const httpResponseContentLength = 'http.response_content_length';
+
+  /// The database system identifier.
+  // TODO: deprecated, needs to be replaced later by db.system.name
+  static const dbSystem = 'db.system';
+
+  /// The database name.
+  // TODO: deprecated, needs to be replaced later by db.namespace
+  static const dbName = 'db.name';
 }

--- a/packages/dart/lib/src/http_client/tracing_client.dart
+++ b/packages/dart/lib/src/http_client/tracing_client.dart
@@ -40,11 +40,13 @@ class TracingClient extends BaseClient {
     }
 
     final parentSpan = _spanFactory.getSpan(_hub);
-    final instrumentationSpan = _spanFactory.createSpan(
-      parentSpan,
-      'http.client',
-      description: description,
-    );
+    final instrumentationSpan = parentSpan != null
+        ? _spanFactory.createSpan(
+            parentSpan: parentSpan,
+            operation: 'http.client',
+            description: description,
+          )
+        : null;
 
     // Regardless whether tracing is enabled or not, we always want to attach
     // Sentry trace headers (tracing without performance).

--- a/packages/dart/lib/src/sentry.dart
+++ b/packages/dart/lib/src/sentry.dart
@@ -28,6 +28,7 @@ import 'telemetry/metric/metrics.dart';
 import 'telemetry/processing/processor_integration.dart';
 import 'telemetry/span/sentry_span_v2.dart';
 import 'tracing.dart';
+import 'tracing/instrumentation/span_factory_integration.dart';
 import 'transport/data_category.dart';
 import 'transport/task_queue.dart';
 import 'feature_flags_integration.dart';
@@ -115,6 +116,7 @@ class Sentry {
 
     options.addIntegration(MetricsSetupIntegration());
     options.addIntegration(LoggerSetupIntegration());
+    options.addIntegration(InstrumentationSpanFactorySetupIntegration());
     options.addIntegration(FeatureFlagsIntegration());
     options.addIntegration(InMemoryTelemetryProcessorIntegration());
 

--- a/packages/dart/lib/src/sentry_trace_origins.dart
+++ b/packages/dart/lib/src/sentry_trace_origins.dart
@@ -9,6 +9,7 @@ class SentryTraceOrigins {
   static const autoHttpDioHttpClientAdapter =
       'auto.http.dio.http_client_adapter';
   static const autoHttpDioTransformer = 'auto.http.dio.transformer';
+  static const autoGraphQlSentryLink = 'auto.graphql.sentry_link';
   static const autoFile = 'auto.file';
   static const autoFileAssetBundle = 'auto.file.asset_bundle';
   static const autoDbSqfliteOpenDatabase = 'auto.db.sqflite.open_database';

--- a/packages/dart/lib/src/tracing/instrumentation/instrumentation_span.dart
+++ b/packages/dart/lib/src/tracing/instrumentation/instrumentation_span.dart
@@ -79,14 +79,16 @@ class StreamingInstrumentationSpan implements InstrumentationSpan {
 
   @override
   String? get origin {
-    final originAttribute = _span.attributes['sentry.origin'];
+    final originAttribute =
+        _span.attributes[SemanticAttributesConstants.sentryOrigin];
     return originAttribute?.value as String?;
   }
 
   @override
   set origin(String? origin) {
     if (origin != null) {
-      _span.setAttribute('sentry.origin', SentryAttribute.string(origin));
+      _span.setAttribute(SemanticAttributesConstants.sentryOrigin,
+          SentryAttribute.string(origin));
     }
   }
 

--- a/packages/dart/lib/src/tracing/instrumentation/instrumentation_span.dart
+++ b/packages/dart/lib/src/tracing/instrumentation/instrumentation_span.dart
@@ -175,7 +175,7 @@ class StreamingInstrumentationSpan implements InstrumentationSpan {
   }
 
   SentrySpanStatusV2 _convertToV2Status(SpanStatus status) {
-    if (status.toString() == 'ok') {
+    if (status == SpanStatus.ok()) {
       return SentrySpanStatusV2.ok;
     }
     return SentrySpanStatusV2.error;

--- a/packages/dart/lib/src/tracing/instrumentation/instrumentation_span.dart
+++ b/packages/dart/lib/src/tracing/instrumentation/instrumentation_span.dart
@@ -129,7 +129,7 @@ class StreamingInstrumentationSpan implements InstrumentationSpan {
     } else if (value is SentryAttribute) {
       _span.setAttribute(key, value);
     } else {
-      internalLogger.warning(
+      internalLogger.info(
           '$StreamingInstrumentationSpan: Unsupported data type in setData: $value');
     }
   }

--- a/packages/dart/lib/src/tracing/instrumentation/instrumentation_span.dart
+++ b/packages/dart/lib/src/tracing/instrumentation/instrumentation_span.dart
@@ -1,6 +1,7 @@
 import 'package:meta/meta.dart';
 
 import '../../../sentry.dart';
+import '../../utils/internal_logger.dart';
 
 /// Opaque span handle enabling swappable tracing backends.
 @internal
@@ -123,8 +124,11 @@ class StreamingInstrumentationSpan implements InstrumentationSpan {
       _span.setAttribute(key, SentryAttribute.double(value));
     } else if (value is bool) {
       _span.setAttribute(key, SentryAttribute.bool(value));
+    } else if (value is SentryAttribute) {
+      _span.setAttribute(key, value);
     } else {
-      // Ignore other types
+      internalLogger.warning(
+          '$StreamingInstrumentationSpan: Unsupported data type in setData: $value');
     }
   }
 

--- a/packages/dart/lib/src/tracing/instrumentation/span_factory.dart
+++ b/packages/dart/lib/src/tracing/instrumentation/span_factory.dart
@@ -72,7 +72,10 @@ class StreamingInstrumentationSpanFactory
 
       if (childSpan is NoOpSentrySpanV2) return null;
 
-      childSpan.setAttribute('sentry.op', SentryAttribute.string(operation));
+      childSpan.setAttribute(
+        SemanticAttributesConstants.sentryOp,
+        SentryAttribute.string(operation),
+      );
 
       return StreamingInstrumentationSpan(childSpan);
     }

--- a/packages/dart/lib/src/tracing/instrumentation/span_factory.dart
+++ b/packages/dart/lib/src/tracing/instrumentation/span_factory.dart
@@ -11,7 +11,6 @@ abstract class InstrumentationSpanFactory {
     InstrumentationSpan? parent,
     String operation, {
     String? description,
-    DateTime? startTimestamp,
   });
 
   /// Returns `null` if no active span or tracing disabled.
@@ -26,7 +25,6 @@ class LegacyInstrumentationSpanFactory implements InstrumentationSpanFactory {
     InstrumentationSpan? parent,
     String operation, {
     String? description,
-    DateTime? startTimestamp,
   }) {
     if (parent == null) return null;
 
@@ -34,7 +32,6 @@ class LegacyInstrumentationSpanFactory implements InstrumentationSpanFactory {
       final child = parent.spanReference.startChild(
         operation,
         description: description,
-        startTimestamp: startTimestamp,
       );
 
       if (child is NoOpSentrySpan) return null;
@@ -64,7 +61,6 @@ class StreamingInstrumentationSpanFactory
     InstrumentationSpan? parent,
     String operation, {
     String? description,
-    DateTime? startTimestamp,
   }) {
     if (parent == null) return null;
 

--- a/packages/dart/lib/src/tracing/instrumentation/span_factory_integration.dart
+++ b/packages/dart/lib/src/tracing/instrumentation/span_factory_integration.dart
@@ -1,0 +1,20 @@
+import '../../../sentry.dart';
+import '../../utils/internal_logger.dart';
+
+class InstrumentationSpanFactorySetupIntegration
+    extends Integration<SentryOptions> {
+  static const integrationName = 'InstrumentationSpanFactorySetup';
+
+  @override
+  void call(Hub hub, SentryOptions options) {
+    if (options.traceLifecycle == SentryTraceLifecycle.static) {
+      options.spanFactory = LegacyInstrumentationSpanFactory();
+    } else {
+      options.spanFactory = StreamingInstrumentationSpanFactory(hub);
+    }
+
+    options.sdk.addIntegration(integrationName);
+    internalLogger
+        .debug('$integrationName: Span factory configured successfully');
+  }
+}

--- a/packages/dart/pubspec.yaml
+++ b/packages/dart/pubspec.yaml
@@ -36,3 +36,5 @@ dev_dependencies:
   coverage: ^1.3.0
   intl: '>=0.17.0 <1.0.0'
   version: ^3.0.2
+  _sentry_testing:
+    path: ../_sentry_testing

--- a/packages/dart/test/protocol/sentry_feature_flag_tests.dart
+++ b/packages/dart/test/protocol/sentry_feature_flag_tests.dart
@@ -1,3 +1,4 @@
+import 'package:_sentry_testing/_sentry_testing.dart';
 import 'package:collection/collection.dart';
 import 'package:sentry/sentry.dart';
 import 'package:test/test.dart';

--- a/packages/dart/test/protocol/sentry_feature_flag_tests.dart
+++ b/packages/dart/test/protocol/sentry_feature_flag_tests.dart
@@ -1,4 +1,3 @@
-import 'package:_sentry_testing/_sentry_testing.dart';
 import 'package:collection/collection.dart';
 import 'package:sentry/sentry.dart';
 import 'package:test/test.dart';

--- a/packages/dart/test/telemetry/span/span_test.dart
+++ b/packages/dart/test/telemetry/span/span_test.dart
@@ -60,7 +60,9 @@ void main() {
       RecordingSentrySpanV2? capturedSpan;
       final span = fixture.createSpan(
         name: 'test-span',
-        onSpanEnded: (s) async { capturedSpan = s; },
+        onSpanEnded: (s) async {
+          capturedSpan = s;
+        },
       );
 
       span.end();
@@ -72,7 +74,9 @@ void main() {
       var callCount = 0;
       final span = fixture.createSpan(
         name: 'test-span',
-        onSpanEnded: (_) async { callCount++; },
+        onSpanEnded: (_) async {
+          callCount++;
+        },
       );
       final firstEndTimestamp = DateTime.utc(2024, 1, 1);
       final secondEndTimestamp = DateTime.utc(2024, 1, 2);

--- a/packages/dio/lib/src/sentry_transformer.dart
+++ b/packages/dio/lib/src/sentry_transformer.dart
@@ -27,11 +27,13 @@ class SentryTransformer implements Transformer {
     }
 
     final parentSpan = _spanFactory.getSpan(_hub);
-    final span = _spanFactory.createSpan(
-      parentSpan,
-      _serializeOp,
-      description: description,
-    );
+    final span = parentSpan != null
+        ? _spanFactory.createSpan(
+            parentSpan: parentSpan,
+            operation: _serializeOp,
+            description: description,
+          )
+        : null;
 
     span?.setData('http.request.method', options.method);
     span?.origin = SentryTraceOrigins.autoHttpDioTransformer;
@@ -65,11 +67,13 @@ class SentryTransformer implements Transformer {
     }
 
     final parentSpan = _spanFactory.getSpan(_hub);
-    final span = _spanFactory.createSpan(
-      parentSpan,
-      _serializeOp,
-      description: description,
-    );
+    final span = parentSpan != null
+        ? _spanFactory.createSpan(
+            parentSpan: parentSpan,
+            operation: _serializeOp,
+            description: description,
+          )
+        : null;
 
     span?.setData('http.request.method', options.method);
     span?.origin = SentryTraceOrigins.autoHttpDioTransformer;

--- a/packages/dio/lib/src/tracing_client_adapter.dart
+++ b/packages/dio/lib/src/tracing_client_adapter.dart
@@ -43,11 +43,13 @@ class TracingClientAdapter implements HttpClientAdapter {
 
     // see https://develop.sentry.dev/sdk/performance/#header-sentry-trace
     final parentSpan = _spanFactory.getSpan(_hub);
-    final instrumentationSpan = _spanFactory.createSpan(
-      parentSpan,
-      'http.client',
-      description: description,
-    );
+    final instrumentationSpan = parentSpan != null
+        ? _spanFactory.createSpan(
+            parentSpan: parentSpan,
+            operation: 'http.client',
+            description: description,
+          )
+        : null;
 
     // Regardless whether tracing is enabled or not, we always want to attach
     // Sentry trace headers (tracing without performance).

--- a/packages/dio/pubspec.yaml
+++ b/packages/dio/pubspec.yaml
@@ -22,6 +22,8 @@ dependencies:
   sentry: 9.11.0-beta.2
 
 dev_dependencies:
+  _sentry_testing:
+    path: ../_sentry_testing
   meta: ^1.3.0
   lints: '>=2.0.0'
   test: ^1.21.1

--- a/packages/dio/test/spanv2_integration_test.dart
+++ b/packages/dio/test/spanv2_integration_test.dart
@@ -1,0 +1,174 @@
+// ignore_for_file: invalid_use_of_internal_member
+
+import 'package:_sentry_testing/_sentry_testing.dart';
+import 'package:dio/dio.dart';
+import 'package:sentry/sentry.dart';
+import 'package:sentry/src/tracing/instrumentation/span_factory_integration.dart';
+import 'package:sentry_dio/src/tracing_client_adapter.dart';
+import 'package:test/test.dart';
+
+import 'mocks.dart';
+import 'mocks/mock_http_client_adapter.dart';
+
+final requestUri = Uri.parse('https://example.com/api/users');
+
+void main() {
+  group('Dio SpanV2 Integration', () {
+    late Fixture fixture;
+
+    setUp(() {
+      fixture = Fixture();
+    });
+
+    tearDown(() {
+      fixture.dispose();
+    });
+
+    test('HTTP GET creates spanv2 with correct attributes', () async {
+      final dio = fixture.getDio(
+        mockAdapter: fixture.getMockAdapter(
+          statusCode: 200,
+          responseBody: '{"success": true}',
+        ),
+      );
+
+      // Start transaction span (root of this trace)
+      // Note: startSpan() with default active: true automatically sets it as active
+      final transactionSpan = fixture.hub.startSpan(
+        'test-transaction',
+        parentSpan: null,
+      );
+
+      // Execute HTTP GET request
+      await dio.get<dynamic>('/api/users');
+
+      // End transaction span and wait for async processing
+      transactionSpan.end();
+      await fixture.processor.waitForProcessing();
+
+      // Assert child span was created
+      final childSpans = fixture.processor.getChildSpans();
+      expect(childSpans.length, greaterThan(0));
+
+      // Find the HTTP client span
+      final span = fixture.processor.findSpanByOperation('http.client');
+      expect(span, isNotNull);
+      expect(span!.isEnded, isTrue);
+      expect(span.status, equals(SentrySpanStatusV2.ok));
+
+      // Verify operation and attributes
+      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value, equals('http.client'));
+      expect(span.attributes[SemanticAttributesConstants.httpRequestMethod]?.value, equals('GET'));
+      expect(span.attributes[SemanticAttributesConstants.url]?.value, equals('https://example.com/api/users'));
+      expect(span.attributes[SemanticAttributesConstants.httpResponseStatusCode]?.value, equals(200));
+      expect(span.attributes[SemanticAttributesConstants.sentryOrigin]?.value, equals('auto.http.dio.http_client_adapter'));
+
+      // Verify parent-child relationship
+      expect(span.parentSpan, equals(transactionSpan));
+      expect(span.traceId, equals(transactionSpan.traceId));
+      expect(span.spanId, isNot(equals(transactionSpan.spanId)));
+    });
+
+    test('HTTP error creates spanv2 with error status', () async {
+      final dio = fixture.getDio(
+        mockAdapter: fixture.getMockAdapter(
+          statusCode: 500,
+          responseBody: '{"error": "Internal Server Error"}',
+        ),
+      );
+
+      // Start transaction span
+      final transactionSpan = fixture.hub.startSpan(
+        'test-transaction',
+        parentSpan: null,
+      );
+
+      // Execute HTTP GET request that will fail
+      try {
+        await dio.get<dynamic>('/api/users');
+      } catch (e) {
+        // Expected to throw due to 500 status
+      }
+
+      // End transaction span and wait for async processing
+      transactionSpan.end();
+      await fixture.processor.waitForProcessing();
+
+      // Find the HTTP client span
+      final span = fixture.processor.findSpanByOperation('http.client');
+      expect(span, isNotNull);
+      expect(span!.isEnded, isTrue);
+
+      // Verify span status reflects the error
+      expect(span.status, equals(SentrySpanStatusV2.error));
+
+      // Verify basic attributes
+      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value, equals('http.client'));
+      // Note: In error cases, the status code might not be set on the span
+      // because the exception is thrown in the catch block
+      expect(span.parentSpan, equals(transactionSpan));
+    });
+  });
+}
+
+class Fixture {
+  late final Hub hub;
+  late final SentryOptions options;
+  late final FakeTelemetryProcessor processor;
+
+  Fixture() {
+    processor = FakeTelemetryProcessor();
+    options = defaultTestOptions()
+      ..tracesSampleRate = 1.0
+      ..traceLifecycle = SentryTraceLifecycle.streaming
+      ..telemetryProcessor = processor;
+    hub = Hub(options);
+
+    // Set up the span factory integration for streaming mode
+    options.addIntegration(InstrumentationSpanFactorySetupIntegration());
+    options.integrations.last.call(hub, options);
+  }
+
+  Dio getDio({required MockHttpClientAdapter mockAdapter}) {
+    final dio = Dio(BaseOptions(baseUrl: 'https://example.com'));
+    dio.httpClientAdapter = TracingClientAdapter(client: mockAdapter, hub: hub);
+    return dio;
+  }
+
+  MockHttpClientAdapter getMockAdapter({
+    required int statusCode,
+    required String responseBody,
+  }) {
+    return MockHttpClientAdapter(
+      (options, requestStream, cancelFuture) async {
+        final headers = <String, List<String>>{
+          'content-type': ['application/json'],
+        };
+
+        if (statusCode >= 400) {
+          throw DioException(
+            requestOptions: options,
+            response: Response(
+              requestOptions: options,
+              statusCode: statusCode,
+              data: responseBody,
+              headers: Headers.fromMap(headers),
+            ),
+            type: DioExceptionType.badResponse,
+          );
+        }
+
+        return ResponseBody.fromString(
+          responseBody,
+          statusCode,
+          headers: headers,
+        );
+      },
+    );
+  }
+
+  void dispose() {
+    processor.clear();
+    hub.close();
+  }
+}

--- a/packages/dio/test/spanv2_integration_test.dart
+++ b/packages/dio/test/spanv2_integration_test.dart
@@ -50,11 +50,19 @@ void main() {
       expect(span!.isEnded, isTrue);
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
-      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value, equals('http.client'));
-      expect(span.attributes[SemanticAttributesConstants.httpRequestMethod]?.value, equals('GET'));
-      expect(span.attributes[SemanticAttributesConstants.url]?.value, equals('https://example.com/api/users'));
-      expect(span.attributes[SemanticAttributesConstants.httpResponseStatusCode]?.value, equals(200));
-      expect(span.attributes[SemanticAttributesConstants.sentryOrigin]?.value, equals('auto.http.dio.http_client_adapter'));
+      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+          equals('http.client'),);
+      expect(
+          span.attributes[SemanticAttributesConstants.httpRequestMethod]?.value,
+          equals('GET'),);
+      expect(span.attributes[SemanticAttributesConstants.url]?.value,
+          equals('https://example.com/api/users'),);
+      expect(
+          span.attributes[SemanticAttributesConstants.httpResponseStatusCode]
+              ?.value,
+          equals(200),);
+      expect(span.attributes[SemanticAttributesConstants.sentryOrigin]?.value,
+          equals('auto.http.dio.http_client_adapter'),);
 
       expect(span.parentSpan, equals(transactionSpan));
       expect(span.traceId, equals(transactionSpan.traceId));
@@ -87,7 +95,8 @@ void main() {
 
       expect(span.status, equals(SentrySpanStatusV2.error));
 
-      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value, equals('http.client'));
+      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+          equals('http.client'),);
       expect(span.parentSpan, equals(transactionSpan));
     });
   });

--- a/packages/dio/test/spanv2_integration_test.dart
+++ b/packages/dio/test/spanv2_integration_test.dart
@@ -50,19 +50,27 @@ void main() {
       expect(span!.isEnded, isTrue);
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
-      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
-          equals('http.client'),);
       expect(
-          span.attributes[SemanticAttributesConstants.httpRequestMethod]?.value,
-          equals('GET'),);
-      expect(span.attributes[SemanticAttributesConstants.url]?.value,
-          equals('https://example.com/api/users'),);
+        span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+        equals('http.client'),
+      );
       expect(
-          span.attributes[SemanticAttributesConstants.httpResponseStatusCode]
-              ?.value,
-          equals(200),);
-      expect(span.attributes[SemanticAttributesConstants.sentryOrigin]?.value,
-          equals('auto.http.dio.http_client_adapter'),);
+        span.attributes[SemanticAttributesConstants.httpRequestMethod]?.value,
+        equals('GET'),
+      );
+      expect(
+        span.attributes[SemanticAttributesConstants.url]?.value,
+        equals('https://example.com/api/users'),
+      );
+      expect(
+        span.attributes[SemanticAttributesConstants.httpResponseStatusCode]
+            ?.value,
+        equals(200),
+      );
+      expect(
+        span.attributes[SemanticAttributesConstants.sentryOrigin]?.value,
+        equals('auto.http.dio.http_client_adapter'),
+      );
 
       expect(span.parentSpan, equals(transactionSpan));
       expect(span.traceId, equals(transactionSpan.traceId));
@@ -95,8 +103,10 @@ void main() {
 
       expect(span.status, equals(SentrySpanStatusV2.error));
 
-      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
-          equals('http.client'),);
+      expect(
+        span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+        equals('http.client'),
+      );
       expect(span.parentSpan, equals(transactionSpan));
     });
   });

--- a/packages/dio/test/spanv2_integration_test.dart
+++ b/packages/dio/test/spanv2_integration_test.dart
@@ -24,7 +24,7 @@ void main() {
       fixture.dispose();
     });
 
-    test('HTTP GET creates spanv2 with correct attributes', () async {
+    test('HTTP GET creates spanv2', () async {
       final dio = fixture.getDio(
         mockAdapter: fixture.getMockAdapter(
           statusCode: 200,

--- a/packages/drift/lib/src/sentry_span_helper.dart
+++ b/packages/drift/lib/src/sentry_span_helper.dart
@@ -49,8 +49,8 @@ class SentrySpanHelper {
     }
 
     final span = _factory.createSpan(
-      parentSpan,
-      operation ?? SentrySpanOperations.dbSqlQuery,
+      parentSpan: parentSpan,
+      operation: operation ?? SentrySpanOperations.dbSqlQuery,
       description: description,
     );
 
@@ -97,8 +97,8 @@ class SentrySpanHelper {
     }
 
     final newParent = _factory.createSpan(
-      parentSpan,
-      SentrySpanOperations.dbSqlTransaction,
+      parentSpan: parentSpan,
+      operation: SentrySpanOperations.dbSqlTransaction,
       description: SentrySpanDescriptions.dbTransaction,
     );
 

--- a/packages/drift/pubspec.yaml
+++ b/packages/drift/pubspec.yaml
@@ -22,6 +22,8 @@ dependencies:
   drift: ^2.24.0
 
 dev_dependencies:
+  _sentry_testing:
+    path: ../_sentry_testing
   lints: '>=2.0.0'
   test: ^1.26.3
   coverage: ^1.3.0

--- a/packages/drift/test/sentry_drift_test.dart
+++ b/packages/drift/test/sentry_drift_test.dart
@@ -785,11 +785,10 @@ class _NullSpanFactory implements InstrumentationSpanFactory {
   InstrumentationSpan? mockParentSpan;
 
   @override
-  InstrumentationSpan? createSpan(
-    InstrumentationSpan? parent,
-    String operation, {
+  InstrumentationSpan? createSpan({
+    required InstrumentationSpan parentSpan,
+    required String operation,
     String? description,
-    DateTime? startTimestamp,
   }) {
     // Always return null to simulate span creation failure
     return null;

--- a/packages/drift/test/spanv2_integration_test.dart
+++ b/packages/drift/test/spanv2_integration_test.dart
@@ -61,10 +61,14 @@ void main() {
 
       expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
           equals('db.sql.query'));
-      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value,
-          equals('db.sqlite'),);
-      expect(span.attributes[SemanticAttributesConstants.sentryOrigin]?.value,
-          equals('auto.db.drift.query.interceptor'),);
+      expect(
+        span.attributes[SemanticAttributesConstants.dbSystem]?.value,
+        equals('db.sqlite'),
+      );
+      expect(
+        span.attributes[SemanticAttributesConstants.sentryOrigin]?.value,
+        equals('auto.db.drift.query.interceptor'),
+      );
 
       expect(span.parentSpan, equals(transactionSpan));
       expect(span.traceId, equals(transactionSpan.traceId));

--- a/packages/drift/test/spanv2_integration_test.dart
+++ b/packages/drift/test/spanv2_integration_test.dart
@@ -1,0 +1,222 @@
+// ignore_for_file: invalid_use_of_internal_member
+@TestOn('vm')
+library;
+
+import 'package:_sentry_testing/_sentry_testing.dart';
+import 'package:drift/drift.dart' hide isNotNull;
+import 'package:drift/native.dart';
+import 'package:sentry/sentry.dart';
+import 'package:sentry/src/tracing/instrumentation/span_factory_integration.dart';
+import 'package:sentry_drift/sentry_drift.dart';
+import 'package:sqlite3/open.dart';
+import 'package:test/test.dart';
+
+import 'test_database.dart';
+import 'utils/windows_helper.dart';
+
+void main() {
+  open.overrideFor(OperatingSystem.windows, openOnWindows);
+
+  group('Drift SpanV2 Integration', () {
+    late Fixture fixture;
+
+    setUp(() async {
+      fixture = Fixture();
+      await fixture.setUp();
+    });
+
+    tearDown(() async {
+      await fixture.tearDown();
+    });
+
+    test('Insert operation creates spanv2 with correct attributes', () async {
+      final db = fixture.db;
+
+      // Start transaction span (root of this trace)
+      final transactionSpan = fixture.hub.startSpan(
+        'test-transaction',
+        parentSpan: null,
+      );
+
+      // Execute insert operation
+      await db.into(db.todoItems).insert(
+            TodoItemsCompanion.insert(
+              title: 'Test Task',
+              content: 'Test content',
+            ),
+          );
+
+      // End transaction span and wait for async processing
+      transactionSpan.end();
+      await fixture.processor.waitForProcessing();
+
+      // Verify data was inserted
+      final result = await db.select(db.todoItems).get();
+      expect(result.length, equals(1));
+      expect(result.first.title, equals('Test Task'));
+
+      // Assert child spans were created
+      final childSpans = fixture.processor.getChildSpans();
+      expect(childSpans.length, greaterThan(0));
+
+      // Find the database operation span
+      final span = fixture.processor.findSpanByOperation('db.sql.query');
+      expect(span, isNotNull);
+      expect(span!.isEnded, isTrue);
+      expect(span.status, equals(SentrySpanStatusV2.ok));
+
+      // Verify operation and attributes
+      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value, equals('db.sql.query'));
+      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value, equals('sqlite'));
+      expect(span.attributes[SemanticAttributesConstants.sentryOrigin]?.value, equals('auto.db.drift'));
+
+      // Verify parent-child relationship
+      expect(span.parentSpan, equals(transactionSpan));
+      expect(span.traceId, equals(transactionSpan.traceId));
+      expect(span.spanId, isNot(equals(transactionSpan.spanId)));
+    });
+
+    test('Select operation creates spanv2', () async {
+      final db = fixture.db;
+
+      // Insert test data
+      await db.into(db.todoItems).insert(
+            TodoItemsCompanion.insert(
+              title: 'Sample Task',
+              content: 'Sample content',
+            ),
+          );
+
+      // Start transaction span
+      final transactionSpan = fixture.hub.startSpan(
+        'test-transaction',
+        parentSpan: null,
+      );
+
+      // Execute select operation
+      final result = await db.select(db.todoItems).get();
+
+      // End transaction span and wait for async processing
+      transactionSpan.end();
+      await fixture.processor.waitForProcessing();
+
+      // Verify result
+      expect(result.length, equals(1));
+      expect(result.first.title, equals('Sample Task'));
+
+      // Assert child span was created
+      final childSpans = fixture.processor.getChildSpans();
+      expect(childSpans.length, greaterThan(0));
+
+      // Find the database operation span
+      final span = fixture.processor.findSpanByOperation('db.sql.query');
+      expect(span, isNotNull);
+      expect(span!.isEnded, isTrue);
+      expect(span.status, equals(SentrySpanStatusV2.ok));
+
+      // Verify basic attributes
+      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value, equals('db.sql.query'));
+      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value, equals('sqlite'));
+      expect(span.parentSpan, equals(transactionSpan));
+    });
+
+    test('Update operation creates spanv2', () async {
+      final db = fixture.db;
+
+      // Insert test data
+      await db.into(db.todoItems).insert(
+            TodoItemsCompanion.insert(
+              title: 'Old Title',
+              content: 'Old content',
+            ),
+          );
+
+      // Start transaction span
+      final transactionSpan = fixture.hub.startSpan(
+        'test-transaction',
+        parentSpan: null,
+      );
+
+      // Execute update operation
+      await (db.update(db.todoItems)
+            ..where((tbl) => tbl.title.equals('Old Title')))
+          .write(
+        TodoItemsCompanion(
+          title: Value('New Title'),
+        ),
+      );
+
+      // End transaction span and wait for async processing
+      transactionSpan.end();
+      await fixture.processor.waitForProcessing();
+
+      // Verify data was updated
+      final result = await db.select(db.todoItems).get();
+      expect(result.first.title, equals('New Title'));
+
+      // Assert child span was created
+      final childSpans = fixture.processor.getChildSpans();
+      expect(childSpans.length, greaterThan(0));
+
+      // Find the database operation span
+      final span = fixture.processor.findSpanByOperation('db.sql.query');
+      expect(span, isNotNull);
+      expect(span!.isEnded, isTrue);
+      expect(span.status, equals(SentrySpanStatusV2.ok));
+
+      // Verify attributes
+      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value, equals('db.sql.query'));
+      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value, equals('sqlite'));
+      expect(span.parentSpan, equals(transactionSpan));
+    });
+  });
+}
+
+class Fixture {
+  late final Hub hub;
+  late final SentryOptions options;
+  late final FakeTelemetryProcessor processor;
+  late AppDatabase db;
+
+  static const String dbName = 'test-db';
+
+  Fixture() {
+    processor = FakeTelemetryProcessor();
+    options = defaultTestOptions()
+      ..tracesSampleRate = 1.0
+      ..traceLifecycle = SentryTraceLifecycle.streaming
+      ..telemetryProcessor = processor;
+    hub = Hub(options);
+
+    // Set up the span factory integration for streaming mode
+    options.addIntegration(InstrumentationSpanFactorySetupIntegration());
+    options.integrations.last.call(hub, options);
+  }
+
+  Future<void> setUp() async {
+    // Open database with Sentry wrapper
+    final queryExecutor = NativeDatabase.memory();
+    final sentryQueryInterceptor = SentryQueryInterceptor(
+      databaseName: dbName,
+      hub: hub,
+    );
+    db = AppDatabase(queryExecutor.interceptWith(sentryQueryInterceptor));
+  }
+
+  Future<void> tearDown() async {
+    processor.clear();
+
+    try {
+      await db.close();
+    } catch (e) {
+      // Ignore errors during cleanup
+    }
+
+    await hub.close();
+  }
+}
+
+SentryOptions defaultTestOptions() {
+  return SentryOptions(dsn: 'https://abc@def.ingest.sentry.io/1234567')
+    ..automatedTestMode = true;
+}

--- a/packages/drift/test/spanv2_integration_test.dart
+++ b/packages/drift/test/spanv2_integration_test.dart
@@ -80,7 +80,6 @@ void main() {
     test('Select operation creates spanv2', () async {
       final db = fixture.db;
 
-      // Insert test data
       await db.into(db.todoItems).insert(
             TodoItemsCompanion.insert(
               title: 'Sample Task',
@@ -123,7 +122,6 @@ void main() {
     test('Update operation creates spanv2', () async {
       final db = fixture.db;
 
-      // Insert test data
       await db.into(db.todoItems).insert(
             TodoItemsCompanion.insert(
               title: 'Old Title',

--- a/packages/drift/test/spanv2_integration_test.dart
+++ b/packages/drift/test/spanv2_integration_test.dart
@@ -59,9 +59,12 @@ void main() {
       expect(span!.isEnded, isTrue);
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
-      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value, equals('db.sql.query'));
-      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value, equals('sqlite'));
-      expect(span.attributes[SemanticAttributesConstants.sentryOrigin]?.value, equals('auto.db.drift'));
+      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+          equals('db.sql.query'));
+      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value,
+          equals('sqlite'));
+      expect(span.attributes[SemanticAttributesConstants.sentryOrigin]?.value,
+          equals('auto.db.drift'));
 
       expect(span.parentSpan, equals(transactionSpan));
       expect(span.traceId, equals(transactionSpan.traceId));
@@ -100,8 +103,10 @@ void main() {
       expect(span!.isEnded, isTrue);
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
-      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value, equals('db.sql.query'));
-      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value, equals('sqlite'));
+      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+          equals('db.sql.query'));
+      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value,
+          equals('sqlite'));
       expect(span.parentSpan, equals(transactionSpan));
     });
 
@@ -143,8 +148,10 @@ void main() {
       expect(span!.isEnded, isTrue);
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
-      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value, equals('db.sql.query'));
-      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value, equals('sqlite'));
+      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+          equals('db.sql.query'));
+      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value,
+          equals('sqlite'));
       expect(span.parentSpan, equals(transactionSpan));
     });
   });

--- a/packages/drift/test/spanv2_integration_test.dart
+++ b/packages/drift/test/spanv2_integration_test.dart
@@ -29,7 +29,7 @@ void main() {
       await fixture.tearDown();
     });
 
-    test('Insert operation creates spanv2 with correct attributes', () async {
+    test('Insert operation creates spanv2', () async {
       final db = fixture.db;
 
       final transactionSpan = fixture.hub.startSpan(

--- a/packages/drift/test/spanv2_integration_test.dart
+++ b/packages/drift/test/spanv2_integration_test.dart
@@ -62,9 +62,9 @@ void main() {
       expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
           equals('db.sql.query'));
       expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value,
-          equals('sqlite'));
+          equals('db.sqlite'),);
       expect(span.attributes[SemanticAttributesConstants.sentryOrigin]?.value,
-          equals('auto.db.drift'));
+          equals('auto.db.drift.query.interceptor'),);
 
       expect(span.parentSpan, equals(transactionSpan));
       expect(span.traceId, equals(transactionSpan.traceId));
@@ -106,7 +106,7 @@ void main() {
       expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
           equals('db.sql.query'));
       expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value,
-          equals('sqlite'));
+          equals('db.sqlite'));
       expect(span.parentSpan, equals(transactionSpan));
     });
 
@@ -151,7 +151,7 @@ void main() {
       expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
           equals('db.sql.query'));
       expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value,
-          equals('sqlite'));
+          equals('db.sqlite'));
       expect(span.parentSpan, equals(transactionSpan));
     });
   });

--- a/packages/drift/test/spanv2_integration_test.dart
+++ b/packages/drift/test/spanv2_integration_test.dart
@@ -59,8 +59,10 @@ void main() {
       expect(span!.isEnded, isTrue);
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
-      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
-          equals('db.sql.query'));
+      expect(
+        span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+        equals('db.sql.query'),
+      );
       expect(
         span.attributes[SemanticAttributesConstants.dbSystem]?.value,
         equals('db.sqlite'),
@@ -107,10 +109,14 @@ void main() {
       expect(span!.isEnded, isTrue);
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
-      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
-          equals('db.sql.query'));
-      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value,
-          equals('db.sqlite'));
+      expect(
+        span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+        equals('db.sql.query'),
+      );
+      expect(
+        span.attributes[SemanticAttributesConstants.dbSystem]?.value,
+        equals('db.sqlite'),
+      );
       expect(span.parentSpan, equals(transactionSpan));
     });
 
@@ -152,10 +158,14 @@ void main() {
       expect(span!.isEnded, isTrue);
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
-      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
-          equals('db.sql.query'));
-      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value,
-          equals('db.sqlite'));
+      expect(
+        span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+        equals('db.sql.query'),
+      );
+      expect(
+        span.attributes[SemanticAttributesConstants.dbSystem]?.value,
+        equals('db.sqlite'),
+      );
       expect(span.parentSpan, equals(transactionSpan));
     });
   });
@@ -182,7 +192,6 @@ class Fixture {
   }
 
   Future<void> setUp() async {
-    // Open database with Sentry wrapper
     final queryExecutor = NativeDatabase.memory();
     final sentryQueryInterceptor = SentryQueryInterceptor(
       databaseName: dbName,

--- a/packages/file/lib/src/sentry_file.dart
+++ b/packages/file/lib/src/sentry_file.dart
@@ -424,11 +424,13 @@ class SentryFile implements File {
     final desc = _getDesc();
 
     final parentSpan = _spanFactory.getSpan(_hub);
-    final span = _spanFactory.createSpan(
-      parentSpan,
-      operation,
-      description: desc,
-    );
+    final span = parentSpan != null
+        ? _spanFactory.createSpan(
+            parentSpan: parentSpan,
+            operation: operation,
+            description: desc,
+          )
+        : null;
 
     span?.origin = SentryTraceOrigins.autoFile;
     span?.setData('file.async', true);
@@ -491,11 +493,13 @@ class SentryFile implements File {
     final desc = _getDesc();
 
     final parentSpan = _spanFactory.getSpan(_hub);
-    final span = _spanFactory.createSpan(
-      parentSpan,
-      operation,
-      description: desc,
-    );
+    final span = parentSpan != null
+        ? _spanFactory.createSpan(
+            parentSpan: parentSpan,
+            operation: operation,
+            description: desc,
+          )
+        : null;
 
     span?.origin = SentryTraceOrigins.autoFile;
     span?.setData('file.async', false);

--- a/packages/file/pubspec.yaml
+++ b/packages/file/pubspec.yaml
@@ -21,6 +21,8 @@ dependencies:
   meta: ^1.3.0
 
 dev_dependencies:
+  _sentry_testing:
+    path: ../_sentry_testing
   lints: '>=2.0.0'
   test: ^1.21.1
   coverage: ^1.3.0

--- a/packages/file/test/spanv2_integration_test.dart
+++ b/packages/file/test/spanv2_integration_test.dart
@@ -1,0 +1,144 @@
+// ignore_for_file: invalid_use_of_internal_member
+@TestOn('vm')
+
+import 'dart:io';
+
+import 'package:_sentry_testing/_sentry_testing.dart';
+import 'package:sentry/sentry.dart';
+import 'package:sentry/src/tracing/instrumentation/span_factory_integration.dart';
+import 'package:sentry_file/sentry_file.dart';
+import 'package:test/test.dart';
+
+import 'mock_sentry_client.dart';
+
+void main() {
+  group('File SpanV2 Integration', () {
+    late Fixture fixture;
+
+    setUp(() {
+      fixture = Fixture();
+    });
+
+    tearDown(() async {
+      await fixture.tearDown();
+    });
+
+    test('File read creates spanv2 with correct attributes', () async {
+      final file = File('test_resources/testfile.txt');
+      final sut = fixture.getSut(file, sendDefaultPii: true);
+
+      // Start transaction span (root of this trace)
+      final transactionSpan = fixture.hub.startSpan(
+        'test-transaction',
+        parentSpan: null,
+      );
+
+      // Execute file read operation
+      final content = await sut.readAsString();
+
+      // End transaction span and wait for async processing
+      transactionSpan.end();
+      await fixture.processor.waitForProcessing();
+
+      // Verify content was read
+      expect(content, isNotEmpty);
+
+      // Assert child span was created
+      final childSpans = fixture.processor.getChildSpans();
+      expect(childSpans.length, greaterThan(0));
+
+      // Find the file operation span
+      final span = fixture.processor.findSpanByOperation('file.read');
+      expect(span, isNotNull);
+      expect(span!.isEnded, isTrue);
+      expect(span.status, equals(SentrySpanStatusV2.ok));
+
+      // Verify operation and attributes
+      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value, equals('file.read'));
+      expect(span.attributes['file.async']?.value, equals(true));
+      expect(span.attributes['file.path']?.value, contains('testfile.txt'));
+      expect(span.attributes[SemanticAttributesConstants.sentryOrigin]?.value, equals('auto.file'));
+
+      // Verify parent-child relationship
+      expect(span.parentSpan, equals(transactionSpan));
+      expect(span.traceId, equals(transactionSpan.traceId));
+      expect(span.spanId, isNot(equals(transactionSpan.spanId)));
+    });
+
+    test('File write creates spanv2', () async {
+      final tempFile = File('${Directory.systemTemp.path}/test_write.txt');
+
+      // Ensure temp file doesn't exist
+      if (await tempFile.exists()) {
+        await tempFile.delete();
+      }
+
+      final sut = fixture.getSut(tempFile, sendDefaultPii: true);
+
+      // Start transaction span
+      final transactionSpan = fixture.hub.startSpan(
+        'test-transaction',
+        parentSpan: null,
+      );
+
+      // Execute file write operation
+      await sut.writeAsString('Test content');
+
+      // End transaction span and wait for async processing
+      transactionSpan.end();
+      await fixture.processor.waitForProcessing();
+
+      // Verify file was written
+      expect(await tempFile.exists(), isTrue);
+      expect(await tempFile.readAsString(), equals('Test content'));
+
+      // Assert child span was created
+      final childSpans = fixture.processor.getChildSpans();
+      expect(childSpans.length, greaterThan(0));
+
+      // Find the file operation span
+      final span = fixture.processor.findSpanByOperation('file.write');
+      expect(span, isNotNull);
+      expect(span!.isEnded, isTrue);
+      expect(span.status, equals(SentrySpanStatusV2.ok));
+
+      // Verify basic attributes
+      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value, equals('file.write'));
+      expect(span.attributes['file.async']?.value, equals(true));
+      expect(span.attributes['file.path']?.value, contains('test_write.txt'));
+      expect(span.parentSpan, equals(transactionSpan));
+
+      // Cleanup
+      await tempFile.delete();
+    });
+  });
+}
+
+class Fixture {
+  late final Hub hub;
+  late final SentryOptions options;
+  late final FakeTelemetryProcessor processor;
+
+  Fixture() {
+    processor = FakeTelemetryProcessor();
+    options = defaultTestOptions()
+      ..tracesSampleRate = 1.0
+      ..traceLifecycle = SentryTraceLifecycle.streaming
+      ..telemetryProcessor = processor;
+    hub = Hub(options);
+
+    // Set up the span factory integration for streaming mode
+    options.addIntegration(InstrumentationSpanFactorySetupIntegration());
+    options.integrations.last.call(hub, options);
+  }
+
+  SentryFile getSut(File file, {bool sendDefaultPii = false}) {
+    options.sendDefaultPii = sendDefaultPii;
+    return SentryFile(file, hub: hub);
+  }
+
+  Future<void> tearDown() async {
+    processor.clear();
+    await hub.close();
+  }
+}

--- a/packages/file/test/spanv2_integration_test.dart
+++ b/packages/file/test/spanv2_integration_test.dart
@@ -1,5 +1,7 @@
 // ignore_for_file: invalid_use_of_internal_member
+
 @TestOn('vm')
+library;
 
 import 'dart:io';
 
@@ -47,10 +49,12 @@ void main() {
       expect(span!.isEnded, isTrue);
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
-      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value, equals('file.read'));
+      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+          equals('file.read'));
       expect(span.attributes['file.async']?.value, equals(true));
       expect(span.attributes['file.path']?.value, contains('testfile.txt'));
-      expect(span.attributes[SemanticAttributesConstants.sentryOrigin]?.value, equals('auto.file'));
+      expect(span.attributes[SemanticAttributesConstants.sentryOrigin]?.value,
+          equals('auto.file'));
 
       expect(span.parentSpan, equals(transactionSpan));
       expect(span.traceId, equals(transactionSpan.traceId));
@@ -88,7 +92,8 @@ void main() {
       expect(span!.isEnded, isTrue);
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
-      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value, equals('file.write'));
+      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+          equals('file.write'));
       expect(span.attributes['file.async']?.value, equals(true));
       expect(span.attributes['file.path']?.value, contains('test_write.txt'));
       expect(span.parentSpan, equals(transactionSpan));

--- a/packages/file/test/spanv2_integration_test.dart
+++ b/packages/file/test/spanv2_integration_test.dart
@@ -25,7 +25,7 @@ void main() {
       await fixture.tearDown();
     });
 
-    test('File read creates spanv2 with correct attributes', () async {
+    test('File read creates spanv2', () async {
       final file = File('test_resources/testfile.txt');
       final sut = fixture.getSut(file, sendDefaultPii: true);
 

--- a/packages/file/test/spanv2_integration_test.dart
+++ b/packages/file/test/spanv2_integration_test.dart
@@ -64,7 +64,6 @@ void main() {
     test('File write creates spanv2', () async {
       final tempFile = File('${Directory.systemTemp.path}/test_write.txt');
 
-      // Ensure temp file doesn't exist
       if (await tempFile.exists()) {
         await tempFile.delete();
       }
@@ -98,7 +97,6 @@ void main() {
       expect(span.attributes['file.path']?.value, contains('test_write.txt'));
       expect(span.parentSpan, equals(transactionSpan));
 
-      // Cleanup
       await tempFile.delete();
     });
   });

--- a/packages/file/test/spanv2_integration_test.dart
+++ b/packages/file/test/spanv2_integration_test.dart
@@ -27,39 +27,31 @@ void main() {
       final file = File('test_resources/testfile.txt');
       final sut = fixture.getSut(file, sendDefaultPii: true);
 
-      // Start transaction span (root of this trace)
       final transactionSpan = fixture.hub.startSpan(
         'test-transaction',
         parentSpan: null,
       );
 
-      // Execute file read operation
       final content = await sut.readAsString();
 
-      // End transaction span and wait for async processing
       transactionSpan.end();
       await fixture.processor.waitForProcessing();
 
-      // Verify content was read
       expect(content, isNotEmpty);
 
-      // Assert child span was created
       final childSpans = fixture.processor.getChildSpans();
       expect(childSpans.length, greaterThan(0));
 
-      // Find the file operation span
       final span = fixture.processor.findSpanByOperation('file.read');
       expect(span, isNotNull);
       expect(span!.isEnded, isTrue);
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
-      // Verify operation and attributes
       expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value, equals('file.read'));
       expect(span.attributes['file.async']?.value, equals(true));
       expect(span.attributes['file.path']?.value, contains('testfile.txt'));
       expect(span.attributes[SemanticAttributesConstants.sentryOrigin]?.value, equals('auto.file'));
 
-      // Verify parent-child relationship
       expect(span.parentSpan, equals(transactionSpan));
       expect(span.traceId, equals(transactionSpan.traceId));
       expect(span.spanId, isNot(equals(transactionSpan.spanId)));
@@ -75,34 +67,27 @@ void main() {
 
       final sut = fixture.getSut(tempFile, sendDefaultPii: true);
 
-      // Start transaction span
       final transactionSpan = fixture.hub.startSpan(
         'test-transaction',
         parentSpan: null,
       );
 
-      // Execute file write operation
       await sut.writeAsString('Test content');
 
-      // End transaction span and wait for async processing
       transactionSpan.end();
       await fixture.processor.waitForProcessing();
 
-      // Verify file was written
       expect(await tempFile.exists(), isTrue);
       expect(await tempFile.readAsString(), equals('Test content'));
 
-      // Assert child span was created
       final childSpans = fixture.processor.getChildSpans();
       expect(childSpans.length, greaterThan(0));
 
-      // Find the file operation span
       final span = fixture.processor.findSpanByOperation('file.write');
       expect(span, isNotNull);
       expect(span!.isEnded, isTrue);
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
-      // Verify basic attributes
       expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value, equals('file.write'));
       expect(span.attributes['file.async']?.value, equals(true));
       expect(span.attributes['file.path']?.value, contains('test_write.txt'));
@@ -127,7 +112,6 @@ class Fixture {
       ..telemetryProcessor = processor;
     hub = Hub(options);
 
-    // Set up the span factory integration for streaming mode
     options.addIntegration(InstrumentationSpanFactorySetupIntegration());
     options.integrations.last.call(hub, options);
   }

--- a/packages/flutter/example/lib/main.dart
+++ b/packages/flutter/example/lib/main.dart
@@ -93,8 +93,8 @@ Future<void> setupSentry(
       options.navigatorKey = navigatorKey;
       options.traceLifecycle = SentryTraceLifecycle.streaming;
 
-      options.replay.sessionSampleRate = 1.0;
-      options.replay.onErrorSampleRate = 1.0;
+      // options.replay.sessionSampleRate = 1.0;
+      // options.replay.onErrorSampleRate = 1.0;
 
       options.enableLogs = true;
 
@@ -627,6 +627,7 @@ class MainScaffold extends StatelessWidget {
   }
 
   Future<void> isarTest() async {
+    final span = Sentry.startSpan('isarTest');
     final tr = Sentry.startTransaction(
       'isarTest',
       'db',
@@ -655,9 +656,11 @@ class MainScaffold extends StatelessWidget {
     });
 
     await tr.finish(status: const SpanStatus.ok());
+    span.end();
   }
 
   Future<void> hiveTest() async {
+    final span = Sentry.startSpan('hiveTest');
     final tr = Sentry.startTransaction(
       'hiveTest',
       'db',
@@ -676,9 +679,11 @@ class MainScaffold extends StatelessWidget {
     SentryHive.close();
 
     await tr.finish(status: const SpanStatus.ok());
+    span.end();
   }
 
   Future<void> sqfliteTest() async {
+    final span = Sentry.startSpan('sqfliteTest');
     final tr = Sentry.startTransaction(
       'sqfliteTest',
       'db',
@@ -722,9 +727,11 @@ class MainScaffold extends StatelessWidget {
     await db.close();
 
     await tr.finish(status: const SpanStatus.ok());
+    span.end();
   }
 
   Future<void> driftTest() async {
+    final span = Sentry.startSpan('driftTest');
     final tr = Sentry.startTransaction(
       'driftTest',
       'db',
@@ -748,6 +755,7 @@ class MainScaffold extends StatelessWidget {
     await db.close();
 
     await tr.finish(status: const SpanStatus.ok());
+    span.end();
   }
 }
 
@@ -1035,6 +1043,7 @@ class SecondaryScaffold extends StatelessWidget {
 }
 
 Future<void> makeWebRequest(BuildContext context) async {
+  final span = Sentry.startSpan('flutterwebrequest');
   final transaction = Sentry.getSpan() ??
       Sentry.startTransaction(
         'flutterwebrequest',
@@ -1050,6 +1059,7 @@ Future<void> makeWebRequest(BuildContext context) async {
   final response = await client.get(Uri.parse(exampleUrl));
 
   await transaction.finish(status: const SpanStatus.ok());
+  span.end();
 
   if (!context.mounted) return;
   await showDialog<void>(
@@ -1075,6 +1085,7 @@ Future<void> makeWebRequestWithDio(BuildContext context) async {
   final dio = Dio();
   dio.addSentry();
 
+  final spanFirst = Sentry.startSpan('dio-web-request');
   final transaction = Sentry.getSpan() ??
       Sentry.startTransaction(
         'dio-web-request',
@@ -1096,6 +1107,7 @@ Future<void> makeWebRequestWithDio(BuildContext context) async {
   } finally {
     await span.finish();
   }
+  spanFirst.end();
 
   if (!context.mounted) return;
   await showDialog<void>(

--- a/packages/flutter/example/lib/main.dart
+++ b/packages/flutter/example/lib/main.dart
@@ -1,4 +1,5 @@
 // ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: invalid_use_of_internal_member
 
 import 'dart:async';
 import 'dart:convert';
@@ -90,6 +91,7 @@ Future<void> setupSentry(
       options.enableTimeToFullDisplayTracing = true;
       options.maxRequestBodySize = MaxRequestBodySize.always;
       options.navigatorKey = navigatorKey;
+      options.traceLifecycle = SentryTraceLifecycle.streaming;
 
       options.replay.sessionSampleRate = 1.0;
       options.replay.onErrorSampleRate = 1.0;
@@ -591,10 +593,17 @@ class MainScaffold extends StatelessWidget {
               text: 'Demonstrates the logging with Sentry Log.',
               buttonTitle: 'Sentry Log with Attribute',
             ),
+            if (Sentry.currentHub.options.traceLifecycle ==
+                SentryTraceLifecycle.streaming)
+              TooltipButton(
+                onPressed: () => spanV2Demo(),
+                text:
+                    'Demonstrates the new SpanV2 API with streaming trace lifecycle. Creates spans and sets attributes.',
+                buttonTitle: 'Emit SpanV2',
+              ),
             if (UniversalPlatform.isIOS || UniversalPlatform.isMacOS)
               const CocoaExample(),
             if (UniversalPlatform.isAndroid) const AndroidExample(),
-            // ignore: invalid_use_of_internal_member
             if (SentryFlutter.native != null)
               ElevatedButton(
                 onPressed: () async {
@@ -812,6 +821,67 @@ Future<void> tryCatch() async {
 
 Future<void> asyncThrows() async {
   throw StateError('async throws');
+}
+
+/// Demonstrates the SpanV2 API with streaming trace lifecycle.
+Future<void> spanV2Demo() async {
+  // Create a root span using the new startSpan API
+  final rootSpan = Sentry.startSpan(
+    'spanv2-demo-root',
+    attributes: {
+      'demo.type': SentryAttribute.string('comprehensive'),
+      'demo.version': SentryAttribute.int(2),
+    },
+  );
+
+  // Set additional attributes after creation
+  rootSpan.setAttribute('root.custom', SentryAttribute.string('root-value'));
+
+  await Future.delayed(const Duration(milliseconds: 50));
+
+  // Create a child span
+  final childSpan = Sentry.startSpan(
+    'spanv2-demo-child',
+    parentSpan: rootSpan,
+  );
+
+  // Set multiple attributes at once
+  childSpan.setAttributes({
+    'child.operation': SentryAttribute.string('database-query'),
+    'child.rows': SentryAttribute.int(42),
+  });
+
+  await Future.delayed(const Duration(milliseconds: 30));
+
+  // Demonstrate setAttributesIfAbsent - this should NOT override existing
+  (childSpan as RecordingSentrySpanV2).setAttributesIfAbsent({
+    'child.operation': SentryAttribute.string('this-should-not-appear'),
+    'child.new_attr': SentryAttribute.string('this-should-appear'),
+  });
+
+  // Create a nested child span
+  final nestedSpan = Sentry.startSpan(
+    'spanv2-demo-nested',
+    parentSpan: childSpan,
+  );
+
+  nestedSpan.setAttribute('nested.level', SentryAttribute.int(2));
+  nestedSpan.status = SentrySpanStatusV2.ok;
+
+  await Future.delayed(const Duration(milliseconds: 20));
+
+  // End spans in reverse order
+  nestedSpan.end();
+
+  await Future.delayed(const Duration(milliseconds: 10));
+
+  childSpan.status = SentrySpanStatusV2.ok;
+  childSpan.end();
+
+  await Future.delayed(const Duration(milliseconds: 10));
+
+  rootSpan.status = SentrySpanStatusV2.ok;
+  rootSpan.end();
 }
 
 class IntegrationTestWidget extends StatefulWidget {

--- a/packages/flutter/lib/src/integrations/load_contexts_integration.dart
+++ b/packages/flutter/lib/src/integrations/load_contexts_integration.dart
@@ -128,7 +128,6 @@ class LoadContextsIntegration implements Integration<SentryFlutterOptions> {
     _cachedAttributes = null;
   }
 
-
   Future<Map<String, SentryAttribute>> _nativeContextAttributes() async {
     if (_cachedAttributes != null) {
       return _cachedAttributes!;

--- a/packages/flutter/test/integrations/load_contexts_integration_test.dart
+++ b/packages/flutter/test/integrations/load_contexts_integration_test.dart
@@ -841,8 +841,7 @@ void main() {
             'fixture-os-version');
       });
 
-      test(
-          'does not register callback when traceLifecycle is not streaming',
+      test('does not register callback when traceLifecycle is not streaming',
           () async {
         fixture.options.traceLifecycle = SentryTraceLifecycle.static;
         await fixture.registerIntegration();
@@ -864,9 +863,12 @@ void main() {
             .dispatchCallback(OnProcessSpan(span));
 
         // Attributes should remain unchanged (empty or just what was set before)
-        expect(span.attributes[SemanticAttributesConstants.deviceBrand], isNull);
-        expect(span.attributes[SemanticAttributesConstants.deviceModel], isNull);
-        expect(span.attributes[SemanticAttributesConstants.deviceFamily], isNull);
+        expect(
+            span.attributes[SemanticAttributesConstants.deviceBrand], isNull);
+        expect(
+            span.attributes[SemanticAttributesConstants.deviceModel], isNull);
+        expect(
+            span.attributes[SemanticAttributesConstants.deviceFamily], isNull);
       });
     });
 

--- a/packages/hive/lib/src/sentry_span_helper.dart
+++ b/packages/hive/lib/src/sentry_span_helper.dart
@@ -27,11 +27,13 @@ class SentrySpanHelper {
     String? dbName,
   }) async {
     final parentSpan = _factory.getSpan(_hub);
-    final span = _factory.createSpan(
-      parentSpan,
-      SentryHiveImpl.dbOp,
-      description: description,
-    );
+    final span = parentSpan != null
+        ? _factory.createSpan(
+            parentSpan: parentSpan,
+            operation: SentryHiveImpl.dbOp,
+            description: description,
+          )
+        : null;
 
     span?.origin = _origin;
     span?.setData(SentryHiveImpl.dbSystemKey, SentryHiveImpl.dbSystem);
@@ -73,11 +75,13 @@ class SentrySpanHelper {
     String? dbName,
   }) {
     final parentSpan = _factory.getSpan(_hub);
-    final span = _factory.createSpan(
-      parentSpan,
-      SentryHiveImpl.dbOp,
-      description: description,
-    );
+    final span = parentSpan != null
+        ? _factory.createSpan(
+            parentSpan: parentSpan,
+            operation: SentryHiveImpl.dbOp,
+            description: description,
+          )
+        : null;
 
     span?.origin = _origin;
     span?.setData('sync', true);

--- a/packages/hive/pubspec.yaml
+++ b/packages/hive/pubspec.yaml
@@ -22,6 +22,8 @@ dependencies:
   meta: ^1.3.0
 
 dev_dependencies:
+  _sentry_testing:
+    path: ../_sentry_testing
   lints: '>=2.0.0'
   test: ^1.21.0
   yaml: ^3.1.0 # needed for version match (code and pubspec)

--- a/packages/hive/test/spanv2_integration_test.dart
+++ b/packages/hive/test/spanv2_integration_test.dart
@@ -28,7 +28,7 @@ void main() {
       await fixture.tearDown();
     });
 
-    test('Box.get() creates spanv2 with correct attributes', () async {
+    test('Box.get() creates spanv2', () async {
       final box = fixture.box;
 
       await box.put('test-key', Person('John Doe'));

--- a/packages/hive/test/spanv2_integration_test.dart
+++ b/packages/hive/test/spanv2_integration_test.dart
@@ -1,0 +1,161 @@
+// ignore_for_file: invalid_use_of_internal_member
+// @TestOn('vm')
+@TestOn('vm')
+
+import 'dart:io';
+
+import 'package:_sentry_testing/_sentry_testing.dart';
+import 'package:hive/hive.dart';
+import 'package:sentry/sentry.dart';
+import 'package:sentry/src/tracing/instrumentation/span_factory_integration.dart';
+import 'package:sentry_hive/sentry_hive.dart';
+import 'package:test/test.dart';
+
+import 'person.dart';
+import 'utils.dart';
+
+void main() {
+  group('Hive SpanV2 Integration', () {
+    late Fixture fixture;
+
+    setUp(() async {
+      fixture = Fixture();
+      await fixture.setUp();
+    });
+
+    tearDown(() async {
+      await fixture.tearDown();
+    });
+
+    test('Box.get() creates spanv2 with correct attributes', () async {
+      final box = fixture.box;
+
+      // Add test data
+      await box.put('test-key', Person('John Doe'));
+
+      // Start transaction span (root of this trace)
+      final transactionSpan = fixture.hub.startSpan(
+        'test-transaction',
+        parentSpan: null,
+      );
+
+      // Execute box.get() operation
+      final result = box.get('test-key');
+
+      // End transaction span and wait for async processing
+      transactionSpan.end();
+      await fixture.processor.waitForProcessing();
+
+      // Verify result
+      expect(result, isNotNull);
+      expect(result!.name, equals('John Doe'));
+
+      // Assert child span was created
+      final childSpans = fixture.processor.getChildSpans();
+      expect(childSpans.length, greaterThan(0));
+
+      // Find the database operation span
+      final span = fixture.processor.findSpanByOperation('db');
+      expect(span, isNotNull);
+      expect(span!.isEnded, isTrue);
+      expect(span.status, equals(SentrySpanStatusV2.ok));
+
+      // Verify operation and attributes
+      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value, equals('db'));
+      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value, equals('flutter_hive'));
+      expect(span.attributes[SemanticAttributesConstants.dbName]?.value, equals('test-box'));
+      expect(span.attributes['sync']?.value, equals(true));
+      expect(span.attributes[SemanticAttributesConstants.sentryOrigin]?.value, equals('auto.db.hive.box_base'));
+
+      // Verify parent-child relationship
+      expect(span.parentSpan, equals(transactionSpan));
+      expect(span.traceId, equals(transactionSpan.traceId));
+      expect(span.spanId, isNot(equals(transactionSpan.spanId)));
+    });
+
+    test('Box.put() creates spanv2', () async {
+      final box = fixture.box;
+
+      // Start transaction span
+      final transactionSpan = fixture.hub.startSpan(
+        'test-transaction',
+        parentSpan: null,
+      );
+
+      // Execute box.put() operation
+      await box.put('new-key', Person('Jane Doe'));
+
+      // End transaction span and wait for async processing
+      transactionSpan.end();
+      await fixture.processor.waitForProcessing();
+
+      // Assert child span was created
+      final childSpans = fixture.processor.getChildSpans();
+      expect(childSpans.length, greaterThan(0));
+
+      // Find the database operation span
+      final span = fixture.processor.findSpanByOperation('db');
+      expect(span, isNotNull);
+      expect(span!.isEnded, isTrue);
+      expect(span.status, equals(SentrySpanStatusV2.ok));
+
+      // Verify basic attributes
+      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value, equals('db'));
+      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value, equals('flutter_hive'));
+      expect(span.attributes[SemanticAttributesConstants.dbName]?.value, equals('test-box'));
+      expect(span.parentSpan, equals(transactionSpan));
+    });
+  });
+}
+
+class Fixture {
+  late final Hub hub;
+  late final SentryOptions options;
+  late final FakeTelemetryProcessor processor;
+  late Box<Person> box;
+
+  static const String boxName = 'test-box';
+
+  Fixture() {
+    processor = FakeTelemetryProcessor();
+    options = defaultTestOptions()
+      ..tracesSampleRate = 1.0
+      ..traceLifecycle = SentryTraceLifecycle.streaming
+      ..telemetryProcessor = processor;
+    hub = Hub(options);
+
+    // Set up the span factory integration for streaming mode
+    options.addIntegration(InstrumentationSpanFactorySetupIntegration());
+    options.integrations.last.call(hub, options);
+  }
+
+  Future<void> setUp() async {
+    // Initialize Hive with a temporary directory
+    Hive.init(Directory.systemTemp.path);
+
+    // Register the Person adapter if not already registered
+    if (!Hive.isAdapterRegistered(0)) {
+      Hive.registerAdapter(PersonAdapter());
+    }
+
+    // Open box with Sentry wrapper
+    SentryHive.setHub(hub);
+    box = await SentryHive.openBox<Person>(boxName);
+  }
+
+  Future<void> tearDown() async {
+    processor.clear();
+
+    try {
+      if (box.isOpen) {
+        await box.deleteFromDisk();
+        await box.close();
+      }
+      await Hive.close();
+    } catch (e) {
+      // Ignore errors during cleanup
+    }
+
+    await hub.close();
+  }
+}

--- a/packages/hive/test/spanv2_integration_test.dart
+++ b/packages/hive/test/spanv2_integration_test.dart
@@ -55,15 +55,23 @@ void main() {
       expect(span!.isEnded, isTrue);
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
-      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
-          equals('db'),);
-      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value,
-          equals('flutter_hive'),);
-      expect(span.attributes[SemanticAttributesConstants.dbName]?.value,
-          equals('test-box'),);
+      expect(
+        span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+        equals('db'),
+      );
+      expect(
+        span.attributes[SemanticAttributesConstants.dbSystem]?.value,
+        equals('flutter_hive'),
+      );
+      expect(
+        span.attributes[SemanticAttributesConstants.dbName]?.value,
+        equals('test-box'),
+      );
       expect(span.attributes['sync']?.value, equals(true));
-      expect(span.attributes[SemanticAttributesConstants.sentryOrigin]?.value,
-          equals('auto.db.hive.box_base'),);
+      expect(
+        span.attributes[SemanticAttributesConstants.sentryOrigin]?.value,
+        equals('auto.db.hive.box_base'),
+      );
 
       expect(span.parentSpan, equals(transactionSpan));
       expect(span.traceId, equals(transactionSpan.traceId));
@@ -91,12 +99,18 @@ void main() {
       expect(span!.isEnded, isTrue);
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
-      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
-          equals('db'),);
-      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value,
-          equals('flutter_hive'),);
-      expect(span.attributes[SemanticAttributesConstants.dbName]?.value,
-          equals('test-box'),);
+      expect(
+        span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+        equals('db'),
+      );
+      expect(
+        span.attributes[SemanticAttributesConstants.dbSystem]?.value,
+        equals('flutter_hive'),
+      );
+      expect(
+        span.attributes[SemanticAttributesConstants.dbName]?.value,
+        equals('test-box'),
+      );
       expect(span.parentSpan, equals(transactionSpan));
     });
   });

--- a/packages/hive/test/spanv2_integration_test.dart
+++ b/packages/hive/test/spanv2_integration_test.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: invalid_use_of_internal_member
-// @TestOn('vm')
+
 @TestOn('vm')
+library;
 
 import 'dart:io';
 
@@ -54,11 +55,15 @@ void main() {
       expect(span!.isEnded, isTrue);
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
-      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value, equals('db'));
-      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value, equals('flutter_hive'));
-      expect(span.attributes[SemanticAttributesConstants.dbName]?.value, equals('test-box'));
+      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+          equals('db'),);
+      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value,
+          equals('flutter_hive'),);
+      expect(span.attributes[SemanticAttributesConstants.dbName]?.value,
+          equals('test-box'),);
       expect(span.attributes['sync']?.value, equals(true));
-      expect(span.attributes[SemanticAttributesConstants.sentryOrigin]?.value, equals('auto.db.hive.box_base'));
+      expect(span.attributes[SemanticAttributesConstants.sentryOrigin]?.value,
+          equals('auto.db.hive.box_base'),);
 
       expect(span.parentSpan, equals(transactionSpan));
       expect(span.traceId, equals(transactionSpan.traceId));
@@ -86,9 +91,12 @@ void main() {
       expect(span!.isEnded, isTrue);
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
-      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value, equals('db'));
-      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value, equals('flutter_hive'));
-      expect(span.attributes[SemanticAttributesConstants.dbName]?.value, equals('test-box'));
+      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+          equals('db'),);
+      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value,
+          equals('flutter_hive'),);
+      expect(span.attributes[SemanticAttributesConstants.dbName]?.value,
+          equals('test-box'),);
       expect(span.parentSpan, equals(transactionSpan));
     });
   });

--- a/packages/hive/test/spanv2_integration_test.dart
+++ b/packages/hive/test/spanv2_integration_test.dart
@@ -31,7 +31,6 @@ void main() {
     test('Box.get() creates spanv2 with correct attributes', () async {
       final box = fixture.box;
 
-      // Add test data
       await box.put('test-key', Person('John Doe'));
 
       final transactionSpan = fixture.hub.startSpan(
@@ -137,15 +136,12 @@ class Fixture {
   }
 
   Future<void> setUp() async {
-    // Initialize Hive with a temporary directory
     Hive.init(Directory.systemTemp.path);
 
-    // Register the Person adapter if not already registered
     if (!Hive.isAdapterRegistered(0)) {
       Hive.registerAdapter(PersonAdapter());
     }
 
-    // Open box with Sentry wrapper
     SentryHive.setHub(hub);
     box = await SentryHive.openBox<Person>(boxName);
   }

--- a/packages/isar/lib/src/sentry_span_helper.dart
+++ b/packages/isar/lib/src/sentry_span_helper.dart
@@ -28,11 +28,13 @@ class SentrySpanHelper {
     String? collectionName,
   }) async {
     final parentSpan = _factory.getSpan(_hub);
-    final span = _factory.createSpan(
-      parentSpan,
-      SentryIsar.dbOp,
-      description: description,
-    );
+    final span = parentSpan != null
+        ? _factory.createSpan(
+            parentSpan: parentSpan,
+            operation: SentryIsar.dbOp,
+            description: description,
+          )
+        : null;
 
     span?.origin = _origin;
     span?.setData(SentryIsar.dbSystemKey, SentryIsar.dbSystem);
@@ -79,11 +81,13 @@ class SentrySpanHelper {
     String? collectionName,
   }) {
     final parentSpan = _factory.getSpan(_hub);
-    final span = _factory.createSpan(
-      parentSpan,
-      SentryIsar.dbOp,
-      description: description,
-    );
+    final span = parentSpan != null
+        ? _factory.createSpan(
+            parentSpan: parentSpan,
+            operation: SentryIsar.dbOp,
+            description: description,
+          )
+        : null;
 
     span?.origin = _origin;
     span?.setData('sync', true);

--- a/packages/isar/pubspec.yaml
+++ b/packages/isar/pubspec.yaml
@@ -25,6 +25,8 @@ dependencies:
   path: ^1.8.3
 
 dev_dependencies:
+  _sentry_testing:
+    path: ../_sentry_testing
   isar_generator: ^3.1.0
   build_runner: ^2.4.6
   lints: '>=2.0.0'

--- a/packages/isar/test/spanv2_integration_test.dart
+++ b/packages/isar/test/spanv2_integration_test.dart
@@ -50,14 +50,22 @@ void main() {
       expect(span!.isEnded, isTrue);
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
-      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
-          equals('db'),);
-      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value,
-          equals('isar'),);
-      expect(span.attributes[SemanticAttributesConstants.dbName]?.value,
-          equals('test-db'),);
-      expect(span.attributes[SemanticAttributesConstants.sentryOrigin]?.value,
-          equals('auto.db.isar.collection'),);
+      expect(
+        span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+        equals('db'),
+      );
+      expect(
+        span.attributes[SemanticAttributesConstants.dbSystem]?.value,
+        equals('isar'),
+      );
+      expect(
+        span.attributes[SemanticAttributesConstants.dbName]?.value,
+        equals('test-db'),
+      );
+      expect(
+        span.attributes[SemanticAttributesConstants.sentryOrigin]?.value,
+        equals('auto.db.isar.collection'),
+      );
 
       expect(span.parentSpan, equals(transactionSpan));
       expect(span.traceId, equals(transactionSpan.traceId));
@@ -90,12 +98,18 @@ void main() {
       expect(span!.isEnded, isTrue);
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
-      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
-          equals('db'),);
-      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value,
-          equals('isar'),);
-      expect(span.attributes[SemanticAttributesConstants.dbName]?.value,
-          equals('test-db'),);
+      expect(
+        span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+        equals('db'),
+      );
+      expect(
+        span.attributes[SemanticAttributesConstants.dbSystem]?.value,
+        equals('isar'),
+      );
+      expect(
+        span.attributes[SemanticAttributesConstants.dbName]?.value,
+        equals('test-db'),
+      );
       expect(span.parentSpan, equals(transactionSpan));
     });
 
@@ -128,10 +142,14 @@ void main() {
       expect(span!.isEnded, isTrue);
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
-      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
-          equals('db'),);
-      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value,
-          equals('isar'),);
+      expect(
+        span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+        equals('db'),
+      );
+      expect(
+        span.attributes[SemanticAttributesConstants.dbSystem]?.value,
+        equals('isar'),
+      );
       expect(span.parentSpan, equals(transactionSpan));
     });
   });

--- a/packages/isar/test/spanv2_integration_test.dart
+++ b/packages/isar/test/spanv2_integration_test.dart
@@ -116,7 +116,6 @@ void main() {
     test('Collection.get() creates spanv2', () async {
       final collection = fixture.isar.persons;
 
-      // Insert test data
       await fixture.isar.writeTxn(() async {
         await collection.put(Person()..name = 'Jane Doe');
       });

--- a/packages/isar/test/spanv2_integration_test.dart
+++ b/packages/isar/test/spanv2_integration_test.dart
@@ -50,10 +50,14 @@ void main() {
       expect(span!.isEnded, isTrue);
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
-      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value, equals('db'));
-      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value, equals('isar'));
-      expect(span.attributes[SemanticAttributesConstants.dbName]?.value, equals('test-db'));
-      expect(span.attributes[SemanticAttributesConstants.sentryOrigin]?.value, equals('auto.db.isar.collection'));
+      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+          equals('db'),);
+      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value,
+          equals('isar'),);
+      expect(span.attributes[SemanticAttributesConstants.dbName]?.value,
+          equals('test-db'),);
+      expect(span.attributes[SemanticAttributesConstants.sentryOrigin]?.value,
+          equals('auto.db.isar.collection'),);
 
       expect(span.parentSpan, equals(transactionSpan));
       expect(span.traceId, equals(transactionSpan.traceId));
@@ -86,9 +90,12 @@ void main() {
       expect(span!.isEnded, isTrue);
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
-      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value, equals('db'));
-      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value, equals('isar'));
-      expect(span.attributes[SemanticAttributesConstants.dbName]?.value, equals('test-db'));
+      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+          equals('db'),);
+      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value,
+          equals('isar'),);
+      expect(span.attributes[SemanticAttributesConstants.dbName]?.value,
+          equals('test-db'),);
       expect(span.parentSpan, equals(transactionSpan));
     });
 
@@ -121,8 +128,10 @@ void main() {
       expect(span!.isEnded, isTrue);
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
-      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value, equals('db'));
-      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value, equals('isar'));
+      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+          equals('db'),);
+      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value,
+          equals('isar'),);
       expect(span.parentSpan, equals(transactionSpan));
     });
   });

--- a/packages/isar/test/spanv2_integration_test.dart
+++ b/packages/isar/test/spanv2_integration_test.dart
@@ -1,0 +1,198 @@
+// ignore_for_file: invalid_use_of_internal_member
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+import 'package:_sentry_testing/_sentry_testing.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:isar/isar.dart';
+import 'package:sentry/sentry.dart';
+import 'package:sentry/src/tracing/instrumentation/span_factory_integration.dart';
+import 'package:sentry_isar/sentry_isar.dart';
+
+import 'person.dart';
+import 'utils.dart';
+
+void main() {
+  group('Isar SpanV2 Integration', () {
+    late Fixture fixture;
+
+    setUp(() async {
+      fixture = Fixture();
+      await fixture.setUp();
+    });
+
+    tearDown(() async {
+      await fixture.tearDown();
+    });
+
+    test('Collection.count() creates spanv2 with correct attributes', () async {
+      final collection = fixture.isar.persons;
+
+      // Start transaction span (root of this trace)
+      final transactionSpan = fixture.hub.startSpan(
+        'test-transaction',
+        parentSpan: null,
+      );
+
+      // Execute count operation
+      final count = await collection.count();
+
+      // End transaction span and wait for async processing
+      transactionSpan.end();
+      await fixture.processor.waitForProcessing();
+
+      // Verify result
+      expect(count, equals(0));
+
+      // Assert child span was created
+      final childSpans = fixture.processor.getChildSpans();
+      expect(childSpans.length, greaterThan(0));
+
+      // Find the database operation span
+      final span = fixture.processor.findSpanByOperation('db');
+      expect(span, isNotNull);
+      expect(span!.isEnded, isTrue);
+      expect(span.status, equals(SentrySpanStatusV2.ok));
+
+      // Verify operation and attributes
+      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value, equals('db'));
+      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value, equals('isar'));
+      expect(span.attributes[SemanticAttributesConstants.dbName]?.value, equals('test-db'));
+      expect(span.attributes[SemanticAttributesConstants.sentryOrigin]?.value, equals('auto.db.isar.collection'));
+
+      // Verify parent-child relationship
+      expect(span.parentSpan, equals(transactionSpan));
+      expect(span.traceId, equals(transactionSpan.traceId));
+      expect(span.spanId, isNot(equals(transactionSpan.spanId)));
+    });
+
+    test('Collection.put() creates spanv2', () async {
+      final collection = fixture.isar.persons;
+
+      // Start transaction span
+      final transactionSpan = fixture.hub.startSpan(
+        'test-transaction',
+        parentSpan: null,
+      );
+
+      // Execute put operation
+      await fixture.isar.writeTxn(() async {
+        await collection.put(Person()..name = 'John Doe');
+      });
+
+      // End transaction span and wait for async processing
+      transactionSpan.end();
+      await fixture.processor.waitForProcessing();
+
+      // Verify data was inserted
+      final count = await collection.count();
+      expect(count, equals(1));
+
+      // Assert child span was created
+      final childSpans = fixture.processor.getChildSpans();
+      expect(childSpans.length, greaterThan(0));
+
+      // Find the database operation span
+      final span = fixture.processor.findSpanByOperation('db');
+      expect(span, isNotNull);
+      expect(span!.isEnded, isTrue);
+      expect(span.status, equals(SentrySpanStatusV2.ok));
+
+      // Verify basic attributes
+      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value, equals('db'));
+      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value, equals('isar'));
+      expect(span.attributes[SemanticAttributesConstants.dbName]?.value, equals('test-db'));
+      expect(span.parentSpan, equals(transactionSpan));
+    });
+
+    test('Collection.get() creates spanv2', () async {
+      final collection = fixture.isar.persons;
+
+      // Insert test data
+      await fixture.isar.writeTxn(() async {
+        await collection.put(Person()..name = 'Jane Doe');
+      });
+
+      // Start transaction span
+      final transactionSpan = fixture.hub.startSpan(
+        'test-transaction',
+        parentSpan: null,
+      );
+
+      // Execute get operation
+      final person = await collection.get(1);
+
+      // End transaction span and wait for async processing
+      transactionSpan.end();
+      await fixture.processor.waitForProcessing();
+
+      // Verify result
+      expect(person, isNotNull);
+      expect(person!.name, equals('Jane Doe'));
+
+      // Assert child span was created
+      final childSpans = fixture.processor.getChildSpans();
+      expect(childSpans.length, greaterThan(0));
+
+      // Find the database operation span
+      final span = fixture.processor.findSpanByOperation('db');
+      expect(span, isNotNull);
+      expect(span!.isEnded, isTrue);
+      expect(span.status, equals(SentrySpanStatusV2.ok));
+
+      // Verify attributes
+      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value, equals('db'));
+      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value, equals('isar'));
+      expect(span.parentSpan, equals(transactionSpan));
+    });
+  });
+}
+
+class Fixture {
+  late final Hub hub;
+  late final SentryOptions options;
+  late final FakeTelemetryProcessor processor;
+  late Isar isar;
+
+  static const String dbName = 'test-db';
+
+  Fixture() {
+    processor = FakeTelemetryProcessor();
+    options = defaultTestOptions()
+      ..tracesSampleRate = 1.0
+      ..traceLifecycle = SentryTraceLifecycle.streaming
+      ..telemetryProcessor = processor;
+    hub = Hub(options);
+
+    // Set up the span factory integration for streaming mode
+    options.addIntegration(InstrumentationSpanFactorySetupIntegration());
+    options.integrations.last.call(hub, options);
+  }
+
+  Future<void> setUp() async {
+    // Open Isar database with Sentry wrapper
+    final dir = Directory.systemTemp.createTempSync('isar_test_');
+    isar = await SentryIsar.open(
+      [PersonSchema],
+      directory: dir.path,
+      name: dbName,
+      hub: hub,
+    );
+  }
+
+  Future<void> tearDown() async {
+    processor.clear();
+
+    try {
+      if (isar.isOpen) {
+        await isar.close(deleteFromDisk: true);
+      }
+    } catch (e) {
+      // Ignore errors during cleanup
+    }
+
+    await hub.close();
+  }
+}

--- a/packages/isar/test/spanv2_integration_test.dart
+++ b/packages/isar/test/spanv2_integration_test.dart
@@ -27,7 +27,7 @@ void main() {
       await fixture.tearDown();
     });
 
-    test('Collection.count() creates spanv2 with correct attributes', () async {
+    test('Collection.count() creates spanv2', () async {
       final collection = fixture.isar.persons;
 
       final transactionSpan = fixture.hub.startSpan(

--- a/packages/isar/test/spanv2_integration_test.dart
+++ b/packages/isar/test/spanv2_integration_test.dart
@@ -193,7 +193,9 @@ class Fixture {
       if (isar.isOpen) {
         await isar.close(deleteFromDisk: true);
       }
-    } catch (e) {}
+    } catch (e) {
+      // Ignore errors during cleanup
+    }
 
     await hub.close();
   }

--- a/packages/isar/test/spanv2_integration_test.dart
+++ b/packages/isar/test/spanv2_integration_test.dart
@@ -176,7 +176,7 @@ class Fixture {
   }
 
   Future<void> setUp() async {
-    // Open Isar database with Sentry wrapper
+    await Isar.initializeIsarCore(download: true);
     final dir = Directory.systemTemp.createTempSync('isar_test_');
     isar = await SentryIsar.open(
       [PersonSchema],
@@ -193,9 +193,7 @@ class Fixture {
       if (isar.isOpen) {
         await isar.close(deleteFromDisk: true);
       }
-    } catch (e) {
-      // Ignore errors during cleanup
-    }
+    } catch (e) {}
 
     await hub.close();
   }

--- a/packages/link/lib/src/sentry_request_serializer.dart
+++ b/packages/link/lib/src/sentry_request_serializer.dart
@@ -20,11 +20,13 @@ class SentryRequestSerializer implements RequestSerializer {
   @override
   Map<String, dynamic> serializeRequest(Request request) {
     final parentSpan = _spanFactory.getSpan(_hub);
-    final span = _spanFactory.createSpan(
-      parentSpan,
-      'serialize.http.client',
-      description: 'GraphGL request serialization',
-    );
+    final span = parentSpan != null
+        ? _spanFactory.createSpan(
+            parentSpan: parentSpan,
+            operation: 'serialize.http.client',
+            description: 'GraphGL request serialization',
+          )
+        : null;
 
     Map<String, dynamic> result;
     try {

--- a/packages/link/lib/src/sentry_response_parser.dart
+++ b/packages/link/lib/src/sentry_response_parser.dart
@@ -20,12 +20,14 @@ class SentryResponseParser implements ResponseParser {
   @override
   Response parseResponse(Map<String, dynamic> body) {
     final parentSpan = _spanFactory.getSpan(_hub);
-    final span = _spanFactory.createSpan(
-      parentSpan,
-      'serialize.http.client',
-      description: 'Response deserialization '
-          'from JSON map to Response object',
-    );
+    final span = parentSpan != null
+        ? _spanFactory.createSpan(
+            parentSpan: parentSpan,
+            operation: 'serialize.http.client',
+            description: 'Response deserialization '
+                'from JSON map to Response object',
+          )
+        : null;
 
     Response result;
     try {

--- a/packages/link/lib/src/sentry_tracing_link.dart
+++ b/packages/link/lib/src/sentry_tracing_link.dart
@@ -89,15 +89,11 @@ class SentryTracingLink extends Link {
     InstrumentationSpan? span;
 
     if (parentSpan == null && shouldStartTransaction) {
-      // No active span but shouldStartTransaction is true - create a root span
       if (_hub.options.traceLifecycle == SentryTraceLifecycle.streaming) {
-        // In streaming mode, just create a new root span using v2 API
-        final rootSpan = _hub.startSpan(description, parentSpan: null, active: true);
+        final rootSpan = _hub.startSpan(description);
         span = StreamingInstrumentationSpan(rootSpan);
-        // Set the operation attribute for the root span
-        span.setData('sentry.op', op);
+        span.setData(SemanticAttributesConstants.sentryOp, op);
       } else {
-        // In legacy mode, use the transaction API
         final transaction =
             _hub.startTransaction(description, op, bindToScope: true);
         span = LegacyInstrumentationSpan(transaction);

--- a/packages/link/lib/src/sentry_tracing_link.dart
+++ b/packages/link/lib/src/sentry_tracing_link.dart
@@ -86,15 +86,18 @@ class SentryTracingLink extends Link {
     bool shouldStartTransaction,
   ) {
     final parentSpan = _spanFactory.getSpan(_hub);
+    InstrumentationSpan? span;
     if (parentSpan == null && shouldStartTransaction) {
       // Start a new transaction - InstrumentationSpan doesn't support this
       // so we use the legacy API and wrap it
       final transaction =
           _hub.startTransaction(description, op, bindToScope: true);
-      return LegacyInstrumentationSpan(transaction);
+      span = LegacyInstrumentationSpan(transaction);
     } else if (parentSpan != null) {
-      return _spanFactory.createSpan(parentSpan, op, description: description);
+      span = _spanFactory.createSpan(parentSpan, op, description: description);
     }
-    return null;
+
+    span?.origin = SentryTraceOrigins.autoGraphQlSentryLink;
+    return span;
   }
 }

--- a/packages/link/lib/src/sentry_tracing_link.dart
+++ b/packages/link/lib/src/sentry_tracing_link.dart
@@ -112,7 +112,8 @@ class SentryTracingLink extends Link {
           break;
       }
     } else if (parentSpan != null) {
-      span = _spanFactory.createSpan(parentSpan, op, description: description);
+      span = _spanFactory.createSpan(
+          parentSpan: parentSpan, operation: op, description: description);
     }
 
     span?.origin = SentryTraceOrigins.autoGraphQlSentryLink;

--- a/packages/link/pubspec.yaml
+++ b/packages/link/pubspec.yaml
@@ -16,6 +16,8 @@ dependencies:
   sentry: 9.11.0-beta.2
 
 dev_dependencies:
+  _sentry_testing:
+    path: ../_sentry_testing
   lints: ^4.0.0
   test: ^1.16.0
   graphql: ^5.1.3

--- a/packages/link/test/spanv2_integration_test.dart
+++ b/packages/link/test/spanv2_integration_test.dart
@@ -23,7 +23,7 @@ void main() {
       await fixture.tearDown();
     });
 
-    test('GraphQL query creates spanv2 with correct attributes', () async {
+    test('GraphQL query creates spanv2', () async {
       final transactionSpan = fixture.hub.startSpan(
         'test-transaction',
         parentSpan: null,

--- a/packages/link/test/spanv2_integration_test.dart
+++ b/packages/link/test/spanv2_integration_test.dart
@@ -130,7 +130,8 @@ void main() {
 
     test('shouldStartTransaction creates root spanv2 when no active span',
         () async {
-      final link = fixture.createSentryTracingLink(shouldStartTransaction: true);
+      final link =
+          fixture.createSentryTracingLink(shouldStartTransaction: true);
       final request = Request(
         operation: Operation(
           document: parseString('query GetUser { user(id: "1") { name } }'),

--- a/packages/link/test/spanv2_integration_test.dart
+++ b/packages/link/test/spanv2_integration_test.dart
@@ -1,0 +1,237 @@
+// ignore_for_file: invalid_use_of_internal_member
+
+import 'dart:async';
+
+import 'package:_sentry_testing/_sentry_testing.dart';
+import 'package:gql/language.dart';
+import 'package:gql_exec/gql_exec.dart';
+import 'package:gql_link/gql_link.dart';
+import 'package:sentry/sentry.dart';
+import 'package:sentry/src/tracing/instrumentation/span_factory_integration.dart';
+import 'package:sentry_link/src/sentry_tracing_link.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Link SpanV2 Integration', () {
+    late Fixture fixture;
+
+    setUp(() {
+      fixture = Fixture();
+    });
+
+    tearDown(() async {
+      await fixture.tearDown();
+    });
+
+    test('GraphQL query creates spanv2 with correct attributes', () async {
+      // Start transaction span (root of this trace)
+      final transactionSpan = fixture.hub.startSpan(
+        'test-transaction',
+        parentSpan: null,
+      );
+
+      // Execute GraphQL query
+      final link = fixture.createSentryTracingLink();
+      final request = Request(
+        operation: Operation(
+          document: parseString('query GetUser { user(id: "1") { name } }'),
+          operationName: 'GetUser',
+        ),
+      );
+
+      try {
+        await link.request(request).first;
+      } catch (e) {
+        // Expected to complete
+      }
+
+      // End transaction span and wait for async processing
+      transactionSpan.end();
+      await fixture.processor.waitForProcessing();
+
+      // Assert child span was created
+      final childSpans = fixture.processor.getChildSpans();
+      expect(childSpans.length, greaterThan(0));
+
+      // Find the GraphQL operation span
+      final span = fixture.processor.findSpanByOperation('http.graphql.query');
+      expect(span, isNotNull);
+      expect(span!.isEnded, isTrue);
+      expect(span.status, equals(SentrySpanStatusV2.ok));
+
+      // Verify operation and attributes
+      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+          equals('http.graphql.query'));
+      expect(span.attributes[SemanticAttributesConstants.sentryOrigin]?.value,
+          equals('auto.graphql.sentry_link'));
+
+      // Verify parent-child relationship
+      expect(span.parentSpan, equals(transactionSpan));
+      expect(span.traceId, equals(transactionSpan.traceId));
+      expect(span.spanId, isNot(equals(transactionSpan.spanId)));
+    });
+
+    test('GraphQL mutation creates spanv2', () async {
+      // Start transaction span
+      final transactionSpan = fixture.hub.startSpan(
+        'test-transaction',
+        parentSpan: null,
+      );
+
+      // Execute GraphQL mutation
+      final link = fixture.createSentryTracingLink();
+      final request = Request(
+        operation: Operation(
+          document: parseString(
+              'mutation CreateUser(\$name: String!) { createUser(name: \$name) { id name } }'),
+          operationName: 'CreateUser',
+        ),
+        variables: {'name': 'John Doe'},
+      );
+
+      try {
+        await link.request(request).first;
+      } catch (e) {
+        // Expected to complete
+      }
+
+      // End transaction span and wait for async processing
+      transactionSpan.end();
+      await fixture.processor.waitForProcessing();
+
+      // Assert child span was created
+      final childSpans = fixture.processor.getChildSpans();
+      expect(childSpans.length, greaterThan(0));
+
+      // Find the GraphQL mutation span
+      final span =
+          fixture.processor.findSpanByOperation('http.graphql.mutation');
+      expect(span, isNotNull);
+      expect(span!.isEnded, isTrue);
+      expect(span.status, equals(SentrySpanStatusV2.ok));
+
+      // Verify basic attributes
+      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+          equals('http.graphql.mutation'));
+      expect(span.parentSpan, equals(transactionSpan));
+    });
+
+    test('GraphQL error creates spanv2 with error status', () async {
+      // Start transaction span
+      final transactionSpan = fixture.hub.startSpan(
+        'test-transaction',
+        parentSpan: null,
+      );
+
+      // Execute GraphQL query that will return errors
+      final link = fixture.createSentryTracingLink(
+        shouldReturnError: true,
+        markErrorsAsFailed: true,
+      );
+      final request = Request(
+        operation: Operation(
+          document: parseString('query GetUser { user(id: "999") { name } }'),
+          operationName: 'GetUser',
+        ),
+      );
+
+      try {
+        await link.request(request).first;
+      } catch (e) {
+        // Expected to complete with errors
+      }
+
+      // End transaction span and wait for async processing
+      transactionSpan.end();
+      await fixture.processor.waitForProcessing();
+
+      // Find the GraphQL operation span
+      final span = fixture.processor.findSpanByOperation('http.graphql.query');
+      expect(span, isNotNull);
+      expect(span!.isEnded, isTrue);
+
+      // Verify span status reflects the error
+      expect(span.status, equals(SentrySpanStatusV2.error));
+
+      // Verify basic attributes
+      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+          equals('http.graphql.query'));
+      expect(span.parentSpan, equals(transactionSpan));
+    });
+  });
+}
+
+class Fixture {
+  late final Hub hub;
+  late final SentryOptions options;
+  late final FakeTelemetryProcessor processor;
+
+  Fixture() {
+    processor = FakeTelemetryProcessor();
+    options = SentryOptions(dsn: 'https://abc@def.ingest.sentry.io/1234567')
+      ..automatedTestMode = true
+      ..tracesSampleRate = 1.0
+      ..traceLifecycle = SentryTraceLifecycle.streaming
+      ..telemetryProcessor = processor;
+    hub = Hub(options);
+
+    // Set up the span factory integration for streaming mode
+    options.addIntegration(InstrumentationSpanFactorySetupIntegration());
+    options.integrations.last.call(hub, options);
+  }
+
+  Link createSentryTracingLink({
+    bool shouldReturnError = false,
+    bool markErrorsAsFailed = false,
+  }) {
+    final sentryLink = SentryTracingLink(
+      shouldStartTransaction: false,
+      graphQlErrorsMarkTransactionAsFailed: markErrorsAsFailed,
+      hub: hub,
+    );
+
+    // Create a mock terminating link that returns a response
+    final mockLink = _MockLink(shouldReturnError: shouldReturnError);
+
+    return Link.from([sentryLink, mockLink]);
+  }
+
+  Future<void> tearDown() async {
+    processor.clear();
+    await hub.close();
+  }
+}
+
+class _MockLink extends Link {
+  final bool shouldReturnError;
+
+  _MockLink({this.shouldReturnError = false});
+
+  @override
+  Stream<Response> request(Request request, [NextLink? forward]) {
+    if (shouldReturnError) {
+      return Stream.value(
+        Response(
+          data: null,
+          errors: [
+            GraphQLError(
+              message: 'User not found',
+              extensions: {'code': 'NOT_FOUND'},
+            ),
+          ],
+          response: {},
+        ),
+      );
+    }
+
+    return Stream.value(
+      Response(
+        data: {
+          'user': {'name': 'John Doe'}
+        },
+        errors: null,
+        response: {},
+      ),
+    );
+  }
+}

--- a/packages/sqflite/lib/src/sentry_batch.dart
+++ b/packages/sqflite/lib/src/sentry_batch.dart
@@ -53,11 +53,13 @@ class SentryBatch implements Batch {
     return Future<List<Object?>>(() async {
       final parent = _spanFactory.getSpan(_hub);
 
-      final span = _spanFactory.createSpan(
-        parent,
-        SentryDatabase.dbOp,
-        description: _buffer.toString().trim(),
-      );
+      final span = parent != null
+          ? _spanFactory.createSpan(
+              parentSpan: parent,
+              operation: SentryDatabase.dbOp,
+              description: _buffer.toString().trim(),
+            )
+          : null;
 
       // ignore: invalid_use_of_internal_member
       span?.origin = SentryTraceOrigins.autoDbSqfliteBatch;
@@ -107,11 +109,13 @@ class SentryBatch implements Batch {
     return Future<List<Object?>>(() async {
       final parent = _spanFactory.getSpan(_hub);
 
-      final span = _spanFactory.createSpan(
-        parent,
-        SentryDatabase.dbOp,
-        description: _buffer.toString().trim(),
-      );
+      final span = parent != null
+          ? _spanFactory.createSpan(
+              parentSpan: parent,
+              operation: SentryDatabase.dbOp,
+              description: _buffer.toString().trim(),
+            )
+          : null;
       // ignore: invalid_use_of_internal_member
       span?.origin = SentryTraceOrigins.autoDbSqfliteBatch;
       setDatabaseAttributeData(span, _dbName);

--- a/packages/sqflite/lib/src/sentry_database.dart
+++ b/packages/sqflite/lib/src/sentry_database.dart
@@ -86,11 +86,13 @@ class SentryDatabase extends SentryDatabaseExecutor implements Database {
     return Future<void>(() async {
       final parent = _spanFactory.getSpan(_hub);
       final description = 'Close DB: ${_database.path}';
-      final span = _spanFactory.createSpan(
-        parent,
-        dbOp,
-        description: description,
-      );
+      final span = parent != null
+          ? _spanFactory.createSpan(
+              parentSpan: parent,
+              operation: dbOp,
+              description: description,
+            )
+          : null;
       // ignore: invalid_use_of_internal_member
       span?.origin = SentryTraceOrigins.autoDbSqfliteDatabase;
 
@@ -151,11 +153,13 @@ class SentryDatabase extends SentryDatabaseExecutor implements Database {
     return Future<T>(() async {
       final parent = _spanFactory.getSpan(_hub);
       final description = 'Transaction DB: ${_database.path}';
-      final span = _spanFactory.createSpan(
-        parent,
-        _dbSqlTransactionOp,
-        description: description,
-      );
+      final span = parent != null
+          ? _spanFactory.createSpan(
+              parentSpan: parent,
+              operation: _dbSqlTransactionOp,
+              description: description,
+            )
+          : null;
       // ignore: invalid_use_of_internal_member
       span?.origin = SentryTraceOrigins.autoDbSqfliteDatabase;
       setDatabaseAttributeData(span, dbName);
@@ -211,11 +215,13 @@ class SentryDatabase extends SentryDatabaseExecutor implements Database {
     return Future<T>(() async {
       final parent = _spanFactory.getSpan(_hub);
       final description = 'Transaction DB: ${_database.path}';
-      final span = _spanFactory.createSpan(
-        parent,
-        _dbSqlReadTransactionOp,
-        description: description,
-      );
+      final span = parent != null
+          ? _spanFactory.createSpan(
+              parentSpan: parent,
+              operation: _dbSqlReadTransactionOp,
+              description: description,
+            )
+          : null;
       // ignore: invalid_use_of_internal_member
       span?.origin = SentryTraceOrigins.autoDbSqfliteDatabase;
       setDatabaseAttributeData(span, dbName);

--- a/packages/sqflite/lib/src/sentry_database_executor.dart
+++ b/packages/sqflite/lib/src/sentry_database_executor.dart
@@ -53,11 +53,13 @@ class SentryDatabaseExecutor implements DatabaseExecutor {
       final parent = _getParent();
       final builder =
           SqlBuilder.delete(table, where: where, whereArgs: whereArgs);
-      final span = _spanFactory.createSpan(
-        parent,
-        SentryDatabase.dbSqlExecuteOp,
-        description: builder.sql,
-      );
+      final span = parent != null
+          ? _spanFactory.createSpan(
+              parentSpan: parent,
+              operation: SentryDatabase.dbSqlExecuteOp,
+              description: builder.sql,
+            )
+          : null;
       // ignore: invalid_use_of_internal_member
       span?.origin = SentryTraceOrigins.autoDbSqfliteDatabaseExecutor;
       setDatabaseAttributeData(span, _dbName);
@@ -97,11 +99,13 @@ class SentryDatabaseExecutor implements DatabaseExecutor {
   Future<void> execute(String sql, [List<Object?>? arguments]) {
     return Future<void>(() async {
       final parent = _getParent();
-      final span = _spanFactory.createSpan(
-        parent,
-        SentryDatabase.dbSqlExecuteOp,
-        description: sql,
-      );
+      final span = parent != null
+          ? _spanFactory.createSpan(
+              parentSpan: parent,
+              operation: SentryDatabase.dbSqlExecuteOp,
+              description: sql,
+            )
+          : null;
       // ignore: invalid_use_of_internal_member
       span?.origin = SentryTraceOrigins.autoDbSqfliteDatabaseExecutor;
       setDatabaseAttributeData(span, _dbName);
@@ -149,11 +153,13 @@ class SentryDatabaseExecutor implements DatabaseExecutor {
         nullColumnHack: nullColumnHack,
         conflictAlgorithm: conflictAlgorithm,
       );
-      final span = _spanFactory.createSpan(
-        parent,
-        SentryDatabase.dbSqlExecuteOp,
-        description: builder.sql,
-      );
+      final span = parent != null
+          ? _spanFactory.createSpan(
+              parentSpan: parent,
+              operation: SentryDatabase.dbSqlExecuteOp,
+              description: builder.sql,
+            )
+          : null;
       // ignore: invalid_use_of_internal_member
       span?.origin = SentryTraceOrigins.autoDbSqfliteDatabaseExecutor;
       setDatabaseAttributeData(span, _dbName);
@@ -220,11 +226,13 @@ class SentryDatabaseExecutor implements DatabaseExecutor {
         offset: offset,
         whereArgs: whereArgs,
       );
-      final span = _spanFactory.createSpan(
-        parent,
-        SentryDatabase.dbSqlQueryOp,
-        description: builder.sql,
-      );
+      final span = parent != null
+          ? _spanFactory.createSpan(
+              parentSpan: parent,
+              operation: SentryDatabase.dbSqlQueryOp,
+              description: builder.sql,
+            )
+          : null;
       // ignore: invalid_use_of_internal_member
       span?.origin = SentryTraceOrigins.autoDbSqfliteDatabaseExecutor;
       setDatabaseAttributeData(span, _dbName);
@@ -298,11 +306,13 @@ class SentryDatabaseExecutor implements DatabaseExecutor {
         offset: offset,
         whereArgs: whereArgs,
       );
-      final span = _spanFactory.createSpan(
-        parent,
-        SentryDatabase.dbSqlQueryOp,
-        description: builder.sql,
-      );
+      final span = parent != null
+          ? _spanFactory.createSpan(
+              parentSpan: parent,
+              operation: SentryDatabase.dbSqlQueryOp,
+              description: builder.sql,
+            )
+          : null;
       // ignore: invalid_use_of_internal_member
       span?.origin = SentryTraceOrigins.autoDbSqfliteDatabaseExecutor;
       setDatabaseAttributeData(span, _dbName);
@@ -353,11 +363,13 @@ class SentryDatabaseExecutor implements DatabaseExecutor {
   Future<int> rawDelete(String sql, [List<Object?>? arguments]) {
     return Future<int>(() async {
       final parent = _getParent();
-      final span = _spanFactory.createSpan(
-        parent,
-        SentryDatabase.dbSqlExecuteOp,
-        description: sql,
-      );
+      final span = parent != null
+          ? _spanFactory.createSpan(
+              parentSpan: parent,
+              operation: SentryDatabase.dbSqlExecuteOp,
+              description: sql,
+            )
+          : null;
       // ignore: invalid_use_of_internal_member
       span?.origin = SentryTraceOrigins.autoDbSqfliteDatabaseExecutor;
       setDatabaseAttributeData(span, _dbName);
@@ -396,11 +408,13 @@ class SentryDatabaseExecutor implements DatabaseExecutor {
   Future<int> rawInsert(String sql, [List<Object?>? arguments]) {
     return Future<int>(() async {
       final parent = _getParent();
-      final span = _spanFactory.createSpan(
-        parent,
-        SentryDatabase.dbSqlExecuteOp,
-        description: sql,
-      );
+      final span = parent != null
+          ? _spanFactory.createSpan(
+              parentSpan: parent,
+              operation: SentryDatabase.dbSqlExecuteOp,
+              description: sql,
+            )
+          : null;
       // ignore: invalid_use_of_internal_member
       span?.origin = SentryTraceOrigins.autoDbSqfliteDatabaseExecutor;
       setDatabaseAttributeData(span, _dbName);
@@ -442,11 +456,13 @@ class SentryDatabaseExecutor implements DatabaseExecutor {
   ]) {
     return Future<List<Map<String, Object?>>>(() async {
       final parent = _getParent();
-      final span = _spanFactory.createSpan(
-        parent,
-        SentryDatabase.dbSqlQueryOp,
-        description: sql,
-      );
+      final span = parent != null
+          ? _spanFactory.createSpan(
+              parentSpan: parent,
+              operation: SentryDatabase.dbSqlQueryOp,
+              description: sql,
+            )
+          : null;
       // ignore: invalid_use_of_internal_member
       span?.origin = SentryTraceOrigins.autoDbSqfliteDatabaseExecutor;
       setDatabaseAttributeData(span, _dbName);
@@ -489,11 +505,13 @@ class SentryDatabaseExecutor implements DatabaseExecutor {
   }) {
     return Future<QueryCursor>(() async {
       final parent = _getParent();
-      final span = _spanFactory.createSpan(
-        parent,
-        SentryDatabase.dbSqlQueryOp,
-        description: sql,
-      );
+      final span = parent != null
+          ? _spanFactory.createSpan(
+              parentSpan: parent,
+              operation: SentryDatabase.dbSqlQueryOp,
+              description: sql,
+            )
+          : null;
       // ignore: invalid_use_of_internal_member
       span?.origin = SentryTraceOrigins.autoDbSqfliteDatabaseExecutor;
       setDatabaseAttributeData(span, _dbName);
@@ -536,11 +554,13 @@ class SentryDatabaseExecutor implements DatabaseExecutor {
   Future<int> rawUpdate(String sql, [List<Object?>? arguments]) {
     return Future<int>(() async {
       final parent = _getParent();
-      final span = _spanFactory.createSpan(
-        parent,
-        SentryDatabase.dbSqlExecuteOp,
-        description: sql,
-      );
+      final span = parent != null
+          ? _spanFactory.createSpan(
+              parentSpan: parent,
+              operation: SentryDatabase.dbSqlExecuteOp,
+              description: sql,
+            )
+          : null;
       // ignore: invalid_use_of_internal_member
       span?.origin = SentryTraceOrigins.autoDbSqfliteDatabaseExecutor;
       setDatabaseAttributeData(span, _dbName);
@@ -592,11 +612,13 @@ class SentryDatabaseExecutor implements DatabaseExecutor {
         whereArgs: whereArgs,
         conflictAlgorithm: conflictAlgorithm,
       );
-      final span = _spanFactory.createSpan(
-        parent,
-        SentryDatabase.dbSqlExecuteOp,
-        description: builder.sql,
-      );
+      final span = parent != null
+          ? _spanFactory.createSpan(
+              parentSpan: parent,
+              operation: SentryDatabase.dbSqlExecuteOp,
+              description: builder.sql,
+            )
+          : null;
       // ignore: invalid_use_of_internal_member
       span?.origin = SentryTraceOrigins.autoDbSqfliteDatabaseExecutor;
       setDatabaseAttributeData(span, _dbName);

--- a/packages/sqflite/lib/src/sentry_sqflite.dart
+++ b/packages/sqflite/lib/src/sentry_sqflite.dart
@@ -43,11 +43,13 @@ Future<Database> openDatabaseWithSentry(
     final spanFactory = newHub.options.spanFactory;
     final description = 'Open DB: $path';
     final parent = spanFactory.getSpan(newHub);
-    final span = spanFactory.createSpan(
-      parent,
-      SentryDatabase.dbOp,
-      description: description,
-    );
+    final span = parent != null
+        ? spanFactory.createSpan(
+            parentSpan: parent,
+            operation: SentryDatabase.dbOp,
+            description: description,
+          )
+        : null;
     // ignore: invalid_use_of_internal_member
     span?.origin = SentryTraceOrigins.autoDbSqfliteOpenDatabase;
 

--- a/packages/sqflite/lib/src/sentry_sqflite_database_factory.dart
+++ b/packages/sqflite/lib/src/sentry_sqflite_database_factory.dart
@@ -66,11 +66,13 @@ class SentrySqfliteDatabaseFactory with SqfliteDatabaseFactoryMixin {
     return Future<sqflite.Database>(() async {
       final description = 'Open DB: $path';
       final parent = _spanFactory.getSpan(_hub);
-      final span = _spanFactory.createSpan(
-        parent,
-        SentryDatabase.dbOp,
-        description: description,
-      );
+      final span = parent != null
+          ? _spanFactory.createSpan(
+              parentSpan: parent,
+              operation: SentryDatabase.dbOp,
+              description: description,
+            )
+          : null;
 
       span?.origin =
           // ignore: invalid_use_of_internal_member

--- a/packages/sqflite/pubspec.yaml
+++ b/packages/sqflite/pubspec.yaml
@@ -22,6 +22,8 @@ dependencies:
   path: ^1.8.3
 
 dev_dependencies:
+  _sentry_testing:
+    path: ../_sentry_testing
   lints: '>=2.0.0'
   flutter_test:
     sdk: flutter

--- a/packages/sqflite/test/spanv2_integration_test.dart
+++ b/packages/sqflite/test/spanv2_integration_test.dart
@@ -25,7 +25,7 @@ void main() {
       await fixture.tearDown();
     });
 
-    test('Database.query() creates spanv2 with correct attributes', () async {
+    test('Database.query() creates spanv2', () async {
       final db = fixture.db;
 
       await db.execute('''

--- a/packages/sqflite/test/spanv2_integration_test.dart
+++ b/packages/sqflite/test/spanv2_integration_test.dart
@@ -184,11 +184,9 @@ class Fixture {
   }
 
   Future<void> setUp() async {
-    // Initialize sqflite_ffi for testing on VM
     sqfliteFfiInit();
     databaseFactory = databaseFactoryFfi;
 
-    // Open database with Sentry wrapper
     db = await SentrySqfliteDatabaseFactory(
       databaseFactory: databaseFactory,
       hub: hub,

--- a/packages/sqflite/test/spanv2_integration_test.dart
+++ b/packages/sqflite/test/spanv2_integration_test.dart
@@ -58,11 +58,11 @@ void main() {
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
       expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
-          equals('db.sql.query'));
+          equals('db.sql.query'),);
       expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value,
-          equals('sqlite'));
+          equals('sqlite'),);
       expect(span.attributes[SemanticAttributesConstants.sentryOrigin]?.value,
-          equals('auto.db.sqflite.database'));
+          equals('auto.db.sqflite.database'),);
 
       expect(span.parentSpan, equals(transactionSpan));
       expect(span.traceId, equals(transactionSpan.traceId));
@@ -101,9 +101,9 @@ void main() {
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
       expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
-          equals('db.sql.query'));
+          equals('db.sql.query'),);
       expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value,
-          equals('sqlite'));
+          equals('sqlite'),);
       expect(span.parentSpan, equals(transactionSpan));
     });
 
@@ -142,9 +142,9 @@ void main() {
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
       expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
-          equals('db.sql.transaction'));
+          equals('db.sql.transaction'),);
       expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value,
-          equals('sqlite'));
+          equals('sqlite'),);
       expect(span.parentSpan, equals(transactionSpan));
     });
   });

--- a/packages/sqflite/test/spanv2_integration_test.dart
+++ b/packages/sqflite/test/spanv2_integration_test.dart
@@ -62,7 +62,7 @@ void main() {
       expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value,
           equals('sqlite'),);
       expect(span.attributes[SemanticAttributesConstants.sentryOrigin]?.value,
-          equals('auto.db.sqflite.database'),);
+          equals('auto.db.sqflite.database_executor'),);
 
       expect(span.parentSpan, equals(transactionSpan));
       expect(span.traceId, equals(transactionSpan.traceId));
@@ -95,13 +95,13 @@ void main() {
       final childSpans = fixture.processor.getChildSpans();
       expect(childSpans.length, greaterThan(0));
 
-      final span = fixture.processor.findSpanByOperation('db.sql.query');
+      final span = fixture.processor.findSpanByOperation('db.sql.execute');
       expect(span, isNotNull);
       expect(span!.isEnded, isTrue);
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
       expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
-          equals('db.sql.query'),);
+          equals('db.sql.execute'),);
       expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value,
           equals('sqlite'),);
       expect(span.parentSpan, equals(transactionSpan));

--- a/packages/sqflite/test/spanv2_integration_test.dart
+++ b/packages/sqflite/test/spanv2_integration_test.dart
@@ -57,12 +57,18 @@ void main() {
       expect(span!.isEnded, isTrue);
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
-      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
-          equals('db.sql.query'),);
-      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value,
-          equals('sqlite'),);
-      expect(span.attributes[SemanticAttributesConstants.sentryOrigin]?.value,
-          equals('auto.db.sqflite.database_executor'),);
+      expect(
+        span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+        equals('db.sql.query'),
+      );
+      expect(
+        span.attributes[SemanticAttributesConstants.dbSystem]?.value,
+        equals('sqlite'),
+      );
+      expect(
+        span.attributes[SemanticAttributesConstants.sentryOrigin]?.value,
+        equals('auto.db.sqflite.database_executor'),
+      );
 
       expect(span.parentSpan, equals(transactionSpan));
       expect(span.traceId, equals(transactionSpan.traceId));
@@ -100,10 +106,14 @@ void main() {
       expect(span!.isEnded, isTrue);
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
-      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
-          equals('db.sql.execute'),);
-      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value,
-          equals('sqlite'),);
+      expect(
+        span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+        equals('db.sql.execute'),
+      );
+      expect(
+        span.attributes[SemanticAttributesConstants.dbSystem]?.value,
+        equals('sqlite'),
+      );
       expect(span.parentSpan, equals(transactionSpan));
     });
 
@@ -141,10 +151,14 @@ void main() {
       expect(span!.isEnded, isTrue);
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
-      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
-          equals('db.sql.transaction'),);
-      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value,
-          equals('sqlite'),);
+      expect(
+        span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+        equals('db.sql.transaction'),
+      );
+      expect(
+        span.attributes[SemanticAttributesConstants.dbSystem]?.value,
+        equals('sqlite'),
+      );
       expect(span.parentSpan, equals(transactionSpan));
     });
   });

--- a/packages/sqflite/test/spanv2_integration_test.dart
+++ b/packages/sqflite/test/spanv2_integration_test.dart
@@ -1,0 +1,226 @@
+// ignore_for_file: invalid_use_of_internal_member
+@TestOn('vm')
+library;
+
+import 'package:_sentry_testing/_sentry_testing.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sentry/sentry.dart';
+import 'package:sentry/src/tracing/instrumentation/span_factory_integration.dart';
+import 'package:sentry_sqflite/sentry_sqflite.dart';
+import 'package:sqflite/sqflite.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('Sqflite SpanV2 Integration', () {
+    late Fixture fixture;
+
+    setUp(() async {
+      fixture = Fixture();
+      await fixture.setUp();
+    });
+
+    tearDown(() async {
+      await fixture.tearDown();
+    });
+
+    test('Database.query() creates spanv2 with correct attributes', () async {
+      final db = fixture.db;
+
+      // Create test table and insert data
+      await db.execute('''
+        CREATE TABLE Test (
+          id INTEGER PRIMARY KEY,
+          name TEXT
+        )
+      ''');
+      await db.insert('Test', {'name': 'John Doe'});
+
+      // Start transaction span (root of this trace)
+      final transactionSpan = fixture.hub.startSpan(
+        'test-transaction',
+        parentSpan: null,
+      );
+
+      // Execute query operation
+      final result = await db.query('Test');
+
+      // End transaction span and wait for async processing
+      transactionSpan.end();
+      await fixture.processor.waitForProcessing();
+
+      // Verify result
+      expect(result.length, equals(1));
+      expect(result.first['name'], equals('John Doe'));
+
+      // Assert child span was created
+      final childSpans = fixture.processor.getChildSpans();
+      expect(childSpans.length, greaterThan(0));
+
+      // Find the database operation span
+      final span = fixture.processor.findSpanByOperation('db.sql.query');
+      expect(span, isNotNull);
+      expect(span!.isEnded, isTrue);
+      expect(span.status, equals(SentrySpanStatusV2.ok));
+
+      // Verify operation and attributes
+      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+          equals('db.sql.query'));
+      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value,
+          equals('sqlite'));
+      expect(span.attributes[SemanticAttributesConstants.sentryOrigin]?.value,
+          equals('auto.db.sqflite.database'));
+
+      // Verify parent-child relationship
+      expect(span.parentSpan, equals(transactionSpan));
+      expect(span.traceId, equals(transactionSpan.traceId));
+      expect(span.spanId, isNot(equals(transactionSpan.spanId)));
+    });
+
+    test('Database.insert() creates spanv2', () async {
+      final db = fixture.db;
+
+      // Create test table
+      await db.execute('''
+        CREATE TABLE Test (
+          id INTEGER PRIMARY KEY,
+          name TEXT
+        )
+      ''');
+
+      // Start transaction span
+      final transactionSpan = fixture.hub.startSpan(
+        'test-transaction',
+        parentSpan: null,
+      );
+
+      // Execute insert operation
+      await db.insert('Test', {'name': 'Jane Doe'});
+
+      // End transaction span and wait for async processing
+      transactionSpan.end();
+      await fixture.processor.waitForProcessing();
+
+      // Verify data was inserted
+      final result = await db.query('Test');
+      expect(result.length, equals(1));
+
+      // Assert child span was created
+      final childSpans = fixture.processor.getChildSpans();
+      expect(childSpans.length, greaterThan(0));
+
+      // Find the database operation span
+      final span = fixture.processor.findSpanByOperation('db.sql.query');
+      expect(span, isNotNull);
+      expect(span!.isEnded, isTrue);
+      expect(span.status, equals(SentrySpanStatusV2.ok));
+
+      // Verify basic attributes
+      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+          equals('db.sql.query'));
+      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value,
+          equals('sqlite'));
+      expect(span.parentSpan, equals(transactionSpan));
+    });
+
+    test('Database.transaction() creates spanv2', () async {
+      final db = fixture.db;
+
+      // Create test table
+      await db.execute('''
+        CREATE TABLE Test (
+          id INTEGER PRIMARY KEY,
+          name TEXT
+        )
+      ''');
+
+      // Start transaction span
+      final transactionSpan = fixture.hub.startSpan(
+        'test-transaction',
+        parentSpan: null,
+      );
+
+      // Execute transaction
+      await db.transaction((txn) async {
+        await txn.insert('Test', {'name': 'Alice'});
+        await txn.insert('Test', {'name': 'Bob'});
+      });
+
+      // End transaction span and wait for async processing
+      transactionSpan.end();
+      await fixture.processor.waitForProcessing();
+
+      // Verify data was inserted
+      final result = await db.query('Test');
+      expect(result.length, equals(2));
+
+      // Assert child span was created
+      final childSpans = fixture.processor.getChildSpans();
+      expect(childSpans.length, greaterThan(0));
+
+      // Find the transaction operation span
+      final span = fixture.processor.findSpanByOperation('db.sql.transaction');
+      expect(span, isNotNull);
+      expect(span!.isEnded, isTrue);
+      expect(span.status, equals(SentrySpanStatusV2.ok));
+
+      // Verify attributes
+      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+          equals('db.sql.transaction'));
+      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value,
+          equals('sqlite'));
+      expect(span.parentSpan, equals(transactionSpan));
+    });
+  });
+}
+
+class Fixture {
+  late final Hub hub;
+  late final SentryOptions options;
+  late final FakeTelemetryProcessor processor;
+  late Database db;
+
+  Fixture() {
+    processor = FakeTelemetryProcessor();
+    options = SentryOptions(dsn: 'https://abc@def.ingest.sentry.io/1234567')
+      ..automatedTestMode = true
+      ..tracesSampleRate = 1.0
+      ..traceLifecycle = SentryTraceLifecycle.streaming
+      ..telemetryProcessor = processor;
+    hub = Hub(options);
+
+    // Set up the span factory integration for streaming mode
+    options.addIntegration(InstrumentationSpanFactorySetupIntegration());
+    options.integrations.last.call(hub, options);
+  }
+
+  Future<void> setUp() async {
+    // Initialize sqflite_ffi for testing on VM
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+
+    // Open database with Sentry wrapper
+    db = await SentrySqfliteDatabaseFactory(
+      databaseFactory: databaseFactory,
+      hub: hub,
+    ).openDatabase(
+      inMemoryDatabasePath,
+      options: OpenDatabaseOptions(version: 1),
+    );
+  }
+
+  Future<void> tearDown() async {
+    processor.clear();
+
+    try {
+      if (db.isOpen) {
+        await db.close();
+      }
+    } catch (e) {
+      // Ignore errors during cleanup
+    }
+
+    await hub.close();
+  }
+}

--- a/packages/supabase/lib/src/sentry_supabase_tracing_client.dart
+++ b/packages/supabase/lib/src/sentry_supabase_tracing_client.dart
@@ -69,8 +69,8 @@ class SentrySupabaseTracingClient extends BaseClient {
     }
 
     final span = _spanFactory.createSpan(
-      parentSpan,
-      'db.${supabaseRequest.operation.value}',
+      parentSpan: parentSpan,
+      operation: 'db.${supabaseRequest.operation.value}',
       description: 'from(${supabaseRequest.table})',
     );
 

--- a/packages/supabase/pubspec.yaml
+++ b/packages/supabase/pubspec.yaml
@@ -14,6 +14,8 @@ dependencies:
   sentry: 9.11.0-beta.2
 
 dev_dependencies:
+  _sentry_testing:
+    path: ../_sentry_testing
   supabase: ^2.6.0
   lints: ^5.0.0
   test: ^1.24.0

--- a/packages/supabase/test/spanv2_integration_test.dart
+++ b/packages/supabase/test/spanv2_integration_test.dart
@@ -23,7 +23,7 @@ void main() {
       await fixture.tearDown();
     });
 
-    test('Select operation creates spanv2 with correct attributes', () async {
+    test('Select operation creates spanv2', () async {
       final client = fixture.client;
 
       final transactionSpan = fixture.hub.startSpan(

--- a/packages/supabase/test/spanv2_integration_test.dart
+++ b/packages/supabase/test/spanv2_integration_test.dart
@@ -48,9 +48,12 @@ void main() {
       expect(span!.isEnded, isTrue);
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
-      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value, equals('db.select'));
-      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value, equals('postgresql'));
-      expect(span.attributes[SemanticAttributesConstants.sentryOrigin]?.value, equals('auto.db.supabase'));
+      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+          equals('db.select'),);
+      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value,
+          equals('postgresql'),);
+      expect(span.attributes[SemanticAttributesConstants.sentryOrigin]?.value,
+          equals('auto.db.supabase'),);
 
       expect(span.parentSpan, equals(transactionSpan));
       expect(span.traceId, equals(transactionSpan.traceId));
@@ -66,7 +69,9 @@ void main() {
       );
 
       try {
-        await client.from('users').insert({'name': 'John Doe', 'email': 'john@example.com'});
+        await client
+            .from('users')
+            .insert({'name': 'John Doe', 'email': 'john@example.com'});
       } catch (e) {
         // Ignore errors from mock HTTP requests
       }
@@ -82,8 +87,10 @@ void main() {
       expect(span!.isEnded, isTrue);
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
-      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value, equals('db.insert'));
-      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value, equals('postgresql'));
+      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+          equals('db.insert'),);
+      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value,
+          equals('postgresql'),);
       expect(span.parentSpan, equals(transactionSpan));
     });
 
@@ -112,8 +119,10 @@ void main() {
       expect(span!.isEnded, isTrue);
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
-      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value, equals('db.update'));
-      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value, equals('postgresql'));
+      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+          equals('db.update'),);
+      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value,
+          equals('postgresql'),);
       expect(span.parentSpan, equals(transactionSpan));
     });
 
@@ -142,8 +151,10 @@ void main() {
       expect(span!.isEnded, isTrue);
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
-      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value, equals('db.delete'));
-      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value, equals('postgresql'));
+      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+          equals('db.delete'),);
+      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value,
+          equals('postgresql'),);
       expect(span.parentSpan, equals(transactionSpan));
     });
   });
@@ -175,7 +186,7 @@ class Fixture {
     client = SupabaseClient(
       'https://test.supabase.co',
       'test-api-key',
-      httpClient: SentrySupabaseClient(mockHttpClient, hub: hub),
+      httpClient: SentrySupabaseClient(client: mockHttpClient, hub: hub),
     );
   }
 

--- a/packages/supabase/test/spanv2_integration_test.dart
+++ b/packages/supabase/test/spanv2_integration_test.dart
@@ -48,12 +48,18 @@ void main() {
       expect(span!.isEnded, isTrue);
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
-      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
-          equals('db.select'),);
-      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value,
-          equals('postgresql'),);
-      expect(span.attributes[SemanticAttributesConstants.sentryOrigin]?.value,
-          equals('auto.db.supabase'),);
+      expect(
+        span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+        equals('db.select'),
+      );
+      expect(
+        span.attributes[SemanticAttributesConstants.dbSystem]?.value,
+        equals('postgresql'),
+      );
+      expect(
+        span.attributes[SemanticAttributesConstants.sentryOrigin]?.value,
+        equals('auto.db.supabase'),
+      );
 
       expect(span.parentSpan, equals(transactionSpan));
       expect(span.traceId, equals(transactionSpan.traceId));
@@ -87,10 +93,14 @@ void main() {
       expect(span!.isEnded, isTrue);
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
-      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
-          equals('db.insert'),);
-      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value,
-          equals('postgresql'),);
+      expect(
+        span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+        equals('db.insert'),
+      );
+      expect(
+        span.attributes[SemanticAttributesConstants.dbSystem]?.value,
+        equals('postgresql'),
+      );
       expect(span.parentSpan, equals(transactionSpan));
     });
 
@@ -119,10 +129,14 @@ void main() {
       expect(span!.isEnded, isTrue);
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
-      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
-          equals('db.update'),);
-      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value,
-          equals('postgresql'),);
+      expect(
+        span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+        equals('db.update'),
+      );
+      expect(
+        span.attributes[SemanticAttributesConstants.dbSystem]?.value,
+        equals('postgresql'),
+      );
       expect(span.parentSpan, equals(transactionSpan));
     });
 
@@ -151,10 +165,14 @@ void main() {
       expect(span!.isEnded, isTrue);
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
-      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value,
-          equals('db.delete'),);
-      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value,
-          equals('postgresql'),);
+      expect(
+        span.attributes[SemanticAttributesConstants.sentryOp]?.value,
+        equals('db.delete'),
+      );
+      expect(
+        span.attributes[SemanticAttributesConstants.dbSystem]?.value,
+        equals('postgresql'),
+      );
       expect(span.parentSpan, equals(transactionSpan));
     });
   });

--- a/packages/supabase/test/spanv2_integration_test.dart
+++ b/packages/supabase/test/spanv2_integration_test.dart
@@ -1,0 +1,226 @@
+// ignore_for_file: invalid_use_of_internal_member
+@TestOn('vm')
+library;
+
+import 'package:_sentry_testing/_sentry_testing.dart';
+import 'package:http/http.dart';
+import 'package:sentry/sentry.dart';
+import 'package:sentry/src/tracing/instrumentation/span_factory_integration.dart';
+import 'package:sentry_supabase/sentry_supabase.dart';
+import 'package:supabase/supabase.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Supabase SpanV2 Integration', () {
+    late Fixture fixture;
+
+    setUp(() async {
+      fixture = Fixture();
+      await fixture.setUp();
+    });
+
+    tearDown(() async {
+      await fixture.tearDown();
+    });
+
+    test('Select operation creates spanv2 with correct attributes', () async {
+      final client = fixture.client;
+
+      // Start transaction span (root of this trace)
+      final transactionSpan = fixture.hub.startSpan(
+        'test-transaction',
+        parentSpan: null,
+      );
+
+      // Execute select operation
+      try {
+        await client.from('users').select().eq('id', 1);
+      } catch (e) {
+        // Ignore errors from mock HTTP requests
+      }
+
+      // End transaction span and wait for async processing
+      transactionSpan.end();
+      await fixture.processor.waitForProcessing();
+
+      // Assert child span was created
+      final childSpans = fixture.processor.getChildSpans();
+      expect(childSpans.length, greaterThan(0));
+
+      // Find the database operation span
+      final span = fixture.processor.findSpanByOperation('db.select');
+      expect(span, isNotNull);
+      expect(span!.isEnded, isTrue);
+      expect(span.status, equals(SentrySpanStatusV2.ok));
+
+      // Verify operation and attributes
+      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value, equals('db.select'));
+      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value, equals('postgresql'));
+      expect(span.attributes[SemanticAttributesConstants.sentryOrigin]?.value, equals('auto.db.supabase'));
+
+      // Verify parent-child relationship
+      expect(span.parentSpan, equals(transactionSpan));
+      expect(span.traceId, equals(transactionSpan.traceId));
+      expect(span.spanId, isNot(equals(transactionSpan.spanId)));
+    });
+
+    test('Insert operation creates spanv2', () async {
+      final client = fixture.client;
+
+      // Start transaction span
+      final transactionSpan = fixture.hub.startSpan(
+        'test-transaction',
+        parentSpan: null,
+      );
+
+      // Execute insert operation
+      try {
+        await client.from('users').insert({'name': 'John Doe', 'email': 'john@example.com'});
+      } catch (e) {
+        // Ignore errors from mock HTTP requests
+      }
+
+      // End transaction span and wait for async processing
+      transactionSpan.end();
+      await fixture.processor.waitForProcessing();
+
+      // Assert child span was created
+      final childSpans = fixture.processor.getChildSpans();
+      expect(childSpans.length, greaterThan(0));
+
+      // Find the database operation span
+      final span = fixture.processor.findSpanByOperation('db.insert');
+      expect(span, isNotNull);
+      expect(span!.isEnded, isTrue);
+      expect(span.status, equals(SentrySpanStatusV2.ok));
+
+      // Verify basic attributes
+      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value, equals('db.insert'));
+      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value, equals('postgresql'));
+      expect(span.parentSpan, equals(transactionSpan));
+    });
+
+    test('Update operation creates spanv2', () async {
+      final client = fixture.client;
+
+      // Start transaction span
+      final transactionSpan = fixture.hub.startSpan(
+        'test-transaction',
+        parentSpan: null,
+      );
+
+      // Execute update operation
+      try {
+        await client.from('users').update({'name': 'Jane Doe'}).eq('id', 1);
+      } catch (e) {
+        // Ignore errors from mock HTTP requests
+      }
+
+      // End transaction span and wait for async processing
+      transactionSpan.end();
+      await fixture.processor.waitForProcessing();
+
+      // Assert child span was created
+      final childSpans = fixture.processor.getChildSpans();
+      expect(childSpans.length, greaterThan(0));
+
+      // Find the database operation span
+      final span = fixture.processor.findSpanByOperation('db.update');
+      expect(span, isNotNull);
+      expect(span!.isEnded, isTrue);
+      expect(span.status, equals(SentrySpanStatusV2.ok));
+
+      // Verify attributes
+      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value, equals('db.update'));
+      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value, equals('postgresql'));
+      expect(span.parentSpan, equals(transactionSpan));
+    });
+
+    test('Delete operation creates spanv2', () async {
+      final client = fixture.client;
+
+      // Start transaction span
+      final transactionSpan = fixture.hub.startSpan(
+        'test-transaction',
+        parentSpan: null,
+      );
+
+      // Execute delete operation
+      try {
+        await client.from('users').delete().eq('id', 1);
+      } catch (e) {
+        // Ignore errors from mock HTTP requests
+      }
+
+      // End transaction span and wait for async processing
+      transactionSpan.end();
+      await fixture.processor.waitForProcessing();
+
+      // Assert child span was created
+      final childSpans = fixture.processor.getChildSpans();
+      expect(childSpans.length, greaterThan(0));
+
+      // Find the database operation span
+      final span = fixture.processor.findSpanByOperation('db.delete');
+      expect(span, isNotNull);
+      expect(span!.isEnded, isTrue);
+      expect(span.status, equals(SentrySpanStatusV2.ok));
+
+      // Verify attributes
+      expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value, equals('db.delete'));
+      expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value, equals('postgresql'));
+      expect(span.parentSpan, equals(transactionSpan));
+    });
+  });
+}
+
+class Fixture {
+  late final Hub hub;
+  late final SentryOptions options;
+  late final FakeTelemetryProcessor processor;
+  late final SupabaseClient client;
+  late final MockHttpClient mockHttpClient;
+
+  Fixture() {
+    processor = FakeTelemetryProcessor();
+    options = SentryOptions(dsn: 'https://abc@def.ingest.sentry.io/1234567')
+      ..automatedTestMode = true
+      ..tracesSampleRate = 1.0
+      ..traceLifecycle = SentryTraceLifecycle.streaming
+      ..telemetryProcessor = processor;
+    hub = Hub(options);
+
+    // Set up the span factory integration for streaming mode
+    options.addIntegration(InstrumentationSpanFactorySetupIntegration());
+    options.integrations.last.call(hub, options);
+
+    // Create mock HTTP client
+    mockHttpClient = MockHttpClient();
+  }
+
+  Future<void> setUp() async {
+    // Create Supabase client with Sentry wrapper
+    client = SupabaseClient(
+      'https://test.supabase.co',
+      'test-api-key',
+      httpClient: SentrySupabaseClient(mockHttpClient, hub: hub),
+    );
+  }
+
+  Future<void> tearDown() async {
+    processor.clear();
+    await hub.close();
+  }
+}
+
+class MockHttpClient extends BaseClient {
+  @override
+  Future<StreamedResponse> send(BaseRequest request) async {
+    // Return a mock response
+    return StreamedResponse(
+      Stream.fromIterable([]),
+      200,
+      headers: {'content-type': 'application/json'},
+    );
+  }
+}

--- a/packages/supabase/test/spanv2_integration_test.dart
+++ b/packages/supabase/test/spanv2_integration_test.dart
@@ -217,7 +217,6 @@ class Fixture {
 class MockHttpClient extends BaseClient {
   @override
   Future<StreamedResponse> send(BaseRequest request) async {
-    // Return a mock response
     return StreamedResponse(
       Stream.fromIterable([]),
       200,

--- a/packages/supabase/test/spanv2_integration_test.dart
+++ b/packages/supabase/test/spanv2_integration_test.dart
@@ -26,39 +26,32 @@ void main() {
     test('Select operation creates spanv2 with correct attributes', () async {
       final client = fixture.client;
 
-      // Start transaction span (root of this trace)
       final transactionSpan = fixture.hub.startSpan(
         'test-transaction',
         parentSpan: null,
       );
 
-      // Execute select operation
       try {
         await client.from('users').select().eq('id', 1);
       } catch (e) {
         // Ignore errors from mock HTTP requests
       }
 
-      // End transaction span and wait for async processing
       transactionSpan.end();
       await fixture.processor.waitForProcessing();
 
-      // Assert child span was created
       final childSpans = fixture.processor.getChildSpans();
       expect(childSpans.length, greaterThan(0));
 
-      // Find the database operation span
       final span = fixture.processor.findSpanByOperation('db.select');
       expect(span, isNotNull);
       expect(span!.isEnded, isTrue);
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
-      // Verify operation and attributes
       expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value, equals('db.select'));
       expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value, equals('postgresql'));
       expect(span.attributes[SemanticAttributesConstants.sentryOrigin]?.value, equals('auto.db.supabase'));
 
-      // Verify parent-child relationship
       expect(span.parentSpan, equals(transactionSpan));
       expect(span.traceId, equals(transactionSpan.traceId));
       expect(span.spanId, isNot(equals(transactionSpan.spanId)));
@@ -67,34 +60,28 @@ void main() {
     test('Insert operation creates spanv2', () async {
       final client = fixture.client;
 
-      // Start transaction span
       final transactionSpan = fixture.hub.startSpan(
         'test-transaction',
         parentSpan: null,
       );
 
-      // Execute insert operation
       try {
         await client.from('users').insert({'name': 'John Doe', 'email': 'john@example.com'});
       } catch (e) {
         // Ignore errors from mock HTTP requests
       }
 
-      // End transaction span and wait for async processing
       transactionSpan.end();
       await fixture.processor.waitForProcessing();
 
-      // Assert child span was created
       final childSpans = fixture.processor.getChildSpans();
       expect(childSpans.length, greaterThan(0));
 
-      // Find the database operation span
       final span = fixture.processor.findSpanByOperation('db.insert');
       expect(span, isNotNull);
       expect(span!.isEnded, isTrue);
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
-      // Verify basic attributes
       expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value, equals('db.insert'));
       expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value, equals('postgresql'));
       expect(span.parentSpan, equals(transactionSpan));
@@ -103,34 +90,28 @@ void main() {
     test('Update operation creates spanv2', () async {
       final client = fixture.client;
 
-      // Start transaction span
       final transactionSpan = fixture.hub.startSpan(
         'test-transaction',
         parentSpan: null,
       );
 
-      // Execute update operation
       try {
         await client.from('users').update({'name': 'Jane Doe'}).eq('id', 1);
       } catch (e) {
         // Ignore errors from mock HTTP requests
       }
 
-      // End transaction span and wait for async processing
       transactionSpan.end();
       await fixture.processor.waitForProcessing();
 
-      // Assert child span was created
       final childSpans = fixture.processor.getChildSpans();
       expect(childSpans.length, greaterThan(0));
 
-      // Find the database operation span
       final span = fixture.processor.findSpanByOperation('db.update');
       expect(span, isNotNull);
       expect(span!.isEnded, isTrue);
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
-      // Verify attributes
       expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value, equals('db.update'));
       expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value, equals('postgresql'));
       expect(span.parentSpan, equals(transactionSpan));
@@ -139,34 +120,28 @@ void main() {
     test('Delete operation creates spanv2', () async {
       final client = fixture.client;
 
-      // Start transaction span
       final transactionSpan = fixture.hub.startSpan(
         'test-transaction',
         parentSpan: null,
       );
 
-      // Execute delete operation
       try {
         await client.from('users').delete().eq('id', 1);
       } catch (e) {
         // Ignore errors from mock HTTP requests
       }
 
-      // End transaction span and wait for async processing
       transactionSpan.end();
       await fixture.processor.waitForProcessing();
 
-      // Assert child span was created
       final childSpans = fixture.processor.getChildSpans();
       expect(childSpans.length, greaterThan(0));
 
-      // Find the database operation span
       final span = fixture.processor.findSpanByOperation('db.delete');
       expect(span, isNotNull);
       expect(span!.isEnded, isTrue);
       expect(span.status, equals(SentrySpanStatusV2.ok));
 
-      // Verify attributes
       expect(span.attributes[SemanticAttributesConstants.sentryOp]?.value, equals('db.delete'));
       expect(span.attributes[SemanticAttributesConstants.dbSystem]?.value, equals('postgresql'));
       expect(span.parentSpan, equals(transactionSpan));
@@ -190,16 +165,13 @@ class Fixture {
       ..telemetryProcessor = processor;
     hub = Hub(options);
 
-    // Set up the span factory integration for streaming mode
     options.addIntegration(InstrumentationSpanFactorySetupIntegration());
     options.integrations.last.call(hub, options);
 
-    // Create mock HTTP client
     mockHttpClient = MockHttpClient();
   }
 
   Future<void> setUp() async {
-    // Create Supabase client with Sentry wrapper
     client = SupabaseClient(
       'https://test.supabase.co',
       'test-api-key',


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Implement streaming span infrastructure to support SpanV2 telemetry:

The streaming implementation enables packages to emit SpanV2 telemetry while maintaining backward compatibility with legacy transaction-based tracing.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Part of #3334 

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps

#skip-changelog