### PR TITLE
fix(flutter): Avoid JNI callbacks for Android scope sync

### DIFF
--- a/packages/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/packages/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -146,10 +146,12 @@ class SentryFlutterPlugin :
               event.setTag("event.origin", "flutter")
               event.setTag("event.environment", "dart")
             }
+
             "sentry.java.android.flutter" -> {
               event.setTag("event.origin", "android")
               event.setTag("event.environment", "java")
             }
+
             "sentry.native.android.flutter" -> {
               event.setTag("event.origin", "android")
               event.setTag("event.environment", "native")

--- a/packages/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/packages/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -17,6 +17,7 @@ import io.sentry.Breadcrumb
 import io.sentry.DateUtils
 import io.sentry.ScopesAdapter
 import io.sentry.Sentry
+import io.sentry.SentryOptions
 import io.sentry.SentryOptions.Proxy
 import io.sentry.android.core.BuildConfig
 import io.sentry.android.core.InternalSentrySdk
@@ -134,6 +135,48 @@ class SentryFlutterPlugin :
     @Suppress("unused") // Used by native/jni bindings
     @JvmStatic
     fun privateSentryGetReplayIntegration(): ReplayIntegration? = replay
+
+    @Suppress("unused") // Used by native/jni bindings
+    @JvmStatic
+    fun setupBeforeSend(options: SentryAndroidOptions) {
+      options.beforeSend =
+        SentryOptions.BeforeSendCallback { event, _ ->
+          when (event.sdk?.name) {
+            "sentry.dart.flutter" -> {
+              event.setTag("event.origin", "flutter")
+              event.setTag("event.environment", "dart")
+            }
+            "sentry.java.android.flutter" -> {
+              event.setTag("event.origin", "android")
+              event.setTag("event.environment", "java")
+            }
+            "sentry.native.android.flutter" -> {
+              event.setTag("event.origin", "android")
+              event.setTag("event.environment", "native")
+            }
+          }
+          event
+        }
+    }
+
+    @Suppress("unused") // Used by native/jni bindings
+    @JvmStatic
+    fun setContext(
+      key: String,
+      value: Any?,
+    ) {
+      Sentry.configureScope { scope ->
+        scope.setContexts(key, value)
+      }
+    }
+
+    @Suppress("unused") // Used by native/jni bindings
+    @JvmStatic
+    fun removeContext(key: String) {
+      Sentry.configureScope { scope ->
+        scope.removeContexts(key)
+      }
+    }
 
     @JvmStatic
     fun setupReplay(

--- a/packages/flutter/lib/src/native/java/binding.dart
+++ b/packages/flutter/lib/src/native/java/binding.dart
@@ -4599,6 +4599,94 @@ class SentryFlutterPlugin$Companion extends jni$_.JObject {
         .object<ReplayIntegration?>(const $ReplayIntegration$NullableType());
   }
 
+  static final _id_setupBeforeSend = _class.instanceMethodId(
+    r'setupBeforeSend',
+    r'(Lio/sentry/android/core/SentryAndroidOptions;)V',
+  );
+
+  static final _setupBeforeSend = jni$_.ProtectedJniExtensions.lookup<
+              jni$_.NativeFunction<
+                  jni$_.JThrowablePtr Function(
+                      jni$_.Pointer<jni$_.Void>,
+                      jni$_.JMethodIDPtr,
+                      jni$_.VarArgs<(jni$_.Pointer<jni$_.Void>,)>)>>(
+          'globalEnv_CallVoidMethod')
+      .asFunction<
+          jni$_.JThrowablePtr Function(jni$_.Pointer<jni$_.Void>,
+              jni$_.JMethodIDPtr, jni$_.Pointer<jni$_.Void>)>();
+
+  /// from: `public final void setupBeforeSend(io.sentry.android.core.SentryAndroidOptions sentryAndroidOptions)`
+  void setupBeforeSend(
+    SentryAndroidOptions sentryAndroidOptions,
+  ) {
+    final _$sentryAndroidOptions = sentryAndroidOptions.reference;
+    _setupBeforeSend(
+            reference.pointer,
+            _id_setupBeforeSend as jni$_.JMethodIDPtr,
+            _$sentryAndroidOptions.pointer)
+        .check();
+  }
+
+  static final _id_setContext = _class.instanceMethodId(
+    r'setContext',
+    r'(Ljava/lang/String;Ljava/lang/Object;)V',
+  );
+
+  static final _setContext = jni$_.ProtectedJniExtensions.lookup<
+          jni$_.NativeFunction<
+              jni$_.JThrowablePtr Function(
+                  jni$_.Pointer<jni$_.Void>,
+                  jni$_.JMethodIDPtr,
+                  jni$_.VarArgs<
+                      (
+                        jni$_.Pointer<jni$_.Void>,
+                        jni$_.Pointer<jni$_.Void>
+                      )>)>>('globalEnv_CallVoidMethod')
+      .asFunction<
+          jni$_.JThrowablePtr Function(
+              jni$_.Pointer<jni$_.Void>,
+              jni$_.JMethodIDPtr,
+              jni$_.Pointer<jni$_.Void>,
+              jni$_.Pointer<jni$_.Void>)>();
+
+  /// from: `public final void setContext(java.lang.String string, java.lang.Object object)`
+  void setContext(
+    jni$_.JString string,
+    jni$_.JObject? object,
+  ) {
+    final _$string = string.reference;
+    final _$object = object?.reference ?? jni$_.jNullReference;
+    _setContext(reference.pointer, _id_setContext as jni$_.JMethodIDPtr,
+            _$string.pointer, _$object.pointer)
+        .check();
+  }
+
+  static final _id_removeContext = _class.instanceMethodId(
+    r'removeContext',
+    r'(Ljava/lang/String;)V',
+  );
+
+  static final _removeContext = jni$_.ProtectedJniExtensions.lookup<
+              jni$_.NativeFunction<
+                  jni$_.JThrowablePtr Function(
+                      jni$_.Pointer<jni$_.Void>,
+                      jni$_.JMethodIDPtr,
+                      jni$_.VarArgs<(jni$_.Pointer<jni$_.Void>,)>)>>(
+          'globalEnv_CallVoidMethod')
+      .asFunction<
+          jni$_.JThrowablePtr Function(jni$_.Pointer<jni$_.Void>,
+              jni$_.JMethodIDPtr, jni$_.Pointer<jni$_.Void>)>();
+
+  /// from: `public final void removeContext(java.lang.String string)`
+  void removeContext(
+    jni$_.JString string,
+  ) {
+    final _$string = string.reference;
+    _removeContext(reference.pointer, _id_removeContext as jni$_.JMethodIDPtr,
+            _$string.pointer)
+        .check();
+  }
+
   static final _id_setupReplay = _class.instanceMethodId(
     r'setupReplay',
     r'(Lio/sentry/android/core/SentryAndroidOptions;Lio/sentry/flutter/ReplayRecorderCallbacks;)V',
@@ -5165,6 +5253,94 @@ class SentryFlutterPlugin extends jni$_.JObject {
     return _privateSentryGetReplayIntegration(_class.reference.pointer,
             _id_privateSentryGetReplayIntegration as jni$_.JMethodIDPtr)
         .object<ReplayIntegration?>(const $ReplayIntegration$NullableType());
+  }
+
+  static final _id_setupBeforeSend = _class.staticMethodId(
+    r'setupBeforeSend',
+    r'(Lio/sentry/android/core/SentryAndroidOptions;)V',
+  );
+
+  static final _setupBeforeSend = jni$_.ProtectedJniExtensions.lookup<
+              jni$_.NativeFunction<
+                  jni$_.JThrowablePtr Function(
+                      jni$_.Pointer<jni$_.Void>,
+                      jni$_.JMethodIDPtr,
+                      jni$_.VarArgs<(jni$_.Pointer<jni$_.Void>,)>)>>(
+          'globalEnv_CallStaticVoidMethod')
+      .asFunction<
+          jni$_.JThrowablePtr Function(jni$_.Pointer<jni$_.Void>,
+              jni$_.JMethodIDPtr, jni$_.Pointer<jni$_.Void>)>();
+
+  /// from: `static public final void setupBeforeSend(io.sentry.android.core.SentryAndroidOptions sentryAndroidOptions)`
+  static void setupBeforeSend(
+    SentryAndroidOptions sentryAndroidOptions,
+  ) {
+    final _$sentryAndroidOptions = sentryAndroidOptions.reference;
+    _setupBeforeSend(
+            _class.reference.pointer,
+            _id_setupBeforeSend as jni$_.JMethodIDPtr,
+            _$sentryAndroidOptions.pointer)
+        .check();
+  }
+
+  static final _id_setContext = _class.staticMethodId(
+    r'setContext',
+    r'(Ljava/lang/String;Ljava/lang/Object;)V',
+  );
+
+  static final _setContext = jni$_.ProtectedJniExtensions.lookup<
+          jni$_.NativeFunction<
+              jni$_.JThrowablePtr Function(
+                  jni$_.Pointer<jni$_.Void>,
+                  jni$_.JMethodIDPtr,
+                  jni$_.VarArgs<
+                      (
+                        jni$_.Pointer<jni$_.Void>,
+                        jni$_.Pointer<jni$_.Void>
+                      )>)>>('globalEnv_CallStaticVoidMethod')
+      .asFunction<
+          jni$_.JThrowablePtr Function(
+              jni$_.Pointer<jni$_.Void>,
+              jni$_.JMethodIDPtr,
+              jni$_.Pointer<jni$_.Void>,
+              jni$_.Pointer<jni$_.Void>)>();
+
+  /// from: `static public final void setContext(java.lang.String string, java.lang.Object object)`
+  static void setContext(
+    jni$_.JString string,
+    jni$_.JObject? object,
+  ) {
+    final _$string = string.reference;
+    final _$object = object?.reference ?? jni$_.jNullReference;
+    _setContext(_class.reference.pointer, _id_setContext as jni$_.JMethodIDPtr,
+            _$string.pointer, _$object.pointer)
+        .check();
+  }
+
+  static final _id_removeContext = _class.staticMethodId(
+    r'removeContext',
+    r'(Ljava/lang/String;)V',
+  );
+
+  static final _removeContext = jni$_.ProtectedJniExtensions.lookup<
+              jni$_.NativeFunction<
+                  jni$_.JThrowablePtr Function(
+                      jni$_.Pointer<jni$_.Void>,
+                      jni$_.JMethodIDPtr,
+                      jni$_.VarArgs<(jni$_.Pointer<jni$_.Void>,)>)>>(
+          'globalEnv_CallStaticVoidMethod')
+      .asFunction<
+          jni$_.JThrowablePtr Function(jni$_.Pointer<jni$_.Void>,
+              jni$_.JMethodIDPtr, jni$_.Pointer<jni$_.Void>)>();
+
+  /// from: `static public final void removeContext(java.lang.String string)`
+  static void removeContext(
+    jni$_.JString string,
+  ) {
+    final _$string = string.reference;
+    _removeContext(_class.reference.pointer,
+            _id_removeContext as jni$_.JMethodIDPtr, _$string.pointer)
+        .check();
   }
 
   static final _id_setupReplay = _class.staticMethodId(

--- a/packages/flutter/lib/src/native/java/sentry_native_java.dart
+++ b/packages/flutter/lib/src/native/java/sentry_native_java.dart
@@ -237,35 +237,21 @@ class SentryNativeJava extends SentryNativeChannel {
 
   @override
   void setContexts(String key, value) => tryCatchSync('setContexts', () {
-        native.Sentry.configureScope(
-          native.ScopeCallback.implement(
-            native.$ScopeCallback(
-              run: (iScope) {
-                using((arena) {
-                  final jKey = key.toJString()..releasedBy(arena);
-                  final jVal = dartToJObject(value)..releasedBy(arena);
+        using((arena) {
+          final jKey = key.toJString()..releasedBy(arena);
+          final jVal = dartToJObject(value)..releasedBy(arena);
 
-                  final scope = iScope.as(const native.$Scope$Type())
-                    ..releasedBy(arena);
-                  scope.setContexts(jKey, jVal);
-                });
-              },
-            ),
-          ),
-        );
+          native.SentryFlutterPlugin.setContext(jKey, jVal);
+        });
       });
 
   @override
   void removeContexts(String key) => tryCatchSync('removeContexts', () {
-        native.Sentry.configureScope(
-            native.ScopeCallback.implement(native.$ScopeCallback(run: (iScope) {
-          using((arena) {
-            final jKey = key.toJString()..releasedBy(arena);
-            final scope = iScope.as(const native.$Scope$Type())
-              ..releasedBy(arena);
-            scope.removeContexts(jKey);
-          });
-        })));
+        using((arena) {
+          final jKey = key.toJString()..releasedBy(arena);
+
+          native.SentryFlutterPlugin.removeContext(jKey);
+        });
       });
 
   @override

--- a/packages/flutter/lib/src/native/java/sentry_native_java_init.dart
+++ b/packages/flutter/lib/src/native/java/sentry_native_java_init.dart
@@ -1,7 +1,5 @@
 part of 'sentry_native_java.dart';
 
-const _flutterSdkName = 'sentry.dart.flutter';
-
 @internal
 const androidSdkName = 'sentry.java.android.flutter';
 
@@ -21,7 +19,6 @@ void initSentryAndroid({
   );
 
   final beforeSendReplayCallback = createBeforeSendReplayCallback(options);
-  final beforeSendEventCallback = createBeforeSendCallback();
 
   using((arena) {
     final context = native.SentryFlutterPlugin.getApplicationContext()
@@ -41,7 +38,6 @@ void initSentryAndroid({
           configureAndroidOptions(
             androidOptions: androidOptions,
             options: options,
-            beforeSend: beforeSendEventCallback,
             beforeSendReplay: beforeSendReplayCallback,
           );
 
@@ -56,47 +52,6 @@ void initSentryAndroid({
       native.SentryAndroid.init$2(context, cb);
     });
   });
-}
-
-/// Builds the general beforeSend callback to tag events with origin/environment
-/// based on SDK name.
-native.SentryOptions$BeforeSendCallback createBeforeSendCallback() {
-  return native.SentryOptions$BeforeSendCallback.implement(
-    native.$SentryOptions$BeforeSendCallback(
-      execute: (sentryEvent, hint) {
-        using((arena) {
-          final sdk = sentryEvent.getSdk()?..releasedBy(arena);
-          if (sdk == null) return;
-
-          final originKey = 'event.origin'.toJString()..releasedBy(arena);
-          final environmentKey = 'event.environment'.toJString()
-            ..releasedBy(arena);
-
-          void setTagPair(String origin, String environment) {
-            final originVal = origin.toJString()..releasedBy(arena);
-            final envVal = environment.toJString()..releasedBy(arena);
-            sentryEvent.setTag(originKey, originVal);
-            sentryEvent.setTag(environmentKey, envVal);
-          }
-
-          switch (sdk.getName().toDartString(releaseOriginal: true)) {
-            case _flutterSdkName:
-              setTagPair('flutter', 'dart');
-              break;
-            case androidSdkName:
-              setTagPair('android', 'java');
-              break;
-            case nativeSdkName:
-              setTagPair('android', 'native');
-              break;
-            default:
-              break;
-          }
-        });
-        return sentryEvent;
-      },
-    ),
-  );
 }
 
 /// Builds the beforeSendReplay callback to override rrweb masking options
@@ -198,7 +153,6 @@ native.ReplayRecorderCallbacks? createReplayRecorderCallbacks({
 void configureAndroidOptions({
   required native.SentryAndroidOptions androidOptions,
   required SentryFlutterOptions options,
-  required native.SentryOptions$BeforeSendCallback beforeSend,
   required native.SentryOptions$BeforeSendReplayCallback beforeSendReplay,
 }) {
   using((arena) {
@@ -301,9 +255,7 @@ void configureAndroidOptions({
       );
     }
 
-    beforeSend.use((cb) {
-      androidOptions.setBeforeSend(cb);
-    });
+    native.SentryFlutterPlugin.setupBeforeSend(androidOptions);
 
     final sessionReplay = androidOptions.getSessionReplay()..releasedBy(arena);
     switch (options.replay.quality) {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Moves Android beforeSend tagging and context sync updates from Dart-backed JNI callbacks to Kotlin static methods. This avoids long-lived or short-lived Java→Dart proxy callbacks in the affected scope-sync path while preserving existing event origin/environment tagging and context behavior.

Since we cannot bump JNI, which may have a fix in v 1.0.0, we go with this workaround.

Also called a sample app launch/close in a loop, but could not re-produce the issue reported. So this is a best effort by moving the most likley affected parts of the code.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #3658
Fixes https://github.com/getsentry/sentry-dart/issues/3601

## :green_heart: How did you test it?

Added temp logs to sample app and called the methods in question:

Console/logcat output:

 ```text
I/flutter: SENTRY_JNI_TEMP starting context/beforeSend verification
I/SentryJniTemp: setContext key=jni-temp-startup-context value={source=startup, value=from-dart, timestamp=2026-04-28T15:26:27.710851}
valueType=java.util.HashMap
I/SentryJniTemp: setContext key=jni-temp-removed-context value=remove-me valueType=java.lang.String
I/SentryJniTemp: removeContext key=jni-temp-removed-context
I/flutter: SENTRY_JNI_TEMP invoking native capture
I/SentryJniTemp: beforeSend sdk=sentry.java.android.flutter origin=android environment=java
I/flutter: SENTRY_JNI_TEMP native capture invoked
 ```

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps

We also have JNI dart side callbacks for replay, but since the original issue is about scope sync, i focused on those first.