### PR TITLE
fix(dart): Output diagnostic logs to print on web

### DIFF
--- a/packages/dart/lib/src/utils/_io_default_log_output.dart
+++ b/packages/dart/lib/src/utils/_io_default_log_output.dart
@@ -1,0 +1,22 @@
+import 'dart:developer' as dev;
+
+import '../protocol/sentry_level.dart';
+
+/// Default log output for non-web platforms. Uses `dart:developer.log` which
+/// integrates with Dart DevTools and the Flutter / IDE log views.
+void defaultLogOutput({
+  required String name,
+  required SentryLevel level,
+  required String message,
+  Object? error,
+  StackTrace? stackTrace,
+}) {
+  dev.log(
+    '[${level.name}] $message',
+    name: name,
+    level: level.toDartLogLevel(),
+    error: error,
+    stackTrace: stackTrace,
+    time: DateTime.now(),
+  );
+}

--- a/packages/dart/lib/src/utils/_web_default_log_output.dart
+++ b/packages/dart/lib/src/utils/_web_default_log_output.dart
@@ -1,0 +1,23 @@
+import '../protocol/sentry_level.dart';
+
+/// Default log output for web. `dart:developer.log` calls do not surface in
+/// the browser dev console, so diagnostic messages would otherwise be
+/// silently dropped. This implementation forwards to `print`, which the
+/// Flutter Web engine routes to `console.log`.
+void defaultLogOutput({
+  required String name,
+  required SentryLevel level,
+  required String message,
+  Object? error,
+  StackTrace? stackTrace,
+}) {
+  final buffer = StringBuffer('[$name] [${level.name}] $message');
+  if (error != null) {
+    buffer.write('\n  error: $error');
+  }
+  if (stackTrace != null) {
+    buffer.write('\n  stack: $stackTrace');
+  }
+  // ignore: avoid_print
+  print(buffer.toString());
+}

--- a/packages/dart/lib/src/utils/internal_logger.dart
+++ b/packages/dart/lib/src/utils/internal_logger.dart
@@ -1,8 +1,8 @@
-import 'dart:developer' as dev;
-
 import 'package:meta/meta.dart';
 
 import '../../sentry.dart';
