### PR TITLE
ci(flutter): fix macOS SPM example build

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -132,6 +132,9 @@ jobs:
       - name: Switch to Xcode 16.4 for iOS 18.5
         run: sudo xcode-select --switch /Applications/Xcode_16.4.app
 
+      # Flutter main derives the local SwiftPM package identity from the plugin path basename on macOS.
+      # Our package lives in packages/flutter, which makes Xcode resolve it as "flutter" and fail with:
+      # "unable to override package 'sentry_flutter' because its identity 'flutter' doesn't match override's identity (directory name) 'sentry_flutter'"
       - name: Rename sentry_flutter package for macOS SwiftPM
         if: matrix.target == 'macos'
         run: mv packages/flutter packages/sentry_flutter

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -107,41 +107,44 @@ jobs:
           ;;
           esac
 
-  # Temporarily disabled to allow for the release of 9.16.1 since this is failing
-  # This must be re-enabled when fixing https://github.com/getsentry/sentry-dart/issues/3624
-  # spm:
-  #   name: 'SPM'
-  #   runs-on: macos-15
-  #   timeout-minutes: 30
-  #   defaults:
-  #     run:
-  #       shell: bash
-  #       working-directory: packages/flutter/example
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       target: [ios, macos]
+  spm:
+    name: 'SPM'
+    runs-on: macos-15
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [ios, macos]
 
-  #   steps:
-  #     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-  #     - uses: subosito/flutter-action@fd55f4c5af5b953cc57a2be44cb082c8f6635e8e # pin@v2.21.0
-  #       with:
-  #         channel: main
+      - uses: subosito/flutter-action@fd55f4c5af5b953cc57a2be44cb082c8f6635e8e # pin@v2.21.0
+        with:
+          channel: main
 
-  #     - run: flutter config --enable-swift-package-manager
+      - name: Log Flutter version
+        run: flutter --version
 
-  #     # QuickFix for failing iOS 18.0 builds https://github.com/actions/runner-images/issues/12758#issuecomment-3187115656
-  #     - name: Switch to Xcode 16.4 for iOS 18.5
-  #       run: sudo xcode-select --switch /Applications/Xcode_16.4.app
+      - run: flutter config --enable-swift-package-manager
 
-  #     - name: Run on iOS
-  #       if: matrix.target == 'ios'
-  #       run: flutter build ios --no-codesign
+      # QuickFix for failing iOS 18.0 builds https://github.com/actions/runner-images/issues/12758#issuecomment-3187115656
+      - name: Switch to Xcode 16.4 for iOS 18.5
+        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
 
-  #     - name: Run on macOS
-  #       if: matrix.target == 'macos'
-  #       run: flutter build macos --debug
+      - name: Rename sentry_flutter package for macOS SwiftPM
+        if: matrix.target == 'macos'
+        run: mv packages/flutter packages/sentry_flutter
+
+      - name: Run on iOS
+        if: matrix.target == 'ios'
+        working-directory: packages/flutter/example
+        run: flutter build ios --no-codesign
+
+      - name: Run on macOS
+        if: matrix.target == 'macos'
+        working-directory: packages/sentry_flutter/example
+        run: flutter build macos --debug
 
   analyze:
     uses: ./.github/workflows/analyze.yml

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -123,10 +123,10 @@ jobs:
         with:
           channel: main
 
+      - run: flutter config --enable-swift-package-manager
+
       - name: Log Flutter version
         run: flutter --version
-
-      - run: flutter config --enable-swift-package-manager
 
       # QuickFix for failing iOS 18.0 builds https://github.com/actions/runner-images/issues/12758#issuecomment-3187115656
       - name: Switch to Xcode 16.4 for iOS 18.5

