### PR TITLE
fix(flutter): Stop re-triggering hitTest in SentryUserInteractionWidget on pointerUp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Stop re-triggering hitTest in SentryUserInteractionWidget on pointerUp ([#3540](https://github.com/getsentry/sentry-dart/pull/3540))
+
 ## 9.14.0
 
 ### Features

--- a/packages/flutter/lib/src/user_interaction/sentry_user_interaction_widget.dart
+++ b/packages/flutter/lib/src/user_interaction/sentry_user_interaction_widget.dart
@@ -569,7 +569,8 @@ class _SentryUserInteractionWidgetState
         // skip offstage elements (e.g. routes behind the current page).
         // This avoids the need for hitTest-based visibility checking which
         // has the side effect of propagating to descendant render objects
-        // and overwriting their state (see #3503).
+        // and overwriting their state.
+        // https://github.com/getsentry/sentry-dart/issues/3503
         element.debugVisitOnstageChildren(elementFinder);
       }
     }

--- a/packages/flutter/lib/src/user_interaction/sentry_user_interaction_widget.dart
+++ b/packages/flutter/lib/src/user_interaction/sentry_user_interaction_widget.dart
@@ -203,7 +203,6 @@
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:meta/meta.dart';
 // ignore: implementation_imports
 import 'package:sentry/src/sentry_tracer.dart';
@@ -549,14 +548,6 @@ class _SentryUserInteractionWidgetState
         return;
       }
 
-      var hitFound = true;
-      if (renderObject is RenderPointerListener) {
-        final hitResult = BoxHitTestResult();
-
-        // Returns false if the hit can continue to other objects below this one.
-        hitFound = renderObject.hitTest(hitResult, position: position);
-      }
-
       final transform = renderObject.getTransformTo(rootElement.renderObject);
       final paintBounds =
           MatrixUtils.transformRect(transform, renderObject.paintBounds);
@@ -573,12 +564,17 @@ class _SentryUserInteractionWidgetState
         );
       }
 
-      if (tappedWidget == null || !hitFound) {
-        element.visitChildElements(elementFinder);
+      if (tappedWidget == null) {
+        // Use debugVisitOnstageChildren instead of visitChildElements to
+        // skip offstage elements (e.g. routes behind the current page).
+        // This avoids the need for hitTest-based visibility checking which
+        // has the side effect of propagating to descendant render objects
+        // and overwriting their state (see #3503).
+        element.debugVisitOnstageChildren(elementFinder);
       }
     }
 
-    rootElement.visitChildElements(elementFinder);
+    rootElement.debugVisitOnstageChildren(elementFinder);
 
     return tappedWidget;
   }

--- a/packages/flutter/test/user_interaction/sentry_user_interaction_widget_test.dart
+++ b/packages/flutter/test/user_interaction/sentry_user_interaction_widget_test.dart
@@ -357,8 +357,8 @@ void main() {
 
         // Page2's btn_page_2 fills the entire screen (SizedBox.expand).
         // Tap at btn_1's center, which is inside both buttons' bounds.
-        final btn1Center = tester.getCenter(
-            find.byKey(Key('btn_1'), skipOffstage: false));
+        final btn1Center =
+            tester.getCenter(find.byKey(Key('btn_1'), skipOffstage: false));
         await tester.tapAt(btn1Center);
 
         final data = fixture.getBreadcrumb().data;

--- a/packages/flutter/test/user_interaction/sentry_user_interaction_widget_test.dart
+++ b/packages/flutter/test/user_interaction/sentry_user_interaction_widget_test.dart
@@ -562,7 +562,7 @@ void main() {
   });
 
   // Regression tests for https://github.com/getsentry/sentry-dart/issues/3503
-  group('$SentryUserInteractionWidget tap distortion (#3503)', () {
+  group('$SentryUserInteractionWidget tap distortion', () {
     testWidgets(
       'does not re-trigger hitTest on descendant render objects during pointerUp',
       (tester) async {

--- a/packages/flutter/test/user_interaction/sentry_user_interaction_widget_test.dart
+++ b/packages/flutter/test/user_interaction/sentry_user_interaction_widget_test.dart
@@ -4,6 +4,7 @@ library;
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
@@ -341,6 +342,33 @@ void main() {
       });
     });
 
+    // Regression test for https://github.com/getsentry/sentry-dart/issues/1208
+    testWidgets(
+        'Add crumb for button on Page2 not Page1 when pages are stacked',
+        (tester) async {
+      await tester.runAsync(() async {
+        final sut = fixture.getSut();
+
+        await tester.pumpWidget(sut);
+
+        // Navigate to Page2 (Page1 stays behind in the nav stack).
+        await tester.tap(find.byKey(Key('btn_go_to_page2')));
+        await tester.pumpAndSettle();
+
+        // Page2's btn_page_2 fills the entire screen (SizedBox.expand).
+        // Tap at btn_1's center, which is inside both buttons' bounds.
+        final btn1Center = tester.getCenter(
+            find.byKey(Key('btn_1'), skipOffstage: false));
+        await tester.tapAt(btn1Center);
+
+        final data = fixture.getBreadcrumb().data;
+        expect(data?['view.id'], equals('btn_page_2'),
+            reason: 'Should identify the Page2 button, not the Page1 button '
+                'behind it in the navigation stack');
+        expect(data?['view.class'], equals('MaterialButton'));
+      });
+    });
+
     testWidgets('Add crumb for button without key', (tester) async {
       await tester.runAsync(() async {
         final sut = fixture.getSut(sendDefaultPii: true);
@@ -532,6 +560,85 @@ void main() {
       });
     });
   });
+
+  // Regression tests for https://github.com/getsentry/sentry-dart/issues/3503
+  group('$SentryUserInteractionWidget tap distortion (#3503)', () {
+    testWidgets(
+      'does not re-trigger hitTest on descendant render objects during pointerUp',
+      (tester) async {
+        final hitTestPositions = <Offset>[];
+        final hitNotifier = ValueNotifier<Offset?>(null);
+
+        await tester.pumpWidget(fixture.getSut(
+          child: MaterialApp(
+            home: Scaffold(
+              body: GestureDetector(
+                onTap: () {},
+                child: HitTestTracker(
+                  hitTestPositions: hitTestPositions,
+                  hitNotifier: hitNotifier,
+                  child: const SizedBox.expand(),
+                ),
+              ),
+            ),
+          ),
+        ));
+
+        hitTestPositions.clear();
+
+        final center = tester.getCenter(find.byType(SizedBox).last);
+        final gesture = await tester.startGesture(center);
+        await tester.pump();
+
+        final hitTestCountAfterDown = hitTestPositions.length;
+
+        await gesture.up();
+        await tester.pumpAndSettle();
+
+        expect(hitTestPositions.length, equals(hitTestCountAfterDown),
+            reason: 'SentryUserInteractionWidget should not re-trigger '
+                'hitTest on pointerUp');
+      },
+    );
+
+    testWidgets(
+      'does not overwrite hitNotifier value that was set during pointerDown',
+      (tester) async {
+        final hitTestPositions = <Offset>[];
+        final hitNotifier = ValueNotifier<Offset?>(null);
+
+        await tester.pumpWidget(fixture.getSut(
+          child: MaterialApp(
+            home: Scaffold(
+              body: GestureDetector(
+                onTap: () {},
+                child: HitTestTracker(
+                  hitTestPositions: hitTestPositions,
+                  hitNotifier: hitNotifier,
+                  child: const SizedBox.expand(),
+                ),
+              ),
+            ),
+          ),
+        ));
+
+        final center = tester.getCenter(find.byType(SizedBox).last);
+        final gesture = await tester.startGesture(center);
+        await tester.pump();
+
+        expect(hitNotifier.value, isNotNull);
+
+        hitNotifier.value = null;
+
+        await gesture.up();
+        await tester.pumpAndSettle();
+
+        expect(hitNotifier.value, isNull,
+            reason: 'SentryUserInteractionWidget should not overwrite '
+                'hitNotifier during pointerUp');
+      },
+    );
+  });
 }
 
 Future<void> tapMe(
@@ -556,6 +663,7 @@ class Fixture {
     bool enableUserInteractionBreadcrumbs = true,
     double? tracesSampleRate = 1.0,
     bool sendDefaultPii = false,
+    Widget? child,
   }) {
     // Missing mock exception
     when(_transport.send(any)).thenAnswer((_) async => SentryId.newId());
@@ -571,7 +679,7 @@ class Fixture {
 
     return SentryUserInteractionWidget(
       hub: hub,
-      child: MyApp(),
+      child: child ?? MyApp(),
     );
   }
 
@@ -681,15 +789,11 @@ class Page2 extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Center(
-        child: Column(
-          children: [
-            MaterialButton(
-              key: Key('btn_page_2'),
-              onPressed: () {},
-              child: const Text('Button Page 2'),
-            ),
-          ],
+      body: SizedBox.expand(
+        child: MaterialButton(
+          key: Key('btn_page_2'),
+          onPressed: () {},
+          child: const Text('Button Page 2'),
         ),
       ),
     );
@@ -725,4 +829,56 @@ extension on List<dynamic> {
           return value;
         }
       });
+}
+
+/// A widget whose [RenderBox] records every [hitTest] call and updates a
+/// [ValueNotifier] — mimicking flutter_map's `LayerHitNotifier` pattern
+/// where state is set during hit testing.
+class HitTestTracker extends SingleChildRenderObjectWidget {
+  const HitTestTracker({
+    required this.hitTestPositions,
+    required this.hitNotifier,
+    super.child,
+    super.key,
+  });
+
+  final List<Offset> hitTestPositions;
+  final ValueNotifier<Offset?> hitNotifier;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) {
+    return RenderHitTestTracker(
+      hitTestPositions: hitTestPositions,
+      hitNotifier: hitNotifier,
+    );
+  }
+
+  @override
+  void updateRenderObject(
+      BuildContext context, RenderHitTestTracker renderObject) {
+    renderObject
+      ..hitTestPositions = hitTestPositions
+      ..hitNotifier = hitNotifier;
+  }
+}
+
+class RenderHitTestTracker extends RenderProxyBox {
+  RenderHitTestTracker({
+    required List<Offset> hitTestPositions,
+    required ValueNotifier<Offset?> hitNotifier,
+  })  : _hitTestPositions = hitTestPositions,
+        _hitNotifier = hitNotifier;
+
+  List<Offset> _hitTestPositions;
+  set hitTestPositions(List<Offset> value) => _hitTestPositions = value;
+
+  ValueNotifier<Offset?> _hitNotifier;
+  set hitNotifier(ValueNotifier<Offset?> value) => _hitNotifier = value;
+
+  @override
+  bool hitTest(BoxHitTestResult result, {required Offset position}) {
+    _hitTestPositions.add(position);
+    _hitNotifier.value = position;
+    return super.hitTest(result, position: position);
+  }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Removes the hitTest call from `_getElementAt` and uses `debugVisitOnstageChildren` to skip offstage elements without side effects.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`_getElementAt` re-triggered hitTest on pointerUp, propagating to descendants and overwriting state set during pointerDown (e.g. flutter_map's hitNotifier).

Fixes #3503

## :green_heart: How did you test it?

Added regression tests for #3503 and #1208.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes
