### PR TITLE
fix(sqflite): Implement SqfliteDatabaseExecutor to prevent TypeError on getVersion/setVersion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Implement `SqfliteDatabaseExecutor` to prevent `TypeError` on `getVersion/setVersion` ([3539](https://github.com/getsentry/sentry-dart/pull/3539))
+
 ## 9.14.0
 
 ### Features

--- a/packages/sqflite/lib/src/sentry_database.dart
+++ b/packages/sqflite/lib/src/sentry_database.dart
@@ -142,10 +142,6 @@ class SentryDatabase extends SentryDatabaseExecutor
     return _database.devInvokeSqlMethod(method, sql);
   }
 
-  // Implement SqfliteDatabaseExecutor so that the cast in
-  // SqfliteDatabaseExecutorExt (this as SqfliteDatabaseExecutor) succeeds.
-  // Without this, calling getVersion()/setVersion() on a SentryDatabase
-  // crashes with a TypeError.
   @override
   SqfliteDatabase get db => (_database as SqfliteDatabaseExecutor).db;
 

--- a/packages/sqflite/lib/src/sentry_database.dart
+++ b/packages/sqflite/lib/src/sentry_database.dart
@@ -3,6 +3,10 @@ import 'dart:async';
 import 'package:meta/meta.dart';
 import 'package:sentry/sentry.dart';
 import 'package:sqflite/sqflite.dart';
+// ignore: implementation_imports
+import 'package:sqflite_common/src/database.dart';
+// ignore: implementation_imports
+import 'package:sqflite_common/src/transaction.dart';
 
 import 'sentry_database_executor.dart';
 import 'sentry_sqflite_transaction.dart';
@@ -20,7 +24,8 @@ import 'package:path/path.dart' as p;
 /// final sentryDatabase = SentryDatabase(database);
 /// ```
 @experimental
-class SentryDatabase extends SentryDatabaseExecutor implements Database {
+class SentryDatabase extends SentryDatabaseExecutor
+    implements Database, SqfliteDatabaseExecutor {
   final Database _database;
   final Hub _hub;
 
@@ -136,6 +141,16 @@ class SentryDatabase extends SentryDatabaseExecutor implements Database {
     // ignore: deprecated_member_use
     return _database.devInvokeSqlMethod(method, sql);
   }
+
+  // Implement SqfliteDatabaseExecutor so that the cast in
+  // SqfliteDatabaseExecutorExt (this as SqfliteDatabaseExecutor) succeeds.
+  // Without this, calling getVersion()/setVersion() on a SentryDatabase
+  // crashes with a TypeError.
+  @override
+  SqfliteDatabase get db => (_database as SqfliteDatabaseExecutor).db;
+
+  @override
+  SqfliteTransaction? get txn => (_database as SqfliteDatabaseExecutor).txn;
 
   @override
   bool get isOpen => _database.isOpen;

--- a/packages/sqflite/lib/src/sentry_database_executor.dart
+++ b/packages/sqflite/lib/src/sentry_database_executor.dart
@@ -15,6 +15,9 @@ import 'utils/sentry_database_span_attributes.dart';
 
 @internal
 // ignore: public_member_api_docs
+// Workaround: sqflite hard-casts DatabaseExecutor to SqfliteDatabaseExecutor
+// (see sqlite_api.dart SqfliteDatabaseExecutorExt), causing a TypeError when wrapped.
+// https://github.com/tekartik/sqflite/blob/c28b35b17f98e714cee6e540ef6a96e48642aafd/sqflite_common/lib/sqlite_api.dart#L349
 class SentryDatabaseExecutor
     implements DatabaseExecutor, SqfliteDatabaseExecutor {
   final DatabaseExecutor _executor;

--- a/packages/sqflite/lib/src/sentry_database_executor.dart
+++ b/packages/sqflite/lib/src/sentry_database_executor.dart
@@ -3,7 +3,11 @@ import 'package:sentry/sentry.dart';
 import 'package:sqflite/sqflite.dart';
 
 // ignore: implementation_imports
+import 'package:sqflite_common/src/database.dart';
+// ignore: implementation_imports
 import 'package:sqflite_common/src/sql_builder.dart';
+// ignore: implementation_imports
+import 'package:sqflite_common/src/transaction.dart';
 
 import 'sentry_batch.dart';
 import 'sentry_database.dart';
@@ -11,7 +15,7 @@ import 'utils/sentry_database_span_attributes.dart';
 
 @internal
 // ignore: public_member_api_docs
-class SentryDatabaseExecutor implements DatabaseExecutor {
+class SentryDatabaseExecutor implements DatabaseExecutor, SqfliteDatabaseExecutor {
   final DatabaseExecutor _executor;
   // ignore: invalid_use_of_internal_member
   final InstrumentationSpan? _parentSpan;
@@ -40,6 +44,16 @@ class SentryDatabaseExecutor implements DatabaseExecutor {
   InstrumentationSpan? _getParent() {
     return _parentSpan ?? _spanFactory.getSpan(_hub);
   }
+
+  // Implement SqfliteDatabaseExecutor so that the cast in
+  // SqfliteDatabaseExecutorExt (this as SqfliteDatabaseExecutor) succeeds.
+  // Without this, calling getVersion()/setVersion() on a SentryDatabaseExecutor
+  // crashes with a TypeError.
+  @override
+  SqfliteDatabase get db => (_executor as SqfliteDatabaseExecutor).db;
+
+  @override
+  SqfliteTransaction? get txn => (_executor as SqfliteDatabaseExecutor).txn;
 
   @override
   Batch batch() => SentryBatch(_executor.batch(), hub: _hub, dbName: _dbName);

--- a/packages/sqflite/lib/src/sentry_database_executor.dart
+++ b/packages/sqflite/lib/src/sentry_database_executor.dart
@@ -15,7 +15,8 @@ import 'utils/sentry_database_span_attributes.dart';
 
 @internal
 // ignore: public_member_api_docs
-class SentryDatabaseExecutor implements DatabaseExecutor, SqfliteDatabaseExecutor {
+class SentryDatabaseExecutor
+    implements DatabaseExecutor, SqfliteDatabaseExecutor {
   final DatabaseExecutor _executor;
   // ignore: invalid_use_of_internal_member
   final InstrumentationSpan? _parentSpan;

--- a/packages/sqflite/lib/src/sentry_database_executor.dart
+++ b/packages/sqflite/lib/src/sentry_database_executor.dart
@@ -46,10 +46,6 @@ class SentryDatabaseExecutor
     return _parentSpan ?? _spanFactory.getSpan(_hub);
   }
 
-  // Implement SqfliteDatabaseExecutor so that the cast in
-  // SqfliteDatabaseExecutorExt (this as SqfliteDatabaseExecutor) succeeds.
-  // Without this, calling getVersion()/setVersion() on a SentryDatabaseExecutor
-  // crashes with a TypeError.
   @override
   SqfliteDatabase get db => (_executor as SqfliteDatabaseExecutor).db;
 

--- a/packages/sqflite/lib/src/sentry_sqflite_transaction.dart
+++ b/packages/sqflite/lib/src/sentry_sqflite_transaction.dart
@@ -37,10 +37,6 @@ class SentrySqfliteTransaction extends Transaction
   })  : _hub = hub ?? HubAdapter(),
         _dbName = dbName;
 
-  // Implement SqfliteDatabaseExecutor so that the cast in
-  // SqfliteDatabaseExecutorExt (this as SqfliteDatabaseExecutor) succeeds.
-  // Without this, calling getVersion()/setVersion() on a SentrySqfliteTransaction
-  // crashes with a TypeError.
   @override
   SqfliteDatabase get db => (_executor as SqfliteDatabaseExecutor).db;
 

--- a/packages/sqflite/lib/src/sentry_sqflite_transaction.dart
+++ b/packages/sqflite/lib/src/sentry_sqflite_transaction.dart
@@ -1,6 +1,10 @@
 import 'package:meta/meta.dart';
 import 'package:sentry/sentry.dart';
 import 'package:sqflite/sqflite.dart';
+// ignore: implementation_imports
+import 'package:sqflite_common/src/database.dart';
+// ignore: implementation_imports
+import 'package:sqflite_common/src/transaction.dart';
 
 import 'sentry_batch.dart';
 
@@ -18,7 +22,8 @@ import 'sentry_batch.dart';
 /// });
 /// ```
 @experimental
-class SentrySqfliteTransaction extends Transaction implements DatabaseExecutor {
+class SentrySqfliteTransaction extends Transaction
+    implements DatabaseExecutor, SqfliteDatabaseExecutor {
   final DatabaseExecutor _executor;
   final Hub _hub;
   final String? _dbName;
@@ -31,6 +36,16 @@ class SentrySqfliteTransaction extends Transaction implements DatabaseExecutor {
     @internal String? dbName,
   })  : _hub = hub ?? HubAdapter(),
         _dbName = dbName;
+
+  // Implement SqfliteDatabaseExecutor so that the cast in
+  // SqfliteDatabaseExecutorExt (this as SqfliteDatabaseExecutor) succeeds.
+  // Without this, calling getVersion()/setVersion() on a SentrySqfliteTransaction
+  // crashes with a TypeError.
+  @override
+  SqfliteDatabase get db => (_executor as SqfliteDatabaseExecutor).db;
+
+  @override
+  SqfliteTransaction? get txn => (_executor as SqfliteDatabaseExecutor).txn;
 
   @override
   Batch batch() => SentryBatch(_executor.batch(), hub: _hub, dbName: _dbName);

--- a/packages/sqflite/test/sentry_database_test.dart
+++ b/packages/sqflite/test/sentry_database_test.dart
@@ -235,7 +235,7 @@ void main() {
 
     test('getVersion does not throw TypeError', () async {
       final db = await fixture.getSut();
-      
+
       final Database dbAsDatabase = db;
       final version = await dbAsDatabase.getVersion();
       expect(version, isA<int>());

--- a/packages/sqflite/test/sentry_database_test.dart
+++ b/packages/sqflite/test/sentry_database_test.dart
@@ -233,6 +233,50 @@ void main() {
       await db.close();
     });
 
+    test('getVersion does not throw TypeError', () async {
+      final db = await fixture.getSut();
+      
+      final Database dbAsDatabase = db;
+      final version = await dbAsDatabase.getVersion();
+      expect(version, isA<int>());
+
+      await db.close();
+    });
+
+    test('setVersion does not throw TypeError', () async {
+      final db = await fixture.getSut();
+
+      final Database dbAsDatabase = db;
+      await dbAsDatabase.setVersion(42);
+      final version = await dbAsDatabase.getVersion();
+      expect(version, 42);
+
+      await db.close();
+    });
+
+    test('getVersion within transaction does not throw TypeError', () async {
+      final db = await fixture.getSut();
+
+      await db.transaction((txn) async {
+        final version = await txn.getVersion();
+        expect(version, isA<int>());
+      });
+
+      await db.close();
+    });
+
+    test('setVersion within transaction does not throw TypeError', () async {
+      final db = await fixture.getSut();
+
+      await db.transaction((txn) async {
+        await txn.setVersion(7);
+      });
+      final version = await db.getVersion();
+      expect(version, 7);
+
+      await db.close();
+    });
+
     test('closing db sets currentDbName to null', () async {
       final db = await fixture.getSut();
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Implement `SqfliteDatabaseExecutor` on Sentry wrapper classes so the hard cast in sqflite_common's getVersion()/setVersion() extension methods succeeds.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #3530 

## :green_heart: How did you test it?

Added tests (were failing before implementing solution)

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes