### PR TITLE
docs(repo): Add branch naming guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ Only packages with staged changes are analyzed — no need to wait for the full 
 Use the format `git-username/type/short-description` for branch names.
 
 * `git-username` should match your Git username or GitHub handle.
-* `type` should be a conventional change type such as `feat`, `fix`, `docs`, `test`, or `chore`.
+* `type` should be a conventional change type according to [conventional commits](https://www.conventionalcommits.org/) such as `feat`, `fix`, `docs`, `test`, or `chore`.
 * `short-description` should be lowercase, hyphen-separated, and describe the change.
 
 For example: `octocat/feat/add-http-timeout`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,16 @@ automatically:
 
 Only packages with staged changes are analyzed — no need to wait for the full monorepo.
 
+## Branch Naming
+
+Use the format `git-username/type/short-description` for branch names.
+
+* `git-username` should match your Git username or GitHub handle.
+* `type` should be a conventional change type such as `feat`, `fix`, `docs`, `test`, or `chore`.
+* `short-description` should be lowercase, hyphen-separated, and describe the change.
+
+For example: `octocat/feat/add-http-timeout`.
+
 ## Changelog
 
 Changelogs are generated automatically during the release process using


### PR DESCRIPTION
Document the preferred branch naming format for contributors.

This adds a short `git-username/type/short-description` convention near the existing contributor workflow docs so branch names stay consistent without adding extra process.

This makes it easy to filter branches by username or type

Made with [Cursor](https://cursor.com)