### PR TITLE
ci: Integrate Warden for AI-powered PR code review

### DIFF
--- a/agents.toml
+++ b/agents.toml
@@ -10,6 +10,10 @@ github_repos = [ "getsentry/skills", "getsentry/sdk-skills", "getsentry/dotagent
 name = "dotagents"
 source = "getsentry/dotagents"
 
+[[skills]]
+name = "warden"
+source = "getsentry/warden"
+
 # getsentry/skills — core development
 [[skills]]
 name = "commit"

--- a/agents.toml
+++ b/agents.toml
@@ -3,7 +3,7 @@ gitignore = false
 agents = ["claude", "cursor"]
 
 [trust]
-github_repos = [ "getsentry/skills", "getsentry/sdk-skills", "getsentry/dotagents" ]
+github_repos = [ "getsentry/skills", "getsentry/sdk-skills", "getsentry/dotagents", "getsentry/warden" ]
 
 
 [[skills]]

--- a/warden.toml
+++ b/warden.toml
@@ -1,0 +1,37 @@
+version = 1
+
+[defaults]
+failOn = "high"
+reportOn = "medium"
+
+[[skills]]
+name = "code-review"
+remote = "getsentry/skills"
+
+[[skills.triggers]]
+type = "pull_request"
+actions = ["opened", "synchronize", "reopened"]
+
+[[skills]]
+name = "find-bugs"
+remote = "getsentry/skills"
+
+[[skills.triggers]]
+type = "pull_request"
+actions = ["opened", "synchronize", "reopened"]
+
+[[skills]]
+name = "security-review"
+remote = "getsentry/skills"
+
+[[skills.triggers]]
+type = "pull_request"
+actions = ["opened", "synchronize", "reopened"]
+
+[[skills]]
+name = "gha-security-review"
+remote = "getsentry/skills"
+
+[[skills.triggers]]
+type = "pull_request"
+actions = ["opened", "synchronize", "reopened"]

--- a/warden.toml
+++ b/warden.toml
@@ -30,6 +30,7 @@ actions = ["opened", "synchronize", "reopened"]
 
 [[skills]]
 name = "gha-security-review"
+paths = [".github/**/*"]
 remote = "getsentry/skills"
 
 [[skills.triggers]]


### PR DESCRIPTION
## :scroll: Description

Adds `warden.toml` at the repo root to enable [Warden](https://warden.sentry.dev/) AI-powered PR reviews. The org-wide workflow in `getsentry/.github` already runs Warden on all repos — this config file activates it for `sentry-dart`.

**Skills enabled:**

- `code-review` — AI code review
- `find-bugs` — bug detection
- `security-review` — security analysis
- `gha-security-review` — GitHub Actions security review

Also adds the `warden` skill to `agents.toml` for local agent usage.

## :bulb: Motivation and Context

Per the [SDK Review and CI standards](https://develop.sentry.dev/sdk/getting-started/standards/review-ci/), SDK repositories should have Warden configured in CI.

See reference rollout in [sentry-react-native#6003](https://github.com/getsentry/sentry-react-native/pull/6003).

## :green_heart: How did you test it?

Warden will run on this PR via the org-wide workflow. Org-level secrets (`WARDEN_APP_ID`, `WARDEN_PRIVATE_KEY`, `WARDEN_ANTHROPIC_API_KEY`, `WARDEN_MODEL`, `WARDEN_SENTRY_DSN`) are picked up automatically — no repo-level configuration needed.

## :pencil: Checklist

- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps