### PR TITLE
build: fetch sentry-native from release zip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Sentry Native not building due to failing `git clone` ([#3621](https://github.com/getsentry/sentry-dart/pull/3621))
+
 ## 9.16.0
 
 ### Dependencies

--- a/packages/flutter/sentry-native/sentry-native.cmake
+++ b/packages/flutter/sentry-native/sentry-native.cmake
@@ -1,5 +1,7 @@
 load_cache("${CMAKE_CURRENT_LIST_DIR}" READ_WITH_PREFIX SENTRY_NATIVE_ repo version)
-message(STATUS "Fetching Sentry native version: ${SENTRY_NATIVE_version} from ${SENTRY_NATIVE_repo}")
+
+set(SENTRY_NATIVE_URL "${SENTRY_NATIVE_repo}/releases/download/${SENTRY_NATIVE_version}/sentry-native.zip")
+message(STATUS "Fetching Sentry native version: ${SENTRY_NATIVE_version} from ${SENTRY_NATIVE_URL}")
 
 set(SENTRY_SDK_NAME "sentry.native.flutter" CACHE STRING "The SDK name to report when sending events." FORCE)
 set(SENTRY_BUILD_SHARED_LIBS ON CACHE BOOL "Build shared libraries (.dll/.so) instead of static ones (.lib/.a)" FORCE)
@@ -10,10 +12,12 @@ if(NOT "$ENV{SENTRY_NATIVE_BACKEND}" STREQUAL "")
 endif()
 
 include(FetchContent)
+if(POLICY CMP0135)
+    cmake_policy(SET CMP0135 NEW)
+endif()
 FetchContent_Declare(
     sentry-native
-    GIT_REPOSITORY ${SENTRY_NATIVE_repo}
-    GIT_TAG ${SENTRY_NATIVE_version}
+    URL ${SENTRY_NATIVE_URL}
     EXCLUDE_FROM_ALL
 )
 


### PR DESCRIPTION
## :scroll: Description
Use the pre-packaged release zip instead of git clone to avoid dependency on chromium.googlesource.com which is unreliable.

## :bulb: Motivation and Context
See https://github.com/getsentry/sentry-native/issues/1625

## :green_heart: How did you test it?
Tested by integrating the fork into a Flutter desktop app (Windows) that previously failed to build due to chromium.googlesource.com being unavailable — the build now completes successfully using the release zip.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes

#skip-changelog
