### PR TITLE
Update codecov-action to use v5

### DIFF
--- a/.github/actions/coverage/action.yml
+++ b/.github/actions/coverage/action.yml
@@ -21,7 +21,7 @@ runs:
   using: composite
 
   steps:
-    - uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # pin@v3
+    - uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # pin@v5
       if: ${{ inputs.coverage != '' }}
       with:
         name: ${{ inputs.coverage != '' }}


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Bumps codecov-action to v5 from legacy v3

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
