### PR TITLE
fix(flutter): Hide internal widget keys

### DIFF
--- a/packages/flutter/lib/sentry_flutter.dart
+++ b/packages/flutter/lib/sentry_flutter.dart
@@ -17,12 +17,13 @@ export 'src/replay/replay_quality.dart';
 export 'src/screenshot/masking_config.dart' show SentryMaskingDecision;
 export 'src/screenshot/sentry_mask_widget.dart';
 export 'src/screenshot/sentry_screenshot_quality.dart';
-export 'src/screenshot/sentry_screenshot_widget.dart';
+export 'src/screenshot/sentry_screenshot_widget.dart'
+    hide sentryScreenshotWidgetGlobalKey;
 export 'src/screenshot/sentry_unmask_widget.dart';
 export 'src/sentry_asset_bundle.dart' show SentryAssetBundle;
 export 'src/sentry_flutter.dart';
 export 'src/sentry_flutter_options.dart';
 export 'src/sentry_privacy_options.dart';
 export 'src/sentry_replay_options.dart';
-export 'src/sentry_widget.dart';
+export 'src/sentry_widget.dart' hide sentryWidgetGlobalKey;
 export 'src/user_interaction/sentry_user_interaction_widget.dart';

--- a/packages/flutter/lib/src/event_processor/widget_event_processor.dart
+++ b/packages/flutter/lib/src/event_processor/widget_event_processor.dart
@@ -1,8 +1,9 @@
 import 'dart:async';
 
 import 'package:flutter/widgets.dart';
+import 'package:sentry/sentry.dart';
 
-import '../../sentry_flutter.dart';
+import '../sentry_widget.dart' show sentryWidgetGlobalKey;
 
 class WidgetEventProcessor implements EventProcessor {
   @override

--- a/packages/flutter/lib/src/screenshot/recorder.dart
+++ b/packages/flutter/lib/src/screenshot/recorder.dart
@@ -7,11 +7,14 @@ import 'package:flutter/material.dart' as material;
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart' as widgets;
 import 'package:meta/meta.dart';
+import 'package:sentry/sentry.dart';
 
-import '../../sentry_flutter.dart';
+import '../sentry_flutter_options.dart';
+import '../sentry_privacy_options.dart';
 import 'masking_config.dart';
 import 'recorder_config.dart';
 import 'screenshot.dart';
+import 'sentry_screenshot_widget.dart' show sentryScreenshotWidgetGlobalKey;
 import 'widget_filter.dart';
 
 @internal


### PR DESCRIPTION
Hide internal widget global keys from the public Flutter barrel export so newer Dart analysis no longer reports `invalid_export_of_internal_element`.

The keys remain available inside the package through direct source imports, while the public `SentryWidget` and `SentryScreenshotWidget` exports stay unchanged for users.

Made with [Cursor](https://cursor.com)