### PR TITLE
feat(span-first): Add transaction and app start type span attributes

### DIFF
--- a/packages/dart/lib/src/constants.dart
+++ b/packages/dart/lib/src/constants.dart
@@ -84,6 +84,11 @@ abstract class SemanticAttributesConstants {
   /// The segment name (e.g., "GET /users")
   static const sentrySegmentName = 'sentry.segment.name';
 
+  /// The Sentry transaction name, also known as the segment name.
+  /// This is deprecated in favour of [sentrySegmentName].
+  /// We should remove this later when Sentry itself supports this deprecation.
+  static const sentryTransaction = 'sentry.transaction';
+
   /// The span id of the segment that this span belongs to.
   static const sentrySegmentId = 'sentry.segment.id';
 

--- a/packages/dart/lib/src/constants.dart
+++ b/packages/dart/lib/src/constants.dart
@@ -85,7 +85,7 @@ abstract class SemanticAttributesConstants {
   static const sentrySegmentName = 'sentry.segment.name';
 
   /// The Sentry transaction name, also known as the segment name.
-  /// This is deprecated in favour of [sentrySegmentName].
+  /// This is deprecated in favor of [sentrySegmentName].
   /// We should remove this later when Sentry itself supports this deprecation.
   static const sentryTransaction = 'sentry.transaction';
 

--- a/packages/dart/lib/src/telemetry/span/span_capture_pipeline.dart
+++ b/packages/dart/lib/src/telemetry/span/span_capture_pipeline.dart
@@ -38,6 +38,8 @@ class SpanCapturePipeline {
           span.addAttributesIfAbsent({
             SemanticAttributesConstants.sentrySegmentName:
                 SentryAttribute.string(span.segmentSpan.name),
+            SemanticAttributesConstants.sentryTransaction:
+                SentryAttribute.string(span.segmentSpan.name),
             SemanticAttributesConstants.sentrySegmentId:
                 SentryAttribute.string(span.segmentSpan.spanId.toString()),
           });

--- a/packages/dart/test/telemetry/span/span_capture_pipeline_test.dart
+++ b/packages/dart/test/telemetry/span/span_capture_pipeline_test.dart
@@ -30,7 +30,7 @@ void main() {
           'custom': SentryAttribute.string('scope-custom'),
         });
 
-        final span = fixture.createRecordingSpan();
+        final span = fixture.createChildRecordingSpan();
         span.setAttributes({
           'custom': SentryAttribute.string('span-custom'),
           SemanticAttributesConstants.sentryRelease:
@@ -51,6 +51,8 @@ void main() {
         expect(
             attributes[SemanticAttributesConstants.userId]?.value, 'user-id');
         expect(attributes[SemanticAttributesConstants.sentrySegmentName]?.value,
+            span.segmentSpan.name);
+        expect(attributes[SemanticAttributesConstants.sentryTransaction]?.value,
             span.segmentSpan.name);
         expect(attributes[SemanticAttributesConstants.sentrySegmentId]?.value,
             span.segmentSpan.spanId.toString());
@@ -265,6 +267,19 @@ class Fixture {
       clock: options.clock,
       dscCreator: (s) => SentryTraceContextHeader(SentryId.newId(), 'key'),
       samplingDecision: SentryTracesSamplingDecision(true),
+    );
+  }
+
+  RecordingSentrySpanV2 createChildRecordingSpan({
+    String rootName = 'root-span',
+    String childName = 'child-span',
+  }) {
+    return RecordingSentrySpanV2.child(
+      parent: createRecordingSpan(name: rootName),
+      name: childName,
+      onSpanEnd: (_) async {},
+      clock: options.clock,
+      dscCreator: (s) => SentryTraceContextHeader(SentryId.newId(), 'key'),
     );
   }
 }

--- a/packages/dart/test/telemetry/span/span_capture_pipeline_test.dart
+++ b/packages/dart/test/telemetry/span/span_capture_pipeline_test.dart
@@ -30,7 +30,14 @@ void main() {
           'custom': SentryAttribute.string('scope-custom'),
         });
 
-        final span = fixture.createChildRecordingSpan();
+        final segmentSpan = fixture.createRecordingSpan(name: 'root-span');
+        final span = RecordingSentrySpanV2.child(
+          parent: segmentSpan,
+          name: 'child-span',
+          onSpanEnd: (_) async {},
+          clock: fixture.options.clock,
+          dscCreator: (s) => SentryTraceContextHeader(SentryId.newId(), 'key'),
+        );
         span.setAttributes({
           'custom': SentryAttribute.string('span-custom'),
           SemanticAttributesConstants.sentryRelease:
@@ -267,19 +274,6 @@ class Fixture {
       clock: options.clock,
       dscCreator: (s) => SentryTraceContextHeader(SentryId.newId(), 'key'),
       samplingDecision: SentryTracesSamplingDecision(true),
-    );
-  }
-
-  RecordingSentrySpanV2 createChildRecordingSpan({
-    String rootName = 'root-span',
-    String childName = 'child-span',
-  }) {
-    return RecordingSentrySpanV2.child(
-      parent: createRecordingSpan(name: rootName),
-      name: childName,
-      onSpanEnd: (_) async {},
-      clock: options.clock,
-      dscCreator: (s) => SentryTraceContextHeader(SentryId.newId(), 'key'),
     );
   }
 }

--- a/packages/flutter/lib/src/integrations/native_app_start_handler_v2.dart
+++ b/packages/flutter/lib/src/integrations/native_app_start_handler_v2.dart
@@ -105,8 +105,6 @@ class NativeAppStartHandlerV2 {
     appStartSpan.setAttribute(legacyValueKey, durationMs);
     appStartSpan.setAttribute(
         SemanticAttributesConstants.appVitalsStartValue, durationMs);
-    appStartSpan.setAttribute(
-        SemanticAttributesConstants.appVitalsStartType, appStartType);
 
     appStartSpan.end(endTimestamp: appStartEnd);
   }

--- a/packages/flutter/lib/src/integrations/native_app_start_handler_v2.dart
+++ b/packages/flutter/lib/src/integrations/native_app_start_handler_v2.dart
@@ -33,11 +33,13 @@ class NativeAppStartHandlerV2 {
       return;
     }
 
+    final appStartType = SentryAttribute.string(appStartInfo.type.name);
     final attributes = {
       SemanticAttributesConstants.sentryOp:
           SentryAttribute.string(appStartInfo.appStartTypeOperation),
       SemanticAttributesConstants.sentryOrigin:
           SentryAttribute.string(SentryTraceOrigins.autoUiTimeToDisplay),
+      SemanticAttributesConstants.appVitalsStartType: appStartType,
     };
 
     final rootSpan = tracker.trackAppStart(
@@ -103,8 +105,8 @@ class NativeAppStartHandlerV2 {
     appStartSpan.setAttribute(legacyValueKey, durationMs);
     appStartSpan.setAttribute(
         SemanticAttributesConstants.appVitalsStartValue, durationMs);
-    appStartSpan.setAttribute(SemanticAttributesConstants.appVitalsStartType,
-        SentryAttribute.string(appStartInfo.type.name));
+    appStartSpan.setAttribute(
+        SemanticAttributesConstants.appVitalsStartType, appStartType);
 
     appStartSpan.end(endTimestamp: appStartEnd);
   }

--- a/packages/flutter/test/integrations/native_app_start_handler_v2_test.dart
+++ b/packages/flutter/test/integrations/native_app_start_handler_v2_test.dart
@@ -303,10 +303,11 @@ void main() {
       }
     });
 
-    test('all app start child spans have app start type', () async {
+    test('all app start spans have app start type', () async {
       await fixture.call();
 
-      final childSpanNames = [
+      final appStartSpanNames = [
+        'Cold Start',
         'App start to plugin registration',
         'Before Sentry Init Setup',
         'First frame render',
@@ -314,7 +315,7 @@ void main() {
         'native span 2',
       ];
 
-      for (final name in childSpanNames) {
+      for (final name in appStartSpanNames) {
         final span = fixture.findSpanByName(name);
         expect(span, isNotNull, reason: 'Expected span: $name');
         expect(

--- a/packages/flutter/test/integrations/native_app_start_handler_v2_test.dart
+++ b/packages/flutter/test/integrations/native_app_start_handler_v2_test.dart
@@ -302,6 +302,29 @@ void main() {
         );
       }
     });
+
+    test('all app start child spans have app start type', () async {
+      await fixture.call();
+
+      final childSpanNames = [
+        'App start to plugin registration',
+        'Before Sentry Init Setup',
+        'First frame render',
+        'native span 1',
+        'native span 2',
+      ];
+
+      for (final name in childSpanNames) {
+        final span = fixture.findSpanByName(name);
+        expect(span, isNotNull, reason: 'Expected span: $name');
+        expect(
+          span!.attributes[SemanticAttributesConstants.appVitalsStartType]
+              ?.value,
+          'cold',
+          reason: 'Wrong app start type for span: $name',
+        );
+      }
+    });
   });
 }
 


### PR DESCRIPTION
## :scroll: Description

Add streaming span attributes for Sentry transaction/segment naming and app start classification.

Streaming spans now include the deprecated `sentry.transaction` attribute alongside `sentry.segment.name`, both populated from the local segment name. V2 native app-start child spans also receive `app.vitals.start.type` so each app-start span carries its cold/warm classification.

`sentry.transaction` is needed for the mobile vitals page to work correctly

## :bulb: Motivation and Context

This keeps span streaming payloads compatible with consumers that still look for the transaction attribute while also exposing app-start type on every app-start child span, not only the top-level app-start span.

## :green_heart: How did you test it?

- `fvm dart test test/telemetry/span/span_capture_pipeline_test.dart`
- `fvm flutter test test/integrations/native_app_start_handler_v2_test.dart`
- `fvm dart analyze lib/src/constants.dart lib/src/telemetry/span/span_capture_pipeline.dart test/telemetry/span/span_capture_pipeline_test.dart`
- `fvm flutter analyze lib/src/integrations/native_app_start_handler_v2.dart test/integrations/native_app_start_handler_v2_test.dart`
- Pre-commit formatting and package analyze checks

## :pencil: Checklist

- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

N/A

Made with [Cursor](https://cursor.com)