### PR TITLE
ci(deps): Pin Cocoa SDK auto-updates to 8.x.x

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
 
 permissions:
   contents: write

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -3,7 +3,7 @@ name: Update Dependencies
 on:
   # Run every day.
   schedule:
-    - cron: "0 3 * * *"
+    - cron: '0 3 * * *'
   # And on every PR merge so we get the updated dependencies ASAP, and to make sure the changelog doesn't conflict.
   push:
     branches:
@@ -31,6 +31,7 @@ jobs:
         with:
           path: packages/flutter/scripts/update-cocoa.sh
           name: Cocoa SDK
+          pattern: '^8\.' # Only update Cocoa SDK 8.x.x until the next major v10
           ssh-key: ${{ secrets.CI_DEPLOY_KEY }}
 
   js:

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+  pull_request:
 
 permissions:
   contents: write
@@ -31,7 +32,7 @@ jobs:
         with:
           path: packages/flutter/scripts/update-cocoa.sh
           name: Cocoa SDK
-          pattern: '^8\.' # Only update Cocoa SDK 8.x.x until the next major v10
+          pattern: '^8\.' # Only update Cocoa SDK 8.x.x until the next Sentry Flutter major v10
           ssh-key: ${{ secrets.CI_DEPLOY_KEY }}
 
   js:


### PR DESCRIPTION
Restrict the dependency updater workflow to only pick up Cocoa SDK 8.x.x
releases by adding a `pattern: '^8\.'` filter to the Cocoa updater job.

The next major Cocoa SDK version (v10) isn't ready to be adopted yet, so
we need to prevent the automated updater from bumping past 8.x.x in the
meantime.

Test PR: https://github.com/getsentry/sentry-dart/pull/3475