### PR TITLE
build(flutter-example): Fix macOS SPM build and bump AGP to 8.6.0

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -75,10 +75,18 @@ jobs:
         if: matrix.os == 'macos'
         run: sudo xcode-select --switch /Applications/Xcode_16.4.app
 
+      # Flutter derives the local SwiftPM package identity from the plugin path basename on macOS.
+      # Our package lives in packages/flutter, which makes Xcode resolve it as "flutter" and fail with:
+      # "unable to override package 'sentry_flutter' because its identity 'flutter' doesn't match override's identity (directory name) 'sentry_flutter'"
+      # See also: spm job below.
+      - name: Rename sentry_flutter package for macOS SwiftPM
+        if: matrix.target == 'macos'
+        run: mv packages/flutter packages/sentry_flutter
+
       - name: Build example for ${{ matrix.target }}
         # The example currently doesn't support compiling for WASM. Should be OK once we add package:web in v9.
         if: matrix.target != 'wasm'
-        working-directory: packages/flutter/example
+        working-directory: ${{ matrix.target == 'macos' && 'packages/sentry_flutter/example' || 'packages/flutter/example' }}
         shell: bash
         run: |
           flutter config --enable-windows-desktop
@@ -135,6 +143,7 @@ jobs:
       # Flutter main derives the local SwiftPM package identity from the plugin path basename on macOS.
       # Our package lives in packages/flutter, which makes Xcode resolve it as "flutter" and fail with:
       # "unable to override package 'sentry_flutter' because its identity 'flutter' doesn't match override's identity (directory name) 'sentry_flutter'"
+      # See also: build job above.
       - name: Rename sentry_flutter package for macOS SwiftPM
         if: matrix.target == 'macos'
         run: mv packages/flutter packages/sentry_flutter

--- a/packages/flutter/example/android/settings.gradle
+++ b/packages/flutter/example/android/settings.gradle
@@ -3,7 +3,7 @@ pluginManagement {
 
     plugins {
         id "org.jetbrains.kotlin.android" version kotlinAndroidVersion
-        id "com.android.application" version "8.2.2"
+        id "com.android.application" version "8.6.0"
         id "io.sentry.android.gradle" version "4.14.1"
     }
 


### PR DESCRIPTION
## :scroll: Description

- Apply the SwiftPM directory rename workaround to the `build` job for macOS targets (was only in the `spm` job)
- Bump Android Gradle Plugin from 8.2.2 to 8.6.0 in the example app

## :bulb: Motivation and Context

Flutter beta (3.44) enables SwiftPM by default, causing the `build` job's macOS example build to fail with:
```
unable to override package 'sentry_flutter' because its identity 'flutter'
doesn't match override's identity (directory name) 'sentry_flutter'
```

The `spm` job already had the rename workaround (from #3640), but the `build` job didn't. Also, Flutter beta now requires AGP >= 8.6.0.

## :green_heart: How did you test it?

CI

## :pencil: Checklist
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps