### PR TITLE
fix: Enable session replay on iOS 26+ with Xcode 26+

### DIFF
--- a/packages/flutter/ios/sentry_flutter/Sources/sentry_flutter/SentryFlutter.swift
+++ b/packages/flutter/ios/sentry_flutter/Sources/sentry_flutter/SentryFlutter.swift
@@ -135,6 +135,10 @@ public final class SentryFlutter {
                             "version": flutterSdk["version"]
                         ], forKey: "sdkInfo")
                 }
+              
+                // Sentry Flutter handles its own screenshot capture and masking in Dart,
+                // so it's not affected by Liquid Glass masking issues on iOS 26+.
+                options.experimental.enableSessionReplayInUnreliableEnvironment = true
             }
         #endif
     }

--- a/packages/flutter/ios/sentry_flutter/Sources/sentry_flutter/SentryFlutter.swift
+++ b/packages/flutter/ios/sentry_flutter/Sources/sentry_flutter/SentryFlutter.swift
@@ -135,7 +135,7 @@ public final class SentryFlutter {
                             "version": flutterSdk["version"]
                         ], forKey: "sdkInfo")
                 }
-              
+
                 // Sentry Flutter handles its own screenshot capture and masking in Dart,
                 // so it's not affected by Liquid Glass masking issues on iOS 26+.
                 options.experimental.enableSessionReplayInUnreliableEnvironment = true


### PR DESCRIPTION
## :scroll: Description

Sets `options.experimental.enableSessionReplayInUnreliableEnvironment = true` when Flutter replay options are configured. This ensures the Cocoa SDK's `SentrySessionReplayIntegration` continues to install on iOS 26+ built with Xcode 26+, keeping Flutter session replay functional.

## :bulb: Motivation and Context

Cocoa SDK 8.58.0 introduced an automatic disable of session replay on iOS 26+ with Xcode 26+ to prevent PII leaks caused by Apple's Liquid Glass rendering changes breaking UIKit-based masking.

However, Flutter replay is **not affected** by this issue because:
- Flutter captures its own widget tree as raw RGBA pixels in Dart via `ReplayScreenshotRecorder`
- Masking/redaction happens entirely in Dart, independent of UIKit rendering
- The native Cocoa masking (which Liquid Glass breaks) is never used for Flutter screenshots

Without this fix, the Cocoa SDK's environment check causes `SentrySessionReplayIntegration` to not install at all, which means `PrivateSentrySDKOnly.configureSessionReplay(with:screenshotProvider:)` becomes a no-op (message sent to nil), and the entire Flutter replay pipeline stops working.

## :green_heart: How did you test it?

- Tested it stops working in iOS 26
- Works with the flag enabled

## :pencil: Checklist
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

#skip-changelog