### PR TITLE
ci: Enable coverage and test results reporting

### DIFF
--- a/.github/workflows/firebase_remote_config.yml
+++ b/.github/workflows/firebase_remote_config.yml
@@ -45,7 +45,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: packages/firebase_remote_config
           coverage: sentry_firebase_remote_config
-          min-coverage: 55
+          min-coverage: 85
 
       - uses: ./.github/actions/test-results
         if: ${{ !cancelled() }}

--- a/.github/workflows/firebase_remote_config.yml
+++ b/.github/workflows/firebase_remote_config.yml
@@ -23,13 +23,13 @@ concurrency:
 
 jobs:
   build:
-    name: '${{ matrix.os }} | ${{ matrix.sdk }}'
-    runs-on: ${{ matrix.os }}-latest
+    name: '${{ matrix.target }} | ${{ matrix.sdk }}'
+    runs-on: ${{ matrix.target == 'linux' && 'ubuntu' || matrix.target }}-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        os: [macos, ubuntu, windows]
+        target: [macos, linux, windows]
         sdk: [stable, beta]
 
     steps:
@@ -38,10 +38,9 @@ jobs:
       - uses: ./.github/actions/flutter-test
         with:
           directory: packages/firebase_remote_config
-          web: false
 
       - uses: ./.github/actions/coverage
-        if: runner.os == 'Linux' && matrix.sdk == 'stable'
+        if: matrix.target == 'linux' && matrix.sdk == 'stable'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: packages/firebase_remote_config
@@ -52,7 +51,7 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          flags: sentry_firebase_remote_config-${{ runner.os }}-${{ matrix.sdk }}
+          flags: sentry_firebase_remote_config-${{ matrix.target }}-${{ matrix.sdk }}
 
   analyze:
     uses: ./.github/workflows/analyze.yml

--- a/.github/workflows/firebase_remote_config.yml
+++ b/.github/workflows/firebase_remote_config.yml
@@ -40,14 +40,19 @@ jobs:
           directory: packages/firebase_remote_config
           web: false
 
-  #       TODO: don't set coverage for now to finish publishing it
-  #      - uses: ./.github/actions/coverage
-  #        if: runner.os == 'Linux' && matrix.sdk == 'stable'
-  #        with:
-  #          token: ${{ secrets.CODECOV_TOKEN }}
-  #          directory: firebase_remote_config
-  #          coverage: sentry_firebase_remote_config
-  #          min-coverage: 55
+      - uses: ./.github/actions/coverage
+        if: runner.os == 'Linux' && matrix.sdk == 'stable'
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: packages/firebase_remote_config
+          coverage: sentry_firebase_remote_config
+          min-coverage: 55
+
+      - uses: ./.github/actions/test-results
+        if: ${{ !cancelled() }}
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: sentry_firebase_remote_config-${{ runner.os }}-${{ matrix.sdk }}
 
   analyze:
     uses: ./.github/workflows/analyze.yml

--- a/.github/workflows/link.yml
+++ b/.github/workflows/link.yml
@@ -39,14 +39,13 @@ jobs:
           directory: packages/link
           web: false
 
-  #       TODO: don't set coverage for now to finish publishing it
-  #      - uses: ./.github/actions/coverage
-  #        if: runner.os == 'Linux' && matrix.sdk == 'stable'
-  #        with:
-  #          token: ${{ secrets.CODECOV_TOKEN }}
-  #          directory: link
-  #          coverage: sentry_link
-  #          min-coverage: 55
+      - uses: ./.github/actions/coverage
+        if: runner.os == 'Linux' && matrix.sdk == 'stable'
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: packages/link
+          coverage: sentry_link
+          min-coverage: 55
 
       - uses: ./.github/actions/test-results
         if: ${{ !cancelled() }}

--- a/.github/workflows/link.yml
+++ b/.github/workflows/link.yml
@@ -45,7 +45,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: packages/link
           coverage: sentry_link
-          min-coverage: 55
+          min-coverage: 3
 
       - uses: ./.github/actions/test-results
         if: ${{ !cancelled() }}

--- a/.github/workflows/supabase.yml
+++ b/.github/workflows/supabase.yml
@@ -41,14 +41,19 @@ jobs:
           directory: packages/supabase
           web: false
 
-#       TODO: don't set coverage for now to finish publishing it
-#      - uses: ./.github/actions/coverage
-#        if: runner.os == 'Linux' && matrix.sdk == 'stable'
-#        with:
-#          token: ${{ secrets.CODECOV_TOKEN }}
-#          directory: packages/supabase
-#          coverage: sentry_supabase
-#          min-coverage: 55
+      - uses: ./.github/actions/coverage
+        if: runner.os == 'Linux' && matrix.sdk == 'stable'
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: packages/supabase
+          coverage: sentry_supabase
+          min-coverage: 55
+
+      - uses: ./.github/actions/test-results
+        if: ${{ !cancelled() }}
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: sentry_supabase-${{ runner.os }}-${{ matrix.sdk }}
 
   analyze:
     uses: ./.github/workflows/analyze.yml

--- a/.github/workflows/supabase.yml
+++ b/.github/workflows/supabase.yml
@@ -46,7 +46,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: packages/supabase
           coverage: sentry_supabase
-          min-coverage: 55
+          min-coverage: 85
 
       - uses: ./.github/actions/test-results
         if: ${{ !cancelled() }}

--- a/.github/workflows/supabase.yml
+++ b/.github/workflows/supabase.yml
@@ -24,13 +24,13 @@ concurrency:
 
 jobs:
   build:
-    name: '${{ matrix.os }} | ${{ matrix.sdk }}'
-    runs-on: ${{ matrix.os }}-latest
+    name: '${{ matrix.target }} | ${{ matrix.sdk }}'
+    runs-on: ${{ matrix.target == 'linux' && 'ubuntu' || matrix.target }}-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        os: [macos, ubuntu, windows]
+        target: [macos, linux, windows]
         sdk: [stable, beta]
 
     steps:
@@ -39,10 +39,9 @@ jobs:
       - uses: ./.github/actions/flutter-test
         with:
           directory: packages/supabase
-          web: false
 
       - uses: ./.github/actions/coverage
-        if: runner.os == 'Linux' && matrix.sdk == 'stable'
+        if: matrix.target == 'linux' && matrix.sdk == 'stable'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: packages/supabase
@@ -53,7 +52,7 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          flags: sentry_supabase-${{ runner.os }}-${{ matrix.sdk }}
+          flags: sentry_supabase-${{ matrix.target }}-${{ matrix.sdk }}
 
   analyze:
     uses: ./.github/workflows/analyze.yml


### PR DESCRIPTION
## :scroll: Description

Enable coverage upload and test results reporting for `sentry_link`, `sentry_supabase`, and `sentry_firebase_remote_config`. These were commented out during initial publishing and never re-enabled.

Also fixes incorrect `directory` paths in the coverage action inputs (e.g. `link` → `packages/link`, `firebase_remote_config` → `packages/firebase_remote_config`).

## :bulb: Motivation and Context

All other packages report coverage and test results to Codecov. These three were left behind with a TODO comment ("don't set coverage for now to finish publishing it"). The packages have been published for a while, so it's time to enable reporting.

Closes #3619

## :green_heart: How did you test it?

CI will validate — coverage and test-results steps will run on the next workflow execution for these packages.

## :pencil: Checklist
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

Monitor CI to verify coverage uploads succeed and adjust `min-coverage` thresholds if needed.

#skip-changelog