### PR TITLE
enh(navigator-observer): make new trace id on navigation opt-in instead of opt-out

### DIFF
--- a/packages/flutter/lib/src/navigation/sentry_navigator_observer.dart
+++ b/packages/flutter/lib/src/navigation/sentry_navigator_observer.dart
@@ -62,8 +62,8 @@ typedef AdditionalInfoExtractor = Map<String, dynamic>? Function(
 /// if those happen to take longer. The transaction will be set to [Scope.span]
 /// if the latter is empty.
 ///
-/// If [enableNewTraceOnNavigation] is true (default), a
-/// fresh trace is generated before each push, pop, or replace event.
+/// If [enableNewTraceOnNavigation] is true, a fresh trace is generated
+/// before each push, pop, or replace event. Disabled by default.
 ///
 /// Enabling the [setRouteNameAsTransaction] option overrides the current
 /// [Scope.transaction] which will also override the name of the current
@@ -77,7 +77,7 @@ class SentryNavigatorObserver extends RouteObserver<PageRoute<dynamic>> {
   SentryNavigatorObserver({
     Hub? hub,
     bool enableAutoTransactions = true,
-    bool enableNewTraceOnNavigation = true,
+    bool enableNewTraceOnNavigation = false,
     Duration autoFinishAfter = const Duration(seconds: 3),
     bool setRouteNameAsTransaction = false,
     RouteNameExtractor? routeNameExtractor,

--- a/packages/flutter/test/navigation/sentry_navigator_observer_traces_test.dart
+++ b/packages/flutter/test/navigation/sentry_navigator_observer_traces_test.dart
@@ -16,7 +16,7 @@ void main() {
   });
 
   group('SentryNavigatorObserver', () {
-    group('when starting traces on navigation is enabled (default)', () {
+    group('when starting traces on navigation is disabled (default)', () {
       test('didPush should not start a new trace on root', () {
         final to = _route(RouteSettings(name: '/'));
         final beforeTraceId = fixture.hub.scope.propagationContext.traceId;
@@ -27,12 +27,47 @@ void main() {
         expect(afterTraceId, equals(beforeTraceId));
       });
 
-      test('didPush should start a new trace', () {
+      test('didPush should not start a new trace', () {
         final from = _route(RouteSettings(name: 'From Route'));
         final to = _route(RouteSettings(name: 'To Route'));
         final beforeTraceId = fixture.hub.scope.propagationContext.traceId;
 
         fixture.getSut().didPush(to, from);
+
+        final afterTraceId = fixture.hub.scope.propagationContext.traceId;
+        expect(afterTraceId, equals(beforeTraceId));
+      });
+
+      test('didPop should not start a new trace', () {
+        final from = _route(RouteSettings(name: 'From Route'));
+        final to = _route(RouteSettings(name: 'To Route'));
+        final beforeTraceId = fixture.hub.scope.propagationContext.traceId;
+
+        fixture.getSut().didPop(to, from);
+
+        final afterTraceId = fixture.hub.scope.propagationContext.traceId;
+        expect(afterTraceId, equals(beforeTraceId));
+      });
+
+      test('didReplace should not start a new trace', () {
+        final from = _route(RouteSettings(name: 'From Route'));
+        final to = _route(RouteSettings(name: 'To Route'));
+        final beforeTraceId = fixture.hub.scope.propagationContext.traceId;
+
+        fixture.getSut().didReplace(newRoute: to, oldRoute: from);
+
+        final afterTraceId = fixture.hub.scope.propagationContext.traceId;
+        expect(afterTraceId, equals(beforeTraceId));
+      });
+    });
+
+    group('when starting traces on navigation is enabled', () {
+      test('didPush should start a new trace', () {
+        final from = _route(RouteSettings(name: 'From Route'));
+        final to = _route(RouteSettings(name: 'To Route'));
+        final beforeTraceId = fixture.hub.scope.propagationContext.traceId;
+
+        fixture.getSut(enableNewTraceOnNavigation: true).didPush(to, from);
 
         final afterTraceId = fixture.hub.scope.propagationContext.traceId;
         expect(afterTraceId, isNot(beforeTraceId));
@@ -43,7 +78,7 @@ void main() {
         final to = _route(RouteSettings(name: 'To Route'));
         final beforeTraceId = fixture.hub.scope.propagationContext.traceId;
 
-        fixture.getSut().didPop(to, from);
+        fixture.getSut(enableNewTraceOnNavigation: true).didPop(to, from);
 
         final afterTraceId = fixture.hub.scope.propagationContext.traceId;
         expect(afterTraceId, isNot(beforeTraceId));
@@ -54,7 +89,9 @@ void main() {
         final to = _route(RouteSettings(name: 'To Route'));
         final beforeTraceId = fixture.hub.scope.propagationContext.traceId;
 
-        fixture.getSut().didReplace(newRoute: to, oldRoute: from);
+        fixture
+            .getSut(enableNewTraceOnNavigation: true)
+            .didReplace(newRoute: to, oldRoute: from);
 
         final afterTraceId = fixture.hub.scope.propagationContext.traceId;
         expect(afterTraceId, isNot(beforeTraceId));
@@ -84,7 +121,10 @@ void main() {
           final to = _route(RouteSettings(name: 'To Route'));
 
           _stubHub();
-          final sut = fixture.getSut(hub: fixture.mockHub);
+          final sut = fixture.getSut(
+            hub: fixture.mockHub,
+            enableNewTraceOnNavigation: true,
+          );
           sut.didPush(to, from);
 
           verifyInOrder([
@@ -103,43 +143,6 @@ void main() {
         });
       });
     });
-
-    group('when starting traces on navigation is disabled', () {
-      test('didPush should not start a new trace', () {
-        final from = _route(RouteSettings(name: 'From Route'));
-        final to = _route(RouteSettings(name: 'To Route'));
-        final beforeTraceId = fixture.hub.scope.propagationContext.traceId;
-
-        fixture.getSut(enableNewTraceOnNavigation: false).didPush(to, from);
-
-        final afterTraceId = fixture.hub.scope.propagationContext.traceId;
-        expect(afterTraceId, equals(beforeTraceId));
-      });
-
-      test('didPop should not start a new trace', () {
-        final from = _route(RouteSettings(name: 'From Route'));
-        final to = _route(RouteSettings(name: 'To Route'));
-        final beforeTraceId = fixture.hub.scope.propagationContext.traceId;
-
-        fixture.getSut(enableNewTraceOnNavigation: false).didPop(to, from);
-
-        final afterTraceId = fixture.hub.scope.propagationContext.traceId;
-        expect(afterTraceId, equals(beforeTraceId));
-      });
-
-      test('didReplace should not start a new trace', () {
-        final from = _route(RouteSettings(name: 'From Route'));
-        final to = _route(RouteSettings(name: 'To Route'));
-        final beforeTraceId = fixture.hub.scope.propagationContext.traceId;
-
-        fixture
-            .getSut(enableNewTraceOnNavigation: false)
-            .didReplace(newRoute: to, oldRoute: from);
-
-        final afterTraceId = fixture.hub.scope.propagationContext.traceId;
-        expect(afterTraceId, equals(beforeTraceId));
-      });
-    });
   });
 }
 
@@ -155,7 +158,7 @@ class Fixture {
 
   SentryNavigatorObserver getSut({
     Hub? hub,
-    bool enableNewTraceOnNavigation = true,
+    bool enableNewTraceOnNavigation = false,
   }) {
     hub ??= this.hub;
     if (hub == mockHub) {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Creating a fresh trace id on each route push/pop/replace by default can break trace continuity for users who don't expect it. And through experience the default (trace by session) is much more useful and understandable.

Flip the default of enableNewTraceOnNavigation to false; users who want the old behavior can opt in.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3589

## :green_heart: How did you test it?
Change existing test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes