### PR TITLE
build: Remove collection runtime dependency

### DIFF
--- a/packages/_sentry_testing/lib/src/fake_telemetry_processor.dart
+++ b/packages/_sentry_testing/lib/src/fake_telemetry_processor.dart
@@ -3,8 +3,6 @@
 import 'dart:async';
 
 import 'package:sentry/sentry.dart';
-// ignore: implementation_imports
-import 'package:sentry/src/utils/iterable_utils.dart';
 import 'package:sentry/src/telemetry/processing/processor.dart';
 
 /// Fake telemetry processor that captures telemetry data for test assertions.

--- a/packages/_sentry_testing/lib/src/fake_telemetry_processor.dart
+++ b/packages/_sentry_testing/lib/src/fake_telemetry_processor.dart
@@ -2,8 +2,9 @@
 
 import 'dart:async';
 
-import 'package:collection/collection.dart';
 import 'package:sentry/sentry.dart';
+// ignore: implementation_imports
+import 'package:sentry/src/utils/iterable_utils.dart';
 import 'package:sentry/src/telemetry/processing/processor.dart';
 
 /// Fake telemetry processor that captures telemetry data for test assertions.

--- a/packages/_sentry_testing/lib/src/fake_telemetry_processor.dart
+++ b/packages/_sentry_testing/lib/src/fake_telemetry_processor.dart
@@ -4,6 +4,8 @@ import 'dart:async';
 
 import 'package:sentry/sentry.dart';
 import 'package:sentry/src/telemetry/processing/processor.dart';
+// ignore: implementation_imports
+import 'package:sentry/src/utils/iterable_utils.dart';
 
 /// Fake telemetry processor that captures telemetry data for test assertions.
 ///
