### PR TITLE
fix(dart): Make sentryOnError synchronous in runZonedGuarded

### DIFF
--- a/packages/dart/lib/src/sentry_run_zoned_guarded.dart
+++ b/packages/dart/lib/src/sentry_run_zoned_guarded.dart
@@ -16,9 +16,20 @@ class SentryRunZonedGuarded {
     Map<Object?, Object?>? zoneValues,
     ZoneSpecification? zoneSpecification,
   }) {
-    final sentryOnError = (exception, stackTrace) async {
+    // Must remain synchronous. `runZonedGuarded` expects a
+    // `void Function(Object, StackTrace)` and never awaits the returned
+    // future. Declaring this `async` made the user-supplied [onError] run
+    // inside an unawaited future of this same zone, which meant a rethrow
+    // (a common pattern to preserve normal crash behaviour) became an
+    // async uncaught error in the same zone and recursively re-entered
+    // `sentryOnError`. Dart breaks that loop by silently dropping the
+    // error, so the unhandled exception ended up swallowed entirely.
+    // See https://github.com/getsentry/sentry-dart/issues/3541.
+    final sentryOnError = (Object exception, StackTrace stackTrace) {
       final options = hub.options;
-      await _captureError(hub, options, exception, stackTrace);
+      // Fire-and-forget so the synchronous contract is preserved. The
+      // event is buffered/queued internally by the hub regardless.
+      unawaited(_captureError(hub, options, exception, stackTrace));
 
       if (onError != null) {
         onError(exception, stackTrace);

--- a/packages/dart/test/sentry_run_zoned_guarded_test.dart
+++ b/packages/dart/test/sentry_run_zoned_guarded_test.dart
@@ -90,6 +90,57 @@ void main() {
       await span?.finish();
     });
 
+    test(
+        'invokes user onError synchronously and captures the event '
+        '(regression for #3541)', () async {
+      // Before the fix `sentryOnError` was declared `async`, returning a
+      // `Future<void>` that `runZonedGuarded` discarded. The user's
+      // `onError` only ran after `await _captureError(...)` resolved on
+      // a later microtask, which meant a rethrow from `onError` became
+      // an uncaught async error of the same zone — recursively
+      // re-entering `sentryOnError` until Dart silently dropped it.
+      //
+      // After the fix `sentryOnError` is synchronous: `_captureError` is
+      // fire-and-forget via `unawaited`, and the user's `onError` runs
+      // (and may rethrow cleanly) before `sentryRunZonedGuarded`
+      // returns. The clearest sync-vs-async discriminator is whether
+      // the user's onError has been invoked by the time control returns
+      // to the caller.
+      final client = MockSentryClient();
+      final hub = Hub(fixture.options);
+      hub.bindClient(client);
+
+      var userOnErrorCalled = false;
+      var userOnErrorCalledSyncFromCaller = false;
+
+      SentryRunZonedGuarded.sentryRunZonedGuarded(
+        hub,
+        () => throw StateError('boom'),
+        (error, stackTrace) {
+          userOnErrorCalled = true;
+        },
+      );
+      // Synchronous snapshot: with the sync handler this must already
+      // be `true`; with the broken async handler it would still be
+      // `false` because `await _captureError(...)` had not yet
+      // resolved.
+      userOnErrorCalledSyncFromCaller = userOnErrorCalled;
+
+      expect(userOnErrorCalledSyncFromCaller, isTrue,
+          reason: "sentryOnError must invoke the user's onError synchronously, "
+              "not after an awaited microtask. Otherwise a rethrow from "
+              "onError becomes an unhandled async error of the same zone "
+              "and recursively re-enters sentryOnError until Dart drops "
+              "the error.");
+
+      // The unawaited `_captureError` still reaches the client; we just
+      // observe it after microtasks drain.
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(client.captureEventCalls, hasLength(1),
+          reason: 'The Sentry event must still be captured even though '
+              '`_captureError` is now fire-and-forget.');
+    });
+
     test('sets level to error instead of fatal', () async {
       final client = MockSentryClient();
       final hub = Hub(fixture.options);

--- a/packages/dart/test/sentry_run_zoned_guarded_test.dart
+++ b/packages/dart/test/sentry_run_zoned_guarded_test.dart
@@ -90,28 +90,13 @@ void main() {
       await span?.finish();
     });
 
-    test(
-        'invokes user onError synchronously and captures the event '
-        '(regression for #3541)', () async {
-      // Before the fix `sentryOnError` was declared `async`, returning a
-      // `Future<void>` that `runZonedGuarded` discarded. The user's
-      // `onError` only ran after `await _captureError(...)` resolved on
-      // a later microtask, which meant a rethrow from `onError` became
-      // an uncaught async error of the same zone — recursively
-      // re-entering `sentryOnError` until Dart silently dropped it.
-      //
-      // After the fix `sentryOnError` is synchronous: `_captureError` is
-      // fire-and-forget via `unawaited`, and the user's `onError` runs
-      // (and may rethrow cleanly) before `sentryRunZonedGuarded`
-      // returns. The clearest sync-vs-async discriminator is whether
-      // the user's onError has been invoked by the time control returns
-      // to the caller.
+    // Regression for https://github.com/getsentry/sentry-dart/issues/3541.
+    test('invokes user onError synchronously and captures the event', () async {
       final client = MockSentryClient();
       final hub = Hub(fixture.options);
       hub.bindClient(client);
 
       var userOnErrorCalled = false;
-      var userOnErrorCalledSyncFromCaller = false;
 
       SentryRunZonedGuarded.sentryRunZonedGuarded(
         hub,
@@ -120,25 +105,14 @@ void main() {
           userOnErrorCalled = true;
         },
       );
-      // Synchronous snapshot: with the sync handler this must already
-      // be `true`; with the broken async handler it would still be
-      // `false` because `await _captureError(...)` had not yet
-      // resolved.
-      userOnErrorCalledSyncFromCaller = userOnErrorCalled;
+      final userOnErrorCalledSyncFromCaller = userOnErrorCalled;
 
       expect(userOnErrorCalledSyncFromCaller, isTrue,
-          reason: "sentryOnError must invoke the user's onError synchronously, "
-              "not after an awaited microtask. Otherwise a rethrow from "
-              "onError becomes an unhandled async error of the same zone "
-              "and recursively re-enters sentryOnError until Dart drops "
-              "the error.");
+          reason:
+              "sentryOnError must invoke the user's onError synchronously.");
 
-      // The unawaited `_captureError` still reaches the client; we just
-      // observe it after microtasks drain.
       await Future<void>.delayed(const Duration(milliseconds: 50));
-      expect(client.captureEventCalls, hasLength(1),
-          reason: 'The Sentry event must still be captured even though '
-              '`_captureError` is now fire-and-forget.');
+      expect(client.captureEventCalls, hasLength(1));
     });
 
     test('sets level to error instead of fatal', () async {


### PR DESCRIPTION
## :scroll: Description

`SentryRunZonedGuarded.sentryRunZonedGuarded` wraps the user's `onError` in `sentryOnError`, which is passed to Dart's `runZonedGuarded`. The wrapper was declared `async`, so it returned a `Future<void>` that the framework silently coerced to `void` and discarded.

Two consequences:

1. `_captureError(...)` was awaited inside an unawaited future, which meant the user-supplied `onError` only ran after the awaited microtask resolved (rather than synchronously during error dispatch).
2. If the user's `onError` rethrew the error — a common pattern to preserve normal crash output — the throw became an uncaught async error in the same zone and recursively re-entered `sentryOnError` until Dart silently dropped it. The unhandled exception was swallowed entirely (no stack trace printed, no Sentry event guaranteed to have been sent).

This PR makes the handler synchronous, fires `_captureError` via `unawaited`, and calls the user's `onError` synchronously so a rethrow propagates out through `runZonedGuarded` instead of looping back into itself.

```dart
// Before
final sentryOnError = (exception, stackTrace) async {
  await _captureError(hub, options, exception, stackTrace);
  if (onError != null) onError(exception, stackTrace);
};

// After
final sentryOnError = (Object exception, StackTrace stackTrace) {
  unawaited(_captureError(hub, options, exception, stackTrace));
  if (onError != null) onError(exception, stackTrace);
};
```

The synchronous prefix of `_captureError` — the `options.log` call, span-status update via `hub.configureScope`, and the call into `hub.captureEvent` — all still run before the first `await`, so the existing tests that observe scope and event state continue to pass.

## :bulb: Motivation and Context

Closes #3541

## :green_heart: How did you test it?

- Added a regression test (`invokes user onError synchronously and captures the event (regression for #3541)`) that observes the user's `onError` synchronously from the caller frame. With the broken `async` handler this snapshot was `false` because the user callback only ran after `await _captureError(...)`; with the fix it is `true`.
- Verified the regression test **fails** when the source fix is reverted (`Expected: true / Actual: <false>`), then passes once restored.
- The existing 4 tests (`calls onError`, `calls zoneSpecification print`, `marks transaction as internal error if no status`, `sets level to error instead of fatal`) all continue to pass — the synchronous prefix of `_captureError` still sets the scope/span state before the existing tests observe it.
- `dart analyze --fatal-warnings` on `packages/dart/` — clean.
- Ran `hub_test.dart` alongside to check for nearby regressions — all 72 tests pass.

## :pencil: Checklist

- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed (no doc changes — internal behaviour)
- [x] All tests passing
- [x] No breaking changes (public API unchanged; the handler's external contract was already `void Function(Object, StackTrace)`, the async return was being discarded)