### PR TITLE
docs(changelog): Expand 9.19.0 entries with usage examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@
 ### Features
 
 - Span-first trace lifecycle (experimental) by @buenaflor in [#3659](https://github.com/getsentry/sentry-dart/pull/3659)
+  - Streams spans to Sentry as each one finishes instead of buffering them into a transaction envelope at the root.
+  - Opt in via `options.traceLifecycle`. The classic transaction-based `SentryTraceLifecycle.static` remains the default.
+  - In stream mode, create spans with the new `Sentry.startSpan` / `Sentry.startSpanSync` APIs — the transaction APIs (`Sentry.startTransaction`, `ISentrySpan.startChild`) do nothing in this mode.
+  - Auto-instrumentations (frames, app start, TTID/TTFD, navigation, user interaction, HTTP, databases, GraphQL link) automatically switch to the streaming API when enabled.
+
+```dart
+// Opt in during SDK init.
+await SentryFlutter.init((options) {
+  options.dsn = 'https://example@sentry.io/add-your-dsn-here';
+  options.tracesSampleRate = 1.0;
+  options.traceLifecycle = SentryTraceLifecycle.stream;
+});
+
+// Async work — the span ends and is sent when the future completes.
+final order = await Sentry.startSpan('checkout', (span) async {
+  span.setAttribute('cart.item_count', SentryAttribute.int(cart.items.length));
+
+  // Automatically parents to 'checkout' via zones.
+  final payment = await Sentry.startSpan('process-payment', (span) {
+    return paymentService.charge(cart.total);
+  });
+
+  return orderService.create(cart, payment: payment);
+});
+
+// Sync variant.
+final total = Sentry.startSpanSync('calculate-total', (span) {
+  return cart.items.fold<double>(0, (sum, item) => sum + item.price);
+});
+```
 
 ### Fixes
 
@@ -12,7 +42,15 @@
 
 ### Enhancements
 
-- (navigator-observer) Make new trace id on navigation opt-in instead of opt-out by @buenaflor in [#3657](https://github.com/getsentry/sentry-dart/pull/3657)
+- (navigator-observer) `enableNewTraceOnNavigation` is now opt-in by @buenaflor in [#3657](https://github.com/getsentry/sentry-dart/pull/3657)
+  - `SentryNavigatorObserver` no longer generates a fresh trace id on every push/pop/replace by default. One trace per session (the previous opt-in behavior) is now the default and preserves trace continuity across navigations.
+  - If you relied on the old behavior, opt back in explicitly:
+
+```dart
+SentryNavigatorObserver(
+  enableNewTraceOnNavigation: true,
+);
+```
 
 ### Dependencies
 


### PR DESCRIPTION
Expand the two headline 9.19.0 changelog entries so users can tell at a glance what changed and how to adopt it.

- **Span-first trace lifecycle (experimental)** — adds four sub-bullets covering the streaming behavior, how to opt in via `options.traceLifecycle = SentryTraceLifecycle.stream`, the API swap (`Sentry.startSpan` / `Sentry.startSpanSync` replace `Sentry.startTransaction` / `ISentrySpan.startChild` in stream mode), and the auto-instrumentation switchover. Follows up with a `dart` snippet showing SDK init, a nested async `startSpan`, and the `startSpanSync` variant.
- **`enableNewTraceOnNavigation` opt-in** — rewords the bullet to make the default flip obvious, explains why (preserving trace continuity across navigations), and includes a `dart` snippet showing how to restore the previous behavior.

Style matches the existing precedent set by the 9.0.0 logging/feedback and 9.14.0 `enableTombstone` entries (sub-bullets plus unindented fenced `dart` blocks). Targeting `release/9.19.0` so the polish ships with the release.

Made with [Cursor](https://cursor.com)