### PR TITLE
chore: add `URL_HASH` when downloading `sentry-native.zip`

### DIFF
--- a/packages/flutter/sentry-native/CMakeCache.txt
+++ b/packages/flutter/sentry-native/CMakeCache.txt
@@ -3,3 +3,4 @@
 
 repo=https://github.com/getsentry/sentry-native
 version=0.13.3
+sha256=b83292650c6a725c867a6c7f9ad7903b178ad13bacb362998fc09bb045acf06d

--- a/packages/flutter/sentry-native/sentry-native.cmake
+++ b/packages/flutter/sentry-native/sentry-native.cmake
@@ -1,4 +1,4 @@
-load_cache("${CMAKE_CURRENT_LIST_DIR}" READ_WITH_PREFIX SENTRY_NATIVE_ repo version)
+load_cache("${CMAKE_CURRENT_LIST_DIR}" READ_WITH_PREFIX SENTRY_NATIVE_ repo version sha256)
 
 set(SENTRY_NATIVE_URL "${SENTRY_NATIVE_repo}/releases/download/${SENTRY_NATIVE_version}/sentry-native.zip")
 message(STATUS "Fetching Sentry native version: ${SENTRY_NATIVE_version} from ${SENTRY_NATIVE_URL}")
@@ -18,6 +18,7 @@ endif()
 FetchContent_Declare(
     sentry-native
     URL ${SENTRY_NATIVE_URL}
+    URL_HASH SHA256=${SENTRY_NATIVE_sha256}
     EXCLUDE_FROM_ALL
 )
 


### PR DESCRIPTION
#skip-changelog

Note: after this PR `update-native.sh` should be updated to fetch the hash and update `CMakeCache.txt` 