### PR TITLE
test(flutter): Fix flaky tests by avoiding HTTP transport in Flutter tests

### DIFF
--- a/packages/flutter/test/mocks.dart
+++ b/packages/flutter/test/mocks.dart
@@ -37,7 +37,19 @@ SentryFlutterOptions defaultTestOptions(
     {Platform? platform, RuntimeChecker? checker}) {
   return SentryFlutterOptions(
       dsn: fakeDsn, platform: platform, checker: checker)
-    ..automatedTestMode = true;
+    ..automatedTestMode = true
+    // defaultTestOptions() is networkless by design. Tests that intentionally
+    // use a real DSN must override `transport` after changing `dsn`.
+    // Do not use NoOpTransport here: SentryClient treats it as unset and
+    // replaces it with HttpTransport, which would send to fakeDsn.
+    ..transport = _NoOpTestTransport();
+}
+
+class _NoOpTestTransport implements Transport {
+  @override
+  Future<SentryId?> send(SentryEnvelope envelope) async {
+    return envelope.header.eventId;
+  }
 }
 
 // https://github.com/dart-lang/mockito/blob/master/NULL_SAFETY_README.md#fallback-generators


### PR DESCRIPTION
## :scroll: Description

Avoid accidental HTTP sends from Flutter unit tests by installing a test-only transport in `defaultTestOptions()`.

## :bulb: Motivation and Context

Flutter tests use a fake Sentry DSN. When a test creates a `SentryClient` with default test options, the SDK replaces `NoOpTransport` with `HttpTransport`, which can try to send envelopes to the fake DSN and flake on macOS stable/beta with hidden network timeout failures.

## :green_heart: How did you test it?

- `fvm flutter analyze test/mocks.dart`
- `fvm flutter test test/integrations/load_contexts_integration_test.dart --plain-name 'LoadContextsIntegration user does not apply default IP to user during captureEvent if ip is null and sendDefaultPii is false'`
- `fvm flutter test test/integrations/load_contexts_integration_test.dart test/integrations/load_native_debug_images_integration_test.dart`
- `fvm flutter test test/sentry_flutter_test.dart`

## :pencil: Checklist

- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
