### PR TITLE
ci(flutter): Set development team for SwiftPM archive

### DIFF
--- a/packages/flutter/example/ios/fastlane/Fastfile
+++ b/packages/flutter/example/ios/fastlane/Fastfile
@@ -67,7 +67,11 @@ platform :ios do
         }
       },
       codesigning_identity: ENV["sigh_io.sentry.flutter.sample_appstore_certificate-name"],
-      output_name: "sentry_flutter_sample.ipa"
+      output_name: "sentry_flutter_sample.ipa",
+      # Swift Package Manager plugin targets (e.g. sqflite_darwin) inherit no
+      # development team from the Runner project, so archiving fails with
+      # "requires a development team". Apply the team to all targets here.
+      xcargs: "DEVELOPMENT_TEAM=97JCY7859U -allowProvisioningUpdates"
     )
 
     delete_keychain(

--- a/packages/flutter/example/ios/fastlane/Fastfile
+++ b/packages/flutter/example/ios/fastlane/Fastfile
@@ -68,10 +68,11 @@ platform :ios do
       },
       codesigning_identity: ENV["sigh_io.sentry.flutter.sample_appstore_certificate-name"],
       output_name: "sentry_flutter_sample.ipa",
-      # Swift Package Manager plugin targets (e.g. sqflite_darwin) inherit no
-      # development team from the Runner project, so archiving fails with
-      # "requires a development team". Apply the team to all targets here.
-      xcargs: "DEVELOPMENT_TEAM=97JCY7859U -allowProvisioningUpdates"
+      # Swift Package Manager plugin targets (e.g. sqflite_darwin, CSQLite)
+      # default to automatic signing with no development team, which conflicts
+      # with the manually specified distribution identity during archive. Force
+      # the team and manual signing across all targets so they sign correctly.
+      xcargs: "DEVELOPMENT_TEAM=97JCY7859U CODE_SIGN_STYLE=Manual -allowProvisioningUpdates"
     )
 
     delete_keychain(


### PR DESCRIPTION
Pass `DEVELOPMENT_TEAM` to `build_app` via `xcargs` so the iOS example app archives correctly when Flutter resolves plugins through Swift Package Manager.

With SwiftPM, each plugin becomes its own Xcode target. During `archive`, Xcode signs every target, but only `Runner` receives a team via `match` / `update_project_provisioning`. The SwiftPM plugin targets (e.g. `sqflite_darwin`) inherit no team and fail with:

```
error: Signing for "sqflite_darwin_sqflite_darwin" requires a development team.
```

The TestFlight release job started hitting this after the hosted runner auto-bumped to Flutter 3.44.0 + Xcode 26.2, which flips plugin resolution to SwiftPM. Setting `DEVELOPMENT_TEAM` as a global build-setting override applies the team to all targets, including the SwiftPM ones. `-allowProvisioningUpdates` is added for resilience.

Made with [Cursor](https://cursor.com)