### PR TITLE
perf(flutter): Optimize Android scope sync

### DIFF
--- a/packages/flutter/AGENTS.md
+++ b/packages/flutter/AGENTS.md
@@ -20,8 +20,8 @@ Flutter SDK with native integrations across all platforms.
 - Release all native memory (JNI local refs, malloc allocations)
 - Handle native exceptions gracefully — never crash the host app
 - JNI bindings use `package:jni`; FFI bindings use `dart:ffi`
+- JNI should pass primitives directly. Small, controlled `Map`/`List` payloads may use direct conversion; arbitrary or large payloads should cross as UTF-8 JSON bytes and deserialize on Kotlin/Java.
 - JNI and FFI can currently only be tested through integration test since they cannot be injected / mocked or faked.
-
 
 ## Key Directories
 

--- a/packages/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/packages/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -15,6 +15,7 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 import io.sentry.Breadcrumb
 import io.sentry.DateUtils
+import io.sentry.JsonObjectReader
 import io.sentry.ScopesAdapter
 import io.sentry.Sentry
 import io.sentry.SentryOptions
@@ -31,8 +32,11 @@ import io.sentry.protocol.DebugImage
 import io.sentry.protocol.SdkVersion
 import io.sentry.protocol.User
 import io.sentry.transport.CurrentDateProvider
-import org.json.JSONObject
 import org.json.JSONArray
+import org.json.JSONObject
+import org.json.JSONTokener
+import java.io.ByteArrayInputStream
+import java.io.InputStreamReader
 import java.lang.ref.WeakReference
 import java.net.Proxy.Type
 import kotlin.math.roundToInt
@@ -169,6 +173,57 @@ class SentryFlutterPlugin :
     ) {
       Sentry.configureScope { scope ->
         scope.setContexts(key, value)
+      }
+    }
+
+    @Suppress("unused", "TooGenericExceptionCaught") // Used by native/jni bindings
+    @JvmStatic
+    fun addBreadcrumbFromJsonBytes(bytes: ByteArray) {
+      try {
+        val options = ScopesAdapter.getInstance().options
+        val breadcrumb =
+          jsonObjectReader(bytes).use { reader ->
+            Breadcrumb.Deserializer().deserialize(reader, options.logger)
+          }
+        Sentry.addBreadcrumb(breadcrumb)
+      } catch (e: Exception) {
+        Log.e("Sentry", "Failed to add breadcrumb from JSON bytes", e)
+      }
+    }
+
+    @Suppress("unused", "TooGenericExceptionCaught") // Used by native/jni bindings
+    @JvmStatic
+    fun setUserFromJsonBytes(bytes: ByteArray?) {
+      try {
+        if (bytes == null) {
+          Sentry.setUser(null)
+          return
+        }
+
+        val options = ScopesAdapter.getInstance().options
+        val user =
+          jsonObjectReader(bytes).use { reader ->
+            User.Deserializer().deserialize(reader, options.logger)
+          }
+        Sentry.setUser(user)
+      } catch (e: Exception) {
+        Log.e("Sentry", "Failed to set user from JSON bytes", e)
+      }
+    }
+
+    @Suppress("unused", "TooGenericExceptionCaught") // Used by native/jni bindings
+    @JvmStatic
+    fun setContextFromJsonBytes(
+      key: String,
+      bytes: ByteArray,
+    ) {
+      try {
+        val value = parseJsonBytes(bytes)
+        Sentry.configureScope { scope ->
+          scope.setContexts(key, value)
+        }
+      } catch (e: Exception) {
+        Log.e("Sentry", "Failed to set context from JSON bytes", e)
       }
     }
 
@@ -394,6 +449,42 @@ class SentryFlutterPlugin :
         "code_id" to codeId,
         "debug_file" to debugFile,
       )
+
+    private fun parseJsonBytes(bytes: ByteArray): Any? {
+      val json = String(bytes, Charsets.UTF_8)
+      return JSONTokener(json).nextValue().toKotlinJsonValue()
+    }
+
+    private fun jsonObjectReader(bytes: ByteArray): JsonObjectReader =
+      JsonObjectReader(InputStreamReader(ByteArrayInputStream(bytes), Charsets.UTF_8))
+
+    private fun Any?.toKotlinJsonValue(): Any? =
+      when (this) {
+        null, JSONObject.NULL -> null
+        is JSONObject -> {
+          val map = mutableMapOf<String, Any?>()
+          val keys = keys()
+          while (keys.hasNext()) {
+            val key = keys.next()
+            val value = opt(key).toKotlinJsonValue()
+            if (value != null) {
+              map[key] = value
+            }
+          }
+          map
+        }
+        is JSONArray -> {
+          val list = mutableListOf<Any?>()
+          for (i in 0 until length()) {
+            val value = opt(i).toKotlinJsonValue()
+            if (value != null) {
+              list.add(value)
+            }
+          }
+          list
+        }
+        else -> this
+      }
 
     private fun Double.adjustReplaySizeToBlockSize(): Double {
       val remainder = this % VIDEO_BLOCK_SIZE

--- a/packages/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/packages/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -15,6 +15,7 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 import io.sentry.Breadcrumb
 import io.sentry.DateUtils
+import io.sentry.IScope
 import io.sentry.JsonObjectReader
 import io.sentry.ScopesAdapter
 import io.sentry.Sentry
@@ -172,17 +173,6 @@ class SentryFlutterPlugin :
         }
     }
 
