### PR TITLE
fix(flutter): Forward sample rate to native SDKs

### DIFF
--- a/packages/flutter/example/integration_test/integration_test.dart
+++ b/packages/flutter/example/integration_test/integration_test.dart
@@ -253,6 +253,7 @@ void main() {
       }, (options) {
         options.dsn = fakeDsn;
         options.debug = true;
+        options.sampleRate = 0.25;
         options.diagnosticLevel = SentryLevel.error;
         options.environment = 'init-test-env';
         options.release = '1.2.3+9';
@@ -297,6 +298,7 @@ void main() {
 
     expect(androidOptions, isNotNull);
     expect(androidOptions.getDsn()?.toDartString(), fakeDsn);
+    expect(androidOptions.getSampleRate()?.doubleValue(), 0.25);
     expect(androidOptions.isDebug(), isTrue);
     final diagnostic = androidOptions.getDiagnosticLevel();
     expect(

--- a/packages/flutter/example/ios/RunnerTests/SentryFlutterTests.swift
+++ b/packages/flutter/example/ios/RunnerTests/SentryFlutterTests.swift
@@ -27,6 +27,7 @@ final class SentryFlutterTests: XCTestCase {
       options: fixture.options,
       with: [
         "dsn": "https://e85b375ffb9f43cf8bdf9787768149e0@o447951.ingest.sentry.io/5428562",
+        "sampleRate": NSNumber(value: 0.25),
         "debug": true,
         "environment": "fixture-environment",
         "release": "fixture-release",
@@ -57,6 +58,7 @@ final class SentryFlutterTests: XCTestCase {
     )
 
     XCTAssertEqual("https://e85b375ffb9f43cf8bdf9787768149e0@o447951.ingest.sentry.io/5428562", fixture.options.dsn)
+    XCTAssertEqual(0.25, fixture.options.sampleRate)
     XCTAssertEqual(true, fixture.options.debug)
     XCTAssertEqual("fixture-environment", fixture.options.environment)
     XCTAssertEqual("fixture-release", fixture.options.releaseName)

--- a/packages/flutter/example/ios/RunnerTests/SentryFlutterTests.swift
+++ b/packages/flutter/example/ios/RunnerTests/SentryFlutterTests.swift
@@ -58,7 +58,7 @@ final class SentryFlutterTests: XCTestCase {
     )
 
     XCTAssertEqual("https://e85b375ffb9f43cf8bdf9787768149e0@o447951.ingest.sentry.io/5428562", fixture.options.dsn)
-    XCTAssertEqual(0.25, fixture.options.sampleRate)
+    XCTAssertEqual(0.25, fixture.options.sampleRate.doubleValue)
     XCTAssertEqual(true, fixture.options.debug)
     XCTAssertEqual("fixture-environment", fixture.options.environment)
     XCTAssertEqual("fixture-release", fixture.options.releaseName)

--- a/packages/flutter/example/ios/RunnerTests/SentryFlutterTests.swift
+++ b/packages/flutter/example/ios/RunnerTests/SentryFlutterTests.swift
@@ -58,7 +58,7 @@ final class SentryFlutterTests: XCTestCase {
     )
 
     XCTAssertEqual("https://e85b375ffb9f43cf8bdf9787768149e0@o447951.ingest.sentry.io/5428562", fixture.options.dsn)
-    XCTAssertEqual(0.25, fixture.options.sampleRate.doubleValue)
+    XCTAssertEqual(0.25, fixture.options.sampleRate?.doubleValue)
     XCTAssertEqual(true, fixture.options.debug)
     XCTAssertEqual("fixture-environment", fixture.options.environment)
     XCTAssertEqual("fixture-release", fixture.options.releaseName)

--- a/packages/flutter/ffi-native.yaml
+++ b/packages/flutter/ffi-native.yaml
@@ -12,6 +12,7 @@ functions:
     - sentry_close
     - sentry_options_new
     - sentry_options_set_dsn
+    - sentry_options_set_sample_rate
     - sentry_options_set_debug
     - sentry_options_set_environment
     - sentry_options_set_release
@@ -57,6 +58,7 @@ functions:
     - sentry_sdk_name
     - sentry_options_free
     - sentry_options_get_dsn
+    - sentry_options_get_sample_rate
     - sentry_options_get_debug
     - sentry_options_get_environment
     - sentry_options_get_release

--- a/packages/flutter/ios/sentry_flutter/Sources/sentry_flutter/SentryFlutter.swift
+++ b/packages/flutter/ios/sentry_flutter/Sources/sentry_flutter/SentryFlutter.swift
@@ -10,6 +10,9 @@ public final class SentryFlutter {
         if let dsn = data["dsn"] as? String {
             options.dsn = dsn
         }
+        if let sampleRate = data["sampleRate"] as? NSNumber {
+            options.sampleRate = sampleRate.floatValue
+        }
         if let isDebug = data["debug"] as? Bool {
             options.debug = isDebug
         }

--- a/packages/flutter/ios/sentry_flutter/Sources/sentry_flutter/SentryFlutter.swift
+++ b/packages/flutter/ios/sentry_flutter/Sources/sentry_flutter/SentryFlutter.swift
@@ -11,7 +11,7 @@ public final class SentryFlutter {
             options.dsn = dsn
         }
         if let sampleRate = data["sampleRate"] as? NSNumber {
-            options.sampleRate = sampleRate.floatValue
+            options.sampleRate = sampleRate
         }
         if let isDebug = data["debug"] as? Bool {
             options.debug = isDebug

--- a/packages/flutter/lib/src/native/c/binding.dart
+++ b/packages/flutter/lib/src/native/c/binding.dart
@@ -58,7 +58,7 @@ class SentryNative {
   }
 
   late final _value_new_int32Ptr =
-      _lookup<ffi.NativeFunction<sentry_value_u Function(ffi.Int)>>(
+      _lookup<ffi.NativeFunction<sentry_value_u Function(ffi.Int32)>>(
           'sentry_value_new_int32');
   late final _value_new_int32 =
       _value_new_int32Ptr.asFunction<sentry_value_u Function(int)>();
@@ -271,7 +271,7 @@ class SentryNative {
   }
 
   late final _value_as_int32Ptr =
-      _lookup<ffi.NativeFunction<ffi.Int Function(sentry_value_u)>>(
+      _lookup<ffi.NativeFunction<ffi.Int32 Function(sentry_value_u)>>(
           'sentry_value_as_int32');
   late final _value_as_int32 =
       _value_as_int32Ptr.asFunction<int Function(sentry_value_u)>();
@@ -975,7 +975,7 @@ class SentryNative {
 /// automatically happens for some shared values in the event payload like
 /// the module list.
 final class sentry_value_u extends ffi.Union {
-  @ffi.Int()
+  @ffi.Uint64()
   external int _bits;
 
   @ffi.Double()

--- a/packages/flutter/lib/src/native/c/binding.dart
+++ b/packages/flutter/lib/src/native/c/binding.dart
@@ -58,7 +58,7 @@ class SentryNative {
   }
 
   late final _value_new_int32Ptr =
-      _lookup<ffi.NativeFunction<sentry_value_u Function(ffi.Int32)>>(
+      _lookup<ffi.NativeFunction<sentry_value_u Function(ffi.Int)>>(
           'sentry_value_new_int32');
   late final _value_new_int32 =
       _value_new_int32Ptr.asFunction<sentry_value_u Function(int)>();
@@ -271,7 +271,7 @@ class SentryNative {
   }
 
   late final _value_as_int32Ptr =
-      _lookup<ffi.NativeFunction<ffi.Int32 Function(sentry_value_u)>>(
+      _lookup<ffi.NativeFunction<ffi.Int Function(sentry_value_u)>>(
           'sentry_value_as_int32');
   late final _value_as_int32 =
       _value_as_int32Ptr.asFunction<int Function(sentry_value_u)>();
@@ -396,6 +396,55 @@ class SentryNative {
               ffi.Pointer<sentry_options_s>)>>('sentry_options_get_dsn');
   late final _options_get_dsn = _options_get_dsnPtr.asFunction<
       ffi.Pointer<ffi.Char> Function(ffi.Pointer<sentry_options_s>)>();
+
+  /// Sets the sample rate, which should be a double between `0.0` and `1.0`.
+  /// Sentry will randomly discard any event that is captured using
+  /// `sentry_capture_event` when a sample rate < 1 is set.
+  ///
+  /// The sampling happens at the end of the event processing according to the
+  /// following order:
+  ///
+  /// https://develop.sentry.dev/sdk/sessions/#filter-order
+  ///
+  /// Only items 3. to 6. are currently applicable to sentry-native. This means
+  /// each processing step is executed even if the sampling discards the event
+  /// before sending it to the backend. This is particularly relevant to users of
+  /// the `before_send` callback.
+  ///
+  /// The above is in contrast to versions up to 0.4.18 where the sampling happened
+  /// at the beginning of the processing/filter sequence.
+  void options_set_sample_rate(
+    ffi.Pointer<sentry_options_s> opts,
+    double sample_rate,
+  ) {
+    return _options_set_sample_rate(
+      opts,
+      sample_rate,
+    );
+  }
+
+  late final _options_set_sample_ratePtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Pointer<sentry_options_s>,
+              ffi.Double)>>('sentry_options_set_sample_rate');
+  late final _options_set_sample_rate = _options_set_sample_ratePtr
+      .asFunction<void Function(ffi.Pointer<sentry_options_s>, double)>();
+
+  /// Gets the sample rate.
+  double options_get_sample_rate(
+    ffi.Pointer<sentry_options_s> opts,
+  ) {
+    return _options_get_sample_rate(
+      opts,
+    );
+  }
+
+  late final _options_get_sample_ratePtr = _lookup<
+          ffi
+          .NativeFunction<ffi.Double Function(ffi.Pointer<sentry_options_s>)>>(
+      'sentry_options_get_sample_rate');
+  late final _options_get_sample_rate = _options_get_sample_ratePtr
+      .asFunction<double Function(ffi.Pointer<sentry_options_s>)>();
 
   /// Sets the release.
   void options_set_release(
@@ -926,7 +975,7 @@ class SentryNative {
 /// automatically happens for some shared values in the event payload like
 /// the module list.
 final class sentry_value_u extends ffi.Union {
-  @ffi.Uint64()
+  @ffi.Int()
   external int _bits;
 
   @ffi.Double()

--- a/packages/flutter/lib/src/native/c/sentry_native.dart
+++ b/packages/flutter/lib/src/native/c/sentry_native.dart
@@ -65,6 +65,9 @@ class SentryNative with SentryNativeSafeInvoker implements SentryNativeBinding {
     try {
       final cOptions = native.options_new();
       native.options_set_dsn(cOptions, c.str(options.dsn));
+      if (options.sampleRate != null) {
+        native.options_set_sample_rate(cOptions, options.sampleRate!);
+      }
       native.options_set_debug(cOptions, options.debug ? 1 : 0);
       native.options_set_environment(cOptions, c.str(options.environment));
       native.options_set_release(cOptions, c.str(options.release));

--- a/packages/flutter/lib/src/native/java/sentry_native_java_init.dart
+++ b/packages/flutter/lib/src/native/java/sentry_native_java_init.dart
@@ -170,6 +170,8 @@ void configureAndroidOptions({
 }) {
   using((arena) {
     androidOptions.setDsn(options.dsn?.toJString()?..releasedBy(arena));
+    androidOptions
+        .setSampleRate(options.sampleRate?.toJDouble()?..releasedBy(arena));
     androidOptions.setDebug(options.debug);
     androidOptions
         .setEnvironment(options.environment?.toJString()?..releasedBy(arena));

--- a/packages/flutter/lib/src/native/sentry_native_channel.dart
+++ b/packages/flutter/lib/src/native/sentry_native_channel.dart
@@ -40,6 +40,7 @@ class SentryNativeChannel
     }
     return channel.invokeMethod('initNativeSdk', <String, dynamic>{
       'dsn': options.dsn,
+      'sampleRate': options.sampleRate,
       'debug': options.debug,
       'environment': options.environment,
       'release': options.release,

--- a/packages/flutter/test/sentry_native/sentry_native_test_ffi.dart
+++ b/packages/flutter/test/sentry_native/sentry_native_test_ffi.dart
@@ -87,6 +87,7 @@ void main() {
       test('options', () {
         options
           ..debug = true
+          ..sampleRate = 0.25
           ..environment = 'foo'
           ..release = 'foo@bar+1'
           ..enableAutoSessionTracking = true
@@ -101,6 +102,7 @@ void main() {
                   .cast<Utf8>()
                   .toDartString(),
               fakeDsn);
+          expect(SentryNative.native.options_get_sample_rate(cOptions), 0.25);
           expect(
               SentryNative.native
                   .options_get_environment(cOptions)

--- a/packages/flutter/test/sentry_native_channel_test.dart
+++ b/packages/flutter/test/sentry_native_channel_test.dart
@@ -503,7 +503,7 @@ void main() {
     });
   }
 
-  group('init captureFailedRequests on iOS/macOS', () {
+  group('init options on iOS/macOS', () {
     late SentryNativeBinding sut;
     late MockMethodChannel channel;
 
@@ -521,6 +521,18 @@ void main() {
 
     setUp(() {
       channel = MockMethodChannel();
+    });
+
+    test('forwards sampleRate', () async {
+      final options = defaultTestOptions()
+        ..platform = MockPlatform.iOS()
+        ..methodChannel = channel
+        ..sampleRate = 0.25;
+      sut = createBinding(options);
+
+      final args = await callInitAndCaptureArgs(options);
+
+      expect(args['sampleRate'], 0.25);
     });
 
     test(


### PR DESCRIPTION
## :scroll: Description

Forward `SentryFlutterOptions.sampleRate` into the native SDK configuration paths for Android, Cocoa, and sentry-native FFI.

This adds the missing MethodChannel payload field, maps it into Android JNI and Cocoa options, exposes the sentry-native FFI setter/getter, and adds coverage for each forwarding path.

Note: Web is not affected, sampleRate has already been propagated to the JS SDK correctly

## :bulb: Motivation and Context

Fixes #3720.

Native crash, hang, and watchdog events could ignore the Dart `sampleRate` option because Flutter initialized native SDKs without forwarding that value. As a result, native SDK events could be sampled at 100% even when Dart events respected a lower sample rate.

## :green_heart: How did you test it?

- `fvm flutter test test/sentry_native_channel_test.dart`
- Pre-commit hooks ran Dart and Flutter analyze for `sentry_flutter` and `sentry_flutter_example`

## :pencil: Checklist

- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

CI should run the Android integration, iOS RunnerTests, and FFI native test coverage that is platform-specific locally.

Made with [Cursor](https://cursor.com)