@@ -39,8 +41,7 @@ class FakeTelemetryProcessor implements TelemetryProcessor {
   }
 
   RecordingSentrySpanV2? findSpanByOperation(String operation) {
-    return SentryIterableUtils.firstWhereOrNull(
-      capturedSpans,
+    return capturedSpans.firstWhereOrNull(
       (span) =>
           span.attributes[SemanticAttributesConstants.sentryOp]?.value ==
           operation,

--- a/packages/_sentry_testing/lib/src/fake_telemetry_processor.dart
+++ b/packages/_sentry_testing/lib/src/fake_telemetry_processor.dart
@@ -39,7 +39,8 @@ class FakeTelemetryProcessor implements TelemetryProcessor {
   }
 
   RecordingSentrySpanV2? findSpanByOperation(String operation) {
-    return capturedSpans.firstWhereOrNull(
+    return SentryIterableUtils.firstWhereOrNull(
+      capturedSpans,
       (span) =>
           span.attributes[SemanticAttributesConstants.sentryOp]?.value ==
           operation,

--- a/packages/_sentry_testing/pubspec.yaml
+++ b/packages/_sentry_testing/pubspec.yaml
@@ -10,7 +10,6 @@ dependencies:
   sentry:
     path: ../dart
   meta: ^1.11.0
-  collection: ^1.18.0
 
 dev_dependencies:
   test: ^1.24.0

--- a/packages/dart/AGENTS.md
+++ b/packages/dart/AGENTS.md
@@ -8,6 +8,9 @@ Core Dart SDK — foundation for all other packages in this monorepo.
 
 - Every new public type must be exported from `lib/sentry.dart`
 - Integration packages (`sentry_flutter`, `sentry_dio`, etc.) depend on this package — regressions here cascade everywhere
+- Do not export internal helpers from `lib/sentry.dart` only for sibling packages; prefer direct `src/` imports within this monorepo when the API is not meant for SDK users
+- Avoid exporting extensions on common Dart/core types like `Iterable`, `String`, or `Map`; they affect user extension resolution and can conflict with `dart:*` or popular packages
+- If a helper truly must be public, prefer an explicit named API over extension methods for common types
 
 ## Key Directories
 

--- a/packages/dart/lib/sentry.dart
+++ b/packages/dart/lib/sentry.dart
@@ -69,3 +69,5 @@ export 'src/utils/breadcrumb_log_level.dart';
 export 'src/telemetry/telemetry.dart';
 // ignore: invalid_export_of_internal_element
 export 'src/utils/internal_logger.dart' show SentryInternalLogger;
+// ignore: invalid_export_of_internal_element
+export 'src/utils/iterable_utils.dart';

--- a/packages/dart/lib/sentry.dart
+++ b/packages/dart/lib/sentry.dart
@@ -69,5 +69,3 @@ export 'src/utils/breadcrumb_log_level.dart';
 export 'src/telemetry/telemetry.dart';
 // ignore: invalid_export_of_internal_element
 export 'src/utils/internal_logger.dart' show SentryInternalLogger;
-// ignore: invalid_export_of_internal_element
-export 'src/utils/iterable_utils.dart';

--- a/packages/dart/lib/src/event_processor/exception/io_exception_event_processor.dart
+++ b/packages/dart/lib/src/event_processor/exception/io_exception_event_processor.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import '../../hint.dart';
 import '../../protocol.dart';
 import '../../sentry_options.dart';
+import '../../utils/iterable_utils.dart';
 import 'exception_event_processor.dart';
 
 ExceptionEventProcessor exceptionEventProcessor(SentryOptions options) =>
@@ -51,7 +52,7 @@ class IoExceptionEventProcessor implements ExceptionEventProcessor {
       // https://api.dart.dev/stable/dart-io/SocketException/osError.html
       // https://api.dart.dev/stable/dart-io/OSError-class.html
       osException = _sentryExceptionFromOsError(osError);
-      final exception = event.exceptions?.firstOrNull;
+      final exception = event.exceptions.firstOrNull;
       if (exception != null) {
         exception.addException(osException);
       } else {
@@ -99,7 +100,7 @@ class IoExceptionEventProcessor implements ExceptionEventProcessor {
       // https://api.dart.dev/stable/dart-io/SocketException/osError.html
       // https://api.dart.dev/stable/dart-io/OSError-class.html
       final osException = _sentryExceptionFromOsError(osError);
-      final exception = event.exceptions?.firstOrNull;
+      final exception = event.exceptions.firstOrNull;
       if (exception != null) {
         exception.addException(osException);
       } else {

--- a/packages/dart/lib/src/event_processor/exception/io_exception_event_processor.dart
+++ b/packages/dart/lib/src/event_processor/exception/io_exception_event_processor.dart
@@ -52,10 +52,7 @@ class IoExceptionEventProcessor implements ExceptionEventProcessor {
       // https://api.dart.dev/stable/dart-io/SocketException/osError.html
       // https://api.dart.dev/stable/dart-io/OSError-class.html
       osException = _sentryExceptionFromOsError(osError);
-      final eventExceptions = event.exceptions;
-      final exception = eventExceptions == null
-          ? null
-          : SentryIterableUtils.firstOrNull(eventExceptions);
+      final exception = event.exceptions?.firstOrNull;
       if (exception != null) {
         exception.addException(osException);
       } else {
@@ -103,10 +100,7 @@ class IoExceptionEventProcessor implements ExceptionEventProcessor {
       // https://api.dart.dev/stable/dart-io/SocketException/osError.html
       // https://api.dart.dev/stable/dart-io/OSError-class.html
       final osException = _sentryExceptionFromOsError(osError);
-      final eventExceptions = event.exceptions;
-      final exception = eventExceptions == null
-          ? null
-          : SentryIterableUtils.firstOrNull(eventExceptions);
+      final exception = event.exceptions?.firstOrNull;
       if (exception != null) {
         exception.addException(osException);
       } else {

--- a/packages/dart/lib/src/event_processor/exception/io_exception_event_processor.dart
+++ b/packages/dart/lib/src/event_processor/exception/io_exception_event_processor.dart
@@ -52,7 +52,7 @@ class IoExceptionEventProcessor implements ExceptionEventProcessor {
       // https://api.dart.dev/stable/dart-io/SocketException/osError.html
       // https://api.dart.dev/stable/dart-io/OSError-class.html
       osException = _sentryExceptionFromOsError(osError);
-      final exception = event.exceptions.firstOrNull;
+      final exception = event.exceptions?.firstOrNull;
       if (exception != null) {
         exception.addException(osException);
       } else {
@@ -100,7 +100,7 @@ class IoExceptionEventProcessor implements ExceptionEventProcessor {
       // https://api.dart.dev/stable/dart-io/SocketException/osError.html
       // https://api.dart.dev/stable/dart-io/OSError-class.html
       final osException = _sentryExceptionFromOsError(osError);
-      final exception = event.exceptions.firstOrNull;
+      final exception = event.exceptions?.firstOrNull;
       if (exception != null) {
         exception.addException(osException);
       } else {

--- a/packages/dart/lib/src/event_processor/exception/io_exception_event_processor.dart
+++ b/packages/dart/lib/src/event_processor/exception/io_exception_event_processor.dart
@@ -52,7 +52,10 @@ class IoExceptionEventProcessor implements ExceptionEventProcessor {
       // https://api.dart.dev/stable/dart-io/SocketException/osError.html
       // https://api.dart.dev/stable/dart-io/OSError-class.html
       osException = _sentryExceptionFromOsError(osError);
-      final exception = event.exceptions?.firstOrNull;
+      final eventExceptions = event.exceptions;
+      final exception = eventExceptions == null
+          ? null
+          : SentryIterableUtils.firstOrNull(eventExceptions);
       if (exception != null) {
         exception.addException(osException);
       } else {
@@ -100,7 +103,10 @@ class IoExceptionEventProcessor implements ExceptionEventProcessor {
       // https://api.dart.dev/stable/dart-io/SocketException/osError.html
       // https://api.dart.dev/stable/dart-io/OSError-class.html
       final osException = _sentryExceptionFromOsError(osError);
-      final exception = event.exceptions?.firstOrNull;
+      final eventExceptions = event.exceptions;
+      final exception = eventExceptions == null
+          ? null
+          : SentryIterableUtils.firstOrNull(eventExceptions);
       if (exception != null) {
         exception.addException(osException);
       } else {

--- a/packages/dart/lib/src/protocol/sentry_event.dart
+++ b/packages/dart/lib/src/protocol/sentry_event.dart
@@ -1,9 +1,9 @@
-import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
 
 import '../protocol.dart';
 import '../throwable_mechanism.dart';
 import '../utils.dart';
+import '../utils/iterable_utils.dart';
 import 'access_aware_map.dart';
 
 /// An event to be reported to Sentry.io.
@@ -415,6 +415,6 @@ class SentryEvent with SentryEventLike<SentryEvent> {
   // Returns first non-null stack trace of this event
   @internal
   SentryStackTrace? get stacktrace =>
-      exceptions?.firstWhereOrNull((e) => e.stackTrace != null)?.stackTrace ??
-      threads?.firstWhereOrNull((t) => t.stacktrace != null)?.stacktrace;
+      exceptions.firstWhereOrNull((e) => e.stackTrace != null)?.stackTrace ??
+      threads.firstWhereOrNull((t) => t.stacktrace != null)?.stacktrace;
 }

--- a/packages/dart/lib/src/protocol/sentry_event.dart
+++ b/packages/dart/lib/src/protocol/sentry_event.dart
@@ -414,20 +414,7 @@ class SentryEvent with SentryEventLike<SentryEvent> {
 
   // Returns first non-null stack trace of this event
   @internal
-  SentryStackTrace? get stacktrace {
-    final eventExceptions = exceptions;
-    final eventThreads = threads;
-    return (eventExceptions == null
-            ? null
-            : SentryIterableUtils.firstWhereOrNull(
-                eventExceptions,
-                (e) => e.stackTrace != null,
-              )?.stackTrace) ??
-        (eventThreads == null
-            ? null
-            : SentryIterableUtils.firstWhereOrNull(
-                eventThreads,
-                (t) => t.stacktrace != null,
-              )?.stacktrace);
-  }
+  SentryStackTrace? get stacktrace =>
+      exceptions?.firstWhereOrNull((e) => e.stackTrace != null)?.stackTrace ??
+      threads?.firstWhereOrNull((t) => t.stacktrace != null)?.stacktrace;
 }

--- a/packages/dart/lib/src/protocol/sentry_event.dart
+++ b/packages/dart/lib/src/protocol/sentry_event.dart
@@ -415,6 +415,6 @@ class SentryEvent with SentryEventLike<SentryEvent> {
   // Returns first non-null stack trace of this event
   @internal
   SentryStackTrace? get stacktrace =>
-      exceptions.firstWhereOrNull((e) => e.stackTrace != null)?.stackTrace ??
-      threads.firstWhereOrNull((t) => t.stacktrace != null)?.stacktrace;
+      exceptions?.firstWhereOrNull((e) => e.stackTrace != null)?.stackTrace ??
+      threads?.firstWhereOrNull((t) => t.stacktrace != null)?.stacktrace;
 }

--- a/packages/dart/lib/src/protocol/sentry_event.dart
+++ b/packages/dart/lib/src/protocol/sentry_event.dart
@@ -414,7 +414,20 @@ class SentryEvent with SentryEventLike<SentryEvent> {
 
   // Returns first non-null stack trace of this event
   @internal
-  SentryStackTrace? get stacktrace =>
-      exceptions?.firstWhereOrNull((e) => e.stackTrace != null)?.stackTrace ??
-      threads?.firstWhereOrNull((t) => t.stacktrace != null)?.stacktrace;
+  SentryStackTrace? get stacktrace {
+    final eventExceptions = exceptions;
+    final eventThreads = threads;
+    return (eventExceptions == null
+            ? null
+            : SentryIterableUtils.firstWhereOrNull(
+                eventExceptions,
+                (e) => e.stackTrace != null,
+              )?.stackTrace) ??
+        (eventThreads == null
+            ? null
+            : SentryIterableUtils.firstWhereOrNull(
+                eventThreads,
+                (t) => t.stacktrace != null,
+              )?.stacktrace);
+  }
 }

--- a/packages/dart/lib/src/protocol/sentry_request.dart
+++ b/packages/dart/lib/src/protocol/sentry_request.dart
@@ -86,10 +86,11 @@ class SentryRequest {
         _headers = headers != null ? Map.from(headers) : null,
         // Look for a 'Set-Cookie' header (case insensitive) if not given.
         cookies = cookies ??
-            IterableUtils.firstWhereOrNull(
-              headers?.entries,
-              (MapEntry<String, String> e) => e.key.toLowerCase() == 'cookie',
-            )?.value,
+            headers?.entries
+                .firstWhereOrNull(
+                  (e) => e.key.toLowerCase() == 'cookie',
+                )
+                ?.value,
         _env = env != null ? Map.from(env) : null;
 
   factory SentryRequest.fromUri({

--- a/packages/dart/lib/src/protocol/sentry_request.dart
+++ b/packages/dart/lib/src/protocol/sentry_request.dart
@@ -86,12 +86,11 @@ class SentryRequest {
         _headers = headers != null ? Map.from(headers) : null,
         // Look for a 'Set-Cookie' header (case insensitive) if not given.
         cookies = cookies ??
-            (headers == null
-                ? null
-                : SentryIterableUtils.firstWhereOrNull(
-                    headers.entries,
-                    (e) => e.key.toLowerCase() == 'cookie',
-                  )?.value),
+            headers?.entries
+                .firstWhereOrNull(
+                  (e) => e.key.toLowerCase() == 'cookie',
+                )
+                ?.value,
         _env = env != null ? Map.from(env) : null;
 
   factory SentryRequest.fromUri({

--- a/packages/dart/lib/src/protocol/sentry_request.dart
+++ b/packages/dart/lib/src/protocol/sentry_request.dart
@@ -86,11 +86,12 @@ class SentryRequest {
         _headers = headers != null ? Map.from(headers) : null,
         // Look for a 'Set-Cookie' header (case insensitive) if not given.
         cookies = cookies ??
-            headers?.entries
-                .firstWhereOrNull(
-                  (e) => e.key.toLowerCase() == 'cookie',
-                )
-                ?.value,
+            (headers == null
+                ? null
+                : SentryIterableUtils.firstWhereOrNull(
+                    headers.entries,
+                    (e) => e.key.toLowerCase() == 'cookie',
+                  )?.value),
         _env = env != null ? Map.from(env) : null;
 
   factory SentryRequest.fromUri({

--- a/packages/dart/lib/src/protocol/sentry_response.dart
+++ b/packages/dart/lib/src/protocol/sentry_response.dart
@@ -51,11 +51,11 @@ class SentryResponse {
         _headers = headers != null ? Map.from(headers) : null,
         // Look for a 'Set-Cookie' header (case insensitive) if not given.
         cookies = cookies ??
-            IterableUtils.firstWhereOrNull(
-              headers?.entries,
-              (MapEntry<String, String> e) =>
-                  e.key.toLowerCase() == 'set-cookie',
-            )?.value;
+            headers?.entries
+                .firstWhereOrNull(
+                  (e) => e.key.toLowerCase() == 'set-cookie',
+                )
+                ?.value;
 
   /// Deserializes a [SentryResponse] from JSON [Map].
   factory SentryResponse.fromJson(Map<String, dynamic> json) {

--- a/packages/dart/lib/src/protocol/sentry_response.dart
+++ b/packages/dart/lib/src/protocol/sentry_response.dart
@@ -51,11 +51,12 @@ class SentryResponse {
         _headers = headers != null ? Map.from(headers) : null,
         // Look for a 'Set-Cookie' header (case insensitive) if not given.
         cookies = cookies ??
-            headers?.entries
-                .firstWhereOrNull(
-                  (e) => e.key.toLowerCase() == 'set-cookie',
-                )
-                ?.value;
+            (headers == null
+                ? null
+                : SentryIterableUtils.firstWhereOrNull(
+                    headers.entries,
+                    (e) => e.key.toLowerCase() == 'set-cookie',
+                  )?.value);
 
   /// Deserializes a [SentryResponse] from JSON [Map].
   factory SentryResponse.fromJson(Map<String, dynamic> json) {

--- a/packages/dart/lib/src/protocol/sentry_response.dart
+++ b/packages/dart/lib/src/protocol/sentry_response.dart
@@ -51,12 +51,11 @@ class SentryResponse {
         _headers = headers != null ? Map.from(headers) : null,
         // Look for a 'Set-Cookie' header (case insensitive) if not given.
         cookies = cookies ??
-            (headers == null
-                ? null
-                : SentryIterableUtils.firstWhereOrNull(
-                    headers.entries,
-                    (e) => e.key.toLowerCase() == 'set-cookie',
-                  )?.value);
+            headers?.entries
+                .firstWhereOrNull(
+                  (e) => e.key.toLowerCase() == 'set-cookie',
+                )
+                ?.value;
 
   /// Deserializes a [SentryResponse] from JSON [Map].
   factory SentryResponse.fromJson(Map<String, dynamic> json) {

--- a/packages/dart/lib/src/sentry.dart
+++ b/packages/dart/lib/src/sentry.dart
@@ -33,6 +33,7 @@ import 'tracing.dart';
 import 'tracing/instrumentation/span_factory_integration.dart';
 import 'transport/data_category.dart';
 import 'transport/task_queue.dart';
+import 'utils/iterable_utils.dart';
 import 'feature_flags_integration.dart';
 import 'telemetry/log/logger.dart';
 import 'telemetry/log/logger_setup_integration.dart';

--- a/packages/dart/lib/src/sentry.dart
+++ b/packages/dart/lib/src/sentry.dart
@@ -522,9 +522,9 @@ class Sentry {
       return;
     }
 
-    final featureFlagsIntegration = SentryIterableUtils.firstOrNull(
-      currentHub.options.integrations.whereType<FeatureFlagsIntegration>(),
-    );
+    final featureFlagsIntegration = currentHub.options.integrations
+        .whereType<FeatureFlagsIntegration>()
+        .firstOrNull;
 
     if (featureFlagsIntegration == null) {
       currentHub.options.log(

--- a/packages/dart/lib/src/sentry.dart
+++ b/packages/dart/lib/src/sentry.dart
@@ -522,9 +522,9 @@ class Sentry {
       return;
     }
 
-    final featureFlagsIntegration = currentHub.options.integrations
-        .whereType<FeatureFlagsIntegration>()
-        .firstOrNull;
+    final featureFlagsIntegration = SentryIterableUtils.firstOrNull(
+      currentHub.options.integrations.whereType<FeatureFlagsIntegration>(),
+    );
 
     if (featureFlagsIntegration == null) {
       currentHub.options.log(

--- a/packages/dart/lib/src/utils/iterable_utils.dart
+++ b/packages/dart/lib/src/utils/iterable_utils.dart
@@ -1,11 +1,14 @@
-import 'package:meta/meta.dart';
+extension SentryIterableUtils<T> on Iterable<T>? {
+  T? get firstOrNull {
+    final iterator = this?.iterator;
+    if (iterator == null || !iterator.moveNext()) {
+      return null;
+    }
+    return iterator.current;
+  }
 
-@internal
-class IterableUtils {
-  static T? firstWhereOrNull<T>(
-    Iterable<T>? iterable,
-    bool Function(T item) test,
-  ) {
+  T? firstWhereOrNull(bool Function(T item) test) {
+    final iterable = this;
     if (iterable == null) {
       return null;
     }

--- a/packages/dart/lib/src/utils/iterable_utils.dart
+++ b/packages/dart/lib/src/utils/iterable_utils.dart
@@ -1,3 +1,6 @@
+import 'package:meta/meta.dart';
+
+@internal
 extension SentryIterableUtils<T> on Iterable<T>? {
   T? get firstOrNull {
     final iterator = this?.iterator;

--- a/packages/dart/lib/src/utils/iterable_utils.dart
+++ b/packages/dart/lib/src/utils/iterable_utils.dart
@@ -1,3 +1,6 @@
+import 'package:meta/meta.dart';
+
+@internal
 abstract final class SentryIterableUtils {
   static T? firstOrNull<T>(Iterable<T> iterable) {
     final iterator = iterable.iterator;

--- a/packages/dart/lib/src/utils/iterable_utils.dart
+++ b/packages/dart/lib/src/utils/iterable_utils.dart
@@ -1,20 +1,17 @@
 import 'package:meta/meta.dart';
 
 @internal
-abstract final class SentryIterableUtils {
-  static T? firstOrNull<T>(Iterable<T> iterable) {
-    final iterator = iterable.iterator;
+extension SentryIterableUtils<T> on Iterable<T> {
+  T? get firstOrNull {
+    final iterator = this.iterator;
     if (!iterator.moveNext()) {
       return null;
     }
     return iterator.current;
   }
 
-  static T? firstWhereOrNull<T>(
-    Iterable<T> iterable,
-    bool Function(T item) test,
-  ) {
-    for (var item in iterable) {
+  T? firstWhereOrNull(bool Function(T item) test) {
+    for (final item in this) {
       if (test(item)) return item;
     }
     return null;

--- a/packages/dart/lib/src/utils/iterable_utils.dart
+++ b/packages/dart/lib/src/utils/iterable_utils.dart
@@ -1,21 +1,17 @@
 import 'package:meta/meta.dart';
 
 @internal
-extension SentryIterableUtils<T> on Iterable<T>? {
+extension SentryIterableUtils<T> on Iterable<T> {
   T? get firstOrNull {
-    final iterator = this?.iterator;
-    if (iterator == null || !iterator.moveNext()) {
+    final iterator = this.iterator;
+    if (!iterator.moveNext()) {
       return null;
     }
     return iterator.current;
   }
 
   T? firstWhereOrNull(bool Function(T item) test) {
-    final iterable = this;
-    if (iterable == null) {
-      return null;
-    }
-    for (var item in iterable) {
+    for (var item in this) {
       if (test(item)) return item;
     }
     return null;

--- a/packages/dart/lib/src/utils/iterable_utils.dart
+++ b/packages/dart/lib/src/utils/iterable_utils.dart
@@ -1,17 +1,17 @@
-import 'package:meta/meta.dart';
-
-@internal
-extension SentryIterableUtils<T> on Iterable<T> {
-  T? get firstOrNull {
-    final iterator = this.iterator;
+abstract final class SentryIterableUtils {
+  static T? firstOrNull<T>(Iterable<T> iterable) {
+    final iterator = iterable.iterator;
     if (!iterator.moveNext()) {
       return null;
     }
     return iterator.current;
   }
 
-  T? firstWhereOrNull(bool Function(T item) test) {
-    for (var item in this) {
+  static T? firstWhereOrNull<T>(
+    Iterable<T> iterable,
+    bool Function(T item) test,
+  ) {
+    for (var item in iterable) {
       if (test(item)) return item;
     }
     return null;

--- a/packages/dart/pubspec.yaml
+++ b/packages/dart/pubspec.yaml
@@ -24,11 +24,11 @@ dependencies:
   meta: ^1.3.0
   stack_trace: ^1.10.0
   uuid: '>=3.0.0 <5.0.0'
-  collection: ^1.16.0
   web: ^1.1.0
 
 dev_dependencies:
   build_runner: ^2.3.0
+  collection: ^1.16.0
   mockito: ^5.1.0
   lints: '>=2.0.0'
   test: ^1.21.1

--- a/packages/dart/test/event_processor/exception/io_exception_event_processor_test.dart
+++ b/packages/dart/test/event_processor/exception/io_exception_event_processor_test.dart
@@ -5,8 +5,9 @@ import 'dart:io';
 
 import 'package:sentry/sentry.dart';
 import 'package:sentry/src/event_processor/exception/io_exception_event_processor.dart';
-import 'package:test/test.dart';
 import 'package:sentry/src/sentry_exception_factory.dart';
+import 'package:sentry/src/utils/iterable_utils.dart';
+import 'package:test/test.dart';
 
 import '../../test_utils.dart';
 
@@ -105,10 +106,7 @@ void main() {
       final rootException = event?.exceptions?.first;
       expect(rootException, sentryException);
 
-      final childExceptions = rootException?.exceptions;
-      final childException = childExceptions == null
-          ? null
-          : SentryIterableUtils.firstOrNull(childExceptions);
+      final childException = rootException?.exceptions?.firstOrNull;
       // Due to the test setup, there's no SentryException for the FileSystemException.
       // And thus only one entry for the added OSError
       expect(childException?.type, 'OSError');

--- a/packages/dart/test/event_processor/exception/io_exception_event_processor_test.dart
+++ b/packages/dart/test/event_processor/exception/io_exception_event_processor_test.dart
@@ -105,7 +105,10 @@ void main() {
       final rootException = event?.exceptions?.first;
       expect(rootException, sentryException);
 
-      final childException = rootException?.exceptions?.firstOrNull;
+      final childExceptions = rootException?.exceptions;
+      final childException = childExceptions == null
+          ? null
+          : SentryIterableUtils.firstOrNull(childExceptions);
       // Due to the test setup, there's no SentryException for the FileSystemException.
       // And thus only one entry for the added OSError
       expect(childException?.type, 'OSError');

--- a/packages/dart/test/protocol/rate_limiter_test.dart
+++ b/packages/dart/test/protocol/rate_limiter_test.dart
@@ -4,6 +4,7 @@ import 'package:sentry/src/sentry_envelope_header.dart';
 import 'package:sentry/src/sentry_tracer.dart';
 import 'package:sentry/src/transport/data_category.dart';
 import 'package:sentry/src/transport/rate_limiter.dart';
+import 'package:sentry/src/utils/iterable_utils.dart';
 import 'package:test/test.dart';
 
 import '../mocks/mock_client_report_recorder.dart';
@@ -231,15 +232,13 @@ void main() {
 
     expect(fixture.mockRecorder.discardedEvents.length, 2);
 
-    final transactionDiscardedEvent = SentryIterableUtils.firstWhereOrNull(
-        fixture.mockRecorder.discardedEvents,
-        (element) =>
+    final transactionDiscardedEvent = fixture.mockRecorder.discardedEvents
+        .firstWhereOrNull((element) =>
             element.category == DataCategory.transaction &&
             element.reason == DiscardReason.rateLimitBackoff);
 
-    final spanDiscardedEvent = SentryIterableUtils.firstWhereOrNull(
-        fixture.mockRecorder.discardedEvents,
-        (element) =>
+    final spanDiscardedEvent = fixture.mockRecorder.discardedEvents
+        .firstWhereOrNull((element) =>
             element.category == DataCategory.span &&
             element.reason == DiscardReason.rateLimitBackoff);
 

--- a/packages/dart/test/protocol/rate_limiter_test.dart
+++ b/packages/dart/test/protocol/rate_limiter_test.dart
@@ -1,4 +1,3 @@
-import 'package:collection/collection.dart';
 import 'package:sentry/sentry.dart';
 import 'package:sentry/src/client_reports/discard_reason.dart';
 import 'package:sentry/src/sentry_envelope_header.dart';

--- a/packages/dart/test/protocol/rate_limiter_test.dart
+++ b/packages/dart/test/protocol/rate_limiter_test.dart
@@ -231,13 +231,15 @@ void main() {
 
     expect(fixture.mockRecorder.discardedEvents.length, 2);
 
-    final transactionDiscardedEvent = fixture.mockRecorder.discardedEvents
-        .firstWhereOrNull((element) =>
+    final transactionDiscardedEvent = SentryIterableUtils.firstWhereOrNull(
+        fixture.mockRecorder.discardedEvents,
+        (element) =>
             element.category == DataCategory.transaction &&
             element.reason == DiscardReason.rateLimitBackoff);
 
-    final spanDiscardedEvent = fixture.mockRecorder.discardedEvents
-        .firstWhereOrNull((element) =>
+    final spanDiscardedEvent = SentryIterableUtils.firstWhereOrNull(
+        fixture.mockRecorder.discardedEvents,
+        (element) =>
             element.category == DataCategory.span &&
             element.reason == DiscardReason.rateLimitBackoff);
 

--- a/packages/dart/test/sentry_client_test.dart
+++ b/packages/dart/test/sentry_client_test.dart
@@ -15,7 +15,6 @@ import 'package:sentry/src/transport/client_report_transport.dart';
 import 'package:sentry/src/transport/data_category.dart';
 import 'package:sentry/src/transport/noop_transport.dart';
 import 'package:sentry/src/transport/spotlight_http_transport.dart';
-import 'package:sentry/src/utils/iterable_utils.dart';
 import 'package:sentry/src/telemetry/span/span_capture_pipeline.dart';
 import 'package:test/test.dart';
 import 'package:mockito/mockito.dart';
@@ -2247,8 +2246,7 @@ void main() {
       await sut.captureEvent(fakeEvent, hint: hint);
 
       final capturedEnvelope = (fixture.transport).envelopes.first;
-      final attachmentItem = IterableUtils.firstWhereOrNull(
-        capturedEnvelope.items,
+      final attachmentItem = capturedEnvelope.items.firstWhereOrNull(
         (SentryEnvelopeItem e) => e.header.type == SentryItemType.attachment,
       );
       expect(attachmentItem?.header.attachmentType,
@@ -2264,8 +2262,7 @@ void main() {
       await sut.captureFeedback(fakeFeedback, hint: hint);
 
       final capturedEnvelope = (fixture.transport).envelopes.first;
-      final attachmentItem = IterableUtils.firstWhereOrNull(
-        capturedEnvelope.items,
+      final attachmentItem = capturedEnvelope.items.firstWhereOrNull(
         (SentryEnvelopeItem e) => e.header.type == SentryItemType.attachment,
       );
       expect(attachmentItem?.header.attachmentType,

--- a/packages/dart/test/sentry_client_test.dart
+++ b/packages/dart/test/sentry_client_test.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:collection/collection.dart';
 import 'package:sentry/sentry.dart';
 import 'package:sentry/src/client_reports/discard_reason.dart';
 import 'package:sentry/src/client_reports/noop_client_report_recorder.dart';

--- a/packages/dart/test/sentry_client_test.dart
+++ b/packages/dart/test/sentry_client_test.dart
@@ -2245,7 +2245,8 @@ void main() {
       await sut.captureEvent(fakeEvent, hint: hint);
 
       final capturedEnvelope = (fixture.transport).envelopes.first;
-      final attachmentItem = capturedEnvelope.items.firstWhereOrNull(
+      final attachmentItem = SentryIterableUtils.firstWhereOrNull(
+        capturedEnvelope.items,
         (SentryEnvelopeItem e) => e.header.type == SentryItemType.attachment,
       );
       expect(attachmentItem?.header.attachmentType,
@@ -2261,7 +2262,8 @@ void main() {
       await sut.captureFeedback(fakeFeedback, hint: hint);
 
       final capturedEnvelope = (fixture.transport).envelopes.first;
-      final attachmentItem = capturedEnvelope.items.firstWhereOrNull(
+      final attachmentItem = SentryIterableUtils.firstWhereOrNull(
+        capturedEnvelope.items,
         (SentryEnvelopeItem e) => e.header.type == SentryItemType.attachment,
       );
       expect(attachmentItem?.header.attachmentType,
@@ -2304,8 +2306,10 @@ void main() {
       await client.captureEvent(fakeEvent, hint: hint);
 
       final capturedEnvelope = (fixture.transport).envelopes.first;
-      final attachmentItem = capturedEnvelope.items.firstWhereOrNull(
-          (element) => element.header.type == SentryItemType.attachment);
+      final attachmentItem = SentryIterableUtils.firstWhereOrNull(
+        capturedEnvelope.items,
+        (element) => element.header.type == SentryItemType.attachment,
+      );
       expect(attachmentItem?.header.fileName, 'screenshot.png');
     });
 
@@ -2319,8 +2323,10 @@ void main() {
       await client.captureFeedback(fakeFeedback, hint: hint);
 
       final capturedEnvelope = (fixture.transport).envelopes.first;
-      final attachmentItem = capturedEnvelope.items.firstWhereOrNull(
-          (element) => element.header.type == SentryItemType.attachment);
+      final attachmentItem = SentryIterableUtils.firstWhereOrNull(
+        capturedEnvelope.items,
+        (element) => element.header.type == SentryItemType.attachment,
+      );
       expect(attachmentItem?.header.fileName, 'screenshot.png');
     });
 
@@ -2333,8 +2339,10 @@ void main() {
       await client.captureEvent(fakeEvent, hint: hint);
 
       final capturedEnvelope = (fixture.transport).envelopes.first;
-      final attachmentItem = capturedEnvelope.items.firstWhereOrNull(
-          (element) => element.header.type == SentryItemType.attachment);
+      final attachmentItem = SentryIterableUtils.firstWhereOrNull(
+        capturedEnvelope.items,
+        (element) => element.header.type == SentryItemType.attachment,
+      );
 
       expect(attachmentItem?.header.attachmentType,
           SentryAttachment.typeViewHierarchy);
@@ -2350,7 +2358,8 @@ void main() {
       await client.captureFeedback(fakeFeedback, hint: hint);
 
       final capturedEnvelope = (fixture.transport).envelopes.first;
-      final attachmentItem = capturedEnvelope.items.firstWhereOrNull(
+      final attachmentItem = SentryIterableUtils.firstWhereOrNull(
+        capturedEnvelope.items,
         (element) => element.header.type == SentryItemType.attachment,
       );
       expect(attachmentItem, isNull);

--- a/packages/dart/test/sentry_client_test.dart
+++ b/packages/dart/test/sentry_client_test.dart
@@ -15,6 +15,7 @@ import 'package:sentry/src/transport/data_category.dart';
 import 'package:sentry/src/transport/noop_transport.dart';
 import 'package:sentry/src/transport/spotlight_http_transport.dart';
 import 'package:sentry/src/telemetry/span/span_capture_pipeline.dart';
+import 'package:sentry/src/utils/iterable_utils.dart';
 import 'package:test/test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:http/http.dart' as http;
@@ -2245,8 +2246,7 @@ void main() {
       await sut.captureEvent(fakeEvent, hint: hint);
 
       final capturedEnvelope = (fixture.transport).envelopes.first;
-      final attachmentItem = SentryIterableUtils.firstWhereOrNull(
-        capturedEnvelope.items,
+      final attachmentItem = capturedEnvelope.items.firstWhereOrNull(
         (SentryEnvelopeItem e) => e.header.type == SentryItemType.attachment,
       );
       expect(attachmentItem?.header.attachmentType,
@@ -2262,8 +2262,7 @@ void main() {
       await sut.captureFeedback(fakeFeedback, hint: hint);
 
       final capturedEnvelope = (fixture.transport).envelopes.first;
-      final attachmentItem = SentryIterableUtils.firstWhereOrNull(
-        capturedEnvelope.items,
+      final attachmentItem = capturedEnvelope.items.firstWhereOrNull(
         (SentryEnvelopeItem e) => e.header.type == SentryItemType.attachment,
       );
       expect(attachmentItem?.header.attachmentType,
@@ -2306,8 +2305,7 @@ void main() {
       await client.captureEvent(fakeEvent, hint: hint);
 
       final capturedEnvelope = (fixture.transport).envelopes.first;
-      final attachmentItem = SentryIterableUtils.firstWhereOrNull(
-        capturedEnvelope.items,
+      final attachmentItem = capturedEnvelope.items.firstWhereOrNull(
         (element) => element.header.type == SentryItemType.attachment,
       );
       expect(attachmentItem?.header.fileName, 'screenshot.png');
@@ -2323,8 +2321,7 @@ void main() {
       await client.captureFeedback(fakeFeedback, hint: hint);
 
       final capturedEnvelope = (fixture.transport).envelopes.first;
-      final attachmentItem = SentryIterableUtils.firstWhereOrNull(
-        capturedEnvelope.items,
+      final attachmentItem = capturedEnvelope.items.firstWhereOrNull(
         (element) => element.header.type == SentryItemType.attachment,
       );
       expect(attachmentItem?.header.fileName, 'screenshot.png');
@@ -2339,8 +2336,7 @@ void main() {
       await client.captureEvent(fakeEvent, hint: hint);
 
       final capturedEnvelope = (fixture.transport).envelopes.first;
-      final attachmentItem = SentryIterableUtils.firstWhereOrNull(
-        capturedEnvelope.items,
+      final attachmentItem = capturedEnvelope.items.firstWhereOrNull(
         (element) => element.header.type == SentryItemType.attachment,
       );
 
@@ -2358,8 +2354,7 @@ void main() {
       await client.captureFeedback(fakeFeedback, hint: hint);
 
       final capturedEnvelope = (fixture.transport).envelopes.first;
-      final attachmentItem = SentryIterableUtils.firstWhereOrNull(
-        capturedEnvelope.items,
+      final attachmentItem = capturedEnvelope.items.firstWhereOrNull(
         (element) => element.header.type == SentryItemType.attachment,
       );
       expect(attachmentItem, isNull);

--- a/packages/dart/test/transport/http_transport_test.dart
+++ b/packages/dart/test/transport/http_transport_test.dart
@@ -1,4 +1,3 @@
-import 'package:collection/collection.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:sentry/sentry.dart';

--- a/packages/dart/test/transport/http_transport_test.dart
+++ b/packages/dart/test/transport/http_transport_test.dart
@@ -117,14 +117,15 @@ void main() {
 
       await sut.send(envelope);
 
-      final transactionDiscardedEvent = fixture
-          .clientReportRecorder.discardedEvents
-          .firstWhereOrNull((element) =>
+      final transactionDiscardedEvent = SentryIterableUtils.firstWhereOrNull(
+          fixture.clientReportRecorder.discardedEvents,
+          (element) =>
               element.category == DataCategory.transaction &&
               element.reason == DiscardReason.networkError);
 
-      final spanDiscardedEvent = fixture.clientReportRecorder.discardedEvents
-          .firstWhereOrNull((element) =>
+      final spanDiscardedEvent = SentryIterableUtils.firstWhereOrNull(
+          fixture.clientReportRecorder.discardedEvents,
+          (element) =>
               element.category == DataCategory.span &&
               element.reason == DiscardReason.networkError);
 
@@ -258,14 +259,15 @@ void main() {
       );
       await sut.send(envelope);
 
-      final transactionDiscardedEvent = fixture
-          .clientReportRecorder.discardedEvents
-          .firstWhereOrNull((element) =>
+      final transactionDiscardedEvent = SentryIterableUtils.firstWhereOrNull(
+          fixture.clientReportRecorder.discardedEvents,
+          (element) =>
               element.category == DataCategory.transaction &&
               element.reason == DiscardReason.networkError);
 
-      final spanDiscardedEvent = fixture.clientReportRecorder.discardedEvents
-          .firstWhereOrNull((element) =>
+      final spanDiscardedEvent = SentryIterableUtils.firstWhereOrNull(
+          fixture.clientReportRecorder.discardedEvents,
+          (element) =>
               element.category == DataCategory.span &&
               element.reason == DiscardReason.networkError);
 

--- a/packages/dart/test/transport/http_transport_test.dart
+++ b/packages/dart/test/transport/http_transport_test.dart
@@ -6,6 +6,7 @@ import 'package:sentry/src/sentry_tracer.dart';
 import 'package:sentry/src/transport/data_category.dart';
 import 'package:sentry/src/transport/http_transport.dart';
 import 'package:sentry/src/transport/rate_limiter.dart';
+import 'package:sentry/src/utils/iterable_utils.dart';
 import 'package:test/test.dart';
 
 import '../mocks.dart';
@@ -117,15 +118,14 @@ void main() {
 
       await sut.send(envelope);
 
-      final transactionDiscardedEvent = SentryIterableUtils.firstWhereOrNull(
-          fixture.clientReportRecorder.discardedEvents,
-          (element) =>
+      final transactionDiscardedEvent = fixture
+          .clientReportRecorder.discardedEvents
+          .firstWhereOrNull((element) =>
               element.category == DataCategory.transaction &&
               element.reason == DiscardReason.networkError);
 
-      final spanDiscardedEvent = SentryIterableUtils.firstWhereOrNull(
-          fixture.clientReportRecorder.discardedEvents,
-          (element) =>
+      final spanDiscardedEvent = fixture.clientReportRecorder.discardedEvents
+          .firstWhereOrNull((element) =>
               element.category == DataCategory.span &&
               element.reason == DiscardReason.networkError);
 
@@ -259,15 +259,14 @@ void main() {
       );
       await sut.send(envelope);
 
-      final transactionDiscardedEvent = SentryIterableUtils.firstWhereOrNull(
-          fixture.clientReportRecorder.discardedEvents,
-          (element) =>
+      final transactionDiscardedEvent = fixture
+          .clientReportRecorder.discardedEvents
+          .firstWhereOrNull((element) =>
               element.category == DataCategory.transaction &&
               element.reason == DiscardReason.networkError);
 
-      final spanDiscardedEvent = SentryIterableUtils.firstWhereOrNull(
-          fixture.clientReportRecorder.discardedEvents,
-          (element) =>
+      final spanDiscardedEvent = fixture.clientReportRecorder.discardedEvents
+          .firstWhereOrNull((element) =>
               element.category == DataCategory.span &&
               element.reason == DiscardReason.networkError);
 

--- a/packages/dart/test/utils/iterable_utils_test.dart
+++ b/packages/dart/test/utils/iterable_utils_test.dart
@@ -1,5 +1,4 @@
-// ignore: implementation_imports
-import 'package:sentry/src/utils/iterable_utils.dart';
+import 'package:sentry/sentry.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/packages/dart/test/utils/iterable_utils_test.dart
+++ b/packages/dart/test/utils/iterable_utils_test.dart
@@ -1,0 +1,45 @@
+// ignore: implementation_imports
+import 'package:sentry/src/utils/iterable_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SentryIterableUtils', () {
+    group('firstOrNull', () {
+      test('returns null for a null iterable', () {
+        final iterable = null as Iterable<int>?;
+
+        expect(iterable.firstOrNull, isNull);
+      });
+
+      test('returns null for an empty iterable', () {
+        expect(<int>[].firstOrNull, isNull);
+      });
+
+      test('returns the first item', () {
+        expect([1, 2, 3].firstOrNull, 1);
+      });
+    });
+
+    group('firstWhereOrNull', () {
+      test('returns null for a null iterable', () {
+        final iterable = null as Iterable<int>?;
+
+        expect(iterable.firstWhereOrNull((item) => item.isEven), isNull);
+      });
+
+      test('returns null when no item matches', () {
+        expect(
+          [1, 3, 5].firstWhereOrNull((item) => item.isEven),
+          isNull,
+        );
+      });
+
+      test('returns the first matching item', () {
+        expect(
+          [1, 2, 4].firstWhereOrNull((item) => item.isEven),
+          2,
+        );
+      });
+    });
+  });
+}

--- a/packages/dart/test/utils/iterable_utils_test.dart
+++ b/packages/dart/test/utils/iterable_utils_test.dart
@@ -1,35 +1,29 @@
-import 'package:sentry/sentry.dart';
+import 'package:sentry/src/utils/iterable_utils.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('SentryIterableUtils', () {
     group('firstOrNull', () {
       test('returns null for an empty iterable', () {
-        expect(SentryIterableUtils.firstOrNull(<int>[]), isNull);
+        expect(<int>[].firstOrNull, isNull);
       });
 
       test('returns the first item', () {
-        expect(SentryIterableUtils.firstOrNull([1, 2, 3]), 1);
+        expect([1, 2, 3].firstOrNull, 1);
       });
     });
 
     group('firstWhereOrNull', () {
       test('returns null when no item matches', () {
         expect(
-          SentryIterableUtils.firstWhereOrNull(
-            [1, 3, 5],
-            (item) => item.isEven,
-          ),
+          [1, 3, 5].firstWhereOrNull((item) => item.isEven),
           isNull,
         );
       });
 
       test('returns the first matching item', () {
         expect(
-          SentryIterableUtils.firstWhereOrNull(
-            [1, 2, 4],
-            (item) => item.isEven,
-          ),
+          [1, 2, 4].firstWhereOrNull((item) => item.isEven),
           2,
         );
       });

--- a/packages/dart/test/utils/iterable_utils_test.dart
+++ b/packages/dart/test/utils/iterable_utils_test.dart
@@ -5,25 +5,31 @@ void main() {
   group('SentryIterableUtils', () {
     group('firstOrNull', () {
       test('returns null for an empty iterable', () {
-        expect(<int>[].firstOrNull, isNull);
+        expect(SentryIterableUtils.firstOrNull(<int>[]), isNull);
       });
 
       test('returns the first item', () {
-        expect([1, 2, 3].firstOrNull, 1);
+        expect(SentryIterableUtils.firstOrNull([1, 2, 3]), 1);
       });
     });
 
     group('firstWhereOrNull', () {
       test('returns null when no item matches', () {
         expect(
-          [1, 3, 5].firstWhereOrNull((item) => item.isEven),
+          SentryIterableUtils.firstWhereOrNull(
+            [1, 3, 5],
+            (item) => item.isEven,
+          ),
           isNull,
         );
       });
 
       test('returns the first matching item', () {
         expect(
-          [1, 2, 4].firstWhereOrNull((item) => item.isEven),
+          SentryIterableUtils.firstWhereOrNull(
+            [1, 2, 4],
+            (item) => item.isEven,
+          ),
           2,
         );
       });

--- a/packages/dart/test/utils/iterable_utils_test.dart
+++ b/packages/dart/test/utils/iterable_utils_test.dart
@@ -4,12 +4,6 @@ import 'package:test/test.dart';
 void main() {
   group('SentryIterableUtils', () {
     group('firstOrNull', () {
-      test('returns null for a null iterable', () {
-        final iterable = null as Iterable<int>?;
-
-        expect(iterable.firstOrNull, isNull);
-      });
-
       test('returns null for an empty iterable', () {
         expect(<int>[].firstOrNull, isNull);
       });
@@ -20,12 +14,6 @@ void main() {
     });
 
     group('firstWhereOrNull', () {
-      test('returns null for a null iterable', () {
-        final iterable = null as Iterable<int>?;
-
-        expect(iterable.firstWhereOrNull((item) => item.isEven), isNull);
-      });
-
       test('returns null when no item matches', () {
         expect(
           [1, 3, 5].firstWhereOrNull((item) => item.isEven),

--- a/packages/flutter/lib/src/event_processor/android_platform_exception_event_processor.dart
+++ b/packages/flutter/lib/src/event_processor/android_platform_exception_event_processor.dart
@@ -3,8 +3,6 @@ import 'dart:isolate';
 
 import 'package:flutter/services.dart';
 import 'package:package_info_plus/package_info_plus.dart';
-// ignore: implementation_imports
-import 'package:sentry/src/utils/iterable_utils.dart';
 import '../../sentry_flutter.dart';
 import '../jvm/jvm_exception.dart';
 import '../jvm/jvm_frame.dart';

--- a/packages/flutter/lib/src/event_processor/android_platform_exception_event_processor.dart
+++ b/packages/flutter/lib/src/event_processor/android_platform_exception_event_processor.dart
@@ -3,6 +3,8 @@ import 'dart:isolate';
 
 import 'package:flutter/services.dart';
 import 'package:package_info_plus/package_info_plus.dart';
+// ignore: implementation_imports
+import 'package:sentry/src/utils/iterable_utils.dart';
 import '../../sentry_flutter.dart';
 import '../jvm/jvm_exception.dart';
 import '../jvm/jvm_frame.dart';
@@ -89,7 +91,7 @@ class AndroidPlatformExceptionEventProcessor implements EventProcessor {
     MapEntry<SentryException, List<SentryThread>>? detailsStackTrace,
   ) {
     _markDartThreadsAsNonCrashed(event.threads);
-    final exception = event.exceptions?.firstOrNull;
+    final exception = event.exceptions.firstOrNull;
 
     // Assumption is that the first exception is the original exception and there is only one.
     if (exception == null) {

--- a/packages/flutter/lib/src/event_processor/android_platform_exception_event_processor.dart
+++ b/packages/flutter/lib/src/event_processor/android_platform_exception_event_processor.dart
@@ -3,6 +3,8 @@ import 'dart:isolate';
 
 import 'package:flutter/services.dart';
 import 'package:package_info_plus/package_info_plus.dart';
+// ignore: implementation_imports
+import 'package:sentry/src/utils/iterable_utils.dart';
 import '../../sentry_flutter.dart';
 import '../jvm/jvm_exception.dart';
 import '../jvm/jvm_frame.dart';
@@ -89,10 +91,7 @@ class AndroidPlatformExceptionEventProcessor implements EventProcessor {
     MapEntry<SentryException, List<SentryThread>>? detailsStackTrace,
   ) {
     _markDartThreadsAsNonCrashed(event.threads);
-    final eventExceptions = event.exceptions;
-    final exception = eventExceptions == null
-        ? null
-        : SentryIterableUtils.firstOrNull(eventExceptions);
+    final exception = event.exceptions?.firstOrNull;
 
     // Assumption is that the first exception is the original exception and there is only one.
     if (exception == null) {

--- a/packages/flutter/lib/src/event_processor/android_platform_exception_event_processor.dart
+++ b/packages/flutter/lib/src/event_processor/android_platform_exception_event_processor.dart
@@ -89,7 +89,7 @@ class AndroidPlatformExceptionEventProcessor implements EventProcessor {
     MapEntry<SentryException, List<SentryThread>>? detailsStackTrace,
   ) {
     _markDartThreadsAsNonCrashed(event.threads);
-    final exception = event.exceptions.firstOrNull;
+    final exception = event.exceptions?.firstOrNull;
 
     // Assumption is that the first exception is the original exception and there is only one.
     if (exception == null) {

--- a/packages/flutter/lib/src/event_processor/android_platform_exception_event_processor.dart
+++ b/packages/flutter/lib/src/event_processor/android_platform_exception_event_processor.dart
@@ -89,7 +89,10 @@ class AndroidPlatformExceptionEventProcessor implements EventProcessor {
     MapEntry<SentryException, List<SentryThread>>? detailsStackTrace,
   ) {
     _markDartThreadsAsNonCrashed(event.threads);
-    final exception = event.exceptions?.firstOrNull;
+    final eventExceptions = event.exceptions;
+    final exception = eventExceptions == null
+        ? null
+        : SentryIterableUtils.firstOrNull(eventExceptions);
 
     // Assumption is that the first exception is the original exception and there is only one.
     if (exception == null) {

--- a/packages/flutter/lib/src/feedback/sentry_feedback_widget.dart
+++ b/packages/flutter/lib/src/feedback/sentry_feedback_widget.dart
@@ -1,10 +1,8 @@
-// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: invalid_use_of_internal_member, library_private_types_in_public_api
 
 import 'package:flutter/material.dart';
 import '../../sentry_flutter.dart';
 import 'package:meta/meta.dart';
-// ignore: implementation_imports
-import 'package:sentry/src/utils/iterable_utils.dart';
 import 'sentry_feedback_options.dart';
 import 'package:flutter/services.dart';
 import 'sentry_logo.dart';
@@ -19,10 +17,8 @@ class SentryFeedbackWidget extends StatefulWidget {
     @internal Hub? hub,
   })  : assert(associatedEventId != const SentryId.empty()),
         _hub = hub ?? HubAdapter() {
-    // ignore: invalid_use_of_internal_member
     assert(_hub.options is SentryFlutterOptions,
         'SentryFlutterOptions is required');
-    // ignore: invalid_use_of_internal_member
     final options = _hub.options as SentryFlutterOptions;
     this.options = options.feedback;
   }
@@ -110,7 +106,6 @@ class _SentryFeedbackWidgetState extends State<SentryFeedbackWidget> {
   }
 
   Future<void> _captureReplay() async {
-    // ignore: invalid_use_of_internal_member
     final integrations = widget._hub.options.integrations;
     final replayIntegration = integrations.firstWhereOrNull(
       (element) => element is ReplayIntegration,
@@ -440,7 +435,6 @@ class _SentryFeedbackWidgetState extends State<SentryFeedbackWidget> {
 
   Future<SentryId> _captureFeedback(SentryFeedback feedback, Hint? hint) {
     hint ??= Hint();
-    // ignore: invalid_use_of_internal_member
     hint.set(TypeCheckHint.isWidgetFeedback, true);
     return widget._hub.captureFeedback(feedback, hint: hint);
   }

--- a/packages/flutter/lib/src/feedback/sentry_feedback_widget.dart
+++ b/packages/flutter/lib/src/feedback/sentry_feedback_widget.dart
@@ -1,9 +1,10 @@
 // ignore_for_file: library_private_types_in_public_api
 
-import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import '../../sentry_flutter.dart';
 import 'package:meta/meta.dart';
+// ignore: implementation_imports
+import 'package:sentry/src/utils/iterable_utils.dart';
 import 'sentry_feedback_options.dart';
 import 'package:flutter/services.dart';
 import 'sentry_logo.dart';
@@ -110,7 +111,8 @@ class _SentryFeedbackWidgetState extends State<SentryFeedbackWidget> {
 
   Future<void> _captureReplay() async {
     // ignore: invalid_use_of_internal_member
-    final replayIntegration = widget._hub.options.integrations.firstWhereOrNull(
+    final integrations = widget._hub.options.integrations;
+    final replayIntegration = integrations.firstWhereOrNull(
       (element) => element is ReplayIntegration,
     ) as ReplayIntegration?;
     if (replayIntegration != null) {

--- a/packages/flutter/lib/src/feedback/sentry_feedback_widget.dart
+++ b/packages/flutter/lib/src/feedback/sentry_feedback_widget.dart
@@ -107,7 +107,8 @@ class _SentryFeedbackWidgetState extends State<SentryFeedbackWidget> {
 
   Future<void> _captureReplay() async {
     final integrations = widget._hub.options.integrations;
-    final replayIntegration = integrations.firstWhereOrNull(
+    final replayIntegration = SentryIterableUtils.firstWhereOrNull(
+      integrations,
       (element) => element is ReplayIntegration,
     ) as ReplayIntegration?;
     if (replayIntegration != null) {

--- a/packages/flutter/lib/src/feedback/sentry_feedback_widget.dart
+++ b/packages/flutter/lib/src/feedback/sentry_feedback_widget.dart
@@ -3,6 +3,8 @@
 import 'package:flutter/material.dart';
 import '../../sentry_flutter.dart';
 import 'package:meta/meta.dart';
+// ignore: implementation_imports
+import 'package:sentry/src/utils/iterable_utils.dart';
 import 'sentry_feedback_options.dart';
 import 'package:flutter/services.dart';
 import 'sentry_logo.dart';
@@ -107,8 +109,7 @@ class _SentryFeedbackWidgetState extends State<SentryFeedbackWidget> {
 
   Future<void> _captureReplay() async {
     final integrations = widget._hub.options.integrations;
-    final replayIntegration = SentryIterableUtils.firstWhereOrNull(
-      integrations,
+    final replayIntegration = integrations.firstWhereOrNull(
       (element) => element is ReplayIntegration,
     ) as ReplayIntegration?;
     if (replayIntegration != null) {

--- a/packages/flutter/lib/src/integrations/load_contexts_integration.dart
+++ b/packages/flutter/lib/src/integrations/load_contexts_integration.dart
@@ -3,9 +3,9 @@
 import 'dart:async';
 
 import 'package:sentry/sentry.dart';
-import 'package:collection/collection.dart';
 import 'package:sentry/src/event_processor/enricher/enricher_event_processor.dart';
 import 'package:sentry/src/telemetry/default_attributes.dart';
+import 'package:sentry/src/utils/iterable_utils.dart';
 import '../native/sentry_native_binding.dart';
 import '../sentry_flutter_options.dart';
 import '../utils/internal_logger.dart';

--- a/packages/flutter/lib/src/integrations/load_contexts_integration.dart
+++ b/packages/flutter/lib/src/integrations/load_contexts_integration.dart
@@ -5,7 +5,6 @@ import 'dart:async';
 import 'package:sentry/sentry.dart';
 import 'package:sentry/src/event_processor/enricher/enricher_event_processor.dart';
 import 'package:sentry/src/telemetry/default_attributes.dart';
-import 'package:sentry/src/utils/iterable_utils.dart';
 import '../native/sentry_native_binding.dart';
 import '../sentry_flutter_options.dart';
 import '../utils/internal_logger.dart';

--- a/packages/flutter/lib/src/integrations/load_contexts_integration.dart
+++ b/packages/flutter/lib/src/integrations/load_contexts_integration.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 import 'package:sentry/sentry.dart';
 import 'package:sentry/src/event_processor/enricher/enricher_event_processor.dart';
 import 'package:sentry/src/telemetry/default_attributes.dart';
+import 'package:sentry/src/utils/iterable_utils.dart';
 import '../native/sentry_native_binding.dart';
 import '../sentry_flutter_options.dart';
 import '../utils/internal_logger.dart';
@@ -43,8 +44,7 @@ class LoadContextsIntegration implements Integration<SentryFlutterOptions> {
     // - user-set context values
     // - context values set from native (this)
     // - values set from IOEnricherEventProcessor
-    final enricherEventProcessor = SentryIterableUtils.firstWhereOrNull(
-      options.eventProcessors,
+    final enricherEventProcessor = options.eventProcessors.firstWhereOrNull(
       (element) => element is EnricherEventProcessor,
     );
     if (enricherEventProcessor != null) {

--- a/packages/flutter/lib/src/integrations/load_contexts_integration.dart
+++ b/packages/flutter/lib/src/integrations/load_contexts_integration.dart
@@ -43,7 +43,8 @@ class LoadContextsIntegration implements Integration<SentryFlutterOptions> {
     // - user-set context values
     // - context values set from native (this)
     // - values set from IOEnricherEventProcessor
-    final enricherEventProcessor = options.eventProcessors.firstWhereOrNull(
+    final enricherEventProcessor = SentryIterableUtils.firstWhereOrNull(
+      options.eventProcessors,
       (element) => element is EnricherEventProcessor,
     );
     if (enricherEventProcessor != null) {

--- a/packages/flutter/lib/src/native/c/sentry_native.dart
+++ b/packages/flutter/lib/src/native/c/sentry_native.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: invalid_use_of_internal_member
+
 import 'dart:async';
 import 'dart:ffi';
 import 'dart:io';
@@ -5,8 +7,6 @@ import 'dart:typed_data';
 
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
-// ignore: implementation_imports
-import 'package:sentry/src/utils/iterable_utils.dart';
 
 import '../../../sentry_flutter.dart';
 import '../../replay/replay_config.dart';

--- a/packages/flutter/lib/src/native/c/sentry_native.dart
+++ b/packages/flutter/lib/src/native/c/sentry_native.dart
@@ -3,9 +3,10 @@ import 'dart:ffi';
 import 'dart:io';
 import 'dart:typed_data';
 
-import 'package:collection/collection.dart';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
+// ignore: implementation_imports
+import 'package:sentry/src/utils/iterable_utils.dart';
 
 import '../../../sentry_flutter.dart';
 import '../../replay/replay_config.dart';

--- a/packages/flutter/lib/src/native/c/sentry_native.dart
+++ b/packages/flutter/lib/src/native/c/sentry_native.dart
@@ -455,7 +455,10 @@ String? _getDefaultCrashpadPath() {
         '$appDir${Platform.pathSeparator}bin${Platform.pathSeparator}crashpad_handler',
         '$appDir${Platform.pathSeparator}lib${Platform.pathSeparator}crashpad_handler'
       ];
-      return candidates.firstWhereOrNull((path) => File(path).existsSync());
+      return SentryIterableUtils.firstWhereOrNull(
+        candidates,
+        (path) => File(path).existsSync(),
+      );
     }
   }
   return null;

--- a/packages/flutter/lib/src/native/c/sentry_native.dart
+++ b/packages/flutter/lib/src/native/c/sentry_native.dart
@@ -7,6 +7,8 @@ import 'dart:typed_data';
 
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
+// ignore: implementation_imports
+import 'package:sentry/src/utils/iterable_utils.dart';
 
 import '../../../sentry_flutter.dart';
 import '../../replay/replay_config.dart';
@@ -455,8 +457,7 @@ String? _getDefaultCrashpadPath() {
         '$appDir${Platform.pathSeparator}bin${Platform.pathSeparator}crashpad_handler',
         '$appDir${Platform.pathSeparator}lib${Platform.pathSeparator}crashpad_handler'
       ];
-      return SentryIterableUtils.firstWhereOrNull(
-        candidates,
+      return candidates.firstWhereOrNull(
         (path) => File(path).existsSync(),
       );
     }

--- a/packages/flutter/lib/src/native/java/sentry_native_java.dart
+++ b/packages/flutter/lib/src/native/java/sentry_native_java.dart
@@ -1,10 +1,10 @@
+// ignore_for_file: invalid_use_of_internal_member
+
 import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:jni/jni.dart';
 import 'package:meta/meta.dart';
-// ignore: implementation_imports
-import 'package:sentry/src/utils/iterable_utils.dart';
 
 import '../../../sentry_flutter.dart';
 import '../../replay/replay_config.dart';

--- a/packages/flutter/lib/src/native/java/sentry_native_java.dart
+++ b/packages/flutter/lib/src/native/java/sentry_native_java.dart
@@ -3,6 +3,8 @@ import 'dart:typed_data';
 
 import 'package:jni/jni.dart';
 import 'package:meta/meta.dart';
+// ignore: implementation_imports
+import 'package:sentry/src/utils/iterable_utils.dart';
 
 import '../../../sentry_flutter.dart';
 import '../../replay/replay_config.dart';

--- a/packages/flutter/lib/src/native/java/sentry_native_java.dart
+++ b/packages/flutter/lib/src/native/java/sentry_native_java.dart
@@ -5,6 +5,8 @@ import 'dart:typed_data';
 
 import 'package:jni/jni.dart';
 import 'package:meta/meta.dart';
+// ignore: implementation_imports
+import 'package:sentry/src/utils/iterable_utils.dart';
 
 import '../../../sentry_flutter.dart';
 import '../../replay/replay_config.dart';

--- a/packages/flutter/lib/src/native/java/sentry_native_java_init.dart
+++ b/packages/flutter/lib/src/native/java/sentry_native_java_init.dart
@@ -65,7 +65,7 @@ native.SentryOptions$BeforeSendReplayCallback createBeforeSendReplayCallback(
           final data = hint
               .getReplayRecording()
               ?.getPayload()
-              ?.use((l) => l.firstOrNull)
+              ?.use((payload) => payload.firstOrNull)
             ?..releasedBy(arena);
           if (data is native.$RRWebOptionsEvent$Type) {
             final payload = data

--- a/packages/flutter/lib/src/native/java/sentry_native_java_init.dart
+++ b/packages/flutter/lib/src/native/java/sentry_native_java_init.dart
@@ -65,7 +65,7 @@ native.SentryOptions$BeforeSendReplayCallback createBeforeSendReplayCallback(
           final data = hint
               .getReplayRecording()
               ?.getPayload()
-              ?.use(SentryIterableUtils.firstOrNull)
+              ?.use((payload) => payload.firstOrNull)
             ?..releasedBy(arena);
           if (data is native.$RRWebOptionsEvent$Type) {
             final payload = data

--- a/packages/flutter/lib/src/native/java/sentry_native_java_init.dart
+++ b/packages/flutter/lib/src/native/java/sentry_native_java_init.dart
@@ -65,7 +65,7 @@ native.SentryOptions$BeforeSendReplayCallback createBeforeSendReplayCallback(
           final data = hint
               .getReplayRecording()
               ?.getPayload()
-              ?.use((payload) => payload.firstOrNull)
+              ?.use(SentryIterableUtils.firstOrNull)
             ?..releasedBy(arena);
           if (data is native.$RRWebOptionsEvent$Type) {
             final payload = data

--- a/packages/flutter/lib/src/navigation/sentry_navigator_observer.dart
+++ b/packages/flutter/lib/src/navigation/sentry_navigator_observer.dart
@@ -2,12 +2,13 @@
 
 import 'dart:async';
 
-import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
 // ignore: implementation_imports
 import 'package:sentry/src/sentry_tracer.dart';
+// ignore: implementation_imports
+import 'package:sentry/src/utils/iterable_utils.dart';
 
 import '../../sentry_flutter.dart';
 import '../event_processor/flutter_enricher_event_processor.dart';

--- a/packages/flutter/lib/src/navigation/sentry_navigator_observer.dart
+++ b/packages/flutter/lib/src/navigation/sentry_navigator_observer.dart
@@ -7,8 +7,6 @@ import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
 // ignore: implementation_imports
 import 'package:sentry/src/sentry_tracer.dart';
-// ignore: implementation_imports
-import 'package:sentry/src/utils/iterable_utils.dart';
 
 import '../../sentry_flutter.dart';
 import '../event_processor/flutter_enricher_event_processor.dart';

--- a/packages/flutter/lib/src/navigation/sentry_navigator_observer.dart
+++ b/packages/flutter/lib/src/navigation/sentry_navigator_observer.dart
@@ -98,9 +98,9 @@ class SentryNavigatorObserver extends RouteObserver<PageRoute<dynamic>> {
     }
     _timeToDisplayTracker = _initializeTimeToDisplayTracker();
     _timeToDisplayTrackerV2 = _initializeTimeToDisplayTrackerV2();
-    final webSessionIntegration = _hub.options.integrations
-        .whereType<WebSessionIntegration>()
-        .firstOrNull;
+    final webSessionIntegration = SentryIterableUtils.firstOrNull(
+      _hub.options.integrations.whereType<WebSessionIntegration>(),
+    );
     webSessionIntegration?.enable();
     _webSessionHandler = webSessionIntegration?.webSessionHandler;
   }

--- a/packages/flutter/lib/src/navigation/sentry_navigator_observer.dart
+++ b/packages/flutter/lib/src/navigation/sentry_navigator_observer.dart
@@ -7,6 +7,8 @@ import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
 // ignore: implementation_imports
 import 'package:sentry/src/sentry_tracer.dart';
+// ignore: implementation_imports
+import 'package:sentry/src/utils/iterable_utils.dart';
 
 import '../../sentry_flutter.dart';
 import '../event_processor/flutter_enricher_event_processor.dart';
@@ -98,9 +100,9 @@ class SentryNavigatorObserver extends RouteObserver<PageRoute<dynamic>> {
     }
     _timeToDisplayTracker = _initializeTimeToDisplayTracker();
     _timeToDisplayTrackerV2 = _initializeTimeToDisplayTrackerV2();
-    final webSessionIntegration = SentryIterableUtils.firstOrNull(
-      _hub.options.integrations.whereType<WebSessionIntegration>(),
-    );
+    final webSessionIntegration = _hub.options.integrations
+        .whereType<WebSessionIntegration>()
+        .firstOrNull;
     webSessionIntegration?.enable();
     _webSessionHandler = webSessionIntegration?.webSessionHandler;
   }

--- a/packages/flutter/lib/src/navigation/time_to_display_tracker.dart
+++ b/packages/flutter/lib/src/navigation/time_to_display_tracker.dart
@@ -1,8 +1,6 @@
 // ignore_for_file: invalid_use_of_internal_member
 
 import 'package:meta/meta.dart';
-// ignore: implementation_imports
-import 'package:sentry/src/utils/iterable_utils.dart';
 
 import '../../sentry_flutter.dart';
 import 'time_to_full_display_tracker.dart';

--- a/packages/flutter/lib/src/navigation/time_to_display_tracker.dart
+++ b/packages/flutter/lib/src/navigation/time_to_display_tracker.dart
@@ -1,7 +1,8 @@
 // ignore_for_file: invalid_use_of_internal_member
 
-import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
+// ignore: implementation_imports
+import 'package:sentry/src/utils/iterable_utils.dart';
 
 import '../../sentry_flutter.dart';
 import 'time_to_full_display_tracker.dart';
@@ -90,10 +91,15 @@ class TimeToDisplayTracker {
   // away from the current route before TTFD or TTID is finished.
   Future<void> cancelUnfinishedSpans(
       SentryTracer transaction, DateTime endTimestamp) async {
-    final ttidSpan = transaction.children.firstWhereOrNull((child) =>
-        child.context.operation == SentrySpanOperations.uiTimeToInitialDisplay);
-    final ttfdSpan = transaction.children.firstWhereOrNull((child) =>
-        child.context.operation == SentrySpanOperations.uiTimeToFullDisplay);
+    final ttidSpan = transaction.children.firstWhereOrNull(
+      (child) =>
+          child.context.operation ==
+          SentrySpanOperations.uiTimeToInitialDisplay,
+    );
+    final ttfdSpan = transaction.children.firstWhereOrNull(
+      (child) =>
+          child.context.operation == SentrySpanOperations.uiTimeToFullDisplay,
+    );
 
     if (ttidSpan != null && !ttidSpan.finished) {
       await ttidSpan.finish(

--- a/packages/flutter/lib/src/navigation/time_to_display_tracker.dart
+++ b/packages/flutter/lib/src/navigation/time_to_display_tracker.dart
@@ -89,12 +89,14 @@ class TimeToDisplayTracker {
   // away from the current route before TTFD or TTID is finished.
   Future<void> cancelUnfinishedSpans(
       SentryTracer transaction, DateTime endTimestamp) async {
-    final ttidSpan = transaction.children.firstWhereOrNull(
+    final ttidSpan = SentryIterableUtils.firstWhereOrNull(
+      transaction.children,
       (child) =>
           child.context.operation ==
           SentrySpanOperations.uiTimeToInitialDisplay,
     );
-    final ttfdSpan = transaction.children.firstWhereOrNull(
+    final ttfdSpan = SentryIterableUtils.firstWhereOrNull(
+      transaction.children,
       (child) =>
           child.context.operation == SentrySpanOperations.uiTimeToFullDisplay,
     );

--- a/packages/flutter/lib/src/navigation/time_to_display_tracker.dart
+++ b/packages/flutter/lib/src/navigation/time_to_display_tracker.dart
@@ -7,6 +7,8 @@ import 'time_to_full_display_tracker.dart';
 import 'time_to_initial_display_tracker.dart';
 // ignore: implementation_imports
 import 'package:sentry/src/sentry_tracer.dart';
+// ignore: implementation_imports
+import 'package:sentry/src/utils/iterable_utils.dart';
 
 @internal
 class TimeToDisplayTracker {
@@ -89,14 +91,12 @@ class TimeToDisplayTracker {
   // away from the current route before TTFD or TTID is finished.
   Future<void> cancelUnfinishedSpans(
       SentryTracer transaction, DateTime endTimestamp) async {
-    final ttidSpan = SentryIterableUtils.firstWhereOrNull(
-      transaction.children,
+    final ttidSpan = transaction.children.firstWhereOrNull(
       (child) =>
           child.context.operation ==
           SentrySpanOperations.uiTimeToInitialDisplay,
     );
-    final ttfdSpan = SentryIterableUtils.firstWhereOrNull(
-      transaction.children,
+    final ttfdSpan = transaction.children.firstWhereOrNull(
       (child) =>
           child.context.operation == SentrySpanOperations.uiTimeToFullDisplay,
     );

--- a/packages/flutter/lib/src/web/sentry_web.dart
+++ b/packages/flutter/lib/src/web/sentry_web.dart
@@ -1,9 +1,10 @@
 import 'dart:async';
 import 'dart:typed_data';
 
-import 'package:collection/collection.dart';
 // ignore: implementation_imports
 import 'package:sentry/src/sentry_item_type.dart';
+// ignore: implementation_imports
+import 'package:sentry/src/utils/iterable_utils.dart';
 
 import '../../sentry_flutter.dart';
 import '../native/native_app_start.dart';
@@ -177,10 +178,11 @@ class SentryWeb with SentryNativeSafeInvoker implements SentryNativeBinding {
       return null;
     }
 
-    final frame = stackTrace.frames.firstWhereOrNull((frame) {
-      return debugIdMap.containsKey(frame.absPath) ||
-          debugIdMap.containsKey(frame.fileName);
-    });
+    final frame = stackTrace.frames.firstWhereOrNull(
+      (frame) =>
+          debugIdMap.containsKey(frame.absPath) ||
+          debugIdMap.containsKey(frame.fileName),
+    );
     if (frame == null) {
       _log('Could not find any frame with a matching debug id.');
       return null;

--- a/packages/flutter/lib/src/web/sentry_web.dart
+++ b/packages/flutter/lib/src/web/sentry_web.dart
@@ -1,10 +1,10 @@
+// ignore_for_file: invalid_use_of_internal_member
+
 import 'dart:async';
 import 'dart:typed_data';
 
 // ignore: implementation_imports
 import 'package:sentry/src/sentry_item_type.dart';
-// ignore: implementation_imports
-import 'package:sentry/src/utils/iterable_utils.dart';
 
 import '../../sentry_flutter.dart';
 import '../native/native_app_start.dart';

--- a/packages/flutter/lib/src/web/sentry_web.dart
+++ b/packages/flutter/lib/src/web/sentry_web.dart
@@ -178,7 +178,8 @@ class SentryWeb with SentryNativeSafeInvoker implements SentryNativeBinding {
       return null;
     }
 
-    final frame = stackTrace.frames.firstWhereOrNull(
+    final frame = SentryIterableUtils.firstWhereOrNull(
+      stackTrace.frames,
       (frame) =>
           debugIdMap.containsKey(frame.absPath) ||
           debugIdMap.containsKey(frame.fileName),

--- a/packages/flutter/lib/src/web/sentry_web.dart
+++ b/packages/flutter/lib/src/web/sentry_web.dart
@@ -5,6 +5,8 @@ import 'dart:typed_data';
 
 // ignore: implementation_imports
 import 'package:sentry/src/sentry_item_type.dart';
+// ignore: implementation_imports
+import 'package:sentry/src/utils/iterable_utils.dart';
 
 import '../../sentry_flutter.dart';
 import '../native/native_app_start.dart';
@@ -178,8 +180,7 @@ class SentryWeb with SentryNativeSafeInvoker implements SentryNativeBinding {
       return null;
     }
 
-    final frame = SentryIterableUtils.firstWhereOrNull(
-      stackTrace.frames,
+    final frame = stackTrace.frames.firstWhereOrNull(
       (frame) =>
           debugIdMap.containsKey(frame.absPath) ||
           debugIdMap.containsKey(frame.fileName),

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -27,12 +27,12 @@ dependencies:
   package_info_plus: '>=1.0.0'
   meta: ^1.3.0
   ffi: ^2.0.0
-  collection: ^1.16.0
   web: ^1.1.0
   jni: 0.14.2
 
 dev_dependencies:
   build_runner: ^2.4.2
+  collection: ^1.16.0
   flutter_test:
     sdk: flutter
   mockito: ^5.1.0

--- a/packages/flutter/test/integrations/native_app_start_handler_test.dart
+++ b/packages/flutter/test/integrations/native_app_start_handler_test.dart
@@ -1,7 +1,6 @@
 @TestOn('vm')
 library;
 
-import 'package:collection/collection.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';

--- a/packages/flutter/test/integrations/native_app_start_handler_test.dart
+++ b/packages/flutter/test/integrations/native_app_start_handler_test.dart
@@ -8,6 +8,8 @@ import 'package:sentry_flutter/src/integrations/integrations.dart';
 import 'package:sentry_flutter/src/integrations/native_app_start_handler.dart';
 import 'package:sentry_flutter/src/integrations/native_app_start_integration.dart';
 import 'package:sentry/src/sentry_tracer.dart';
+// ignore: implementation_imports
+import 'package:sentry/src/utils/iterable_utils.dart';
 import 'package:sentry_flutter/src/native/native_app_start.dart';
 import 'package:sentry_flutter/src/navigation/time_to_display_tracker.dart';
 
@@ -88,21 +90,16 @@ void main() {
 
       final spans = transaction.spans;
 
-      final appStartSpan = SentryIterableUtils.firstWhereOrNull(
-          spans, (element) => element.context.description == 'Cold Start');
+      final appStartSpan = spans.firstWhereOrNull(
+          (element) => element.context.description == 'Cold Start');
 
-      final pluginRegistrationSpan = SentryIterableUtils.firstWhereOrNull(
-          spans,
-          (element) =>
-              element.context.description ==
-              'App start to plugin registration');
+      final pluginRegistrationSpan = spans.firstWhereOrNull((element) =>
+          element.context.description == 'App start to plugin registration');
 
-      final sentrySetupSpan = SentryIterableUtils.firstWhereOrNull(
-          spans,
-          (element) =>
-              element.context.description == 'Before Sentry Init Setup');
+      final sentrySetupSpan = spans.firstWhereOrNull((element) =>
+          element.context.description == 'Before Sentry Init Setup');
 
-      final firstFrameRenderSpan = SentryIterableUtils.firstWhereOrNull(spans,
+      final firstFrameRenderSpan = spans.firstWhereOrNull(
           (element) => element.context.description == 'First frame render');
 
       expect(appStartSpan, isNotNull);
@@ -213,17 +210,12 @@ void main() {
 
       final transaction = fixture.capturedTransaction();
 
-      final ttidSpan = SentryIterableUtils.firstWhereOrNull(
-          transaction.spans,
-          (child) =>
-              child.context.operation ==
-              SentrySpanOperations.uiTimeToInitialDisplay);
+      final ttidSpan = transaction.spans.firstWhereOrNull((child) =>
+          child.context.operation ==
+          SentrySpanOperations.uiTimeToInitialDisplay);
 
-      final ttfdSpan = SentryIterableUtils.firstWhereOrNull(
-          transaction.spans,
-          (child) =>
-              child.context.operation ==
-              SentrySpanOperations.uiTimeToFullDisplay);
+      final ttfdSpan = transaction.spans.firstWhereOrNull((child) =>
+          child.context.operation == SentrySpanOperations.uiTimeToFullDisplay);
 
       expect(ttidSpan, isNotNull);
       expect(ttfdSpan, isNotNull);
@@ -407,21 +399,16 @@ void main() {
 
       final spans = enriched.spans;
 
-      coldStartSpan = SentryIterableUtils.firstWhereOrNull(
-          spans, (element) => element.context.description == 'Cold Start');
+      coldStartSpan = spans.firstWhereOrNull(
+          (element) => element.context.description == 'Cold Start');
 
-      pluginRegistrationSpan = SentryIterableUtils.firstWhereOrNull(
-          spans,
-          (element) =>
-              element.context.description ==
-              'App start to plugin registration');
+      pluginRegistrationSpan = spans.firstWhereOrNull((element) =>
+          element.context.description == 'App start to plugin registration');
 
-      sentrySetupSpan = SentryIterableUtils.firstWhereOrNull(
-          spans,
-          (element) =>
-              element.context.description == 'Before Sentry Init Setup');
+      sentrySetupSpan = spans.firstWhereOrNull((element) =>
+          element.context.description == 'Before Sentry Init Setup');
 
-      firstFrameRenderSpan = SentryIterableUtils.firstWhereOrNull(spans,
+      firstFrameRenderSpan = spans.firstWhereOrNull(
           (element) => element.context.description == 'First frame render');
     });
 

--- a/packages/flutter/test/integrations/native_app_start_handler_test.dart
+++ b/packages/flutter/test/integrations/native_app_start_handler_test.dart
@@ -88,16 +88,21 @@ void main() {
 
       final spans = transaction.spans;
 
-      final appStartSpan = spans.firstWhereOrNull(
-          (element) => element.context.description == 'Cold Start');
+      final appStartSpan = SentryIterableUtils.firstWhereOrNull(
+          spans, (element) => element.context.description == 'Cold Start');
 
-      final pluginRegistrationSpan = spans.firstWhereOrNull((element) =>
-          element.context.description == 'App start to plugin registration');
+      final pluginRegistrationSpan = SentryIterableUtils.firstWhereOrNull(
+          spans,
+          (element) =>
+              element.context.description ==
+              'App start to plugin registration');
 
-      final sentrySetupSpan = spans.firstWhereOrNull((element) =>
-          element.context.description == 'Before Sentry Init Setup');
+      final sentrySetupSpan = SentryIterableUtils.firstWhereOrNull(
+          spans,
+          (element) =>
+              element.context.description == 'Before Sentry Init Setup');
 
-      final firstFrameRenderSpan = spans.firstWhereOrNull(
+      final firstFrameRenderSpan = SentryIterableUtils.firstWhereOrNull(spans,
           (element) => element.context.description == 'First frame render');
 
       expect(appStartSpan, isNotNull);
@@ -208,12 +213,17 @@ void main() {
 
       final transaction = fixture.capturedTransaction();
 
-      final ttidSpan = transaction.spans.firstWhereOrNull((child) =>
-          child.context.operation ==
-          SentrySpanOperations.uiTimeToInitialDisplay);
+      final ttidSpan = SentryIterableUtils.firstWhereOrNull(
+          transaction.spans,
+          (child) =>
+              child.context.operation ==
+              SentrySpanOperations.uiTimeToInitialDisplay);
 
-      final ttfdSpan = transaction.spans.firstWhereOrNull((child) =>
-          child.context.operation == SentrySpanOperations.uiTimeToFullDisplay);
+      final ttfdSpan = SentryIterableUtils.firstWhereOrNull(
+          transaction.spans,
+          (child) =>
+              child.context.operation ==
+              SentrySpanOperations.uiTimeToFullDisplay);
 
       expect(ttidSpan, isNotNull);
       expect(ttfdSpan, isNotNull);
@@ -397,16 +407,21 @@ void main() {
 
       final spans = enriched.spans;
 
-      coldStartSpan = spans.firstWhereOrNull(
-          (element) => element.context.description == 'Cold Start');
+      coldStartSpan = SentryIterableUtils.firstWhereOrNull(
+          spans, (element) => element.context.description == 'Cold Start');
 
-      pluginRegistrationSpan = spans.firstWhereOrNull((element) =>
-          element.context.description == 'App start to plugin registration');
+      pluginRegistrationSpan = SentryIterableUtils.firstWhereOrNull(
+          spans,
+          (element) =>
+              element.context.description ==
+              'App start to plugin registration');
 
-      sentrySetupSpan = spans.firstWhereOrNull((element) =>
-          element.context.description == 'Before Sentry Init Setup');
+      sentrySetupSpan = SentryIterableUtils.firstWhereOrNull(
+          spans,
+          (element) =>
+              element.context.description == 'Before Sentry Init Setup');
 
-      firstFrameRenderSpan = spans.firstWhereOrNull(
+      firstFrameRenderSpan = SentryIterableUtils.firstWhereOrNull(spans,
           (element) => element.context.description == 'First frame render');
     });
 

--- a/packages/flutter/test/integrations/native_app_start_handler_v2_test.dart
+++ b/packages/flutter/test/integrations/native_app_start_handler_v2_test.dart
@@ -3,6 +3,8 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
+// ignore: implementation_imports
+import 'package:sentry/src/utils/iterable_utils.dart';
 import 'package:sentry_flutter/src/integrations/native_app_start_handler_v2.dart';
 import 'package:sentry_flutter/src/native/native_app_start.dart';
 import 'package:sentry_flutter/src/navigation/time_to_display_tracker_v2.dart';
@@ -400,8 +402,7 @@ class Fixture {
   }
 
   RecordingSentrySpanV2? findSpanByName(String name) {
-    return SentryIterableUtils.firstWhereOrNull(
-      capturedSpans,
+    return capturedSpans.firstWhereOrNull(
       (s) => s.name == name,
     );
   }

--- a/packages/flutter/test/integrations/native_app_start_handler_v2_test.dart
+++ b/packages/flutter/test/integrations/native_app_start_handler_v2_test.dart
@@ -400,6 +400,9 @@ class Fixture {
   }
 
   RecordingSentrySpanV2? findSpanByName(String name) {
-    return capturedSpans.firstWhereOrNull((s) => s.name == name);
+    return SentryIterableUtils.firstWhereOrNull(
+      capturedSpans,
+      (s) => s.name == name,
+    );
   }
 }

--- a/packages/flutter/test/integrations/native_app_start_handler_v2_test.dart
+++ b/packages/flutter/test/integrations/native_app_start_handler_v2_test.dart
@@ -1,6 +1,5 @@
 // ignore_for_file: invalid_use_of_internal_member, experimental_member_use
 
-import 'package:collection/collection.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';

--- a/packages/flutter/test/sentry_flutter_util.dart
+++ b/packages/flutter/test/sentry_flutter_util.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
+// ignore: implementation_imports
+import 'package:sentry/src/utils/iterable_utils.dart';
 import 'package:sentry_flutter/src/native/native_scope_observer.dart';
 
 void testScopeObserver(
@@ -41,16 +43,14 @@ void testConfiguration({
   Integration? nativeIntegration;
   Integration? loadDebugImagesIntegration;
   if (kIsWeb) {
-    nativeIntegration = SentryIterableUtils.firstWhereOrNull(
-        integrations, (x) => x.runtimeType.toString() == 'WebSdkIntegration');
-    loadDebugImagesIntegration = SentryIterableUtils.firstWhereOrNull(
-        integrations,
+    nativeIntegration = integrations.firstWhereOrNull(
+        (x) => x.runtimeType.toString() == 'WebSdkIntegration');
+    loadDebugImagesIntegration = integrations.firstWhereOrNull(
         (x) => x.runtimeType.toString() == 'LoadWebDebugImagesIntegration');
   } else {
-    nativeIntegration = SentryIterableUtils.firstWhereOrNull(integrations,
+    nativeIntegration = integrations.firstWhereOrNull(
         (x) => x.runtimeType.toString() == 'NativeSdkIntegration');
-    loadDebugImagesIntegration = SentryIterableUtils.firstWhereOrNull(
-        integrations,
+    loadDebugImagesIntegration = integrations.firstWhereOrNull(
         (x) => x.runtimeType.toString() == 'LoadNativeDebugImagesIntegration');
   }
   expect(loadDebugImagesIntegration, isNotNull);

--- a/packages/flutter/test/sentry_flutter_util.dart
+++ b/packages/flutter/test/sentry_flutter_util.dart
@@ -1,4 +1,3 @@
-import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';

--- a/packages/flutter/test/sentry_flutter_util.dart
+++ b/packages/flutter/test/sentry_flutter_util.dart
@@ -41,14 +41,16 @@ void testConfiguration({
   Integration? nativeIntegration;
   Integration? loadDebugImagesIntegration;
   if (kIsWeb) {
-    nativeIntegration = integrations.firstWhereOrNull(
-        (x) => x.runtimeType.toString() == 'WebSdkIntegration');
-    loadDebugImagesIntegration = integrations.firstWhereOrNull(
+    nativeIntegration = SentryIterableUtils.firstWhereOrNull(
+        integrations, (x) => x.runtimeType.toString() == 'WebSdkIntegration');
+    loadDebugImagesIntegration = SentryIterableUtils.firstWhereOrNull(
+        integrations,
         (x) => x.runtimeType.toString() == 'LoadWebDebugImagesIntegration');
   } else {
-    nativeIntegration = integrations.firstWhereOrNull(
+    nativeIntegration = SentryIterableUtils.firstWhereOrNull(integrations,
         (x) => x.runtimeType.toString() == 'NativeSdkIntegration');
-    loadDebugImagesIntegration = integrations.firstWhereOrNull(
+    loadDebugImagesIntegration = SentryIterableUtils.firstWhereOrNull(
+        integrations,
         (x) => x.runtimeType.toString() == 'LoadNativeDebugImagesIntegration');
   }
   expect(loadDebugImagesIntegration, isNotNull);


### PR DESCRIPTION
## :scroll: Description
Removes `collection` from runtime dependencies in `sentry`, `sentry_flutter`, and `_sentry_testing` by replacing production nullable iterable lookups with a small `SentryIterableUtils` extension in the core SDK.

`collection` remains available as a dev dependency where tests still use its equality helpers.

## :bulb: Motivation and Context
Production code only relied on `firstOrNull` and `firstWhereOrNull`, so shipping the full `collection` package for runtime use is unnecessary. Keeping those helpers in the core SDK avoids an extra runtime dependency while preserving existing behavior.

## :green_heart: How did you test it?
- `fvm dart analyze` on changed Dart SDK files
- `fvm flutter analyze` on changed Flutter SDK files
- `fvm dart analyze` in `_sentry_testing`
- `fvm dart test test/utils/iterable_utils_test.dart test/sentry_event_test.dart test/event_processor/exception/io_exception_event_processor_test.dart test/sentry_test.dart`
- `fvm flutter test test/integrations/load_contexts_integration_test.dart test/navigation/time_to_display_tracker_test.dart test/navigation/sentry_navigator_observer_test.dart test/feedback/sentry_feedback_widget_test.dart`
- pre-commit analyze hooks

Closes #3679 

## :pencil: Checklist
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
None.

Made with [Cursor](https://cursor.com)