### PR TITLE
chore: Add dep update pattern to Dependencies changelog category

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -27,6 +27,7 @@ changelog:
     - title: Dependencies
       commit_patterns:
         - "^(?<type>(?:deps)(?:\\((?<scope>[^)]+)\\))?!?:\\s*)"
+        - "chore(deps): update (JavaScript|Native|Cocoa|Android) SDK"
       semver: patch
     - title: Internal Changes
       commit_patterns:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -27,7 +27,7 @@ changelog:
     - title: Dependencies
       commit_patterns:
         - "^(?<type>(?:deps)(?:\\((?<scope>[^)]+)\\))?!?:\\s*)"
-        - "chore(deps): update (JavaScript|Native|Cocoa|Android) SDK"
+        - "chore\\(deps\\): update (JavaScript|Native|Cocoa|Android) SDK"
       semver: patch
     - title: Internal Changes
       commit_patterns:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -27,7 +27,7 @@ changelog:
     - title: Dependencies
       commit_patterns:
         - "^(?<type>(?:deps)(?:\\((?<scope>[^)]+)\\))?!?:\\s*)"
-        - "chore\\(deps\\): update (JavaScript|Native|Cocoa|Android) SDK"
+        - "^chore\\(deps\\): update (JavaScript|Native|Cocoa|Android) SDK"
       semver: patch
     - title: Internal Changes
       commit_patterns:


### PR DESCRIPTION
Route SDK dependency update PRs to the "Dependencies" changelog section.

The updater workflow creates PRs with titles like `chore(deps): update Android SDK to v8.33.0`. The existing Dependencies category pattern (`^deps(...)`) only matches commit prefixes starting with `deps`, so these `chore(deps):` titled PRs fall through to "Internal Changes" instead.

This adds an explicit pattern to catch the four SDK dependency updates (JavaScript, Native, Cocoa, Android) and place them under Dependencies where they belong.

Categories are evaluated in order, so Dependencies (listed before Internal Changes) matches first. Other `chore:` commits that don't match the SDK pattern continue to fall through to Internal Changes as expected.