### PR TITLE
feat(span-first): Add `startSpan` and `startSpanSync`

### DIFF
--- a/packages/dart/lib/src/hub.dart
+++ b/packages/dart/lib/src/hub.dart
@@ -669,11 +669,10 @@ class Hub {
         return () async {
           final forkedScope = _forkScopeWithActiveSpan(recordingSpan);
           try {
-            final result = await runZoned(
+            return await runZoned(
               () => callback(recordingSpan),
               zoneValues: {_scopeKey: forkedScope},
             );
-            return result;
           } catch (_) {
             span.status = SentrySpanStatusV2.error;
             rethrow;
@@ -712,11 +711,10 @@ class Hub {
       case RecordingSentrySpanV2 recordingSpan:
         final forkedScope = _forkScopeWithActiveSpan(recordingSpan);
         try {
-          final result = runZoned(
+          return runZoned(
             () => callback(recordingSpan),
             zoneValues: {_scopeKey: forkedScope},
           );
-          return result;
         } catch (_) {
           span.status = SentrySpanStatusV2.error;
           rethrow;

--- a/packages/dart/lib/src/hub.dart
+++ b/packages/dart/lib/src/hub.dart
@@ -627,23 +627,24 @@ class Hub {
 
   static final _scopeKey = Object();
 
-  /// The scope forked by the innermost [startSpan] call on the current zone
-  /// chain, or `null` if we are outside any [startSpan] callback.
+  /// The scope forked by the innermost [startSpan] or [startSpanSync] call on
+  /// the current zone chain, or `null` if we are outside any span callback.
   Scope? get _zoneScope => Zone.current[_scopeKey] as Scope?;
 
   /// Returns the active span from the current zone's forked scope, or `null`
   /// if no span is active.
   ///
-  /// Only zone-forked scopes (created by [startSpan]) carry an active span.
+  /// Only zone-forked scopes (created by [startSpan] or [startSpanSync]) carry
+  /// an active span.
   /// The hub's top-level scope is never mutated, so calling this outside a
   /// [startSpan] callback always returns `null`.
   @internal
   RecordingSentrySpanV2? getActiveSpan() =>
       _zoneScope?.getActiveSpan() ?? _currentIdleSpan;
 
-  T startSpan<T>(
+  Future<T> startSpan<T>(
     String name,
-    T Function(SentrySpanV2 span) callback, {
+    Future<T> Function(SentrySpanV2 span) callback, {
     Map<String, SentryAttribute>? attributes,
     SentrySpanV2? parentSpan = const UnsetSentrySpanV2(),
     DateTime? startTimestamp,
@@ -664,52 +665,79 @@ class Hub {
           'This is a bug — the sentinel should never leak out of _createSpan.',
         );
         return callback(span);
-      case RecordingSentrySpanV2():
-        break;
+      case RecordingSentrySpanV2 recordingSpan:
+        return () async {
+          final forkedScope = _forkScopeWithActiveSpan(recordingSpan);
+          try {
+            final result = await runZoned(
+              () => callback(recordingSpan),
+              zoneValues: {_scopeKey: forkedScope},
+            );
+            _endActiveSpan(recordingSpan, forkedScope);
+            return result;
+          } catch (_) {
+            _endActiveSpan(recordingSpan, forkedScope, isError: true);
+            rethrow;
+          }
+        }();
     }
+  }
 
+  T startSpanSync<T>(
+    String name,
+    T Function(SentrySpanV2 span) callback, {
+    Map<String, SentryAttribute>? attributes,
+    SentrySpanV2? parentSpan = const UnsetSentrySpanV2(),
+    DateTime? startTimestamp,
+  }) {
+    final span = _createSpan(
+      name,
+      parentSpan: parentSpan,
+      attributes: attributes,
+      startTimestamp: startTimestamp,
+    );
+    switch (span) {
+      case NoOpSentrySpanV2():
+        internalLogger
+            .info('Hub: startSpanSync returning no-op for \'$name\'.');
+        return callback(span);
+      case UnsetSentrySpanV2():
+        internalLogger.error(
+          'Hub: _createSpan returned UnsetSentrySpanV2 for \'$name\'. '
+          'This is a bug — the sentinel should never leak out of _createSpan.',
+        );
+        return callback(span);
+      case RecordingSentrySpanV2 recordingSpan:
+        final forkedScope = _forkScopeWithActiveSpan(recordingSpan);
+        try {
+          final result = runZoned(
+            () => callback(recordingSpan),
+            zoneValues: {_scopeKey: forkedScope},
+          );
+          _endActiveSpan(recordingSpan, forkedScope);
+          return result;
+        } catch (_) {
+          _endActiveSpan(recordingSpan, forkedScope, isError: true);
+          rethrow;
+        }
+    }
+  }
+
+  Scope _forkScopeWithActiveSpan(RecordingSentrySpanV2 span) {
     final parentScope = _zoneScope ?? scope;
-    final forkedScope = parentScope.clone()..setActiveSpan(span);
+    return parentScope.clone()..setActiveSpan(span);
+  }
 
-    // Error handling is split into sync and async paths to preserve the
-    // FutureOr<T> return type — callers with a sync callback get a sync result.
-    //
-    // Note: We intentionally use runZoned() (not runZonedGuarded()) because
-    // the purpose is to propagate zone-local scope values, not to intercept
-    // errors. Using runZonedGuarded() would create an error-zone boundary
-    // that prevents errors from reaching the caller's await / catchError.
-    // The trade-off is that fire-and-forget async work inside the callback
-    // (e.g. unawaited futures, Timer.run) can throw errors that are not
-    // caught here — this is expected Dart zone behavior.
-    void endSpan({bool isError = false}) {
-      if (isError) span.status = SentrySpanStatusV2.error;
-      span.end();
-      forkedScope.removeActiveSpan(span);
+  void _endActiveSpan(
+    RecordingSentrySpanV2 span,
+    Scope forkedScope, {
+    bool isError = false,
+  }) {
+    if (isError) {
+      span.status = SentrySpanStatusV2.error;
     }
-
-    T result;
-    try {
-      result = runZoned(
-        () => callback(span),
-        zoneValues: {_scopeKey: forkedScope},
-      );
-    } catch (_) {
-      endSpan(isError: true);
-      rethrow;
-    }
-
-    if (result is Future) {
-      return (result as Future).then((value) {
-        endSpan();
-        return value;
-      }, onError: (Object error, StackTrace stackTrace) {
-        endSpan(isError: true);
-        return Future<T>.error(error, stackTrace);
-      }) as T;
-    }
-
-    endSpan();
-    return result;
+    span.end();
+    forkedScope.removeActiveSpan(span);
   }
 
   SentrySpanV2 startInactiveSpan(

--- a/packages/dart/lib/src/hub.dart
+++ b/packages/dart/lib/src/hub.dart
@@ -641,16 +641,18 @@ class Hub {
   RecordingSentrySpanV2? getActiveSpan() =>
       _zoneScope?.getActiveSpan() ?? _currentIdleSpan;
 
-  FutureOr<T> startSpan<T>(
+  T startSpan<T>(
     String name,
-    FutureOr<T> Function(SentrySpanV2 span) callback, {
+    T Function(SentrySpanV2 span) callback, {
     Map<String, SentryAttribute>? attributes,
     SentrySpanV2? parentSpan = const UnsetSentrySpanV2(),
+    DateTime? startTimestamp,
   }) {
     final span = _createSpan(
       name,
       parentSpan: parentSpan,
       attributes: attributes,
+      startTimestamp: startTimestamp,
     );
     switch (span) {
       case NoOpSentrySpanV2():
@@ -685,7 +687,7 @@ class Hub {
       forkedScope.removeActiveSpan(span);
     }
 
-    FutureOr<T> result;
+    T result;
     try {
       result = runZoned(
         () => callback(span),
@@ -696,14 +698,14 @@ class Hub {
       rethrow;
     }
 
-    if (result is Future<T>) {
-      return result.then((value) {
+    if (result is Future) {
+      return (result as Future).then((value) {
         endSpan();
         return value;
       }, onError: (Object error, StackTrace stackTrace) {
         endSpan(isError: true);
         return Future<T>.error(error, stackTrace);
-      });
+      }) as T;
     }
 
     endSpan();

--- a/packages/dart/lib/src/hub.dart
+++ b/packages/dart/lib/src/hub.dart
@@ -673,11 +673,13 @@ class Hub {
               () => callback(recordingSpan),
               zoneValues: {_scopeKey: forkedScope},
             );
-            _endActiveSpan(recordingSpan, forkedScope);
             return result;
           } catch (_) {
-            _endActiveSpan(recordingSpan, forkedScope, isError: true);
+            span.status = SentrySpanStatusV2.error;
             rethrow;
+          } finally {
+            span.end();
+            forkedScope.removeActiveSpan(span);
           }
         }();
     }
@@ -714,11 +716,13 @@ class Hub {
             () => callback(recordingSpan),
             zoneValues: {_scopeKey: forkedScope},
           );
-          _endActiveSpan(recordingSpan, forkedScope);
           return result;
         } catch (_) {
-          _endActiveSpan(recordingSpan, forkedScope, isError: true);
+          span.status = SentrySpanStatusV2.error;
           rethrow;
+        } finally {
+          span.end();
+          forkedScope.removeActiveSpan(span);
         }
     }
   }
@@ -726,18 +730,6 @@ class Hub {
   Scope _forkScopeWithActiveSpan(RecordingSentrySpanV2 span) {
     final parentScope = _zoneScope ?? scope;
     return parentScope.clone()..setActiveSpan(span);
-  }
-
-  void _endActiveSpan(
-    RecordingSentrySpanV2 span,
-    Scope forkedScope, {
-    bool isError = false,
-  }) {
-    if (isError) {
-      span.status = SentrySpanStatusV2.error;
-    }
-    span.end();
-    forkedScope.removeActiveSpan(span);
   }
 
   SentrySpanV2 startInactiveSpan(

--- a/packages/dart/lib/src/hub.dart
+++ b/packages/dart/lib/src/hub.dart
@@ -634,8 +634,6 @@ class Hub {
   /// Returns the active span from the current zone's forked scope, or `null`
   /// if no span is active.
   ///
-  /// Only zone-forked scopes (created by [startSpan] or [startSpanSync]) carry
-  /// an active span.
   /// The hub's top-level scope is never mutated, so calling this outside a
   /// [startSpan] callback always returns `null`.
   @internal

--- a/packages/dart/lib/src/hub.dart
+++ b/packages/dart/lib/src/hub.dart
@@ -654,7 +654,7 @@ class Hub {
     Map<String, SentryAttribute>? attributes,
     SentrySpanV2? parentSpan = const UnsetSentrySpanV2(),
     DateTime? startTimestamp,
-  }) {
+  }) async {
     final span = _createSpan(
       name,
       parentSpan: parentSpan,
@@ -672,21 +672,19 @@ class Hub {
         );
         return callback(span);
       case RecordingSentrySpanV2 recordingSpan:
-        return () async {
-          final forkedScope = _forkScopeWithActiveSpan(recordingSpan);
-          try {
-            return await runZoned(
-              () => callback(recordingSpan),
-              zoneValues: {_scopeKey: forkedScope},
-            );
-          } catch (_) {
-            span.status = SentrySpanStatusV2.error;
-            rethrow;
-          } finally {
-            span.end();
-            forkedScope.removeActiveSpan(span);
-          }
-        }();
+        final forkedScope = _forkScopeWithActiveSpan(recordingSpan);
+        try {
+          return await runZoned(
+            () => callback(recordingSpan),
+            zoneValues: {_scopeKey: forkedScope},
+          );
+        } catch (_) {
+          span.status = SentrySpanStatusV2.error;
+          rethrow;
+        } finally {
+          span.end();
+          forkedScope.removeActiveSpan(span);
+        }
     }
   }
 

--- a/packages/dart/lib/src/hub.dart
+++ b/packages/dart/lib/src/hub.dart
@@ -627,15 +627,23 @@ class Hub {
 
   static final _scopeKey = Object();
 
-  /// The scope forked by the innermost [startSpan] or [startSpanSync] call on
-  /// the current zone chain, or `null` if we are outside any span callback.
+  /// The [Scope] forked by the innermost [startSpan] or [startSpanSync] call
+  /// on the current zone chain, or `null` if the current zone has no
+  /// associated scope (i.e. we are outside any span callback).
+  ///
+  /// Each call to [startSpan]/[startSpanSync] creates a new [Zone] with a
+  /// forked scope stored under [_scopeKey]. Walking up the zone chain via
+  /// `Zone.current[_scopeKey]` therefore gives the most recently pushed scope.
   Scope? get _zoneScope => Zone.current[_scopeKey] as Scope?;
 
-  /// Returns the active span from the current zone's forked scope, or `null`
-  /// if no span is active.
+  /// Returns the currently active span, or `null` if no span is in progress.
   ///
-  /// The hub's top-level scope is never mutated, so calling this outside a
-  /// [startSpan] callback always returns `null`.
+  /// Resolution order:
+  /// 1. The active span on the zone-forked scope ([_zoneScope]) — this is set
+  ///    when code is running inside a [startSpan] or [startSpanSync] callback.
+  /// 2. The hub-level idle span ([_currentIdleSpan]) — present when an idle
+  ///    span has been started and has not yet ended.
+  /// 3. `null` — no span is active.
   @internal
   RecordingSentrySpanV2? getActiveSpan() =>
       _zoneScope?.getActiveSpan() ?? _currentIdleSpan;

--- a/packages/dart/lib/src/hub_adapter.dart
+++ b/packages/dart/lib/src/hub_adapter.dart
@@ -237,12 +237,15 @@ class HubAdapter implements Hub {
   }
 
   @override
-  FutureOr<T> startSpan<T>(
-      String name, FutureOr<T> Function(SentrySpanV2 span) callback,
+  T startSpan<T>(
+      String name, T Function(SentrySpanV2 span) callback,
       {Map<String, SentryAttribute>? attributes,
-      SentrySpanV2? parentSpan = const UnsetSentrySpanV2()}) {
+      SentrySpanV2? parentSpan = const UnsetSentrySpanV2(),
+      DateTime? startTimestamp}) {
     return Sentry.currentHub.startSpan(name, callback,
-        attributes: attributes, parentSpan: parentSpan);
+        attributes: attributes,
+        parentSpan: parentSpan,
+        startTimestamp: startTimestamp);
   }
 
   @override

--- a/packages/dart/lib/src/hub_adapter.dart
+++ b/packages/dart/lib/src/hub_adapter.dart
@@ -237,12 +237,23 @@ class HubAdapter implements Hub {
   }
 
   @override
-  T startSpan<T>(
-      String name, T Function(SentrySpanV2 span) callback,
+  Future<T> startSpan<T>(
+      String name, Future<T> Function(SentrySpanV2 span) callback,
       {Map<String, SentryAttribute>? attributes,
       SentrySpanV2? parentSpan = const UnsetSentrySpanV2(),
       DateTime? startTimestamp}) {
     return Sentry.currentHub.startSpan(name, callback,
+        attributes: attributes,
+        parentSpan: parentSpan,
+        startTimestamp: startTimestamp);
+  }
+
+  @override
+  T startSpanSync<T>(String name, T Function(SentrySpanV2 span) callback,
+      {Map<String, SentryAttribute>? attributes,
+      SentrySpanV2? parentSpan = const UnsetSentrySpanV2(),
+      DateTime? startTimestamp}) {
+    return Sentry.currentHub.startSpanSync(name, callback,
         attributes: attributes,
         parentSpan: parentSpan,
         startTimestamp: startTimestamp);

--- a/packages/dart/lib/src/noop_hub.dart
+++ b/packages/dart/lib/src/noop_hub.dart
@@ -174,7 +174,16 @@ class NoOpHub implements Hub {
   }
 
   @override
-  T startSpan<T>(String name, T Function(SentrySpanV2 span) callback,
+  Future<T> startSpan<T>(
+      String name, Future<T> Function(SentrySpanV2 span) callback,
+      {Map<String, SentryAttribute>? attributes,
+      SentrySpanV2? parentSpan = const UnsetSentrySpanV2(),
+      DateTime? startTimestamp}) {
+    return callback(NoOpSentrySpanV2.instance);
+  }
+
+  @override
+  T startSpanSync<T>(String name, T Function(SentrySpanV2 span) callback,
       {Map<String, SentryAttribute>? attributes,
       SentrySpanV2? parentSpan = const UnsetSentrySpanV2(),
       DateTime? startTimestamp}) {

--- a/packages/dart/lib/src/noop_hub.dart
+++ b/packages/dart/lib/src/noop_hub.dart
@@ -174,10 +174,10 @@ class NoOpHub implements Hub {
   }
 
   @override
-  FutureOr<T> startSpan<T>(
-      String name, FutureOr<T> Function(SentrySpanV2 span) callback,
+  T startSpan<T>(String name, T Function(SentrySpanV2 span) callback,
       {Map<String, SentryAttribute>? attributes,
-      SentrySpanV2? parentSpan = const UnsetSentrySpanV2()}) {
+      SentrySpanV2? parentSpan = const UnsetSentrySpanV2(),
+      DateTime? startTimestamp}) {
     return callback(NoOpSentrySpanV2.instance);
   }
 

--- a/packages/dart/lib/src/noop_hub.dart
+++ b/packages/dart/lib/src/noop_hub.dart
@@ -178,7 +178,7 @@ class NoOpHub implements Hub {
       String name, Future<T> Function(SentrySpanV2 span) callback,
       {Map<String, SentryAttribute>? attributes,
       SentrySpanV2? parentSpan = const UnsetSentrySpanV2(),
-      DateTime? startTimestamp}) {
+      DateTime? startTimestamp}) async {
     return callback(NoOpSentrySpanV2.instance);
   }
 
@@ -186,7 +186,7 @@ class NoOpHub implements Hub {
   T startSpanSync<T>(String name, T Function(SentrySpanV2 span) callback,
       {Map<String, SentryAttribute>? attributes,
       SentrySpanV2? parentSpan = const UnsetSentrySpanV2(),
-      DateTime? startTimestamp}) {
+      DateTime? startTimestamp}) async {
     return callback(NoOpSentrySpanV2.instance);
   }
 

--- a/packages/dart/lib/src/noop_hub.dart
+++ b/packages/dart/lib/src/noop_hub.dart
@@ -186,7 +186,7 @@ class NoOpHub implements Hub {
   T startSpanSync<T>(String name, T Function(SentrySpanV2 span) callback,
       {Map<String, SentryAttribute>? attributes,
       SentrySpanV2? parentSpan = const UnsetSentrySpanV2(),
-      DateTime? startTimestamp}) async {
+      DateTime? startTimestamp}) {
     return callback(NoOpSentrySpanV2.instance);
   }
 

--- a/packages/dart/lib/src/sentry.dart
+++ b/packages/dart/lib/src/sentry.dart
@@ -398,6 +398,13 @@ class Sentry {
   /// the span's status is set to [SentrySpanStatusV2.error] before ending.
   /// Use [startSpanSync] when the work completes synchronously.
   ///
+  /// Both variants can be freely nested — parent-child relationships resolve
+  /// correctly across sync/async boundaries.
+  ///
+  /// When the span is not sent — due to sampling or ignore rules — the
+  /// [callback] still executes but receives a [NoOpSentrySpanV2]. All
+  /// operations on it (e.g. [SentrySpanV2.setAttribute]) are safe no-ops.
+  ///
   /// By default, the span is created as a child of the currently active span.
   /// Pass a [SentrySpanV2] as [parentSpan] to override the parent, or pass
   /// `null` to create a root span.
@@ -429,8 +436,24 @@ class Sentry {
   /// Starts a new span, executes a synchronous [callback], and ends the span
   /// before returning the callback result.
   ///
-  /// This is the synchronous variant of [startSpan]. Use [startSpan] when the
-  /// work is asynchronous.
+  /// The span is set as the active span within the [callback]'s scope via
+  /// zones, so any nested [startSpan] or [startSpanSync] calls will
+  /// automatically parent to it.
+  ///
+  /// If the [callback] throws, the span's status is set to
+  /// [SentrySpanStatusV2.error] before ending.
+  /// Use [startSpan] when the work is asynchronous.
+  ///
+  /// Both variants can be freely nested — parent-child relationships resolve
+  /// correctly across sync/async boundaries.
+  ///
+  /// When the span is not sent — due to sampling or ignore rules — the
+  /// [callback] still executes but receives a [NoOpSentrySpanV2]. All
+  /// operations on it (e.g. [SentrySpanV2.setAttribute]) are safe no-ops.
+  ///
+  /// By default, the span is created as a child of the currently active span.
+  /// Pass a [SentrySpanV2] as [parentSpan] to override the parent, or pass
+  /// `null` to create a root span.
   static T startSpanSync<T>(
     String name,
     T Function(SentrySpanV2 span) callback, {

--- a/packages/dart/lib/src/sentry.dart
+++ b/packages/dart/lib/src/sentry.dart
@@ -411,14 +411,17 @@ class Sentry {
   ///   return orderService.create(cart, payment);
   /// });
   /// ```
-  static FutureOr<T> startSpan<T>(
+  static T startSpan<T>(
     String name,
-    FutureOr<T> Function(SentrySpanV2 span) callback, {
+    T Function(SentrySpanV2 span) callback, {
     Map<String, SentryAttribute>? attributes,
     SentrySpanV2? parentSpan = const UnsetSentrySpanV2(),
+    DateTime? startTimestamp,
   }) =>
       _hub.startSpan(name, callback,
-          attributes: attributes, parentSpan: parentSpan);
+          attributes: attributes,
+          parentSpan: parentSpan,
+          startTimestamp: startTimestamp);
 
   /// Creates a span that is not set as the active span.
   ///

--- a/packages/dart/lib/src/sentry.dart
+++ b/packages/dart/lib/src/sentry.dart
@@ -387,13 +387,15 @@ class Sentry {
         onFinish: onFinish,
       );
 
-  /// Starts a new span, executes [callback], and ends the span automatically.
+  /// Starts a new span, executes an async [callback], and ends the span
+  /// automatically when the returned future completes.
   ///
   /// The span is set as the active span within the [callback]'s scope via
   /// zones, so any nested [startSpan] calls will automatically parent to it.
   ///
   /// If the [callback] throws or the returned future completes with an error,
   /// the span's status is set to [SentrySpanStatusV2.error] before ending.
+  /// Use [startSpanSync] when the work completes synchronously.
   ///
   /// By default, the span is created as a child of the currently active span.
   /// Pass a [SentrySpanV2] as [parentSpan] to override the parent, or pass
@@ -411,14 +413,31 @@ class Sentry {
   ///   return orderService.create(cart, payment);
   /// });
   /// ```
-  static T startSpan<T>(
+  static Future<T> startSpan<T>(
+    String name,
+    Future<T> Function(SentrySpanV2 span) callback, {
+    Map<String, SentryAttribute>? attributes,
+    SentrySpanV2? parentSpan = const UnsetSentrySpanV2(),
+    DateTime? startTimestamp,
+  }) =>
+      _hub.startSpan(name, callback,
+          attributes: attributes,
+          parentSpan: parentSpan,
+          startTimestamp: startTimestamp);
+
+  /// Starts a new span, executes a synchronous [callback], and ends the span
+  /// before returning the callback result.
+  ///
+  /// This is the synchronous variant of [startSpan]. Use [startSpan] when the
+  /// work is asynchronous.
+  static T startSpanSync<T>(
     String name,
     T Function(SentrySpanV2 span) callback, {
     Map<String, SentryAttribute>? attributes,
     SentrySpanV2? parentSpan = const UnsetSentrySpanV2(),
     DateTime? startTimestamp,
   }) =>
-      _hub.startSpan(name, callback,
+      _hub.startSpanSync(name, callback,
           attributes: attributes,
           parentSpan: parentSpan,
           startTimestamp: startTimestamp);
@@ -434,8 +453,8 @@ class Sentry {
   /// Pass a [SentrySpanV2] as [parentSpan] to override the parent, or pass
   /// `null` to create a root span.
   ///
-  /// Prefer [startSpan] when the work fits inside a single callback. Use
-  /// this method when the span must survive across execution boundaries
+  /// Prefer [startSpan] or [startSpanSync] when the work fits inside a single
+  /// callback. Use this method when the span must survive across execution boundaries
   /// that a callback cannot wrap — for example, widget lifecycles, stream
   /// subscriptions, or platform channel round-trips.
   ///

--- a/packages/dart/lib/src/sentry.dart
+++ b/packages/dart/lib/src/sentry.dart
@@ -391,7 +391,8 @@ class Sentry {
   /// automatically when the returned future completes.
   ///
   /// The span is set as the active span within the [callback]'s scope via
-  /// zones, so any nested [startSpan] calls will automatically parent to it.
+  /// zones, so any nested [startSpan] or [startSpanSync] calls will
+  /// automatically parent to it.
   ///
   /// If the [callback] throws or the returned future completes with an error,
   /// the span's status is set to [SentrySpanStatusV2.error] before ending.

--- a/packages/dart/test/hub_span_test.dart
+++ b/packages/dart/test/hub_span_test.dart
@@ -461,12 +461,12 @@ void main() {
       });
     });
 
-    group('startSpan', () {
+    group('startSpanSync', () {
       group('with sync callback', () {
         test('returns callback result', () {
           final hub = fixture.getSut();
 
-          final result = hub.startSpan('test-span', (span) => 42);
+          final result = hub.startSpanSync('test-span', (span) => 42);
 
           expect(result, equals(42));
         });
@@ -475,7 +475,7 @@ void main() {
           final hub = fixture.getSut();
           late RecordingSentrySpanV2 capturedSpan;
 
-          hub.startSpan('test-span', (span) {
+          hub.startSpanSync('test-span', (span) {
             capturedSpan = span as RecordingSentrySpanV2;
             expect(span.isEnded, isFalse);
           });
@@ -486,7 +486,7 @@ void main() {
         test('provides RecordingSentrySpanV2 when tracing is enabled', () {
           final hub = fixture.getSut();
 
-          hub.startSpan('test-span', (span) {
+          hub.startSpanSync('test-span', (span) {
             expect(span, isA<RecordingSentrySpanV2>());
           });
         });
@@ -494,7 +494,7 @@ void main() {
         test('provides NoOpSentrySpanV2 when tracing is disabled', () {
           final hub = fixture.getSut(tracesSampleRate: null);
 
-          hub.startSpan('test-span', (span) {
+          hub.startSpanSync('test-span', (span) {
             expect(span, isA<NoOpSentrySpanV2>());
           });
         });
@@ -504,7 +504,7 @@ void main() {
           late RecordingSentrySpanV2 capturedSpan;
 
           expect(
-            () => hub.startSpan('test-span', (span) {
+            () => hub.startSpanSync('test-span', (span) {
               capturedSpan = span as RecordingSentrySpanV2;
               throw StateError('test error');
             }),
@@ -516,6 +516,179 @@ void main() {
         });
       });
 
+      group('with zone-based scope forking', () {
+        test('nested calls build correct parent-child chain', () {
+          final hub = fixture.getSut();
+          late SentrySpanV2 outerSpan;
+          late SentrySpanV2 innerSpan;
+
+          hub.startSpanSync('outer', (span) {
+            outerSpan = span;
+            hub.startSpanSync('inner', (span) {
+              innerSpan = span;
+            });
+          });
+
+          expect(outerSpan.parentSpan, isNull);
+          expect(innerSpan.parentSpan, equals(outerSpan));
+        });
+
+        test('sibling spans share same parent', () {
+          final hub = fixture.getSut();
+          late SentrySpanV2 parent;
+          late SentrySpanV2 child1;
+          late SentrySpanV2 child2;
+
+          hub.startSpanSync('parent', (span) {
+            parent = span;
+            hub.startSpanSync('child-1', (span) {
+              child1 = span;
+            });
+            hub.startSpanSync('child-2', (span) {
+              child2 = span;
+            });
+          });
+
+          expect(child1.parentSpan, equals(parent));
+          expect(child2.parentSpan, equals(parent));
+        });
+
+        test('does not leak active span to outer scope after callback', () {
+          final hub = fixture.getSut();
+
+          hub.startSpanSync('outer', (span) {
+            final outerActiveSpan = hub.getActiveSpan();
+            expect(outerActiveSpan, equals(span));
+
+            hub.startSpanSync('inner', (innerSpan) {
+              final innerActiveSpan = hub.getActiveSpan();
+              expect(innerActiveSpan, equals(innerSpan));
+            });
+
+            final afterInner = hub.getActiveSpan();
+            expect(afterInner, equals(span));
+          });
+        });
+
+        test('does not pollute hub scope active span', () {
+          final hub = fixture.getSut();
+
+          expect(hub.scope.activeSpan, isNull);
+
+          hub.startSpanSync('test-span', (span) {});
+
+          expect(hub.scope.activeSpan, isNull);
+        });
+      });
+
+      group('with explicit parentSpan', () {
+        test('uses provided parent instead of zone-resolved parent', () {
+          final hub = fixture.getSut();
+          late SentrySpanV2 explicitParent;
+          late SentrySpanV2 child;
+
+          hub.startSpanSync('explicit-parent', (span) {
+            explicitParent = span;
+          });
+
+          hub.startSpanSync('outer', (outerSpan) {
+            hub.startSpanSync('child', (span) {
+              child = span;
+            }, parentSpan: explicitParent);
+          });
+
+          expect(child.parentSpan, equals(explicitParent));
+        });
+
+        test('creates root span when parentSpan is null', () {
+          final hub = fixture.getSut();
+          late SentrySpanV2 child;
+
+          hub.startSpanSync('outer', (outerSpan) {
+            hub.startSpanSync('root-child', (span) {
+              child = span;
+            }, parentSpan: null);
+          });
+
+          expect(child.parentSpan, isNull);
+        });
+      });
+
+      group('with attributes', () {
+        test('passes attributes to created span', () {
+          final hub = fixture.getSut();
+          final attrs = {
+            'http.method': SentryAttribute.string('GET'),
+            'http.status_code': SentryAttribute.int(200),
+          };
+
+          hub.startSpanSync('test-span', (span) {
+            expect(span.attributes, equals(attrs));
+          }, attributes: attrs);
+        });
+      });
+
+      group('with startTimestamp', () {
+        test('uses provided timestamp', () {
+          final hub = fixture.getSut();
+          final past = DateTime(2024, 1, 1, 12, 0, 0);
+          late RecordingSentrySpanV2 capturedSpan;
+
+          hub.startSpanSync('test-span', (span) {
+            capturedSpan = span as RecordingSentrySpanV2;
+          }, startTimestamp: past);
+
+          expect(capturedSpan.startTimestamp, equals(past.toUtc()));
+          expect(capturedSpan.startTimestamp.isUtc, isTrue);
+        });
+      });
+
+      group('when capturing spans', () {
+        test('captures span via client on end', () {
+          final hub = fixture.getSut();
+
+          hub.startSpanSync('test-span', (span) {});
+
+          expect(fixture.client.captureSpanCalls, hasLength(1));
+        });
+
+        test('captures all nested spans', () {
+          final hub = fixture.getSut();
+
+          hub.startSpanSync('outer', (span) {
+            hub.startSpanSync('inner', (span) {});
+          });
+
+          expect(fixture.client.captureSpanCalls, hasLength(2));
+        });
+      });
+
+      group('when ignoreSpans rules are configured', () {
+        test('does not capture ignored span', () {
+          fixture.options.ignoreSpans = [
+            IgnoreSpanRule.nameEquals('ignored-span'),
+          ];
+          final hub = fixture.getSut();
+
+          hub.startSpanSync('ignored-span', (span) {});
+
+          expect(fixture.client.captureSpanCalls, isEmpty);
+        });
+
+        test('still returns sync callback result for ignored span', () {
+          fixture.options.ignoreSpans = [
+            IgnoreSpanRule.nameEquals('ignored-span'),
+          ];
+          final hub = fixture.getSut();
+
+          final result = hub.startSpanSync('ignored-span', (span) => 42);
+
+          expect(result, equals(42));
+        });
+      });
+    });
+
+    group('startSpan', () {
       group('with async callback', () {
         test('returns callback result', () async {
           final hub = fixture.getSut();
@@ -537,6 +710,23 @@ void main() {
           expect(capturedSpan.isEnded, isTrue);
         });
 
+        test('provides RecordingSentrySpanV2 when tracing is enabled',
+            () async {
+          final hub = fixture.getSut();
+
+          await hub.startSpan('test-span', (span) async {
+            expect(span, isA<RecordingSentrySpanV2>());
+          });
+        });
+
+        test('provides NoOpSentrySpanV2 when tracing is disabled', () async {
+          final hub = fixture.getSut(tracesSampleRate: null);
+
+          await hub.startSpan('test-span', (span) async {
+            expect(span, isA<NoOpSentrySpanV2>());
+          });
+        });
+
         test('sets error status and ends span on async error', () async {
           final hub = fixture.getSut();
           late RecordingSentrySpanV2 capturedSpan;
@@ -555,15 +745,16 @@ void main() {
       });
 
       group('with zone-based scope forking', () {
-        test('nested calls build correct parent-child chain', () {
+        test('nested calls build correct parent-child chain', () async {
           final hub = fixture.getSut();
           late SentrySpanV2 outerSpan;
           late SentrySpanV2 innerSpan;
 
-          hub.startSpan('outer', (span) {
+          await hub.startSpan('outer', (span) async {
             outerSpan = span;
-            hub.startSpan('inner', (span) {
+            await hub.startSpan('inner', (span) async {
               innerSpan = span;
+              await Future<void>.delayed(Duration.zero);
             });
           });
 
@@ -571,39 +762,18 @@ void main() {
           expect(innerSpan.parentSpan, equals(outerSpan));
         });
 
-        test('3-level nesting builds correct parent chain', () {
-          final hub = fixture.getSut();
-          late SentrySpanV2 level1;
-          late SentrySpanV2 level2;
-          late SentrySpanV2 level3;
-
-          hub.startSpan('level-1', (span) {
-            level1 = span;
-            hub.startSpan('level-2', (span) {
-              level2 = span;
-              hub.startSpan('level-3', (span) {
-                level3 = span;
-              });
-            });
-          });
-
-          expect(level1.parentSpan, isNull);
-          expect(level2.parentSpan, equals(level1));
-          expect(level3.parentSpan, equals(level2));
-        });
-
-        test('sibling spans share same parent', () {
+        test('sibling spans share same parent', () async {
           final hub = fixture.getSut();
           late SentrySpanV2 parent;
           late SentrySpanV2 child1;
           late SentrySpanV2 child2;
 
-          hub.startSpan('parent', (span) {
+          await hub.startSpan('parent', (span) async {
             parent = span;
-            hub.startSpan('child-1', (span) {
+            await hub.startSpan('child-1', (span) async {
               child1 = span;
             });
-            hub.startSpan('child-2', (span) {
+            await hub.startSpan('child-2', (span) async {
               child2 = span;
             });
           });
@@ -612,20 +782,20 @@ void main() {
           expect(child2.parentSpan, equals(parent));
         });
 
-        test('does not leak active span to outer scope after callback', () {
+        test('does not leak active span to outer scope after callback',
+            () async {
           final hub = fixture.getSut();
 
-          hub.startSpan('outer', (span) {
+          await hub.startSpan('outer', (span) async {
             final outerActiveSpan = hub.getActiveSpan();
             expect(outerActiveSpan, equals(span));
 
-            hub.startSpan('inner', (innerSpan) {
+            await hub.startSpan('inner', (innerSpan) async {
               final innerActiveSpan = hub.getActiveSpan();
               expect(innerActiveSpan, equals(innerSpan));
+              await Future<void>.delayed(Duration.zero);
             });
 
-            // After inner callback, zone pops so active span should still
-            // be the outer span in this zone.
             final afterInner = hub.getActiveSpan();
             expect(afterInner, equals(span));
           });
@@ -637,60 +807,59 @@ void main() {
           late SentrySpanV2 child1;
           late SentrySpanV2 child2;
 
-          await hub.startSpan<void>('parent', (span) async {
+          await hub.startSpan('parent', (span) async {
             parent = span;
-            final f1 = hub.startSpan<void>('child-1', (span) async {
+            final f1 = hub.startSpan('child-1', (span) async {
               child1 = span;
-              await Future.delayed(Duration.zero);
+              await Future<void>.delayed(Duration.zero);
             });
-            final f2 = hub.startSpan<void>('child-2', (span) async {
+            final f2 = hub.startSpan('child-2', (span) async {
               child2 = span;
-              await Future.delayed(Duration.zero);
+              await Future<void>.delayed(Duration.zero);
             });
-            await Future.wait([f1 as Future<void>, f2 as Future<void>]);
+            await Future.wait([f1, f2]);
           });
 
           expect(child1.parentSpan, equals(parent));
           expect(child2.parentSpan, equals(parent));
         });
 
-        test('does not pollute hub scope active span', () {
+        test('does not pollute hub scope active span', () async {
           final hub = fixture.getSut();
 
           expect(hub.scope.activeSpan, isNull);
 
-          hub.startSpan('test-span', (span) {});
+          await hub.startSpan('test-span', (span) async {});
 
           expect(hub.scope.activeSpan, isNull);
         });
       });
 
       group('with explicit parentSpan', () {
-        test('uses provided parent instead of zone-resolved parent', () {
+        test('uses provided parent instead of zone-resolved parent', () async {
           final hub = fixture.getSut();
           late SentrySpanV2 explicitParent;
           late SentrySpanV2 child;
 
-          hub.startSpan('explicit-parent', (span) {
+          await hub.startSpan('explicit-parent', (span) async {
             explicitParent = span;
           });
 
-          hub.startSpan('outer', (outerSpan) {
-            child = hub.startInactiveSpan(
-              'child',
-              parentSpan: explicitParent,
-            );
+          await hub.startSpan('outer', (outerSpan) async {
+            await hub.startSpan('child', (span) async {
+              child = span;
+            }, parentSpan: explicitParent);
           });
 
           expect(child.parentSpan, equals(explicitParent));
         });
 
-        test('creates root span when parentSpan is null', () {
+        test('creates root span when parentSpan is null', () async {
           final hub = fixture.getSut();
           late SentrySpanV2 child;
 
-          hub.startSpan('outer', (outerSpan) {
-            hub.startSpan('root-child', (span) {
+          await hub.startSpan('outer', (outerSpan) async {
+            await hub.startSpan('root-child', (span) async {
               child = span;
             }, parentSpan: null);
           });
@@ -700,36 +869,76 @@ void main() {
       });
 
       group('with attributes', () {
-        test('passes attributes to created span', () {
+        test('passes attributes to created span', () async {
           final hub = fixture.getSut();
           final attrs = {
             'http.method': SentryAttribute.string('GET'),
             'http.status_code': SentryAttribute.int(200),
           };
 
-          hub.startSpan('test-span', (span) {
+          await hub.startSpan('test-span', (span) async {
             expect(span.attributes, equals(attrs));
           }, attributes: attrs);
         });
       });
 
+      group('with startTimestamp', () {
+        test('uses provided timestamp', () async {
+          final hub = fixture.getSut();
+          final past = DateTime(2024, 1, 1, 12, 0, 0);
+          late RecordingSentrySpanV2 capturedSpan;
+
+          await hub.startSpan('test-span', (span) async {
+            capturedSpan = span as RecordingSentrySpanV2;
+          }, startTimestamp: past);
+
+          expect(capturedSpan.startTimestamp, equals(past.toUtc()));
+          expect(capturedSpan.startTimestamp.isUtc, isTrue);
+        });
+      });
+
       group('when capturing spans', () {
-        test('captures span via client on end', () {
+        test('captures span via client on end', () async {
           final hub = fixture.getSut();
 
-          hub.startSpan('test-span', (span) {});
+          await hub.startSpan('test-span', (span) async {});
 
           expect(fixture.client.captureSpanCalls, hasLength(1));
         });
 
-        test('captures all nested spans', () {
+        test('captures all nested spans', () async {
           final hub = fixture.getSut();
 
-          hub.startSpan('outer', (span) {
-            hub.startSpan('inner', (span) {});
+          await hub.startSpan('outer', (span) async {
+            await hub.startSpan('inner', (span) async {});
           });
 
           expect(fixture.client.captureSpanCalls, hasLength(2));
+        });
+      });
+
+      group('when ignoreSpans rules are configured', () {
+        test('does not capture ignored span', () async {
+          fixture.options.ignoreSpans = [
+            IgnoreSpanRule.nameEquals('ignored-span'),
+          ];
+          final hub = fixture.getSut();
+
+          await hub.startSpan('ignored-span', (span) async {});
+
+          expect(fixture.client.captureSpanCalls, isEmpty);
+        });
+
+        test('still returns async callback result for ignored span', () async {
+          fixture.options.ignoreSpans = [
+            IgnoreSpanRule.nameEquals('ignored-span'),
+          ];
+          final hub = fixture.getSut();
+
+          final result =
+              await hub.startSpan('ignored-span', (span) async => 42);
+
+          expect(result, equals(42));
         });
       });
     });
@@ -867,6 +1076,8 @@ void main() {
         await hub.close();
 
         await hub.captureSpan(span);
+        await Sentry.startSpan('test-span', (span) async => 42);
+        Sentry.startSpanSync('test-span', (span) => 42);
 
         expect(fixture.client.captureSpanCalls, isEmpty);
       });
@@ -882,132 +1093,6 @@ void main() {
 
         expect(hub.scope.activeSpan, isNull);
         expect(fixture.client.captureSpanCalls, isEmpty);
-      });
-    });
-
-    group('startSpan', () {
-      group('when ignoreSpans rules are configured', () {
-        test('provides NoOpSentrySpanV2 for matching rule', () {
-          fixture.options.ignoreSpans = [
-            IgnoreSpanRule.nameEquals('ignored-span'),
-          ];
-          final hub = fixture.getSut();
-
-          hub.startSpan('ignored-span', (span) {
-            expect(span, isA<NoOpSentrySpanV2>());
-          });
-        });
-
-        test('provides RecordingSentrySpanV2 for non-matching rule', () {
-          fixture.options.ignoreSpans = [
-            IgnoreSpanRule.nameEquals('ignored-span'),
-          ];
-          final hub = fixture.getSut();
-
-          hub.startSpan('other-span', (span) {
-            expect(span, isA<RecordingSentrySpanV2>());
-          });
-        });
-
-        test('does not capture ignored span', () {
-          fixture.options.ignoreSpans = [
-            IgnoreSpanRule.nameEquals('ignored-span'),
-          ];
-          final hub = fixture.getSut();
-
-          hub.startSpan('ignored-span', (span) {});
-
-          expect(fixture.client.captureSpanCalls, isEmpty);
-        });
-
-        test('still returns sync callback result for ignored span', () {
-          fixture.options.ignoreSpans = [
-            IgnoreSpanRule.nameEquals('ignored-span'),
-          ];
-          final hub = fixture.getSut();
-
-          final result = hub.startSpan('ignored-span', (span) => 42);
-
-          expect(result, equals(42));
-        });
-
-        test('still returns async callback result for ignored span', () async {
-          fixture.options.ignoreSpans = [
-            IgnoreSpanRule.nameEquals('ignored-span'),
-          ];
-          final hub = fixture.getSut();
-
-          final result =
-              await hub.startSpan('ignored-span', (span) async => 42);
-
-          expect(result, equals(42));
-        });
-
-        test('re-parents through multiple consecutive ignored spans', () {
-          fixture.options.ignoreSpans = [
-            IgnoreSpanRule.nameEquals('ignored-1'),
-            IgnoreSpanRule.nameEquals('ignored-2'),
-            IgnoreSpanRule.nameEquals('ignored-3'),
-          ];
-          final hub = fixture.getSut();
-
-          final root = hub.startInactiveSpan('root', parentSpan: null);
-          final ignored1 = hub.startInactiveSpan('ignored-1', parentSpan: root);
-          final ignored2 =
-              hub.startInactiveSpan('ignored-2', parentSpan: ignored1);
-          final ignored3 =
-              hub.startInactiveSpan('ignored-3', parentSpan: ignored2);
-
-          hub.startSpan('child', parentSpan: ignored3, (span) {
-            expect(span, isA<RecordingSentrySpanV2>());
-            expect(span.parentSpan, same(root));
-          });
-        });
-
-        test('re-parents correctly with ignored spans at different levels', () {
-          fixture.options.ignoreSpans = [
-            IgnoreSpanRule.nameEquals('ignored-span'),
-          ];
-          final hub = fixture.getSut();
-
-          final root = hub.startInactiveSpan('root', parentSpan: null);
-          final ignored1 =
-              hub.startInactiveSpan('ignored-span', parentSpan: root);
-          final child1 = hub.startInactiveSpan('child1', parentSpan: ignored1);
-          final ignored2 =
-              hub.startInactiveSpan('ignored-span', parentSpan: child1);
-
-          hub.startSpan('child2', parentSpan: ignored2, (span) {
-            expect(span, isA<RecordingSentrySpanV2>());
-            expect(span.parentSpan, same(child1));
-          });
-        });
-
-        test('creates root span when ignored span has no parent', () {
-          fixture.options.ignoreSpans = [
-            IgnoreSpanRule.nameEquals('ignored-root'),
-          ];
-          final hub = fixture.getSut();
-
-          final ignored =
-              hub.startInactiveSpan('ignored-root', parentSpan: null);
-
-          hub.startSpan('child', parentSpan: ignored, (span) {
-            expect(span, isA<RecordingSentrySpanV2>());
-            expect(span.parentSpan, isNull);
-          });
-        });
-
-        test('does not re-parent when parent is unsampled NoOp', () {
-          final hub = fixture.getSut(tracesSampleRate: 0.0);
-
-          final unsampledRoot = hub.startInactiveSpan('root', parentSpan: null);
-
-          hub.startSpan('child', parentSpan: unsampledRoot, (span) {
-            expect(span, isA<NoOpSentrySpanV2>());
-            expect((span as NoOpSentrySpanV2).isIgnored, isFalse);
-          });
-        });
       });
     });
   });

--- a/packages/dart/test/hub_span_test.dart
+++ b/packages/dart/test/hub_span_test.dart
@@ -1021,6 +1021,132 @@ void main() {
       });
     });
 
+    group('when mixing startSpan and startSpanSync', () {
+      test('parents sync child to async parent', () async {
+        final hub = fixture.getSut();
+        late SentrySpanV2 asyncParent;
+        late SentrySpanV2 syncChild;
+
+        await hub.startSpan('async-parent', (span) async {
+          asyncParent = span;
+          hub.startSpanSync('sync-child', (span) {
+            syncChild = span;
+          });
+        });
+
+        expect(asyncParent.parentSpan, isNull);
+        expect(syncChild.parentSpan, equals(asyncParent));
+      });
+
+      test('parents async child to sync parent', () async {
+        final hub = fixture.getSut();
+        late SentrySpanV2 syncParent;
+        late SentrySpanV2 asyncChild;
+
+        await hub.startSpanSync('sync-parent', (span) {
+          syncParent = span;
+          return hub.startSpan('async-child', (span) async {
+            asyncChild = span;
+          });
+        });
+
+        expect(syncParent.parentSpan, isNull);
+        expect(asyncChild.parentSpan, equals(syncParent));
+      });
+
+      test('builds correct chain with deeply nested alternating calls',
+          () async {
+        final hub = fixture.getSut();
+        late SentrySpanV2 span1;
+        late SentrySpanV2 span2;
+        late SentrySpanV2 span3;
+        late SentrySpanV2 span4;
+
+        await hub.startSpan('async-1', (s1) async {
+          span1 = s1;
+          hub.startSpanSync('sync-2', (s2) {
+            span2 = s2;
+            hub.startSpanSync('sync-3', (s3) {
+              span3 = s3;
+            });
+          });
+          await hub.startSpan('async-4', (s4) async {
+            span4 = s4;
+          });
+        });
+
+        expect(span1.parentSpan, isNull);
+        expect(span2.parentSpan, equals(span1));
+        expect(span3.parentSpan, equals(span2));
+        expect(span4.parentSpan, equals(span1));
+      });
+
+      test('resolves active span to sync child inside async parent', () async {
+        final hub = fixture.getSut();
+
+        await hub.startSpan('async-parent', (asyncSpan) async {
+          hub.startSpanSync('sync-child', (syncSpan) {
+            expect(hub.getActiveSpan(), equals(syncSpan));
+          });
+          expect(hub.getActiveSpan(), equals(asyncSpan));
+        });
+      });
+
+      test('resolves active span to async child inside sync parent', () async {
+        final hub = fixture.getSut();
+
+        await hub.startSpanSync('sync-parent', (syncSpan) {
+          expect(hub.getActiveSpan(), equals(syncSpan));
+          return hub.startSpan('async-child', (asyncSpan) async {
+            expect(hub.getActiveSpan(), equals(asyncSpan));
+          });
+        });
+      });
+
+      test('parents sibling sync and async children to same parent', () async {
+        final hub = fixture.getSut();
+        late SentrySpanV2 parent;
+        late SentrySpanV2 syncChild;
+        late SentrySpanV2 asyncChild;
+
+        await hub.startSpan('parent', (span) async {
+          parent = span;
+          hub.startSpanSync('sync-child', (span) {
+            syncChild = span;
+          });
+          await hub.startSpan('async-child', (span) async {
+            asyncChild = span;
+          });
+        });
+
+        expect(syncChild.parentSpan, equals(parent));
+        expect(asyncChild.parentSpan, equals(parent));
+      });
+
+      test('does not pollute hub scope active span', () async {
+        final hub = fixture.getSut();
+
+        expect(hub.scope.activeSpan, isNull);
+
+        await hub.startSpan('async-parent', (span) async {
+          hub.startSpanSync('sync-child', (span) {});
+        });
+
+        expect(hub.scope.activeSpan, isNull);
+      });
+
+      test('captures all nested spans', () async {
+        final hub = fixture.getSut();
+
+        await hub.startSpan('async-root', (span) async {
+          hub.startSpanSync('sync-child', (span) {});
+          await hub.startSpan('async-child', (span) async {});
+        });
+
+        expect(fixture.client.captureSpanCalls, hasLength(3));
+      });
+    });
+
     group('when using idle spans', () {
       test('uses startTimestamp when provided', () {
         final hub = fixture.getSut();

--- a/packages/dart/test/hub_span_test.dart
+++ b/packages/dart/test/hub_span_test.dart
@@ -514,6 +514,45 @@ void main() {
           expect(capturedSpan.isEnded, isTrue);
           expect(capturedSpan.status, equals(SentrySpanStatusV2.error));
         });
+
+        test(
+          'provides NoOpSentrySpanV2 and still calls callback when hub is closed',
+          () async {
+            final hub = fixture.getSut();
+            await hub.close();
+            var callbackInvoked = false;
+
+            final result = hub.startSpanSync('test-span', (span) {
+              callbackInvoked = true;
+              expect(span, isA<NoOpSentrySpanV2>());
+              return 42;
+            });
+
+            expect(callbackInvoked, isTrue);
+            expect(result, equals(42));
+            expect(fixture.client.captureSpanCalls, isEmpty);
+          },
+        );
+
+        test(
+          'provides NoOpSentrySpanV2 and still calls callback when traceLifecycle is static',
+          () {
+            final hub = fixture.getSut(
+              traceLifecycle: SentryTraceLifecycle.static,
+            );
+            var callbackInvoked = false;
+
+            final result = hub.startSpanSync('test-span', (span) {
+              callbackInvoked = true;
+              expect(span, isA<NoOpSentrySpanV2>());
+              return 42;
+            });
+
+            expect(callbackInvoked, isTrue);
+            expect(result, equals(42));
+            expect(fixture.client.captureSpanCalls, isEmpty);
+          },
+        );
       });
 
       group('with zone-based scope forking', () {
@@ -742,6 +781,45 @@ void main() {
           expect(capturedSpan.isEnded, isTrue);
           expect(capturedSpan.status, equals(SentrySpanStatusV2.error));
         });
+
+        test(
+          'provides NoOpSentrySpanV2 and still calls callback when hub is closed',
+          () async {
+            final hub = fixture.getSut();
+            await hub.close();
+            var callbackInvoked = false;
+
+            final result = await hub.startSpan('test-span', (span) async {
+              callbackInvoked = true;
+              expect(span, isA<NoOpSentrySpanV2>());
+              return 42;
+            });
+
+            expect(callbackInvoked, isTrue);
+            expect(result, equals(42));
+            expect(fixture.client.captureSpanCalls, isEmpty);
+          },
+        );
+
+        test(
+          'provides NoOpSentrySpanV2 and still calls callback when traceLifecycle is static',
+          () async {
+            final hub = fixture.getSut(
+              traceLifecycle: SentryTraceLifecycle.static,
+            );
+            var callbackInvoked = false;
+
+            final result = await hub.startSpan('test-span', (span) async {
+              callbackInvoked = true;
+              expect(span, isA<NoOpSentrySpanV2>());
+              return 42;
+            });
+
+            expect(callbackInvoked, isTrue);
+            expect(result, equals(42));
+            expect(fixture.client.captureSpanCalls, isEmpty);
+          },
+        );
       });
 
       group('with zone-based scope forking', () {

--- a/packages/dart/test/hub_span_test.dart
+++ b/packages/dart/test/hub_span_test.dart
@@ -1150,12 +1150,11 @@ void main() {
 
       test('does nothing when hub is closed', () async {
         final hub = fixture.getSut();
+        // using startInactiveSpan for convenience in creating a span
         final span = hub.startInactiveSpan('test-span');
         await hub.close();
 
         await hub.captureSpan(span);
-        await Sentry.startSpan('test-span', (span) async => 42);
-        Sentry.startSpanSync('test-span', (span) => 42);
 
         expect(fixture.client.captureSpanCalls, isEmpty);
       });

--- a/packages/flutter/example/lib/main.dart
+++ b/packages/flutter/example/lib/main.dart
@@ -951,6 +951,11 @@ Future<void> spanV2Demo() async {
     });
   });
 
+  final syncResult =
+      Sentry.startSpan('span3 sync function', (_) => 'sync works!');
+  // ignore: avoid_print
+  print('span3 sync function result: $syncResult');
+
   await Sentry.startSpan(
     'spanv2-demo-root',
     (rootSpan) async {

--- a/packages/flutter/example/lib/main.dart
+++ b/packages/flutter/example/lib/main.dart
@@ -952,7 +952,7 @@ Future<void> spanV2Demo() async {
   });
 
   final syncResult =
-      Sentry.startSpan('span3 sync function', (_) => 'sync works!');
+      Sentry.startSpanSync('span3 sync function', (_) => 'sync works!');
   // ignore: avoid_print
   print('span3 sync function result: $syncResult');
 

--- a/packages/flutter/test/mocks.mocks.dart
+++ b/packages/flutter/test/mocks.mocks.dart
@@ -4367,11 +4367,12 @@ class MockHub extends _i1.Mock implements _i2.Hub {
       ) as _i2.ISentrySpan);
 
   @override
-  _i12.FutureOr<T> startSpan<T>(
+  _i12.Future<T> startSpan<T>(
     String? name,
-    _i12.FutureOr<T> Function(_i2.SentrySpanV2)? callback, {
+    _i12.Future<T> Function(_i2.SentrySpanV2)? callback, {
     Map<String, _i2.SentryAttribute>? attributes,
     _i2.SentrySpanV2? parentSpan = const _i2.UnsetSentrySpanV2(),
+    DateTime? startTimestamp,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4383,6 +4384,7 @@ class MockHub extends _i1.Mock implements _i2.Hub {
           {
             #attributes: attributes,
             #parentSpan: parentSpan,
+            #startTimestamp: startTimestamp,
           },
         ),
         returnValue: _i15.ifNotNull(
@@ -4397,6 +4399,7 @@ class MockHub extends _i1.Mock implements _i2.Hub {
                   {
                     #attributes: attributes,
                     #parentSpan: parentSpan,
+                    #startTimestamp: startTimestamp,
                   },
                 ),
               ),
@@ -4413,16 +4416,55 @@ class MockHub extends _i1.Mock implements _i2.Hub {
                 {
                   #attributes: attributes,
                   #parentSpan: parentSpan,
+                  #startTimestamp: startTimestamp,
                 },
               ),
             ),
-      ) as _i12.FutureOr<T>);
+      ) as _i12.Future<T>);
+
+  @override
+  T startSpanSync<T>(
+    String? name,
+    T Function(_i2.SentrySpanV2)? callback, {
+    Map<String, _i2.SentryAttribute>? attributes,
+    _i2.SentrySpanV2? parentSpan = const _i2.UnsetSentrySpanV2(),
+    DateTime? startTimestamp,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #startSpanSync,
+          [
+            name,
+            callback,
+          ],
+          {
+            #attributes: attributes,
+            #parentSpan: parentSpan,
+            #startTimestamp: startTimestamp,
+          },
+        ),
+        returnValue: _i15.dummyValue<T>(
+          this,
+          Invocation.method(
+            #startSpanSync,
+            [
+              name,
+              callback,
+            ],
+            {
+              #attributes: attributes,
+              #parentSpan: parentSpan,
+              #startTimestamp: startTimestamp,
+            },
+          ),
+        ),
+      ) as T);
 
   @override
   _i2.SentrySpanV2 startInactiveSpan(
     String? name, {
-    _i2.SentrySpanV2? parentSpan = const _i2.UnsetSentrySpanV2(),
     Map<String, _i2.SentryAttribute>? attributes,
+    _i2.SentrySpanV2? parentSpan = const _i2.UnsetSentrySpanV2(),
     DateTime? startTimestamp,
   }) =>
       (super.noSuchMethod(
@@ -4430,8 +4472,8 @@ class MockHub extends _i1.Mock implements _i2.Hub {
           #startInactiveSpan,
           [name],
           {
-            #parentSpan: parentSpan,
             #attributes: attributes,
+            #parentSpan: parentSpan,
             #startTimestamp: startTimestamp,
           },
         ),
@@ -4441,8 +4483,8 @@ class MockHub extends _i1.Mock implements _i2.Hub {
             #startInactiveSpan,
             [name],
             {
-              #parentSpan: parentSpan,
               #attributes: attributes,
+              #parentSpan: parentSpan,
               #startTimestamp: startTimestamp,
             },
           ),

--- a/packages/flutter/test/user_interaction/sentry_user_interaction_widget_test.dart
+++ b/packages/flutter/test/user_interaction/sentry_user_interaction_widget_test.dart
@@ -658,7 +658,7 @@ void main() {
         expect(firstSpan, isA<IdleRecordingSentrySpanV2>());
 
         // Simulate descendant activity by starting a child span
-        fixture.hub.startSpanSync('child-work', (span) {});
+        fixture.hub.startSpanSync('child-work', (_) {});
 
         await Future<void>.delayed(Duration.zero);
         // Tap a different widget

--- a/packages/flutter/test/user_interaction/sentry_user_interaction_widget_test.dart
+++ b/packages/flutter/test/user_interaction/sentry_user_interaction_widget_test.dart
@@ -658,9 +658,8 @@ void main() {
         expect(firstSpan, isA<IdleRecordingSentrySpanV2>());
 
         // Simulate descendant activity by starting a child span
-        fixture.hub.startSpan('child-work', (span) async {
-          span.end();
-        });
+        fixture.hub.startSpanSync('child-work', (span) {});
+
         await Future<void>.delayed(Duration.zero);
         // Tap a different widget
         await tapMe(tester, sut, 'btn_2', pumpWidget: false);


### PR DESCRIPTION
## :scroll: Description

Updates from a single `FutureOr<T> startSpan` to two distinct ones.

## :bulb: Motivation and Context

`FutureOr` gets dropped because it pushes ambiguity onto every caller.

It's ergonomically also not well to work with and we want to maximize dev experience as much as possible

## :green_heart: How did you test it?

- Manually, existing tests and update `hub_span_test`

## :pencil: Checklist
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

#skip-changelog