### PR TITLE
fix(dart): Route SDK diagnostic logs to browser console on web

### DIFF
--- a/packages/dart/lib/src/utils/_io_default_log_output.dart
+++ b/packages/dart/lib/src/utils/_io_default_log_output.dart
@@ -1,0 +1,22 @@
+import 'dart:developer' as dev;
+
+import '../protocol/sentry_level.dart';
+
+/// Default log output for non-web platforms. Uses `dart:developer.log` which
+/// integrates with Dart DevTools and the Flutter / IDE log views.
+void defaultLogOutput({
+  required String name,
+  required SentryLevel level,
+  required String message,
+  Object? error,
+  StackTrace? stackTrace,
+}) {
+  dev.log(
+    '[${level.name}] $message',
+    name: name,
+    level: level.toDartLogLevel(),
+    error: error,
+    stackTrace: stackTrace,
+    time: DateTime.now(),
+  );
+}

--- a/packages/dart/lib/src/utils/_web_default_log_output.dart
+++ b/packages/dart/lib/src/utils/_web_default_log_output.dart
@@ -1,0 +1,51 @@
+import 'dart:js_interop';
+
+import 'package:web/web.dart' as web;
+
+import '../protocol/sentry_level.dart';
+
+/// Default log output for web. `dart:developer.log` calls do not surface in
+/// the browser dev console on Flutter Web, so diagnostic SDK messages were
+/// otherwise silently dropped.
+///
+/// We deliberately forward to `window.console.*` (via `package:web`) instead
+/// of using Dart's top-level `print`. Sentry installs a print-zone hook in
+/// `runZonedGuarded` to record `print` calls as breadcrumbs, and routing the
+/// SDK's own diagnostic output through `print` would feed those internal
+/// lines back as user-visible breadcrumbs. Calling `console.*` directly
+/// bypasses that hook entirely.
+///
+/// The SDK's internal logger is also short-circuited by `kDebugMode` in
+/// release builds, so this code is tree-shaken from production.
+void defaultLogOutput({
+  required String name,
+  required SentryLevel level,
+  required String message,
+  Object? error,
+  StackTrace? stackTrace,
+}) {
+  final formatted = '[$name] [${level.name}] $message'.toJS;
+  final errorJs = error?.toString().toJS;
+  final stackJs = stackTrace?.toString().toJS;
+
+  switch (level) {
+    case SentryLevel.fatal:
+    case SentryLevel.error:
+      web.console.error(formatted);
+      if (errorJs != null) web.console.error(errorJs);
+      if (stackJs != null) web.console.error(stackJs);
+    case SentryLevel.warning:
+      web.console.warn(formatted);
+      if (errorJs != null) web.console.warn(errorJs);
+      if (stackJs != null) web.console.warn(stackJs);
+    case SentryLevel.info:
+      web.console.info(formatted);
+      if (errorJs != null) web.console.info(errorJs);
+      if (stackJs != null) web.console.info(stackJs);
+    case SentryLevel.debug:
+    default:
+      web.console.debug(formatted);
+      if (errorJs != null) web.console.debug(errorJs);
+      if (stackJs != null) web.console.debug(stackJs);
+  }
+}

--- a/packages/dart/lib/src/utils/internal_logger.dart
+++ b/packages/dart/lib/src/utils/internal_logger.dart
@@ -1,8 +1,8 @@
-import 'dart:developer' as dev;
-
 import 'package:meta/meta.dart';
 
 import '../../sentry.dart';
