### PR TITLE
fix(dart): Dont guard user behind `sendDefaultPii`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Dont guard user attributes behind `sendDefaultPii` for logs and metrics ([#3524](https://github.com/getsentry/sentry-dart/pull/3524))
+
 ### Dependencies
 
 - Bump Native SDK from v0.12.6 to v0.12.7 ([#3514](https://github.com/getsentry/sentry-dart/pull/3514))

--- a/packages/dart/lib/src/constants.dart
+++ b/packages/dart/lib/src/constants.dart
@@ -89,16 +89,16 @@ abstract class SemanticAttributesConstants {
   static const sentryInternalReplayIsBuffering =
       'sentry._internal.replay_is_buffering';
 
-  /// The user ID (gated by `sendDefaultPii`).
+  /// The user ID.
+  /// Users are manually set on the scope, therefore this is not gated by `sendDefaultPii`.
   static const userId = 'user.id';
 
-  /// The user email (gated by `sendDefaultPii`).
+  /// The user email.
+  /// Users are manually set on the scope, therefore this is not gated by `sendDefaultPii`.
   static const userEmail = 'user.email';
 
-  /// The user IP address (gated by `sendDefaultPii`).
-  static const userIpAddress = 'user.ip_address';
-
-  /// The user username (gated by `sendDefaultPii`).
+  /// The user username.
+  /// Users are manually set on the scope, therefore this is not gated by `sendDefaultPii`.
   static const userName = 'user.name';
 
   /// The operating system name.

--- a/packages/dart/lib/src/constants.dart
+++ b/packages/dart/lib/src/constants.dart
@@ -90,15 +90,18 @@ abstract class SemanticAttributesConstants {
       'sentry._internal.replay_is_buffering';
 
   /// The user ID.
-  /// Users are manually set on the scope, therefore this is not gated by `sendDefaultPii`.
+  /// Users are always manually set and never automatically inferred,
+  /// therefore this is not gated by `sendDefaultPii`.
   static const userId = 'user.id';
 
   /// The user email.
-  /// Users are manually set on the scope, therefore this is not gated by `sendDefaultPii`.
+  /// Users are always manually set and never automatically inferred,
+  /// therefore this is not gated by `sendDefaultPii`.
   static const userEmail = 'user.email';
 
   /// The user username.
-  /// Users are manually set on the scope, therefore this is not gated by `sendDefaultPii`.
+  /// Users are always manually set and never automatically inferred,
+  /// therefore this is not gated by `sendDefaultPii`.
   static const userName = 'user.name';
 
   /// The operating system name.

--- a/packages/dart/lib/src/telemetry/default_attributes.dart
+++ b/packages/dart/lib/src/telemetry/default_attributes.dart
@@ -23,7 +23,8 @@ Map<String, SentryAttribute> defaultAttributes(SentryOptions options,
         SentryAttribute.string(options.release!);
   }
 
-  // Users are manually set on the scope, therefore this is not gated by `sendDefaultPii`.
+  // Users are always manually set and never automatically inferred,
+  // therefore this is not gated by `sendDefaultPii`.
   final user = scope?.user;
   if (user != null) {
     if (user.id != null) {

--- a/packages/dart/lib/src/telemetry/default_attributes.dart
+++ b/packages/dart/lib/src/telemetry/default_attributes.dart
@@ -23,21 +23,20 @@ Map<String, SentryAttribute> defaultAttributes(SentryOptions options,
         SentryAttribute.string(options.release!);
   }
 
-  if (options.sendDefaultPii) {
-    final user = scope?.user;
-    if (user != null) {
-      if (user.id != null) {
-        attributes[SemanticAttributesConstants.userId] =
-            SentryAttribute.string(user.id!);
-      }
-      if (user.name != null) {
-        attributes[SemanticAttributesConstants.userName] =
-            SentryAttribute.string(user.name!);
-      }
-      if (user.email != null) {
-        attributes[SemanticAttributesConstants.userEmail] =
-            SentryAttribute.string(user.email!);
-      }
+  // Users are manually set on the scope, therefore this is not gated by `sendDefaultPii`.
+  final user = scope?.user;
+  if (user != null) {
+    if (user.id != null) {
+      attributes[SemanticAttributesConstants.userId] =
+          SentryAttribute.string(user.id!);
+    }
+    if (user.name != null) {
+      attributes[SemanticAttributesConstants.userName] =
+          SentryAttribute.string(user.name!);
+    }
+    if (user.email != null) {
+      attributes[SemanticAttributesConstants.userEmail] =
+          SentryAttribute.string(user.email!);
     }
   }
 

--- a/packages/dart/test/telemetry/log/log_capture_pipeline_test.dart
+++ b/packages/dart/test/telemetry/log/log_capture_pipeline_test.dart
@@ -129,21 +129,6 @@ void main() {
         expect(attributes[SemanticAttributesConstants.sentryEnvironment]?.value,
             'callback-env');
       });
-
-      test('does not add user attributes when sendDefaultPii is false',
-          () async {
-        fixture.options.sendDefaultPii = false;
-        await fixture.scope.setUser(SentryUser(id: 'user-id'));
-
-        final log = givenLog();
-
-        await fixture.pipeline.captureLog(log, scope: fixture.scope);
-
-        expect(
-          log.attributes.containsKey(SemanticAttributesConstants.userId),
-          isFalse,
-        );
-      });
     });
 
     group('when logs are disabled', () {
@@ -239,7 +224,6 @@ class Fixture {
   final options = defaultTestOptions()
     ..environment = 'test-env'
     ..release = 'test-release'
-    ..sendDefaultPii = true
     ..enableLogs = true;
 
   final processor = MockTelemetryProcessor();

--- a/packages/dart/test/telemetry/metric/metric_capture_pipeline_test.dart
+++ b/packages/dart/test/telemetry/metric/metric_capture_pipeline_test.dart
@@ -118,21 +118,6 @@ void main() {
         expect(attributes[SemanticAttributesConstants.sentryEnvironment]?.value,
             'callback-env');
       });
-
-      test('does not add user attributes when sendDefaultPii is false',
-          () async {
-        fixture.options.sendDefaultPii = false;
-        await fixture.scope.setUser(SentryUser(id: 'user-id'));
-
-        final metric = fixture.createMetric();
-
-        await fixture.pipeline.captureMetric(metric, scope: fixture.scope);
-
-        expect(
-          metric.attributes.containsKey(SemanticAttributesConstants.userId),
-          isFalse,
-        );
-      });
     });
 
     group('when metrics are disabled', () {
@@ -196,7 +181,6 @@ class Fixture {
   final options = defaultTestOptions()
     ..environment = 'test-env'
     ..release = 'test-release'
-    ..sendDefaultPii = true
     ..enableMetrics = true;
 
   final processor = MockTelemetryProcessor();

--- a/packages/flutter/example/lib/main.dart
+++ b/packages/flutter/example/lib/main.dart
@@ -114,6 +114,15 @@ Future<void> setupSentry(
     // Init your App.
     appRunner: appRunner,
   );
+
+  Sentry.configureScope((scope) {
+    final user = SentryUser(
+      id: SentryId.newId().toString(),
+      name: 'J. Smith',
+      email: 'j.smith@example.com',
+    );
+    scope.setUser(user);
+  });
 }
 
 class MyApp extends StatefulWidget {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
The user API is manual (not inferred) so that's why we do not need to gate it behind `sendDefaultPii`

This has recently been discovered to be a develop documentation issue and therefore a bug.

See https://develop.sentry.dev/sdk/telemetry/metrics/#user-attributes

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/getsentry/sentry-dart/issues/3504

## :green_heart: How did you test it?
Unit tests, manual

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
