### PR TITLE
internal(web): add sdk name for native js errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
   - [changelog](https://github.com/getsentry/sentry-native/blob/master/CHANGELOG.md#0127)
   - [diff](https://github.com/getsentry/sentry-native/compare/0.12.6...0.12.7)
 
+<summary><b>Internal Changes</b></summary>
+
+- Add `sentry.javascript.browser.flutter` sdk name for native js errors ([#3525](https://github.com/getsentry/sentry-dart/pull/3525))
+
+</details>
+
 ## 9.13.0
 
 ### Features

--- a/packages/flutter/lib/src/web/web_sentry_js_binding.dart
+++ b/packages/flutter/lib/src/web/web_sentry_js_binding.dart
@@ -35,13 +35,8 @@ class WebSentryJsBinding implements SentryJsBinding {
     _options = _client?.getOptions();
   }
 
-  static JSObject? _beforeSend(JSObject event, JSObject hint) {
-    var sdk = event['sdk'];
-    if (sdk == null || !sdk.isA<JSObject>()) {
-      sdk = <String, dynamic>{}.jsify() as JSObject;
-      event['sdk'] = sdk;
-    }
-    (sdk as JSObject)['name'] = _jsSdkName.toJS;
+  static _JsErrorEvent? _beforeSend(_JsErrorEvent event, JSObject hint) {
+    (event.sdk ??= _createJsObject() as _JsSdkInfo).name = _jsSdkName.toJS;
     return event;
   }
 
@@ -229,3 +224,17 @@ external JSObject _dedupeIntegration();
 @JS('globalThis')
 @internal
 external JSObject get globalThis;
+
+@JS('Object')
+external JSObject _createJsObject();
+
+@JS()
+extension type _JsErrorEvent._(JSObject _) implements JSObject {
+  external _JsSdkInfo? get sdk;
+  external set sdk(_JsSdkInfo? value);
+}
+
+@JS()
+extension type _JsSdkInfo._(JSObject _) implements JSObject {
+  external set name(JSString value);
+}

--- a/packages/flutter/lib/src/web/web_sentry_js_binding.dart
+++ b/packages/flutter/lib/src/web/web_sentry_js_binding.dart
@@ -5,6 +5,8 @@ import 'package:meta/meta.dart';
 
 import 'sentry_js_binding.dart';
 
+const String _jsSdkName = 'sentry.javascript.browser.flutter';
+
 SentryJsBinding createJsBinding() {
   return WebSentryJsBinding();
 }
@@ -26,9 +28,21 @@ class WebSentryJsBinding implements SentryJsBinding {
       options['defaultIntegrations'] = options['defaultIntegrations']
           .map((String integration) => _createIntegration(integration));
     }
-    _init(options.jsify());
+    final jsOptions = options.jsify() as JSObject;
+    jsOptions['beforeSend'] = _beforeSend.toJS;
+    _init(jsOptions);
     _client = SentryJsClient();
     _options = _client?.getOptions();
+  }
+
+  static JSObject? _beforeSend(JSObject event, JSObject hint) {
+    var sdk = event['sdk'];
+    if (sdk == null || !sdk.isA<JSObject>()) {
+      sdk = <String, dynamic>{}.jsify() as JSObject;
+      event['sdk'] = sdk;
+    }
+    (sdk as JSObject)['name'] = _jsSdkName.toJS;
+    return event;
   }
 
   @override

--- a/packages/flutter/lib/src/web/web_sentry_js_binding.dart
+++ b/packages/flutter/lib/src/web/web_sentry_js_binding.dart
@@ -37,7 +37,7 @@ class WebSentryJsBinding implements SentryJsBinding {
   }
 
   static _JsErrorEvent? _beforeSend(_JsErrorEvent event, JSAny? _) {
-    (event.sdk ??= _createJsObject() as _JsSdkInfo).name = jsSdkName.toJS;
+    (event.sdk ??= _JsSdkInfo()).name = jsSdkName.toJS;
     return event;
   }
 
@@ -226,9 +226,6 @@ external JSObject _dedupeIntegration();
 @internal
 external JSObject get globalThis;
 
-@JS('Object')
-external JSObject _createJsObject();
-
 @JS()
 extension type _JsErrorEvent._(JSObject _) implements JSObject {
   external _JsSdkInfo? get sdk;
@@ -238,4 +235,6 @@ extension type _JsErrorEvent._(JSObject _) implements JSObject {
 @JS()
 extension type _JsSdkInfo._(JSObject _) implements JSObject {
   external set name(JSString value);
+
+  factory _JsSdkInfo() => _JsSdkInfo._(JSObject());
 }

--- a/packages/flutter/lib/src/web/web_sentry_js_binding.dart
+++ b/packages/flutter/lib/src/web/web_sentry_js_binding.dart
@@ -82,7 +82,9 @@ class WebSentryJsBinding implements SentryJsBinding {
 
   @override
   void captureEnvelope(List<Object> envelope) {
-    throwExceptionInJsRuntime();
+    if (_client != null) {
+      _client?.sendEnvelope(envelope.jsify());
+    }
   }
 
   @visibleForTesting
@@ -99,18 +101,6 @@ class WebSentryJsBinding implements SentryJsBinding {
   @override
   void captureSession() {
     _captureSession();
-  }
-
-  void throwExceptionInJsRuntime({
-    String message = 'Sentry JS runtime exception',
-    int delayMs = 0,
-  }) {
-    final escapedMessage = message
-        .replaceAll(r'\', r'\\')
-        .replaceAll("'", r"\'")
-        .replaceAll('\n', r'\n')
-        .replaceAll('\r', r'\r');
-    _setTimeout("throw new Error('$escapedMessage');".toJS, delayMs.toJS);
   }
 
   @override
@@ -225,9 +215,6 @@ external void _startSession(JSAny? context);
 
 @JS('Sentry.captureSession')
 external void _captureSession();
-
-@JS('setTimeout')
-external JSAny? _setTimeout(JSAny? handler, JSNumber timeout);
 
 @JS('Sentry.globalHandlersIntegration')
 external JSObject _globalHandlersIntegration();

--- a/packages/flutter/lib/src/web/web_sentry_js_binding.dart
+++ b/packages/flutter/lib/src/web/web_sentry_js_binding.dart
@@ -5,7 +5,8 @@ import 'package:meta/meta.dart';
 
 import 'sentry_js_binding.dart';
 
-const String _jsSdkName = 'sentry.javascript.browser.flutter';
+@visibleForTesting
+const String jsSdkName = 'sentry.javascript.browser.flutter';
 
 SentryJsBinding createJsBinding() {
   return WebSentryJsBinding();
@@ -35,8 +36,8 @@ class WebSentryJsBinding implements SentryJsBinding {
     _options = _client?.getOptions();
   }
 
-  static _JsErrorEvent? _beforeSend(_JsErrorEvent event, JSObject hint) {
-    (event.sdk ??= _createJsObject() as _JsSdkInfo).name = _jsSdkName.toJS;
+  static _JsErrorEvent? _beforeSend(_JsErrorEvent event, JSAny? _) {
+    (event.sdk ??= _createJsObject() as _JsSdkInfo).name = jsSdkName.toJS;
     return event;
   }
 
@@ -81,9 +82,7 @@ class WebSentryJsBinding implements SentryJsBinding {
 
   @override
   void captureEnvelope(List<Object> envelope) {
-    if (_client != null) {
-      _client?.sendEnvelope(envelope.jsify());
-    }
+    throwExceptionInJsRuntime();
   }
 
   @visibleForTesting
@@ -100,6 +99,18 @@ class WebSentryJsBinding implements SentryJsBinding {
   @override
   void captureSession() {
     _captureSession();
+  }
+
+  void throwExceptionInJsRuntime({
+    String message = 'Sentry JS runtime exception',
+    int delayMs = 0,
+  }) {
+    final escapedMessage = message
+        .replaceAll(r'\', r'\\')
+        .replaceAll("'", r"\'")
+        .replaceAll('\n', r'\n')
+        .replaceAll('\r', r'\r');
+    _setTimeout("throw new Error('$escapedMessage');".toJS, delayMs.toJS);
   }
 
   @override
@@ -214,6 +225,9 @@ external void _startSession(JSAny? context);
 
 @JS('Sentry.captureSession')
 external void _captureSession();
+
+@JS('setTimeout')
+external JSAny? _setTimeout(JSAny? handler, JSNumber timeout);
 
 @JS('Sentry.globalHandlersIntegration')
 external JSObject _globalHandlersIntegration();

--- a/packages/flutter/test/web/web_sentry_js_binding_test.dart
+++ b/packages/flutter/test/web/web_sentry_js_binding_test.dart
@@ -1,6 +1,7 @@
 @TestOn('browser')
 library;
 
+import 'dart:async';
 import 'dart:js_interop';
 import 'dart:js_interop_unsafe';
 
@@ -36,6 +37,94 @@ void main() {
       expect(firstResult, cachedResult);
       expect(secondResult, cachedResult);
     });
+
+    test('sets the JS SDK name for native JS errors', () async {
+      final sut = await fixture.getSut();
+      sut.init({'dsn': fakeDsn});
+
+      const expectedMessage = 'native js captureException error';
+      final client = _getClient();
+      if (client == null) {
+        throw StateError('Sentry client is not registered');
+      }
+
+      final interceptedEvent = Completer<Map<dynamic, dynamic>>();
+      void completeFailure(String message) {
+        if (!interceptedEvent.isCompleted) {
+          interceptedEvent.completeError(StateError(message));
+        }
+      }
+
+      final JSFunction beforeSendEventCallback = ((JSAny? event, JSAny? _) {
+        if (interceptedEvent.isCompleted) {
+          return;
+        }
+        if (event == null) {
+          completeFailure('beforeSendEvent callback received a null event.');
+          return;
+        }
+        if (!event.isA<JSObject>()) {
+          completeFailure(
+              'beforeSendEvent callback received a non-JSObject event.');
+          return;
+        }
+
+        final eventMap = (event as JSObject).dartify() as Map<dynamic, dynamic>;
+        final exception = eventMap['exception'];
+        if (exception is! Map) {
+          completeFailure(
+              "beforeSendEvent event is missing an 'exception' map.");
+          return;
+        }
+
+        final values = exception['values'];
+        if (values is! List || values.isEmpty) {
+          completeFailure(
+              "beforeSendEvent event exception map is missing a non-empty 'values' list.");
+          return;
+        }
+
+        final firstValue = values.first;
+        if (firstValue is! Map) {
+          completeFailure(
+              "beforeSendEvent event exception values first item is not a map.");
+          return;
+        }
+
+        final value = firstValue['value'];
+        if (value == null) {
+          completeFailure(
+              "beforeSendEvent event is missing exception 'value'.");
+          return;
+        }
+
+        if (!value.toString().contains(expectedMessage)) {
+          completeFailure(
+            "beforeSendEvent exception value does not contain '$expectedMessage'. Actual: '$value'",
+          );
+          return;
+        }
+
+        interceptedEvent.complete(eventMap);
+      }).toJS;
+      client.on('beforeSendEvent'.toJS, beforeSendEventCallback);
+
+      final sentry = _globalThis['Sentry'] as JSObject?;
+      final jsError =
+          _globalThis.callMethod('Error'.toJS, expectedMessage.toJS);
+      sentry!.callMethod('captureException'.toJS, jsError);
+
+      final processedEvent =
+          await interceptedEvent.future.timeout(const Duration(seconds: 5));
+      final sdk = processedEvent['sdk'] as Map<dynamic, dynamic>?;
+      final exception = processedEvent['exception'] as Map<dynamic, dynamic>?;
+      final values = exception?['values'] as List<dynamic>?;
+      final firstValue = values?.first as Map<dynamic, dynamic>?;
+
+      expect(sdk, isNotNull);
+      expect(sdk!['name'], jsSdkName);
+      expect(firstValue?['value'], contains(expectedMessage));
+    });
   });
 }
 
@@ -51,3 +140,16 @@ class Fixture {
 
 @JS('globalThis')
 external JSObject get _globalThis;
+
+@JS('Sentry.getClient')
+external SentryJsClient? _getClient();
+
+@JS()
+@staticInterop
+class SentryJsClient {
+  external factory SentryJsClient();
+}
+
+extension _SentryJsClientExtension on SentryJsClient {
+  external void on(JSString event, JSFunction callback);
+}


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Currently we have no idea how many errors occurred in native js, so we should attach a custom sdk name.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3523 

## :green_heart: How did you test it?
Manually

<img width="2733" height="1163" alt="image" src="https://github.com/user-attachments/assets/f8cd236b-1919-4ffa-aab7-4ee043b4eb10" />


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