+import '_io_default_log_output.dart'
+    if (dart.library.js_interop) '_web_default_log_output.dart' as log_output;
 
 typedef LogOutputFunction = void Function({
   required String name,
@@ -70,13 +70,12 @@ class SentryInternalLogger {
     Object? error,
     StackTrace? stackTrace,
   }) {
-    dev.log(
-      '[${level.name}] $message',
+    log_output.defaultLogOutput(
       name: name,
-      level: level.toDartLogLevel(),
+      level: level,
+      message: message,
       error: error,
       stackTrace: stackTrace,
-      time: DateTime.now(),
     );
   }
 

--- a/packages/dart/test/utils/default_log_output_test.dart
+++ b/packages/dart/test/utils/default_log_output_test.dart
@@ -1,0 +1,59 @@
+@TestOn('vm')
+library;
+
+import 'dart:async';
+
+import 'package:sentry/sentry.dart';
+import 'package:sentry/src/utils/_io_default_log_output.dart' as io_log;
+import 'package:test/test.dart';
+
+void main() {
+  group('defaultLogOutput (IO)', () {
+    // The IO implementation routes to `dart:developer.log`, not `print`,
+    // so it must never appear via the zone's `print` hook. This is the
+    // same property we rely on for the web implementation, which forwards
+    // to `console.*` directly instead of `print` — see #3043 and the
+    // accompanying note in `_web_default_log_output.dart` about avoiding
+    // Sentry's print-breadcrumb integration.
+    test('does not forward the message to print', () {
+      final captured = <String>[];
+
+      runZoned(
+        () {
+          io_log.defaultLogOutput(
+            name: 'sentry_dart',
+            level: SentryLevel.warning,
+            message: 'hello world',
+          );
+        },
+        zoneSpecification: ZoneSpecification(
+          print: (_, __, ___, line) => captured.add(line),
+        ),
+      );
+
+      expect(captured, isEmpty);
+    });
+
+    test('does not throw for any SentryLevel', () {
+      for (final level in const [
+        SentryLevel.fatal,
+        SentryLevel.error,
+        SentryLevel.warning,
+        SentryLevel.info,
+        SentryLevel.debug,
+      ]) {
+        expect(
+          () => io_log.defaultLogOutput(
+            name: 'sentry_dart',
+            level: level,
+            message: 'msg',
+            error: StateError('e'),
+            stackTrace: StackTrace.current,
+          ),
+          returnsNormally,
+          reason: 'defaultLogOutput must accept all SentryLevels',
+        );
+      }
+    });
+  });
+}

--- a/packages/dart/test/utils/internal_logger_test.dart
+++ b/packages/dart/test/utils/internal_logger_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:sentry/sentry.dart';
 import 'package:sentry/src/utils/internal_logger.dart';
 import 'package:test/test.dart';
@@ -164,6 +166,34 @@ void main() {
 
         expect(logs, hasLength(1));
         expect(logs.first.stackTrace, stackTrace);
+      });
+    });
+
+    group('default platform routing', () {
+      // When no custom `logOutput` is supplied, the logger must dispatch
+      // to the platform-specific default. On the VM this is the IO file
+      // (`dart:developer.log`); on Flutter Web it is
+      // `_web_default_log_output.dart`, which forwards to `console.*`
+      // via `package:web` so output reaches the browser dev console
+      // without going through `print` (which Sentry's print-breadcrumb
+      // integration would otherwise capture). See #3043.
+      test('on VM, default output does not call print', () {
+        final captured = <String>[];
+
+        runZoned(
+          () {
+            SentryInternalLogger.configure(
+              isEnabled: true,
+              minLevel: SentryLevel.debug,
+            );
+            internalLogger.warning('routed via dev.log on the VM');
+          },
+          zoneSpecification: ZoneSpecification(
+            print: (_, __, ___, line) => captured.add(line),
+          ),
+        );
+
+        expect(captured, isEmpty);
       });
     });
 


### PR DESCRIPTION
## :scroll: Description

Splits the default output for `SentryInternalLogger` into platform-specific implementations selected via the existing `_io_*` / `_web_*` companion-file pattern (already used by `_io_platform.dart` / `_web_platform.dart`, `origin_io.dart` / `origin_web.dart`, `dart_exception_type_identifier_io.dart` / `_web.dart`, etc.):

- `_io_default_log_output.dart` keeps the existing `dart:developer.log` behaviour on the VM, so DevTools and IDE log views are unchanged.
- `_web_default_log_output.dart` forwards to `window.console.*` via `package:web`, mapping `SentryLevel` to the matching console method:

  | `SentryLevel`     | `console.*`     |
  | ----------------- | --------------- |
  | `fatal` / `error` | `console.error` |
  | `warning`         | `console.warn`  |
  | `info`            | `console.info`  |
  | `debug`           | `console.debug` |

## :bulb: Motivation and Context

`dart:developer.log` does not surface in the browser dev console on Flutter Web, so SDK diagnostic messages (the ones gated by `options.debug = true`) were silently dropped during web development.

I deliberately used `package:web` `console.*` instead of `print`, to address @buenaflor's concern from [the issue thread](https://github.com/getsentry/sentry-dart/issues/3043#issuecomment-4423246375):

> "Something we need to be careful of is that we have an integration that reports prints as breadcrumbs, I want to make sure we don't spill out internal prints as breadcrumbs."

Sentry's print-breadcrumb integration installs a `ZoneSpecification(print:)` hook inside `runZonedGuarded` and records every `print` call as a `Breadcrumb`. If the SDK's own internal diagnostic logger went through `print`, every internal line would feed back as a user-visible breadcrumb on captured events. Calling `console.*` directly bypasses that hook entirely.

Additionally, `RuntimeChecker.kDebugMode` already short-circuits the logger at the top of `_log()`, so the whole code path is tree-shaken from release builds regardless of platform — providing a second layer of safety against the breadcrumb-feedback scenario even if a future integration changes how `print` is intercepted.

Closes #3043

## :green_heart: How did you test it?

- Added `packages/dart/test/utils/default_log_output_test.dart` with two tests for the IO path: (a) it never produces output via `print` (so the same property holds for the web path, which uses `console.*`); (b) it accepts all `SentryLevel`s without throwing.
- Added a routing test to `internal_logger_test.dart` that verifies the conditional import resolves to the IO file on the VM (no `print` output when logging through the public `SentryInternalLogger`).
- Verified the web target compiles cleanly: `dart compile js -o build/main.dart.js web/main.dart` in `packages/dart/example_web/` succeeds with the new conditional import in place.
- The existing 25 `internal_logger_test.dart` tests still pass.
- `dart analyze --fatal-warnings` on `packages/dart/` — clean.

The web `console.*` behaviour itself is not unit-tested on the VM (the web file can't be exercised there); the `example_web` compile path provides the static-typecheck guarantee, and a Flutter Web app with `options.debug = true` would surface the diagnostic logs at the appropriate severity in the dev console.

## :pencil: Checklist

- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed (no doc changes — internal logger format)
- [x] All tests passing (existing + new)
- [x] No breaking changes (purely an additive platform split; VM behaviour unchanged)