### PR TITLE
ci: Notify linked issues on release

### DIFF
--- a/.github/workflows/release-comment-issues.yml
+++ b/.github/workflows/release-comment-issues.yml
@@ -7,7 +7,7 @@ on:
     inputs:
       version:
         description: Which version to notify issues for
-        required: false
+        required: true
 
 jobs:
   release-comment-issues:

--- a/.github/workflows/release-comment-issues.yml
+++ b/.github/workflows/release-comment-issues.yml
@@ -9,6 +9,11 @@ on:
         description: Which version to notify issues for
         required: true
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
 jobs:
   release-comment-issues:
     runs-on: ubuntu-24.04

--- a/.github/workflows/release-comment-issues.yml
+++ b/.github/workflows/release-comment-issues.yml
@@ -1,0 +1,34 @@
+name: 'Automation: Notify issues for release'
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Which version to notify issues for
+        required: false
+
+jobs:
+  release-comment-issues:
+    runs-on: ubuntu-24.04
+    name: 'Notify issues'
+    steps:
+      - name: Get version
+        id: get_version
+        env:
+          INPUTS_VERSION: ${{ github.event.inputs.version }}
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+        run: echo "version=${INPUTS_VERSION:-$RELEASE_TAG_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Comment on linked issues that are mentioned in release
+        if: |
+          steps.get_version.outputs.version != ''
+          && !contains(steps.get_version.outputs.version, '-beta.')
+          && !contains(steps.get_version.outputs.version, '-alpha.')
+          && !contains(steps.get_version.outputs.version, '-rc.')
+
+        uses: getsentry/release-comment-issues-gh-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ steps.get_version.outputs.version }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,11 @@ each PR so you can verify how the entry will look before merging.
 
 If a PR should be excluded from the changelog, apply the `skip-changelog` label.
 
+If a PR should notify a linked issue after release, use a GitHub closing keyword in the PR
+description, such as `Fixes #123`, `Closes #123`, or `Resolves #123`. Release notification
+automation only comments on issues GitHub recognizes as closed by the released PR; mentioning an
+issue without a closing keyword is not enough.
+
 ### Custom Changelog Entries from PR Descriptions
 
 By default, the changelog entry for a PR is generated from its title. However, PR authors can


### PR DESCRIPTION
## :scroll: Description

Add a release workflow that comments on GitHub issues closed by PRs included in a published stable release.

Also document that PR authors need to use GitHub closing keywords, such as `Fixes #123`, for linked issues to receive the release notification.

## :bulb: Motivation and Context

This mirrors the release issue notification automation used by other Sentry SDK repositories and makes the required PR issue-linking behavior explicit for contributors.

## :green_heart: How did you test it?

Reviewed the workflow against this repo's release and changelog conventions. No automated tests were run because this is a GitHub Actions and documentation-only change.

## :pencil: Checklist

- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

Monitor the first stable release run to confirm the action comments on issues linked through closing keywords.

Made with [Cursor](https://cursor.com)