+import '_io_default_log_output.dart'
+    if (dart.library.js_interop) '_web_default_log_output.dart' as log_output;
 
 typedef LogOutputFunction = void Function({
   required String name,
@@ -70,13 +70,12 @@ class SentryInternalLogger {
     Object? error,
     StackTrace? stackTrace,
   }) {
-    dev.log(
-      '[${level.name}] $message',
+    log_output.defaultLogOutput(
       name: name,
-      level: level.toDartLogLevel(),
+      level: level,
+      message: message,
       error: error,
       stackTrace: stackTrace,
-      time: DateTime.now(),
     );
   }
 

--- a/packages/dart/test/utils/default_log_output_test.dart
+++ b/packages/dart/test/utils/default_log_output_test.dart
@@ -1,0 +1,107 @@
+@TestOn('vm')
+library;
+
+import 'dart:async';
+
+import 'package:sentry/sentry.dart';
+import 'package:sentry/src/utils/_io_default_log_output.dart' as io_log;
+import 'package:sentry/src/utils/_web_default_log_output.dart' as web_log;
+import 'package:test/test.dart';
+
+void main() {
+  group('defaultLogOutput (IO)', () {
+    // The IO implementation routes to `dart:developer.log`, not `print`,
+    // so it should never produce stdout output via `print`.
+    test('does not forward the message to print', () {
+      final captured = <String>[];
+
+      runZoned(
+        () {
+          io_log.defaultLogOutput(
+            name: 'sentry_dart',
+            level: SentryLevel.warning,
+            message: 'hello world',
+          );
+        },
+        zoneSpecification: ZoneSpecification(
+          print: (_, __, ___, line) => captured.add(line),
+        ),
+      );
+
+      expect(captured, isEmpty);
+    });
+  });
+
+  group('defaultLogOutput (Web)', () {
+    test('forwards the message to print with name and level prefix', () {
+      final captured = <String>[];
+
+      runZoned(
+        () {
+          web_log.defaultLogOutput(
+            name: 'sentry_dart',
+            level: SentryLevel.warning,
+            message: 'hello world',
+          );
+        },
+        zoneSpecification: ZoneSpecification(
+          print: (_, __, ___, line) => captured.add(line),
+        ),
+      );
+
+      expect(captured, hasLength(1));
+      expect(captured.first, '[sentry_dart] [warning] hello world');
+    });
+
+    test('appends error and stack trace when provided', () {
+      final captured = <String>[];
+      final error = StateError('boom');
+      final stackTrace = StackTrace.current;
+
+      runZoned(
+        () {
+          web_log.defaultLogOutput(
+            name: 'sentry_flutter',
+            level: SentryLevel.error,
+            message: 'failed to do something',
+            error: error,
+            stackTrace: stackTrace,
+          );
+        },
+        zoneSpecification: ZoneSpecification(
+          print: (_, __, ___, line) => captured.add(line),
+        ),
+      );
+
+      expect(captured, hasLength(1));
+      final output = captured.first;
+      expect(output,
+          startsWith('[sentry_flutter] [error] failed to do something'));
+      expect(output, contains('\n  error: Bad state: boom'));
+      expect(output, contains('\n  stack: '));
+    });
+
+    test('does not append empty error/stack lines when null', () {
+      final captured = <String>[];
+
+      runZoned(
+        () {
+          web_log.defaultLogOutput(
+            name: 'sentry_dart',
+            level: SentryLevel.info,
+            message: 'plain message',
+          );
+        },
+        zoneSpecification: ZoneSpecification(
+          print: (_, __, ___, line) => captured.add(line),
+        ),
+      );
+
+      expect(captured, hasLength(1));
+      final output = captured.first;
+      expect(output, '[sentry_dart] [info] plain message');
+      expect(output, isNot(contains('error:')));
+      expect(output, isNot(contains('stack:')));
+    });
+  });
+}

--- a/packages/dart/test/utils/internal_logger_test.dart
+++ b/packages/dart/test/utils/internal_logger_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:sentry/sentry.dart';
 import 'package:sentry/src/utils/internal_logger.dart';
 import 'package:test/test.dart';
@@ -164,6 +166,32 @@ void main() {
 
         expect(logs, hasLength(1));
         expect(logs.first.stackTrace, stackTrace);
+      });
+    });
+
+    group('default platform routing', () {
+      // When no custom `logOutput` is supplied, the logger must dispatch to
+      // the platform-specific default. On the VM this is `dart:developer.log`,
+      // so nothing should reach the zone's `print` hook. On Flutter Web, a
+      // companion file (`_web_default_log_output.dart`) routes to `print` so
+      // diagnostic output is visible in the browser dev console — see #3043.
+      test('on VM, default output does not call print', () {
+        final captured = <String>[];
+
+        runZoned(
+          () {
+            SentryInternalLogger.configure(
+              isEnabled: true,
+              minLevel: SentryLevel.debug,
+            );
+            internalLogger.warning('routed via dev.log on the VM');
+          },
+          zoneSpecification: ZoneSpecification(
+            print: (_, __, ___, line) => captured.add(line),
+          ),
+        );
+
+        expect(captured, isEmpty);
       });
     });
 


### PR DESCRIPTION
## :scroll: Description

Splits the default output for `SentryInternalLogger` into platform-specific implementations selected via conditional import:

- `_io_default_log_output.dart` keeps the existing `dart:developer.log` behaviour on the VM, so DevTools and IDE log views continue to work unchanged.
- `_web_default_log_output.dart` formats the message and forwards it to `print`, which the Flutter Web engine routes to `console.log`.

The wiring follows the existing `_io_*` / `_web_*` companion-file pattern already used in `packages/dart/lib/src/` (see `_io_platform.dart` / `_web_platform.dart`, `origin_io.dart` / `origin_web.dart`, `dart_exception_type_identifier_io.dart` / `_web.dart`).

## :bulb: Motivation and Context

`dart:developer.log` does not surface in the browser dev console on Flutter Web, so SDK diagnostic logs (the ones gated by `options.debug = true`) were silently dropped during web development.

Closes #3043

## :green_heart: How did you test it?

- Added `packages/dart/test/utils/default_log_output_test.dart` with direct unit tests for both `_io_default_log_output.dart` (asserts no `print` output) and `_web_default_log_output.dart` (asserts `print` is called with the expected `[name] [level] message` prefix, and that `error` / `stackTrace` are appended only when present).
- Extended `internal_logger_test.dart` with a routing test confirming that on the VM the default path does **not** call `print` (i.e. the conditional import resolves to the IO file).
- Verified the existing `internal_logger_test.dart` suite still passes (30 tests).
- Ran `dart analyze --fatal-warnings` on `packages/dart/` — clean.
- Verified `dart compile js -o build/main.dart.js web/main.dart` of `packages/dart/example_web/` compiles successfully with the conditional import.

## :pencil: Checklist

- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed (no doc changes needed — internal logger format)
- [x] All tests passing (existing + new)
- [x] No breaking changes (purely an additive platform split; VM behaviour unchanged)