-    @Suppress("unused") // Used by native/jni bindings
-    @JvmStatic
-    fun setContext(
-      key: String,
-      value: Any?,
-    ) {
-      Sentry.configureScope { scope ->
-        scope.setContexts(key, value)
-      }
-    }
-
     @Suppress("unused", "TooGenericExceptionCaught") // Used by native/jni bindings
     @JvmStatic
     fun addBreadcrumbFromJsonBytes(bytes: ByteArray) {
@@ -227,7 +217,7 @@ class SentryFlutterPlugin :
       try {
         val value = parseJsonBytes(bytes)
         Sentry.configureScope { scope ->
-          scope.setContexts(key, value)
+          setContextValue(scope, key, value)
         }
       } catch (e: Exception) {
         Log.e("Sentry", "Failed to set context from JSON bytes", e)
@@ -456,6 +446,25 @@ class SentryFlutterPlugin :
         "code_id" to codeId,
         "debug_file" to debugFile,
       )
+
+    private fun setContextValue(
+      scope: IScope,
+      key: String,
+      value: Any?,
+    ) {
+      // Force sentry-java's typed overloads so primitive contexts are wrapped
+      // as {"value": ...} instead of being stored as invalid raw values.
+      when (value) {
+        null -> scope.setContexts(key, null as Any?)
+        is Boolean -> scope.setContexts(key, value)
+        is String -> scope.setContexts(key, value)
+        is Number -> scope.setContexts(key, value)
+        is Collection<*> -> scope.setContexts(key, value)
+        is Array<*> -> scope.setContexts(key, value)
+        is Char -> scope.setContexts(key, value)
+        else -> scope.setContexts(key, value)
+      }
+    }
 
     private fun parseJsonBytes(bytes: ByteArray): Any? =
       jsonObjectReader(bytes).use { reader ->

--- a/packages/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/packages/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -459,6 +459,8 @@ class SentryFlutterPlugin :
 
     private fun parseJsonBytes(bytes: ByteArray): Any? =
       jsonObjectReader(bytes).use { reader ->
+        // Despite the name, sentry-java's JsonObjectReader accepts
+        // primitives here as well as objects and arrays.
         reader.nextObjectOrNull()
       }
 

--- a/packages/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/packages/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -456,7 +456,9 @@ class SentryFlutterPlugin :
     }
 
     private fun jsonObjectReader(bytes: ByteArray): JsonObjectReader =
-      JsonObjectReader(InputStreamReader(ByteArrayInputStream(bytes), Charsets.UTF_8))
+      JsonObjectReader(
+        InputStreamReader(ByteArrayInputStream(bytes), Charsets.UTF_8),
+      )
 
     private fun Any?.toKotlinJsonValue(): Any? =
       when (this) {

--- a/packages/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/packages/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -34,7 +34,6 @@ import io.sentry.protocol.User
 import io.sentry.transport.CurrentDateProvider
 import org.json.JSONArray
 import org.json.JSONObject
-import org.json.JSONTokener
 import java.io.ByteArrayInputStream
 import java.io.InputStreamReader
 import java.lang.ref.WeakReference
@@ -458,44 +457,15 @@ class SentryFlutterPlugin :
         "debug_file" to debugFile,
       )
 
-    private fun parseJsonBytes(bytes: ByteArray): Any? {
-      val json = String(bytes, Charsets.UTF_8)
-      return toKotlinJsonValue(JSONTokener(json).nextValue())
-    }
+    private fun parseJsonBytes(bytes: ByteArray): Any? =
+      jsonObjectReader(bytes).use { reader ->
+        reader.nextObjectOrNull()
+      }
 
     private fun jsonObjectReader(bytes: ByteArray): JsonObjectReader =
       JsonObjectReader(
         InputStreamReader(ByteArrayInputStream(bytes), Charsets.UTF_8),
       )
-
-    private fun toKotlinJsonValue(value: Any?): Any? =
-      when (value) {
-        null, JSONObject.NULL -> {
-          null
-        }
-
-        is JSONObject -> {
-          val map = mutableMapOf<String, Any?>()
-          val keys = value.keys()
-          while (keys.hasNext()) {
-            val key = keys.next()
-            map[key] = toKotlinJsonValue(value.opt(key))
-          }
-          map
-        }
-
-        is JSONArray -> {
-          val list = mutableListOf<Any?>()
-          for (i in 0 until value.length()) {
-            list.add(toKotlinJsonValue(value.opt(i)))
-          }
-          list
-        }
-
-        else -> {
-          value
-        }
-      }
 
     private fun Double.adjustReplaySizeToBlockSize(): Double {
       val remainder = this % VIDEO_BLOCK_SIZE

--- a/packages/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/packages/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -471,10 +471,7 @@ class SentryFlutterPlugin :
           val keys = keys()
           while (keys.hasNext()) {
             val key = keys.next()
-            val value = opt(key).toKotlinJsonValue()
-            if (value != null) {
-              map[key] = value
-            }
+            map[key] = opt(key).toKotlinJsonValue()
           }
           map
         }
@@ -482,10 +479,7 @@ class SentryFlutterPlugin :
         is JSONArray -> {
           val list = mutableListOf<Any?>()
           for (i in 0 until length()) {
-            val value = opt(i).toKotlinJsonValue()
-            if (value != null) {
-              list.add(value)
-            }
+            list.add(opt(i).toKotlinJsonValue())
           }
           list
         }

--- a/packages/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/packages/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -462,7 +462,10 @@ class SentryFlutterPlugin :
 
     private fun Any?.toKotlinJsonValue(): Any? =
       when (this) {
-        null, JSONObject.NULL -> null
+        null, JSONObject.NULL -> {
+          null
+        }
+
         is JSONObject -> {
           val map = mutableMapOf<String, Any?>()
           val keys = keys()
@@ -475,6 +478,7 @@ class SentryFlutterPlugin :
           }
           map
         }
+
         is JSONArray -> {
           val list = mutableListOf<Any?>()
           for (i in 0 until length()) {
@@ -485,7 +489,10 @@ class SentryFlutterPlugin :
           }
           list
         }
-        else -> this
+
+        else -> {
+          this
+        }
       }
 
     private fun Double.adjustReplaySizeToBlockSize(): Double {

--- a/packages/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/packages/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -117,6 +117,14 @@ class SentryFlutterPlugin :
 
     private const val NATIVE_CRASH_WAIT_TIME = 500L
 
+    private val breadcrumbDeserializer by lazy {
+      Breadcrumb.Deserializer()
+    }
+
+    private val userDeserializer by lazy {
+      User.Deserializer()
+    }
+
     /**
      * Tears down the current ReplayIntegration to avoid invoking callbacks from a stale
      * Flutter isolate after hot restart.
@@ -183,7 +191,7 @@ class SentryFlutterPlugin :
         val options = ScopesAdapter.getInstance().options
         val breadcrumb =
           jsonObjectReader(bytes).use { reader ->
-            Breadcrumb.Deserializer().deserialize(reader, options.logger)
+            breadcrumbDeserializer.deserialize(reader, options.logger)
           }
         Sentry.addBreadcrumb(breadcrumb)
       } catch (e: Exception) {
@@ -203,7 +211,7 @@ class SentryFlutterPlugin :
         val options = ScopesAdapter.getInstance().options
         val user =
           jsonObjectReader(bytes).use { reader ->
-            User.Deserializer().deserialize(reader, options.logger)
+            userDeserializer.deserialize(reader, options.logger)
           }
         Sentry.setUser(user)
       } catch (e: Exception) {
@@ -452,7 +460,7 @@ class SentryFlutterPlugin :
 
     private fun parseJsonBytes(bytes: ByteArray): Any? {
       val json = String(bytes, Charsets.UTF_8)
-      return JSONTokener(json).nextValue().toKotlinJsonValue()
+      return toKotlinJsonValue(JSONTokener(json).nextValue())
     }
 
     private fun jsonObjectReader(bytes: ByteArray): JsonObjectReader =
@@ -460,32 +468,32 @@ class SentryFlutterPlugin :
         InputStreamReader(ByteArrayInputStream(bytes), Charsets.UTF_8),
       )
 
-    private fun Any?.toKotlinJsonValue(): Any? =
-      when (this) {
+    private fun toKotlinJsonValue(value: Any?): Any? =
+      when (value) {
         null, JSONObject.NULL -> {
           null
         }
 
         is JSONObject -> {
           val map = mutableMapOf<String, Any?>()
-          val keys = keys()
+          val keys = value.keys()
           while (keys.hasNext()) {
             val key = keys.next()
-            map[key] = opt(key).toKotlinJsonValue()
+            map[key] = toKotlinJsonValue(value.opt(key))
           }
           map
         }
 
         is JSONArray -> {
           val list = mutableListOf<Any?>()
-          for (i in 0 until length()) {
-            list.add(opt(i).toKotlinJsonValue())
+          for (i in 0 until value.length()) {
+            list.add(toKotlinJsonValue(value.opt(i)))
           }
           list
         }
 
         else -> {
-          this
+          value
         }
       }
 

--- a/packages/flutter/example/integration_test/integration_test.dart
+++ b/packages/flutter/example/integration_test/integration_test.dart
@@ -174,12 +174,15 @@ void main() {
         'items': largeItems,
         'customObject': CustomObject(),
         'nullEntry': null,
+        'sparseList': ['a', null, 'c'],
       });
       await scope.setUser(SentryUser(
         id: 'large-user',
         data: {
           'items': largeItems,
           'customObject': CustomObject(),
+          'nullEntry': null,
+          'sparseList': ['a', null, 'c'],
         },
       ));
       await scope.addBreadcrumb(Breadcrumb(
@@ -188,6 +191,7 @@ void main() {
           'items': largeItems,
           'customObject': CustomObject(),
           'nullEntry': null,
+          'sparseList': ['a', null, 'c'],
         },
       ));
     });
@@ -203,10 +207,17 @@ void main() {
 
     expect((largeContext?['items'] as List?)?.length, 64);
     expect(largeContext?['customObject'], CustomObject().toString());
+    expect(largeContext?.containsKey('nullEntry'), isTrue);
+    expect(largeContext?['nullEntry'], isNull);
+    expect(largeContext?['sparseList'], ['a', null, 'c']);
     expect(nativeUser?['id'], 'large-user');
-    expect(((nativeUser?['data'] as Map?)?['items'] as List?)?.length, 64);
-    expect(
-        ((nativeBreadcrumb?['data'] as Map?)?['items'] as List?)?.length, 64);
+    final userData = nativeUser?['data'] as Map?;
+    expect((userData?['items'] as List?)?.length, 64);
+    expect(userData?['sparseList'], ['a', null, 'c']);
+
+    final breadcrumbData = nativeBreadcrumb?['data'] as Map?;
+    expect((breadcrumbData?['items'] as List?)?.length, 64);
+    expect(breadcrumbData?['sparseList'], ['a', null, 'c']);
   }, skip: !Platform.isAndroid);
 
   testWidgets('setup sentry and start transaction', (tester) async {

--- a/packages/flutter/example/integration_test/integration_test.dart
+++ b/packages/flutter/example/integration_test/integration_test.dart
@@ -1012,13 +1012,13 @@ void main() {
       expect(values['key4'], {'value': 12}, reason: 'key4 mismatch');
       expect(values['key5'], {'value': 12.3}, reason: 'key5 mismatch');
     } else if (Platform.isAndroid) {
-      expect(values['key1'], 'randomValue', reason: 'key1 mismatch');
+      expect(values['key1'], {'value': 'randomValue'}, reason: 'key1 mismatch');
       expect(values['key2'],
           {'String': 'Value', 'Bool': true, 'Int': 123, 'Double': 12.3},
           reason: 'key2 mismatch');
-      expect(values['key3'], true, reason: 'key3 mismatch');
-      expect(values['key4'], 12, reason: 'key4 mismatch');
-      expect(values['key5'], 12.3, reason: 'key5 mismatch');
+      expect(values['key3'], {'value': true}, reason: 'key3 mismatch');
+      expect(values['key4'], {'value': 12}, reason: 'key4 mismatch');
+      expect(values['key5'], {'value': 12.3}, reason: 'key5 mismatch');
     }
 
     await Sentry.configureScope((scope) async {

--- a/packages/flutter/example/integration_test/integration_test.dart
+++ b/packages/flutter/example/integration_test/integration_test.dart
@@ -151,6 +151,64 @@ void main() {
     });
   });
 
+  testWidgets('syncs large scope maps to native on Android', (tester) async {
+    await restoreFlutterOnErrorAfter(() async {
+      await setupSentryAndApp(tester);
+    });
+
+    final largeItems = List.generate(
+      64,
+      (index) => {
+        'index': index,
+        'label': 'item-$index',
+        'nested': {
+          'enabled': index.isEven,
+          'value': index * 1.5,
+          'nullEntry': null,
+        },
+      },
+    );
+
+    await Sentry.configureScope((scope) async {
+      await scope.setContexts('large_context', {
+        'items': largeItems,
+        'customObject': CustomObject(),
+        'nullEntry': null,
+      });
+      await scope.setUser(SentryUser(
+        id: 'large-user',
+        data: {
+          'items': largeItems,
+          'customObject': CustomObject(),
+        },
+      ));
+      await scope.addBreadcrumb(Breadcrumb(
+        message: 'large-breadcrumb',
+        data: {
+          'items': largeItems,
+          'customObject': CustomObject(),
+          'nullEntry': null,
+        },
+      ));
+    });
+
+    final nativeContexts = await SentryFlutter.native?.loadContexts();
+    final contextData = nativeContexts?['contexts'] as Map?;
+    final largeContext = contextData?['large_context'] as Map?;
+    final nativeUser = nativeContexts?['user'] as Map?;
+    final breadcrumbs = nativeContexts?['breadcrumbs'] as List?;
+    final nativeBreadcrumb = breadcrumbs?.cast<Map>().firstWhere(
+          (breadcrumb) => breadcrumb['message'] == 'large-breadcrumb',
+        );
+
+    expect((largeContext?['items'] as List?)?.length, 64);
+    expect(largeContext?['customObject'], CustomObject().toString());
+    expect(nativeUser?['id'], 'large-user');
+    expect(((nativeUser?['data'] as Map?)?['items'] as List?)?.length, 64);
+    expect(
+        ((nativeBreadcrumb?['data'] as Map?)?['items'] as List?)?.length, 64);
+  }, skip: !Platform.isAndroid);
+
   testWidgets('setup sentry and start transaction', (tester) async {
     await setupSentryAndApp(tester);
 
@@ -806,23 +864,12 @@ void main() {
     expect(user['data']['map'], isNotNull);
     expect(user['data']['list'], isNotNull);
     expect(user['data']['custom object'], equals(customObject.toString()));
-
-    if (Platform.isAndroid) {
-      // On Android, the Java SDK's User.data field only supports Map<String, String>.
-      // Nested Maps and Lists are converted to Java's HashMap/ArrayList toString()
-      // format (e.g., {key=value} instead of {"key":"value"}).
-      expect(user['data']['map'],
-          equals('{nested=data, custom object=${customObject.toString()}}'));
-      expect(
-          user['data']['list'], equals('[1, ${customObject.toString()}, 3]'));
-    } else {
-      expect(user['data']['map']['nested'], equals('data'));
-      expect(user['data']['map']['custom object'],
-          equals(customObject.toString()));
-      expect(user['data']['list'][0], equals(1));
-      expect(user['data']['list'][1], equals(customObject.toString()));
-      expect(user['data']['list'][2], equals(3));
-    }
+    expect(user['data']['map']['nested'], equals('data'));
+    expect(
+        user['data']['map']['custom object'], equals(customObject.toString()));
+    expect(user['data']['list'][0], equals(1));
+    expect(user['data']['list'][1], equals(customObject.toString()));
+    expect(user['data']['list'][2], equals(3));
 
     // 3. Clear user (after clearing the id should remain)
     await Sentry.configureScope((scope) async {

--- a/packages/flutter/example/integration_test/native_jni_utils_test.dart
+++ b/packages/flutter/example/integration_test/native_jni_utils_test.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: depend_on_referenced_packages
+// ignore_for_file: depend_on_referenced_packages, invalid_use_of_internal_member
 @TestOn('vm')
 
 import 'dart:io';
@@ -6,6 +6,7 @@ import 'dart:io';
 import 'package:test/test.dart';
 import 'package:jni/jni.dart';
 import 'package:sentry_flutter/src/native/java/sentry_native_java.dart';
+import 'package:sentry_flutter/src/native/utils/utf8_json.dart';
 
 import 'utils.dart';
 
@@ -47,6 +48,10 @@ void main() {
     'innerList': [1, 2],
     'innerNull': null,
   };
+  final expectedNormalizedNestedMap = {
+    'innerString': 'nested',
+    'innerList': [1, 2],
+  };
   final expectedList = [
     'value',
     1,
@@ -65,6 +70,19 @@ void main() {
     'key5': customObject.toString(),
     'list': expectedList,
     'nestedMap': expectedNestedMap,
+  };
+  final expectedNormalizedMap = {
+    ...expectedMap,
+    'list': [
+      'value',
+      1,
+      1.1,
+      true,
+      customObject.toString(),
+      expectedNestedList,
+      expectedNormalizedNestedMap,
+    ],
+    'nestedMap': expectedNormalizedNestedMap,
   };
 
   group('JNI (Android)', () {
@@ -110,6 +128,23 @@ void main() {
       using((arena) {
         final javaMap = dartToJMap(inputMap)..releasedBy(arena);
         _expectJniMap(javaMap, expectedMap, arena);
+      });
+    });
+
+    test('normalizeNativeJson normalizes values for JSON bytes', () {
+      final actual = normalizeNativeJson(inputMap);
+
+      expect(actual, expectedNormalizedMap);
+    });
+
+    test('jsonToJByteArray converts normalized JSON to bytes', () {
+      using((arena) {
+        final javaBytes = jsonToJByteArray(inputMap)..releasedBy(arena);
+        final byteRange = javaBytes.getRange(0, javaBytes.length);
+        final bytes = byteRange.buffer
+            .asUint8List(byteRange.offsetInBytes, byteRange.length);
+
+        expect(bytes, isNotEmpty);
       });
     });
   }, skip: !Platform.isAndroid);

--- a/packages/flutter/example/integration_test/native_jni_utils_test.dart
+++ b/packages/flutter/example/integration_test/native_jni_utils_test.dart
@@ -6,7 +6,7 @@ import 'dart:io';
 import 'package:test/test.dart';
 import 'package:jni/jni.dart';
 import 'package:sentry_flutter/src/native/java/sentry_native_java.dart';
-import 'package:sentry_flutter/src/native/utils/utf8_json.dart';
+import 'package:sentry_flutter/src/native/utils/data_normalizer.dart';
 
 import 'utils.dart';
 
@@ -50,7 +50,8 @@ void main() {
   };
   final expectedNormalizedNestedMap = {
     'innerString': 'nested',
-    'innerList': [1, 2],
+    'innerList': [1, null, 2],
+    'innerNull': null,
   };
   final expectedList = [
     'value',
@@ -73,14 +74,16 @@ void main() {
   };
   final expectedNormalizedMap = {
     ...expectedMap,
+    'nullEntry': null,
     'list': [
       'value',
       1,
       1.1,
       true,
       customObject.toString(),
-      expectedNestedList,
+      ['nestedList', 2],
       expectedNormalizedNestedMap,
+      null,
     ],
     'nestedMap': expectedNormalizedNestedMap,
   };
@@ -131,8 +134,8 @@ void main() {
       });
     });
 
-    test('normalizeNativeJson normalizes values for JSON bytes', () {
-      final actual = normalizeNativeJson(inputMap);
+    test('normalize normalizes values for JSON bytes', () {
+      final actual = normalize(inputMap);
 
       expect(actual, expectedNormalizedMap);
     });

--- a/packages/flutter/lib/src/native/java/binding.dart
+++ b/packages/flutter/lib/src/native/java/binding.dart
@@ -4661,6 +4661,96 @@ class SentryFlutterPlugin$Companion extends jni$_.JObject {
         .check();
   }
 
+  static final _id_addBreadcrumbFromJsonBytes = _class.instanceMethodId(
+    r'addBreadcrumbFromJsonBytes',
+    r'([B)V',
+  );
+
+  static final _addBreadcrumbFromJsonBytes =
+      jni$_.ProtectedJniExtensions.lookup<
+                  jni$_.NativeFunction<
+                      jni$_.JThrowablePtr Function(
+                          jni$_.Pointer<jni$_.Void>,
+                          jni$_.JMethodIDPtr,
+                          jni$_.VarArgs<(jni$_.Pointer<jni$_.Void>,)>)>>(
+              'globalEnv_CallVoidMethod')
+          .asFunction<
+              jni$_.JThrowablePtr Function(jni$_.Pointer<jni$_.Void>,
+                  jni$_.JMethodIDPtr, jni$_.Pointer<jni$_.Void>)>();
+
+  /// from: `public final void addBreadcrumbFromJsonBytes(byte[] bs)`
+  void addBreadcrumbFromJsonBytes(
+    jni$_.JByteArray bs,
+  ) {
+    final _$bs = bs.reference;
+    _addBreadcrumbFromJsonBytes(reference.pointer,
+            _id_addBreadcrumbFromJsonBytes as jni$_.JMethodIDPtr, _$bs.pointer)
+        .check();
+  }
+
+  static final _id_setUserFromJsonBytes = _class.instanceMethodId(
+    r'setUserFromJsonBytes',
+    r'([B)V',
+  );
+
+  static final _setUserFromJsonBytes = jni$_.ProtectedJniExtensions.lookup<
+              jni$_.NativeFunction<
+                  jni$_.JThrowablePtr Function(
+                      jni$_.Pointer<jni$_.Void>,
+                      jni$_.JMethodIDPtr,
+                      jni$_.VarArgs<(jni$_.Pointer<jni$_.Void>,)>)>>(
+          'globalEnv_CallVoidMethod')
+      .asFunction<
+          jni$_.JThrowablePtr Function(jni$_.Pointer<jni$_.Void>,
+              jni$_.JMethodIDPtr, jni$_.Pointer<jni$_.Void>)>();
+
+  /// from: `public final void setUserFromJsonBytes(byte[] bs)`
+  void setUserFromJsonBytes(
+    jni$_.JByteArray? bs,
+  ) {
+    final _$bs = bs?.reference ?? jni$_.jNullReference;
+    _setUserFromJsonBytes(reference.pointer,
+            _id_setUserFromJsonBytes as jni$_.JMethodIDPtr, _$bs.pointer)
+        .check();
+  }
+
+  static final _id_setContextFromJsonBytes = _class.instanceMethodId(
+    r'setContextFromJsonBytes',
+    r'(Ljava/lang/String;[B)V',
+  );
+
+  static final _setContextFromJsonBytes = jni$_.ProtectedJniExtensions.lookup<
+          jni$_.NativeFunction<
+              jni$_.JThrowablePtr Function(
+                  jni$_.Pointer<jni$_.Void>,
+                  jni$_.JMethodIDPtr,
+                  jni$_.VarArgs<
+                      (
+                        jni$_.Pointer<jni$_.Void>,
+                        jni$_.Pointer<jni$_.Void>
+                      )>)>>('globalEnv_CallVoidMethod')
+      .asFunction<
+          jni$_.JThrowablePtr Function(
+              jni$_.Pointer<jni$_.Void>,
+              jni$_.JMethodIDPtr,
+              jni$_.Pointer<jni$_.Void>,
+              jni$_.Pointer<jni$_.Void>)>();
+
+  /// from: `public final void setContextFromJsonBytes(java.lang.String string, byte[] bs)`
+  void setContextFromJsonBytes(
+    jni$_.JString string,
+    jni$_.JByteArray bs,
+  ) {
+    final _$string = string.reference;
+    final _$bs = bs.reference;
+    _setContextFromJsonBytes(
+            reference.pointer,
+            _id_setContextFromJsonBytes as jni$_.JMethodIDPtr,
+            _$string.pointer,
+            _$bs.pointer)
+        .check();
+  }
+
   static final _id_removeContext = _class.instanceMethodId(
     r'removeContext',
     r'(Ljava/lang/String;)V',
@@ -5314,6 +5404,96 @@ class SentryFlutterPlugin extends jni$_.JObject {
     final _$object = object?.reference ?? jni$_.jNullReference;
     _setContext(_class.reference.pointer, _id_setContext as jni$_.JMethodIDPtr,
             _$string.pointer, _$object.pointer)
+        .check();
+  }
+
+  static final _id_addBreadcrumbFromJsonBytes = _class.staticMethodId(
+    r'addBreadcrumbFromJsonBytes',
+    r'([B)V',
+  );
+
+  static final _addBreadcrumbFromJsonBytes =
+      jni$_.ProtectedJniExtensions.lookup<
+                  jni$_.NativeFunction<
+                      jni$_.JThrowablePtr Function(
+                          jni$_.Pointer<jni$_.Void>,
+                          jni$_.JMethodIDPtr,
+                          jni$_.VarArgs<(jni$_.Pointer<jni$_.Void>,)>)>>(
+              'globalEnv_CallStaticVoidMethod')
+          .asFunction<
+              jni$_.JThrowablePtr Function(jni$_.Pointer<jni$_.Void>,
+                  jni$_.JMethodIDPtr, jni$_.Pointer<jni$_.Void>)>();
+
+  /// from: `static public final void addBreadcrumbFromJsonBytes(byte[] bs)`
+  static void addBreadcrumbFromJsonBytes(
+    jni$_.JByteArray bs,
+  ) {
+    final _$bs = bs.reference;
+    _addBreadcrumbFromJsonBytes(_class.reference.pointer,
+            _id_addBreadcrumbFromJsonBytes as jni$_.JMethodIDPtr, _$bs.pointer)
+        .check();
+  }
+
+  static final _id_setUserFromJsonBytes = _class.staticMethodId(
+    r'setUserFromJsonBytes',
+    r'([B)V',
+  );
+
+  static final _setUserFromJsonBytes = jni$_.ProtectedJniExtensions.lookup<
+              jni$_.NativeFunction<
+                  jni$_.JThrowablePtr Function(
+                      jni$_.Pointer<jni$_.Void>,
+                      jni$_.JMethodIDPtr,
+                      jni$_.VarArgs<(jni$_.Pointer<jni$_.Void>,)>)>>(
+          'globalEnv_CallStaticVoidMethod')
+      .asFunction<
+          jni$_.JThrowablePtr Function(jni$_.Pointer<jni$_.Void>,
+              jni$_.JMethodIDPtr, jni$_.Pointer<jni$_.Void>)>();
+
+  /// from: `static public final void setUserFromJsonBytes(byte[] bs)`
+  static void setUserFromJsonBytes(
+    jni$_.JByteArray? bs,
+  ) {
+    final _$bs = bs?.reference ?? jni$_.jNullReference;
+    _setUserFromJsonBytes(_class.reference.pointer,
+            _id_setUserFromJsonBytes as jni$_.JMethodIDPtr, _$bs.pointer)
+        .check();
+  }
+
+  static final _id_setContextFromJsonBytes = _class.staticMethodId(
+    r'setContextFromJsonBytes',
+    r'(Ljava/lang/String;[B)V',
+  );
+
+  static final _setContextFromJsonBytes = jni$_.ProtectedJniExtensions.lookup<
+          jni$_.NativeFunction<
+              jni$_.JThrowablePtr Function(
+                  jni$_.Pointer<jni$_.Void>,
+                  jni$_.JMethodIDPtr,
+                  jni$_.VarArgs<
+                      (
+                        jni$_.Pointer<jni$_.Void>,
+                        jni$_.Pointer<jni$_.Void>
+                      )>)>>('globalEnv_CallStaticVoidMethod')
+      .asFunction<
+          jni$_.JThrowablePtr Function(
+              jni$_.Pointer<jni$_.Void>,
+              jni$_.JMethodIDPtr,
+              jni$_.Pointer<jni$_.Void>,
+              jni$_.Pointer<jni$_.Void>)>();
+
+  /// from: `static public final void setContextFromJsonBytes(java.lang.String string, byte[] bs)`
+  static void setContextFromJsonBytes(
+    jni$_.JString string,
+    jni$_.JByteArray bs,
+  ) {
+    final _$string = string.reference;
+    final _$bs = bs.reference;
+    _setContextFromJsonBytes(
+            _class.reference.pointer,
+            _id_setContextFromJsonBytes as jni$_.JMethodIDPtr,
+            _$string.pointer,
+            _$bs.pointer)
         .check();
   }
 

--- a/packages/flutter/lib/src/native/java/binding.dart
+++ b/packages/flutter/lib/src/native/java/binding.dart
@@ -4627,40 +4627,6 @@ class SentryFlutterPlugin$Companion extends jni$_.JObject {
         .check();
   }
 
-  static final _id_setContext = _class.instanceMethodId(
-    r'setContext',
-    r'(Ljava/lang/String;Ljava/lang/Object;)V',
-  );
-
-  static final _setContext = jni$_.ProtectedJniExtensions.lookup<
-          jni$_.NativeFunction<
-              jni$_.JThrowablePtr Function(
-                  jni$_.Pointer<jni$_.Void>,
-                  jni$_.JMethodIDPtr,
-                  jni$_.VarArgs<
-                      (
-                        jni$_.Pointer<jni$_.Void>,
-                        jni$_.Pointer<jni$_.Void>
-                      )>)>>('globalEnv_CallVoidMethod')
-      .asFunction<
-          jni$_.JThrowablePtr Function(
-              jni$_.Pointer<jni$_.Void>,
-              jni$_.JMethodIDPtr,
-              jni$_.Pointer<jni$_.Void>,
-              jni$_.Pointer<jni$_.Void>)>();
-
-  /// from: `public final void setContext(java.lang.String string, java.lang.Object object)`
-  void setContext(
-    jni$_.JString string,
-    jni$_.JObject? object,
-  ) {
-    final _$string = string.reference;
-    final _$object = object?.reference ?? jni$_.jNullReference;
-    _setContext(reference.pointer, _id_setContext as jni$_.JMethodIDPtr,
-            _$string.pointer, _$object.pointer)
-        .check();
-  }
-
   static final _id_addBreadcrumbFromJsonBytes = _class.instanceMethodId(
     r'addBreadcrumbFromJsonBytes',
     r'([B)V',
@@ -5370,40 +5336,6 @@ class SentryFlutterPlugin extends jni$_.JObject {
             _class.reference.pointer,
             _id_setupBeforeSend as jni$_.JMethodIDPtr,
             _$sentryAndroidOptions.pointer)
-        .check();
-  }
-
-  static final _id_setContext = _class.staticMethodId(
-    r'setContext',
-    r'(Ljava/lang/String;Ljava/lang/Object;)V',
-  );
-
-  static final _setContext = jni$_.ProtectedJniExtensions.lookup<
-          jni$_.NativeFunction<
-              jni$_.JThrowablePtr Function(
-                  jni$_.Pointer<jni$_.Void>,
-                  jni$_.JMethodIDPtr,
-                  jni$_.VarArgs<
-                      (
-                        jni$_.Pointer<jni$_.Void>,
-                        jni$_.Pointer<jni$_.Void>
-                      )>)>>('globalEnv_CallStaticVoidMethod')
-      .asFunction<
-          jni$_.JThrowablePtr Function(
-              jni$_.Pointer<jni$_.Void>,
-              jni$_.JMethodIDPtr,
-              jni$_.Pointer<jni$_.Void>,
-              jni$_.Pointer<jni$_.Void>)>();
-
-  /// from: `static public final void setContext(java.lang.String string, java.lang.Object object)`
-  static void setContext(
-    jni$_.JString string,
-    jni$_.JObject? object,
-  ) {
-    final _$string = string.reference;
-    final _$object = object?.reference ?? jni$_.jNullReference;
-    _setContext(_class.reference.pointer, _id_setContext as jni$_.JMethodIDPtr,
-            _$string.pointer, _$object.pointer)
         .check();
   }
 

--- a/packages/flutter/lib/src/native/java/sentry_native_java.dart
+++ b/packages/flutter/lib/src/native/java/sentry_native_java.dart
@@ -409,7 +409,7 @@ JObject dartToJObject(Object? value) => switch (value) {
 
 @visibleForTesting
 JByteArray jsonToJByteArray(Object? value) =>
-    JByteArray.from(encodeUtf8Json(normalizeNativeJson(value)));
+    JByteArray.from(encodeUtf8Json(normalize(value)));
 
 @visibleForTesting
 JList<JObject> dartToJList(List<dynamic> values) {

--- a/packages/flutter/lib/src/native/java/sentry_native_java.dart
+++ b/packages/flutter/lib/src/native/java/sentry_native_java.dart
@@ -207,19 +207,9 @@ class SentryNativeJava extends SentryNativeChannel {
   void addBreadcrumb(Breadcrumb breadcrumb) =>
       tryCatchSync('addBreadcrumb', () {
         using((arena) {
-          final scopesAdapter = native.ScopesAdapter.getInstance()
-            ?..releasedBy(arena);
-          if (scopesAdapter == null) return;
-          final nativeOptions = scopesAdapter.getOptions()..releasedBy(arena);
-
-          final jMap = dartToJMap(breadcrumb.toJson());
-          final nativeBreadcrumb =
-              native.Breadcrumb.fromMap(jMap, nativeOptions)
-                ?..releasedBy(arena);
-          // release jMap directly after use
-          jMap.release();
-          if (nativeBreadcrumb == null) return;
-          native.Sentry.addBreadcrumb$1(nativeBreadcrumb);
+          final jBytes = jsonToJByteArray(breadcrumb.toJson())
+            ..releasedBy(arena);
+          native.SentryFlutterPlugin.addBreadcrumbFromJsonBytes(jBytes);
         });
       });
 
@@ -232,21 +222,10 @@ class SentryNativeJava extends SentryNativeChannel {
   void setUser(SentryUser? user) => tryCatchSync('setUser', () {
         using((arena) {
           if (user == null) {
-            native.Sentry.setUser(null);
+            native.SentryFlutterPlugin.setUserFromJsonBytes(null);
           } else {
-            final scopesAdapter = native.ScopesAdapter.getInstance()
-              ?..releasedBy(arena);
-            if (scopesAdapter == null) return;
-            final nativeOptions = scopesAdapter.getOptions()..releasedBy(arena);
-
-            final jMap = dartToJMap(user.toJson());
-            final nativeUser = native.User.fromMap(jMap, nativeOptions)
-              ?..releasedBy(arena);
-            // release jMap directly after use
-            jMap.release();
-            if (nativeUser == null) return;
-
-            native.Sentry.setUser(nativeUser);
+            final jBytes = jsonToJByteArray(user.toJson())..releasedBy(arena);
+            native.SentryFlutterPlugin.setUserFromJsonBytes(jBytes);
           }
         });
       });
@@ -255,9 +234,9 @@ class SentryNativeJava extends SentryNativeChannel {
   void setContexts(String key, value) => tryCatchSync('setContexts', () {
         using((arena) {
           final jKey = key.toJString()..releasedBy(arena);
-          final jVal = dartToJObject(value)..releasedBy(arena);
+          final jBytes = jsonToJByteArray(value)..releasedBy(arena);
 
-          native.SentryFlutterPlugin.setContext(jKey, jVal);
+          native.SentryFlutterPlugin.setContextFromJsonBytes(jKey, jBytes);
         });
       });
 
@@ -412,6 +391,11 @@ class SentryNativeJava extends SentryNativeChannel {
   }
 }
 
+// Direct JNI conversion is fine for primitives. Use the Map/List conversion
+// branches below only for small, known-shape payloads. Arbitrary,
+// user-controlled, or potentially large maps/lists should cross JNI as UTF-8
+// JSON bytes and be deserialized on the Java/Kotlin side to avoid per-entry JNI
+// calls and local reference churn.
 @visibleForTesting
 JObject dartToJObject(Object? value) => switch (value) {
       String s => s.toJString(),
@@ -422,6 +406,10 @@ JObject dartToJObject(Object? value) => switch (value) {
       Map<String, dynamic> m => dartToJMap(m),
       _ => value.toString().toJString()
     };
+
+@visibleForTesting
+JByteArray jsonToJByteArray(Object? value) =>
+    JByteArray.from(encodeUtf8Json(normalizeNativeJson(value)));
 
 @visibleForTesting
 JList<JObject> dartToJList(List<dynamic> values) {

--- a/packages/flutter/lib/src/native/utils/utf8_json.dart
+++ b/packages/flutter/lib/src/native/utils/utf8_json.dart
@@ -10,21 +10,6 @@ Uint8List encodeUtf8Json(Object? data) {
 }
 
 @internal
-Object? normalizeNativeJson(Object? value) => switch (value) {
-      null => 'null',
-      String s => s,
-      bool b => b,
-      num n => n,
-      List<dynamic> l =>
-        l.nonNulls.map(normalizeNativeJson).toList(growable: false),
-      Map<String, dynamic> m => {
-          for (final entry in m.entries.where((e) => e.value != null))
-            entry.key: normalizeNativeJson(entry.value)
-        },
-      _ => value.toString()
-    };
-
-@internal
 Map<String, dynamic> decodeUtf8JsonMap(Uint8List bytes) {
   final jsonString = utf8.decode(bytes);
   final decoded = json.decode(jsonString);

--- a/packages/flutter/lib/src/native/utils/utf8_json.dart
+++ b/packages/flutter/lib/src/native/utils/utf8_json.dart
@@ -4,6 +4,27 @@ import 'dart:typed_data';
 import 'package:meta/meta.dart';
 
 @internal
+Uint8List encodeUtf8Json(Object? data) {
+  final jsonString = json.encode(data);
+  return Uint8List.fromList(utf8.encode(jsonString));
+}
+
+@internal
+Object? normalizeNativeJson(Object? value) => switch (value) {
+      null => 'null',
+      String s => s,
+      bool b => b,
+      num n => n,
+      List<dynamic> l =>
+        l.nonNulls.map(normalizeNativeJson).toList(growable: false),
+      Map<String, dynamic> m => {
+          for (final entry in m.entries.where((e) => e.value != null))
+            entry.key: normalizeNativeJson(entry.value)
+        },
+      _ => value.toString()
+    };
+
+@internal
 Map<String, dynamic> decodeUtf8JsonMap(Uint8List bytes) {
   final jsonString = utf8.decode(bytes);
   final decoded = json.decode(jsonString);


### PR DESCRIPTION
## :scroll: Description

Optimize Android scope sync by sending breadcrumb, user, and context payloads over JNI as UTF-8 JSON bytes instead of recursively constructing Java `Map`/`List` objects from Dart.

This keeps primitive JNI calls direct, preserves structured nested user data through native deserialization, and reduces per-entry JNI object churn for large user-controlled scope payloads.

## :bulb: Motivation and Context

Large arbitrary maps in breadcrumbs, contexts, or user data can be expensive on lower-end Android devices when each nested value crosses JNI as an object. Passing the serialized payload once and deserializing on the Kotlin/Java side keeps the bridge coarse-grained and aligns with the existing byte-based native context/debug-image paths.

This lead to ANRs or even crashes in lower end devices.

Fixes #3709

## :green_heart: How did you test it?

- `fvm flutter analyze lib/src/native/utils/utf8_json.dart lib/src/native/java/sentry_native_java.dart example/integration_test/native_jni_utils_test.dart`
- `JAVA_HOME="$(/usr/libexec/java_home -v 17)" PATH="$(/usr/libexec/java_home -v 17)/bin:$PATH" ./gradlew :sentry_flutter:compileReleaseKotlin`
- `fvm flutter test test/native/sentry_native_java_test.dart`
- `fvm flutter test -d emulator-5554 integration_test/native_jni_utils_test.dart`
- `fvm flutter test -d emulator-5554 integration_test/integration_test.dart --plain-name "syncs large scope maps to native on Android"`
- `fvm flutter test -d emulator-5554 integration_test/integration_test.dart --plain-name "setUser syncs to native"`
- Full `fvm flutter test -d emulator-5554 integration_test` was also run locally; the token-gated `e2e captureException` test failed because `SENTRY_AUTH_TOKEN_E2E` was unset.

## :pencil: Checklist

- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps