### PR TITLE
fix(logs): Use seconds since the Unix epoch for `log.timestamp`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Stop re-triggering hitTest in SentryUserInteractionWidget on pointerUp ([#3540](https://github.com/getsentry/sentry-dart/pull/3540))
+- Use seconds since the Unix epoch for `log.timestamp` ([#3558](https://github.com/getsentry/sentry-dart/pull/3558))
 
 ## 9.14.0
 

--- a/packages/dart/lib/src/telemetry/log/log.dart
+++ b/packages/dart/lib/src/telemetry/log/log.dart
@@ -27,7 +27,7 @@ class SentryLog {
 
   Map<String, dynamic> toJson() {
     return {
-      'timestamp': timestamp.toIso8601String(),
+      'timestamp': timestamp.microsecondsSinceEpoch / 1000000.0,
       'trace_id': traceId.toString(),
       if (spanId != null) 'span_id': spanId.toString(),
       'level': level.value,

--- a/packages/dart/lib/src/telemetry/log/log.dart
+++ b/packages/dart/lib/src/telemetry/log/log.dart
@@ -28,7 +28,7 @@ class SentryLog {
 
   Map<String, dynamic> toJson() {
     return {
-      'timestamp': timestamp.microsecondsSinceEpoch / 1000000.0,
+      'timestamp': timestamp.secondsSinceEpoch,
       'trace_id': traceId.toString(),
       if (spanId != null) 'span_id': spanId.toString(),
       'level': level.value,

--- a/packages/dart/lib/src/telemetry/log/log.dart
+++ b/packages/dart/lib/src/telemetry/log/log.dart
@@ -1,6 +1,7 @@
 import '../../protocol/sentry_attribute.dart';
 import '../../protocol/sentry_id.dart';
 import '../../protocol/span_id.dart';
+import '../../utils/date_time_extension.dart';
 import 'log_level.dart';
 
 class SentryLog {

--- a/packages/dart/lib/src/telemetry/metric/metric.dart
+++ b/packages/dart/lib/src/telemetry/metric/metric.dart
@@ -1,6 +1,7 @@
 import 'package:meta/meta.dart';
 
 import '../../../sentry.dart';
+import '../../utils/date_time_extension.dart';
 
 /// Base class for metric data points sent to Sentry.
 ///
@@ -47,7 +48,7 @@ abstract class SentryMetric {
   @internal
   Map<String, dynamic> toJson() {
     return {
-      'timestamp': timestamp.millisecondsSinceEpoch / 1000.0,
+      'timestamp': timestamp.secondsSinceEpoch,
       'type': type,
       'name': name,
       'value': value,

--- a/packages/dart/lib/src/utils/date_time_extension.dart
+++ b/packages/dart/lib/src/utils/date_time_extension.dart
@@ -1,0 +1,3 @@
+extension DateTimeExtension on DateTime {
+  double get secondsSinceEpoch => microsecondsSinceEpoch / 1000000.0;
+}

--- a/packages/dart/test/telemetry/log/log_test.dart
+++ b/packages/dart/test/telemetry/log/log_test.dart
@@ -1,10 +1,9 @@
 import 'package:test/test.dart';
 import 'package:sentry/sentry.dart';
-import 'package:sentry/src/utils/date_time_extension.dart';
 
 void main() {
   test('$SentryLog to json', () {
-    final timestamp = DateTime.now();
+    final timestamp = DateTime.utc(2024, 1, 15, 10, 30, 0, 123, 456);
     final traceId = SentryId.newId();
     final spanId = SpanId.newId();
 
@@ -26,7 +25,7 @@ void main() {
     final json = logItem.toJson();
 
     expect(json, {
-      'timestamp': timestamp.secondsSinceEpoch,
+      'timestamp': 1705314600.123456,
       'trace_id': traceId.toString(),
       'span_id': spanId.toString(),
       'level': 'info',

--- a/packages/dart/test/telemetry/log/log_test.dart
+++ b/packages/dart/test/telemetry/log/log_test.dart
@@ -25,7 +25,7 @@ void main() {
     final json = logItem.toJson();
 
     expect(json, {
-      'timestamp': timestamp.toIso8601String(),
+      'timestamp': timestamp.microsecondsSinceEpoch / 1000000.0,
       'trace_id': traceId.toString(),
       'span_id': spanId.toString(),
       'level': 'info',

--- a/packages/dart/test/telemetry/log/log_test.dart
+++ b/packages/dart/test/telemetry/log/log_test.dart
@@ -26,7 +26,7 @@ void main() {
     final json = logItem.toJson();
 
     expect(json, {
-      'timestamp': timestamp.microsecondsSinceEpoch / 1000000.0,
+      'timestamp': timestamp.secondsSinceEpoch,
       'trace_id': traceId.toString(),
       'span_id': spanId.toString(),
       'level': 'info',

--- a/packages/dart/test/telemetry/log/log_test.dart
+++ b/packages/dart/test/telemetry/log/log_test.dart
@@ -1,5 +1,6 @@
 import 'package:test/test.dart';
 import 'package:sentry/sentry.dart';
+import 'package:sentry/src/utils/date_time_extension.dart';
 
 void main() {
   test('$SentryLog to json', () {

--- a/packages/dart/test/telemetry/metric/metric_test.dart
+++ b/packages/dart/test/telemetry/metric/metric_test.dart
@@ -6,7 +6,7 @@ void main() {
     test('serializes all fields correctly', () {
       final traceId = SentryId.newId();
       final spanId = SpanId.newId();
-      final timestamp = DateTime.utc(2024, 1, 15, 10, 30, 0);
+      final timestamp = DateTime.utc(2024, 1, 15, 10, 30, 0, 123, 456);
 
       final metric = SentryCounterMetric(
         timestamp: timestamp,
@@ -20,7 +20,7 @@ void main() {
 
       final json = metric.toJson();
 
-      expect(json['timestamp'], 1705314600.0);
+      expect(json['timestamp'], 1705314600.123456);
       expect(json['type'], 'counter');
       expect(json['name'], 'button_clicks');
       expect(json['value'], 5);

--- a/packages/flutter/test/user_interaction/sentry_user_interaction_widget_test.dart
+++ b/packages/flutter/test/user_interaction/sentry_user_interaction_widget_test.dart
@@ -15,7 +15,9 @@ import '../mocks.mocks.dart';
 
 // The Scaffold widget tree uses AnimatedBuilder on stable but Builder on beta.
 // Use anyOf to accept either name since this is a framework-internal detail.
-final _animatedBuilderElement = {'element': anyOf('AnimatedBuilder', 'Builder')};
+final _animatedBuilderElement = {
+  'element': anyOf('AnimatedBuilder', 'Builder')
+};
 
 void main() {
   late Fixture fixture;

--- a/packages/flutter/test/user_interaction/sentry_user_interaction_widget_test.dart
+++ b/packages/flutter/test/user_interaction/sentry_user_interaction_widget_test.dart
@@ -13,6 +13,10 @@ import 'package:sentry/src/sentry_tracer.dart';
 import '../mocks.dart';
 import '../mocks.mocks.dart';
 
+// The Scaffold widget tree uses AnimatedBuilder on stable but Builder on beta.
+// Use anyOf to accept either name since this is a framework-internal detail.
+final _animatedBuilderElement = {'element': anyOf('AnimatedBuilder', 'Builder')};
+
 void main() {
   late Fixture fixture;
   setUp(() async {
@@ -121,7 +125,7 @@ void main() {
                 {'name': '_ScaffoldSlot.body', 'element': 'LayoutId'},
                 {'element': 'CustomMultiChildLayout'},
                 {'element': 'Actions'},
-                {'element': 'AnimatedBuilder'},
+                _animatedBuilderElement,
                 {'element': 'DefaultTextStyle'}
               ],
               'view.id': 'btn_1',
@@ -148,7 +152,7 @@ void main() {
                 {'name': '_ScaffoldSlot.body', 'element': 'LayoutId'},
                 {'element': 'CustomMultiChildLayout'},
                 {'element': 'Actions'},
-                {'element': 'AnimatedBuilder'},
+                _animatedBuilderElement,
                 {'element': 'DefaultTextStyle'}
               ],
               'label': 'Button 1',
@@ -176,7 +180,7 @@ void main() {
                 {'name': '_ScaffoldSlot.body', 'element': 'LayoutId'},
                 {'element': 'CustomMultiChildLayout'},
                 {'element': 'Actions'},
-                {'element': 'AnimatedBuilder'},
+                _animatedBuilderElement,
                 {'element': 'DefaultTextStyle'}
               ],
               'label': 'My Icon',
@@ -204,7 +208,7 @@ void main() {
                 {'name': '_ScaffoldSlot.body', 'element': 'LayoutId'},
                 {'element': 'CustomMultiChildLayout'},
                 {'element': 'Actions'},
-                {'element': 'AnimatedBuilder'},
+                _animatedBuilderElement,
                 {'element': 'DefaultTextStyle'}
               ],
               'label': 'Button 2',
@@ -276,7 +280,7 @@ void main() {
                 {'name': '_ScaffoldSlot.body', 'element': 'LayoutId'},
                 {'element': 'CustomMultiChildLayout'},
                 {'element': 'Actions'},
-                {'element': 'AnimatedBuilder'},
+                _animatedBuilderElement,
                 {'element': 'DefaultTextStyle'}
               ],
               'view.id': 'popup_menu_button',
@@ -394,7 +398,7 @@ void main() {
                 {'name': '_ScaffoldSlot.body', 'element': 'LayoutId'},
                 {'element': 'CustomMultiChildLayout'},
                 {'element': 'Actions'},
-                {'element': 'AnimatedBuilder'},
+                _animatedBuilderElement,
                 {'element': 'DefaultTextStyle'}
               ],
               'label': 'Button 5',


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

We have incorrectly used `timestamp.toIso8601String()` and this was only accepted because the backend does lenient date/timestamp parsing.

On the native Android SDK it does lead to parsing issues though, as reported by a user.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #3554

## :green_heart: How did you test it?

Unit tests. Sample app log Android app.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes
