### PR TITLE
Add enableTombstone option for native crash reporting on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Features
+
+- Add `enableTombstone` option for improved native crash reporting on Android 12+ ([#XXXX](https://github.com/getsentry/sentry-dart/pull/XXXX))
+  - When enabled, uses Android's `ApplicationExitInfo.REASON_CRASH_NATIVE` to capture native crashes with more detailed thread information
+  - Disabled by default
+
 ### Dependencies
 
 - Bump Native SDK from v0.12.6 to v0.12.7 ([#3514](https://github.com/getsentry/sentry-dart/pull/3514))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Add `enableTombstone` option for improved native crash reporting on Android 12+ ([#XXXX](https://github.com/getsentry/sentry-dart/pull/XXXX))
+- Add `enableTombstone` option for improved native crash reporting on Android 12+ ([#3526](https://github.com/getsentry/sentry-dart/pull/3526))
   - When enabled, uses Android's `ApplicationExitInfo.REASON_CRASH_NATIVE` to capture native crashes with more detailed thread information
   - Disabled by default
 

--- a/packages/flutter/example/integration_test/integration_test.dart
+++ b/packages/flutter/example/integration_test/integration_test.dart
@@ -217,7 +217,7 @@ void main() {
         options.anrTimeoutInterval = const Duration(seconds: 2);
         options.connectionTimeout = const Duration(milliseconds: 1234);
         options.readTimeout = const Duration(milliseconds: 2345);
-        options.enableTombstone = false;
+        options.enableTombstone = true;
       });
     });
 
@@ -281,7 +281,7 @@ void main() {
       expect(findMatchingPackage, isNotNull);
     }
     expect(androidOptions.isEnableAutoTraceIdGeneration(), isFalse);
-    expect(androidOptions.isTombstoneEnabled(), isFalse);
+    expect(androidOptions.isTombstoneEnabled(), isTrue);
 
     final androidProxy = androidOptions.getProxy();
     expect(androidProxy, isNotNull);

--- a/packages/flutter/example/integration_test/integration_test.dart
+++ b/packages/flutter/example/integration_test/integration_test.dart
@@ -217,6 +217,7 @@ void main() {
         options.anrTimeoutInterval = const Duration(seconds: 2);
         options.connectionTimeout = const Duration(milliseconds: 1234);
         options.readTimeout = const Duration(milliseconds: 2345);
+        options.enableTombstone = false;
       });
     });
 
@@ -280,12 +281,15 @@ void main() {
       expect(findMatchingPackage, isNotNull);
     }
     expect(androidOptions.isEnableAutoTraceIdGeneration(), isFalse);
+    expect(androidOptions.isTombstoneEnabled(), isFalse);
+
     final androidProxy = androidOptions.getProxy();
     expect(androidProxy, isNotNull);
     expect(androidProxy!.getHost()?.toDartString(), 'proxy.local');
     expect(androidProxy.getPort()?.toDartString(), '8084');
     expect(androidProxy.getUser()?.toDartString(), 'u');
     expect(androidProxy.getPass()?.toDartString(), 'p');
+
     final r = androidOptions.getSessionReplay();
     expect(r.getQuality(), jni.SentryReplayOptions$SentryReplayQuality.HIGH);
     expect(r.getSessionSampleRate(), isNotNull);

--- a/packages/flutter/lib/src/native/java/sentry_native_java_init.dart
+++ b/packages/flutter/lib/src/native/java/sentry_native_java_init.dart
@@ -215,6 +215,7 @@ void configureAndroidOptions({
     androidOptions
         .setAnrTimeoutIntervalMillis(options.anrTimeoutInterval.inMilliseconds);
     androidOptions.setAnrEnabled(options.anrEnabled);
+    androidOptions.setTombstoneEnabled(options.enableTombstone);
     androidOptions.setAttachThreads(options.attachThreads);
     androidOptions.setAttachStacktrace(options.attachStacktrace);
 

--- a/packages/flutter/lib/src/sentry_flutter_options.dart
+++ b/packages/flutter/lib/src/sentry_flutter_options.dart
@@ -68,6 +68,12 @@ class SentryFlutterOptions extends SentryOptions {
   /// Available only for Android. Enabled by default.
   bool anrEnabled = true;
 
+  /// Enable or disable Tombstone reporting for improved native crash reporting.
+  /// When enabled, uses Android's `ApplicationExitInfo.REASON_CRASH_NATIVE` to
+  /// capture native crashes with more detailed thread information.
+  /// Available only for Android 12+ (API level 30+). Disabled by default.
+  bool enableTombstone = false;
+
   Duration _anrTimeoutInterval = Duration(milliseconds: 5000);
 
   /// ANR Timeout internal. Default is 5000 milliseconds or 5 seconds.

--- a/packages/flutter/test/sentry_flutter_options_test.dart
+++ b/packages/flutter/test/sentry_flutter_options_test.dart
@@ -51,5 +51,12 @@ void main() {
       expect(options.enableMemoryPressureBreadcrumbs, isTrue);
       expect(options.enableAutoNativeBreadcrumbs, isFalse);
     });
+
+    testWidgets('enableTombstone defaults to false',
+        (WidgetTester tester) async {
+      final options = defaultTestOptions();
+
+      expect(options.enableTombstone, isFalse);
+    });
   });
 }


### PR DESCRIPTION
## :scroll: Description

This PR adds a new `enableTombstone` configuration option to `SentryFlutterOptions` that enables improved native crash reporting on Android 12+ (API level 30+). When enabled, the SDK uses Android's `ApplicationExitInfo.REASON_CRASH_NATIVE` to capture native crashes with more detailed thread information.

The changes include:
- Added `enableTombstone` boolean property to `SentryFlutterOptions` (disabled by default)
- Wired the option to the native Android configuration via `setTombstoneEnabled()`
- Added unit test to verify the default value is `false`
- Updated CHANGELOG with feature documentation

## :bulb: Motivation and Context

This feature provides developers with an opt-in mechanism to capture more detailed native crash information on Android 12+ devices. The tombstone reporting mechanism leverages Android's native crash reporting capabilities to provide enhanced debugging information for native crashes.

## :green_heart: How did you test it?

Added unit test `enableTombstone defaults to false` in `sentry_flutter_options_test.dart` to verify the option defaults to disabled.

## :pencil: Checklist
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

The native Android SDK implementation for `setTombstoneEnabled()` should be verified to ensure it properly handles the tombstone reporting configuration.

https://claude.ai/code/session_016kkosYW3XG2rhHafEfspqA