--- a/packages/flutter/example/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/packages/flutter/example/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,7 +5,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/simolus3/CSQLite.git",
       "state" : {
-        "revision" : "ae972b235e8b3c5af6d8f4e5bf18c800bdddb27e"
+        "revision" : "1ee46d19a4f451a7aa64ffc64fc99b4748131e62"
       }
     },
     {
@@ -13,8 +13,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa",
       "state" : {
-        "revision" : "9e193ac0b71760603aa666bad7e9e303dd7031a8",
-        "version" : "8.56.2"
+        "revision" : "7238c483dca47b5419e42dec1906f6f2d5cd3630",
+        "version" : "8.58.1"
       }
     }
   ],

--- a/packages/flutter/example/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/packages/flutter/example/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,7 +5,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/simolus3/CSQLite.git",
       "state" : {
-        "revision" : "ae972b235e8b3c5af6d8f4e5bf18c800bdddb27e"
+        "revision" : "1ee46d19a4f451a7aa64ffc64fc99b4748131e62"
       }
     },
     {
@@ -13,8 +13,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa",
       "state" : {
-        "revision" : "9e193ac0b71760603aa666bad7e9e303dd7031a8",
-        "version" : "8.56.2"
+        "revision" : "7238c483dca47b5419e42dec1906f6f2d5cd3630",
+        "version" : "8.58.1"
       }
     }
   ],

--- a/packages/flutter/example/macos/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/packages/flutter/example/macos/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,22 @@
+{
+  "pins" : [
+    {
+      "identity" : "csqlite",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/simolus3/CSQLite.git",
+      "state" : {
+        "revision" : "ae972b235e8b3c5af6d8f4e5bf18c800bdddb27e"
+      }
+    },
+    {
+      "identity" : "sentry-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/getsentry/sentry-cocoa",
+      "state" : {
+        "revision" : "9e193ac0b71760603aa666bad7e9e303dd7031a8",
+        "version" : "8.56.2"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/packages/flutter/example/macos/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/packages/flutter/example/macos/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,7 +5,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/simolus3/CSQLite.git",
       "state" : {
-        "revision" : "ae972b235e8b3c5af6d8f4e5bf18c800bdddb27e"
+        "revision" : "1ee46d19a4f451a7aa64ffc64fc99b4748131e62"
       }
     },
     {
@@ -13,8 +13,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa",
       "state" : {
-        "revision" : "9e193ac0b71760603aa666bad7e9e303dd7031a8",
-        "version" : "8.56.2"
+        "revision" : "7238c483dca47b5419e42dec1906f6f2d5cd3630",
+        "version" : "8.58.1"
       }
     }
   ],

--- a/packages/flutter/example/macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/packages/flutter/example/macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,22 @@
+{
+  "pins" : [
+    {
+      "identity" : "csqlite",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/simolus3/CSQLite.git",
+      "state" : {
+        "revision" : "ae972b235e8b3c5af6d8f4e5bf18c800bdddb27e"
+      }
+    },
+    {
+      "identity" : "sentry-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/getsentry/sentry-cocoa",
+      "state" : {
+        "revision" : "9e193ac0b71760603aa666bad7e9e303dd7031a8",
+        "version" : "8.56.2"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/packages/flutter/example/macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/packages/flutter/example/macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,7 +5,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/simolus3/CSQLite.git",
       "state" : {
-        "revision" : "ae972b235e8b3c5af6d8f4e5bf18c800bdddb27e"
+        "revision" : "1ee46d19a4f451a7aa64ffc64fc99b4748131e62"
       }
     },
     {
@@ -13,8 +13,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa",
       "state" : {
-        "revision" : "9e193ac0b71760603aa666bad7e9e303dd7031a8",
-        "version" : "8.56.2"
+        "revision" : "7238c483dca47b5419e42dec1906f6f2d5cd3630",
+        "version" : "8.58.1"
       }
     }
   ],


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->

 - Add current SwiftPM lockfiles for the Flutter example and re-enable the SPM CI job.
 - Work around Flutter main’s macOS local-package identity issue by renaming packages/flutter to packages/sentry_flutter only for the macOS SPM build.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #3624


## :green_heart: How did you test it?

Ci

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes