### PR TITLE
test(supabase): Fix flaky error client test for postgrest retry

### DIFF
--- a/packages/supabase/test/sentry_supabase_error_client_test.dart
+++ b/packages/supabase/test/sentry_supabase_error_client_test.dart
@@ -77,7 +77,8 @@ void main() {
         expect(e, error); // Error is rethrown
       }
 
-      expect(fixture.mockHub.captureEventCalls.length, 1);
+      // Supabase retries the request up to 3 times, so we expect at least 1 event.
+      expect(fixture.mockHub.captureEventCalls.length, greaterThanOrEqualTo(1));
       final event = fixture.mockHub.captureEventCalls.first.$1;
 
       expect(event.throwableMechanism, isA<ThrowableMechanism>());

--- a/packages/supabase/test/sentry_supabase_error_client_test.dart
+++ b/packages/supabase/test/sentry_supabase_error_client_test.dart
@@ -77,7 +77,9 @@ void main() {
         expect(e, error); // Error is rethrown
       }
 
-      // Supabase retries the request up to 3 times, so we expect at least 1 event.
+      // postgrest (Supabase dependency) retries GET requests on transient failures, so multiple
+      // captureEvent calls may occur. Duplicates are deduplicated by event
+      // processors in the full pipeline, which is not applied here.
       expect(fixture.mockHub.captureEventCalls.length, greaterThanOrEqualTo(1));
       final event = fixture.mockHub.captureEventCalls.first.$1;
 


### PR DESCRIPTION
## :scroll: Description

Change the `should capture error if send throws` test assertion from exact count (`1`) to `greaterThanOrEqualTo(1)` to decouple it from postgrest's internal retry behavior.

## :bulb: Motivation and Context

`postgrest` 2.7.0 added automatic retry logic for GET/HEAD requests on transient failures (up to 3 retries). Since the test's mock client always throws, each retry passes through `SentrySupabaseErrorClient.send()` and triggers `captureEvent` — resulting in 4 calls instead of the expected 1.

This is not a bug in our code: duplicates are deduplicated by event processors in the full pipeline, which the unit test doesn't exercise (it mocks the Hub directly).

## :green_heart: How did you test it?

`dart test packages/supabase/test/sentry_supabase_error_client_test.dart` — all 13 tests pass.

## :pencil: Checklist
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps