### PR TITLE
fix(flutter): Send frame delay in seconds

### DIFF
--- a/packages/dart/lib/src/sentry_measurement.dart
+++ b/packages/dart/lib/src/sentry_measurement.dart
@@ -30,7 +30,7 @@ class SentryMeasurement {
       : name = frozenFramesName,
         unit = SentryMeasurementUnit.none;
 
-  /// Total duration of frames delayed.
+  /// Total duration of frames delayed in seconds.
   SentryMeasurement.framesDelay(this.value)
       : name = framesDelayName,
         unit = SentryMeasurementUnit.none;

--- a/packages/dart/lib/src/sentry_measurement.dart
+++ b/packages/dart/lib/src/sentry_measurement.dart
@@ -33,7 +33,7 @@ class SentryMeasurement {
   /// Total duration of frames delayed in seconds.
   SentryMeasurement.framesDelay(this.value)
       : name = framesDelayName,
-        unit = SentryMeasurementUnit.none;
+        unit = DurationSentryMeasurementUnit.second;
 
   /// Duration of the Cold App start in milliseconds
   SentryMeasurement.coldAppStart(Duration duration)

--- a/packages/dart/test/sentry_measurement_test.dart
+++ b/packages/dart/test/sentry_measurement_test.dart
@@ -18,6 +18,11 @@ void main() {
           SentryMeasurement.frozenFrames(10).unit, SentryMeasurementUnit.none);
     });
 
+    test('frames delay has seconds unit', () {
+      expect(SentryMeasurement.framesDelay(1.5).unit,
+          DurationSentryMeasurementUnit.second);
+    });
+
     test('warm start has milliseconds unit', () {
       expect(SentryMeasurement.warmAppStart(Duration(seconds: 1)).unit,
           DurationSentryMeasurementUnit.milliSecond);

--- a/packages/flutter/lib/src/frames_tracking/sentry_delayed_frames_tracker.dart
+++ b/packages/flutter/lib/src/frames_tracking/sentry_delayed_frames_tracker.dart
@@ -263,7 +263,11 @@ class SpanFrameMetrics {
       span.setMeasurement(SentryMeasurement.totalFramesName, totalFrameCount);
       span.setMeasurement(SentryMeasurement.slowFramesName, slowFrameCount);
       span.setMeasurement(SentryMeasurement.frozenFramesName, frozenFrameCount);
-      span.setMeasurement(SentryMeasurement.framesDelayName, framesDelay);
+      span.setMeasurement(
+        SentryMeasurement.framesDelayName,
+        framesDelay,
+        unit: DurationSentryMeasurementUnit.second,
+      );
     } else {
       _setData(span);
     }

--- a/packages/flutter/lib/src/frames_tracking/sentry_delayed_frames_tracker.dart
+++ b/packages/flutter/lib/src/frames_tracking/sentry_delayed_frames_tracker.dart
@@ -129,7 +129,7 @@ class SentryDelayedFramesTracker {
               (spanDuration / _expectedFrameDuration.inMilliseconds).ceil(),
           slowFrameCount: 0,
           frozenFrameCount: 0,
-          framesDelay: 0);
+          framesDelay: 0.0);
     }
 
     final spanStartMs = spanStartTimestamp.millisecondsSinceEpoch;
@@ -141,7 +141,7 @@ class SentryDelayedFramesTracker {
     int frozenFrameCount = 0;
     int slowFramesDuration = 0;
     int frozenFramesDuration = 0;
-    int framesDelay = 0;
+    int framesDelayMs = 0;
 
     for (final timing in relevantFrames) {
       final frameStartMs = timing.startTimestamp.millisecondsSinceEpoch;
@@ -188,7 +188,7 @@ class SentryDelayedFramesTracker {
         slowFramesDuration += effectiveDuration;
       }
 
-      framesDelay += effectiveDelay;
+      framesDelayMs += effectiveDelay;
     }
 
     final normalFramesCount =
@@ -200,7 +200,7 @@ class SentryDelayedFramesTracker {
     if (totalFrameCount < 0 ||
         slowFrameCount < 0 ||
         frozenFrameCount < 0 ||
-        framesDelay < 0) {
+        framesDelayMs < 0) {
       return null;
     }
 
@@ -213,7 +213,7 @@ class SentryDelayedFramesTracker {
         totalFrameCount: totalFrameCount,
         slowFrameCount: slowFrameCount,
         frozenFrameCount: frozenFrameCount,
-        framesDelay: framesDelay);
+        framesDelay: framesDelayMs / Duration.millisecondsPerSecond);
   }
 
   /// Clears the state of the tracker.
@@ -242,7 +242,9 @@ class SpanFrameMetrics {
   final int totalFrameCount;
   final int slowFrameCount;
   final int frozenFrameCount;
-  final int framesDelay;
+
+  /// Total delayed frame duration in seconds.
+  final double framesDelay;
 
   SpanFrameMetrics({
     required this.totalFrameCount,

--- a/packages/flutter/lib/src/frames_tracking/span_frame_metrics_collector.dart
+++ b/packages/flutter/lib/src/frames_tracking/span_frame_metrics_collector.dart
@@ -105,7 +105,7 @@ extension _InstrumentationSpanFrameMetrics on InstrumentationSpan {
         attributes[SemanticAttributesConstants.framesFrozen] =
             SentryAttribute.int(metrics.frozenFrameCount);
         attributes[SemanticAttributesConstants.framesDelay] =
-            SentryAttribute.int(metrics.framesDelay);
+            SentryAttribute.double(metrics.framesDelay);
         spanRef.setAttributesIfAbsent(attributes);
       }
     } else {

--- a/packages/flutter/test/frame_tracking/sentry_delayed_frames_tracker_test.dart
+++ b/packages/flutter/test/frame_tracking/sentry_delayed_frames_tracker_test.dart
@@ -109,7 +109,7 @@ void main() {
       expect(metrics!.totalFrameCount, 63); // 1000ms / 16ms ≈ 63 frames
       expect(metrics.slowFrameCount, 0);
       expect(metrics.frozenFrameCount, 0);
-      expect(metrics.framesDelay, 0);
+      expect(metrics.framesDelay, 0.0);
     });
 
     test('calculates metrics for frames fully contained within span', () {
@@ -132,7 +132,7 @@ void main() {
       expect(metrics!.totalFrameCount, 63);
       expect(metrics.slowFrameCount, 1);
       expect(metrics.frozenFrameCount, 0);
-      expect(metrics.framesDelay, 4); // 20ms - 16ms = 4ms delay
+      expect(metrics.framesDelay, 0.004); // 20ms - 16ms = 4ms delay
     });
 
     test('calculates metrics for frames partially contained within span', () {
@@ -156,7 +156,7 @@ void main() {
       expect(metrics!.totalFrameCount, 24); // ~500ms / 16ms = 31 frames
       expect(metrics.slowFrameCount, 2);
       expect(metrics.frozenFrameCount, 0);
-      expect(metrics.framesDelay, 134);
+      expect(metrics.framesDelay, 0.134);
     });
 
     test('calculates metrics for frozen frames', () {
@@ -175,7 +175,7 @@ void main() {
       expect(metrics, isNotNull);
       expect(metrics!.frozenFrameCount, 1);
       expect(metrics.slowFrameCount, 0);
-      expect(metrics.framesDelay, 784); // 800ms - 16ms = 784ms delay
+      expect(metrics.framesDelay, 0.784); // 800ms - 16ms = 784ms delay
     });
 
     test('removeIrrelevantFrames removes the correct frames', () {

--- a/packages/flutter/test/frame_tracking/span_frame_metrics_collector_test.dart
+++ b/packages/flutter/test/frame_tracking/span_frame_metrics_collector_test.dart
@@ -45,7 +45,7 @@ void main() {
         totalFrameCount: 10,
         slowFrameCount: 2,
         frozenFrameCount: 1,
-        framesDelay: 500,
+        framesDelay: 0.5,
       );
       when(fixture.mockFrameTracker.getFrameMetrics(
         spanStartTimestamp: startTime,
@@ -61,12 +61,12 @@ void main() {
       expect(tracer.data[SpanDataConvention.totalFrames], 10);
       expect(tracer.data[SpanDataConvention.slowFrames], 2);
       expect(tracer.data[SpanDataConvention.frozenFrames], 1);
-      expect(tracer.data[SpanDataConvention.framesDelay], 500);
+      expect(tracer.data[SpanDataConvention.framesDelay], 0.5);
       expect(tracer.measurements[SentryMeasurement.totalFramesName]?.value, 10);
       expect(tracer.measurements[SentryMeasurement.slowFramesName]?.value, 2);
       expect(tracer.measurements[SentryMeasurement.frozenFramesName]?.value, 1);
       expect(
-          tracer.measurements[SentryMeasurement.framesDelayName]?.value, 500);
+          tracer.measurements[SentryMeasurement.framesDelayName]?.value, 0.5);
       expect(sut.activeSpans, isEmpty);
     });
 
@@ -94,7 +94,7 @@ void main() {
         totalFrameCount: 10,
         slowFrameCount: 2,
         frozenFrameCount: 1,
-        framesDelay: 500,
+        framesDelay: 0.5,
       );
       when(fixture.mockFrameTracker.getFrameMetrics(
         spanStartTimestamp: startTimeForSpan1,
@@ -105,7 +105,7 @@ void main() {
         totalFrameCount: 5,
         slowFrameCount: 1,
         frozenFrameCount: 3,
-        framesDelay: 400,
+        framesDelay: 0.4,
       );
       when(fixture.mockFrameTracker.getFrameMetrics(
         spanStartTimestamp: startTimeForSpan2,
@@ -122,17 +122,17 @@ void main() {
       expect(tracer.data[SpanDataConvention.totalFrames], 10);
       expect(tracer.data[SpanDataConvention.slowFrames], 2);
       expect(tracer.data[SpanDataConvention.frozenFrames], 1);
-      expect(tracer.data[SpanDataConvention.framesDelay], 500);
+      expect(tracer.data[SpanDataConvention.framesDelay], 0.5);
       expect(tracer.measurements[SentryMeasurement.totalFramesName]?.value, 10);
       expect(tracer.measurements[SentryMeasurement.slowFramesName]?.value, 2);
       expect(tracer.measurements[SentryMeasurement.frozenFramesName]?.value, 1);
       expect(
-          tracer.measurements[SentryMeasurement.framesDelayName]?.value, 500);
+          tracer.measurements[SentryMeasurement.framesDelayName]?.value, 0.5);
 
       expect(span2.data[SpanDataConvention.totalFrames], 5);
       expect(span2.data[SpanDataConvention.slowFrames], 1);
       expect(span2.data[SpanDataConvention.frozenFrames], 3);
-      expect(span2.data[SpanDataConvention.framesDelay], 400);
+      expect(span2.data[SpanDataConvention.framesDelay], 0.4);
 
       expect(sut.activeSpans, isEmpty);
     });
@@ -168,7 +168,7 @@ void main() {
         totalFrameCount: 15,
         slowFrameCount: 3,
         frozenFrameCount: 2,
-        framesDelay: 600,
+        framesDelay: 0.6,
       );
       when(fixture.mockFrameTracker.getFrameMetrics(
         spanStartTimestamp: startTime,
@@ -187,7 +187,7 @@ void main() {
       expect(
           span.attributes[SemanticAttributesConstants.framesFrozen]?.value, 2);
       expect(
-          span.attributes[SemanticAttributesConstants.framesDelay]?.value, 600);
+          span.attributes[SemanticAttributesConstants.framesDelay]?.value, 0.6);
       expect(sut.activeSpans, isEmpty);
     });
 
@@ -222,7 +222,7 @@ void main() {
         totalFrameCount: 10,
         slowFrameCount: 1,
         frozenFrameCount: 0,
-        framesDelay: 100,
+        framesDelay: 0.1,
       );
       when(fixture.mockFrameTracker.getFrameMetrics(
         spanStartTimestamp: startTime1,
@@ -233,7 +233,7 @@ void main() {
         totalFrameCount: 20,
         slowFrameCount: 4,
         frozenFrameCount: 2,
-        framesDelay: 800,
+        framesDelay: 0.8,
       );
       when(fixture.mockFrameTracker.getFrameMetrics(
         spanStartTimestamp: startTime2,
@@ -254,7 +254,7 @@ void main() {
       expect(
           span1.attributes[SemanticAttributesConstants.framesFrozen]?.value, 0);
       expect(span1.attributes[SemanticAttributesConstants.framesDelay]?.value,
-          100);
+          0.1);
 
       expect(
           span2.attributes[SemanticAttributesConstants.framesTotal]?.value, 20);
@@ -263,7 +263,7 @@ void main() {
       expect(
           span2.attributes[SemanticAttributesConstants.framesFrozen]?.value, 2);
       expect(span2.attributes[SemanticAttributesConstants.framesDelay]?.value,
-          800);
+          0.8);
 
       expect(sut.activeSpans, isEmpty);
     });
@@ -348,7 +348,7 @@ void main() {
         totalFrameCount: 10,
         slowFrameCount: 2,
         frozenFrameCount: 1,
-        framesDelay: 500,
+        framesDelay: 0.5,
       );
       when(fixture.mockFrameTracker.getFrameMetrics(
         spanStartTimestamp: startTime,
@@ -384,7 +384,7 @@ void main() {
         totalFrameCount: 15,
         slowFrameCount: 3,
         frozenFrameCount: 2,
-        framesDelay: 600,
+        framesDelay: 0.6,
       );
       when(fixture.mockFrameTracker.getFrameMetrics(
         spanStartTimestamp: startTime,
@@ -412,7 +412,7 @@ void main() {
         totalFrameCount: 10,
         slowFrameCount: 2,
         frozenFrameCount: 1,
-        framesDelay: 500,
+        framesDelay: 0.5,
       );
       when(fixture.mockFrameTracker.getFrameMetrics(
         spanStartTimestamp: startTime,

--- a/packages/flutter/test/frame_tracking/span_frame_metrics_collector_test.dart
+++ b/packages/flutter/test/frame_tracking/span_frame_metrics_collector_test.dart
@@ -67,6 +67,8 @@ void main() {
       expect(tracer.measurements[SentryMeasurement.frozenFramesName]?.value, 1);
       expect(
           tracer.measurements[SentryMeasurement.framesDelayName]?.value, 0.5);
+      expect(tracer.measurements[SentryMeasurement.framesDelayName]?.unit,
+          DurationSentryMeasurementUnit.second);
       expect(sut.activeSpans, isEmpty);
     });
 
@@ -128,6 +130,8 @@ void main() {
       expect(tracer.measurements[SentryMeasurement.frozenFramesName]?.value, 1);
       expect(
           tracer.measurements[SentryMeasurement.framesDelayName]?.value, 0.5);
+      expect(tracer.measurements[SentryMeasurement.framesDelayName]?.unit,
+          DurationSentryMeasurementUnit.second);
 
       expect(span2.data[SpanDataConvention.totalFrames], 5);
       expect(span2.data[SpanDataConvention.slowFrames], 1);

--- a/packages/flutter/test/frame_tracking/span_frame_metrics_test.dart
+++ b/packages/flutter/test/frame_tracking/span_frame_metrics_test.dart
@@ -22,7 +22,7 @@ void main() {
     verify(span.setData(SpanDataConvention.totalFrames, 10)).called(1);
     verify(span.setData(SpanDataConvention.slowFrames, 2)).called(1);
     verify(span.setData(SpanDataConvention.frozenFrames, 1)).called(1);
-    verify(span.setData(SpanDataConvention.framesDelay, 30)).called(1);
+    verify(span.setData(SpanDataConvention.framesDelay, 0.03)).called(1);
   });
 
   test('applyTo sets data and measurements on root spans', () {
@@ -36,14 +36,14 @@ void main() {
     verify(tracer.setData(SpanDataConvention.totalFrames, 10)).called(1);
     verify(tracer.setData(SpanDataConvention.slowFrames, 2)).called(1);
     verify(tracer.setData(SpanDataConvention.frozenFrames, 1)).called(1);
-    verify(tracer.setData(SpanDataConvention.framesDelay, 30)).called(1);
+    verify(tracer.setData(SpanDataConvention.framesDelay, 0.03)).called(1);
 
     verify(span.setMeasurement(SentryMeasurement.totalFramesName, 10))
         .called(1);
     verify(span.setMeasurement(SentryMeasurement.slowFramesName, 2)).called(1);
     verify(span.setMeasurement(SentryMeasurement.frozenFramesName, 1))
         .called(1);
-    verify(span.setMeasurement(SentryMeasurement.framesDelayName, 30))
+    verify(span.setMeasurement(SentryMeasurement.framesDelayName, 0.03))
         .called(1);
   });
 }
@@ -54,7 +54,7 @@ class _Fixture {
       totalFrameCount: 10,
       slowFrameCount: 2,
       frozenFrameCount: 1,
-      framesDelay: 30,
+      framesDelay: 0.03,
     );
   }
 }

--- a/packages/flutter/test/frame_tracking/span_frame_metrics_test.dart
+++ b/packages/flutter/test/frame_tracking/span_frame_metrics_test.dart
@@ -43,8 +43,11 @@ void main() {
     verify(span.setMeasurement(SentryMeasurement.slowFramesName, 2)).called(1);
     verify(span.setMeasurement(SentryMeasurement.frozenFramesName, 1))
         .called(1);
-    verify(span.setMeasurement(SentryMeasurement.framesDelayName, 0.03))
-        .called(1);
+    verify(span.setMeasurement(
+      SentryMeasurement.framesDelayName,
+      0.03,
+      unit: DurationSentryMeasurementUnit.second,
+    )).called(1);
   });
 }
 


### PR DESCRIPTION
## :scroll: Description

Send Flutter frame delay metrics in seconds instead of milliseconds.

The frame tracker still computes delays from millisecond timestamps internally,
but converts the accumulated value before writing `frames.delay` and
`frames_delay`. This matches the backend convention and the Android SDK
behavior.

## :bulb: Motivation and Context

The backend processes frame delay values as seconds. Flutter was sending
millisecond values directly, which made frame delay data 1000x too large.

Fixes https://github.com/getsentry/sentry-dart/issues/3686

## :green_heart: How did you test it?

`fvm flutter test test/frame_tracking/sentry_delayed_frames_tracker_test.dart test/frame_tracking/span_frame_metrics_test.dart test/frame_tracking/span_frame_metrics_collector_test.dart`

`fvm flutter analyze lib/src/frames_tracking/sentry_delayed_frames_tracker.dart lib/src/frames_tracking/span_frame_metrics_collector.dart test/frame_tracking/sentry_delayed_frames_tracker_test.dart test/frame_tracking/span_frame_metrics_test.dart test/frame_tracking/span_frame_metrics_collector_test.dart`

`fvm dart analyze lib/src/sentry_measurement.dart`

Pre-commit checks also ran `dart analyze --fatal-warnings` for `sentry` and
`flutter analyze --fatal-warnings` for `sentry_flutter`.

## :pencil: Checklist

- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

None.
