### PR TITLE
ref(sdk): Ignore devtools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ Podfile.lock
 
 .gradle
 packages/flutter/.gradle
+packages/link/devtools_options.yaml
 
 # Local Claude Code settings that should not be committed
 .claude/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ build/
 .vscode/
 .fvm/
 .fvmrc
+**/devtools_options.yaml
 
 .test_coverage.dart
 packages/**/coverage/*
@@ -23,7 +24,6 @@ Podfile.lock
 
 .gradle
 packages/flutter/.gradle
-packages/link/devtools_options.yaml
 
 # Local Claude Code settings that should not be committed
 .claude/settings.local.json


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

The PR prevents committing auto-generated, local-only Flutter DevTools configuration.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This file was automatically created by Flutter DevTools and contains developer-specific preferences (e.g., UI state, last-used settings). These values are environment-specific and do not impact application behavior, builds, or runtime.

## :green_heart: How did you test it?

Seeing if the file was suggested for commit.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
