### PR TITLE
chore(changelog): Remove stale unreleased entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## Unreleased
-
-### Fixes 
-
-- Harden float JSON encoding (#7802)
-
 ## 9.18.0
 
 ### Dependencies


### PR DESCRIPTION
## Summary
- remove the stale `Unreleased` fix entry from `CHANGELOG.md`
- keep changelog state aligned with the already published `9.18.0` release

## Test plan
- [x] Verified diff only removes the stale changelog section
- [x] Confirmed PR diff against `main` contains only `CHANGELOG.md`

Made with [Cursor](https://cursor.com)