### PR TITLE
ci: Pin macOS runners to macos-15

### DIFF
--- a/.github/workflows/size-analysis.yml
+++ b/.github/workflows/size-analysis.yml
@@ -66,7 +66,7 @@ jobs:
 
   ios:
     name: iOS
-    runs-on: macos-latest
+    runs-on: macos-15
     timeout-minutes: 45
     defaults:
       run:

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -34,7 +34,7 @@ jobs:
           ssh-key: ${{ secrets.CI_DEPLOY_KEY }}
 
   cocoa:
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
       - uses: getsentry/github-workflows/updater@607fed74f812e69201531a5185b6c3c57caa4e89 # v3
         with:


### PR DESCRIPTION
#### Description

Replaces `runs-on: macos-latest` with `runs-on: macos-15` in GitHub Actions workflows.

- `.github/workflows/update-deps.yml` (`cocoa` job)
- `.github/workflows/size-analysis.yml` (`ios` job)

#### Motivation

GitHub is migrating the `macos-latest` label to macOS 15. Pinning explicitly to `macos-15` avoids unexpected runner image changes and keeps CI stable.

#### How was this tested?

CI on this PR.

Made with [Cursor](https://cursor.com)