### PR TITLE
chore(example): Add app hang button and enable Sentry Gradle plugin

### DIFF
--- a/packages/flutter/example/android/app/build.gradle
+++ b/packages/flutter/example/android/app/build.gradle
@@ -2,9 +2,7 @@ plugins {
     id "com.android.application"
     id "kotlin-android"
     id "dev.flutter.flutter-gradle-plugin"
-//    uncomment this to upload proguard mapping file and debug symbols to Sentry
-//    and also set the token (sentry.properties) file
-   id "io.sentry.android.gradle"
+    id "io.sentry.android.gradle"
 }
 
 def localProperties = new Properties()
@@ -97,11 +95,9 @@ dependencies {
     implementation "androidx.annotation:annotation:1.1.0"
 }
 
-// uncomment this to upload debug symbols to Sentry
 sentry {
     autoInstallation {
       enabled = false
     }
     uploadNativeSymbols = true
-    includeNativeSources = true
 }

--- a/packages/flutter/example/android/app/build.gradle
+++ b/packages/flutter/example/android/app/build.gradle
@@ -2,7 +2,8 @@ plugins {
     id "com.android.application"
     id "kotlin-android"
     id "dev.flutter.flutter-gradle-plugin"
-    id "io.sentry.android.gradle"
+    // uncomment this to upload debug symbols to Sentry, currently disabled since it fails in CI
+    // id "io.sentry.android.gradle"
 }
 
 def localProperties = new Properties()
@@ -95,9 +96,10 @@ dependencies {
     implementation "androidx.annotation:annotation:1.1.0"
 }
 
-sentry {
-    autoInstallation {
-      enabled = false
-    }
-    uploadNativeSymbols = true
-}
+// uncomment this to upload debug symbols to Sentry, currently disabled since it fails in CI
+// sentry {
+//     autoInstallation {
+//       enabled = false
+//     }
+//     uploadNativeSymbols = true
+// }

--- a/packages/flutter/example/android/app/build.gradle
+++ b/packages/flutter/example/android/app/build.gradle
@@ -2,10 +2,9 @@ plugins {
     id "com.android.application"
     id "kotlin-android"
     id "dev.flutter.flutter-gradle-plugin"
-
 //    uncomment this to upload proguard mapping file and debug symbols to Sentry
 //    and also set the token (sentry.properties) file
-//    id "io.sentry.android.gradle"
+   id "io.sentry.android.gradle"
 }
 
 def localProperties = new Properties()
@@ -99,7 +98,10 @@ dependencies {
 }
 
 // uncomment this to upload debug symbols to Sentry
-// sentry {
-//     uploadNativeSymbols = true
-//     includeNativeSources = true
-// }
+sentry {
+    autoInstallation {
+      enabled = false
+    }
+    uploadNativeSymbols = true
+    includeNativeSources = true
+}

--- a/packages/flutter/example/android/app/build.gradle
+++ b/packages/flutter/example/android/app/build.gradle
@@ -2,8 +2,7 @@ plugins {
     id "com.android.application"
     id "kotlin-android"
     id "dev.flutter.flutter-gradle-plugin"
-    // uncomment this to upload debug symbols to Sentry, currently disabled since it fails in CI
-    // id "io.sentry.android.gradle"
+    id "io.sentry.android.gradle"
 }
 
 def localProperties = new Properties()
@@ -96,10 +95,12 @@ dependencies {
     implementation "androidx.annotation:annotation:1.1.0"
 }
 
-// uncomment this to upload debug symbols to Sentry, currently disabled since it fails in CI
-// sentry {
-//     autoInstallation {
-//       enabled = false
-//     }
-//     uploadNativeSymbols = true
-// }
+sentry {
+    autoInstallation {
+      enabled = false
+    }
+    uploadNativeSymbols = true
+    org = "sentry-sdks"
+    projectName = "sentry-flutter"
+    authToken = System.getenv("SENTRY_AUTH_TOKEN")
+}

--- a/packages/flutter/example/android/app/build.gradle
+++ b/packages/flutter/example/android/app/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id "dev.flutter.flutter-gradle-plugin"
     // Disabled by default because symbol upload fails on CI when SENTRY_AUTH_TOKEN
     // is unavailable (e.g. on fork PRs). Uncomment together with the sentry { } block
-    // below to upload debug symbols to Sentry locally.
+    // below to upload ProGuard mappings to Sentry.
     // id "io.sentry.android.gradle"
 }
 
@@ -100,12 +100,11 @@ dependencies {
 
 // Disabled by default because symbol upload fails on CI when SENTRY_AUTH_TOKEN
 // is unavailable (e.g. on fork PRs). Uncomment together with the
-// io.sentry.android.gradle plugin above to upload debug symbols to Sentry locally.
+// io.sentry.android.gradle plugin above to upload ProGuard mappings to Sentry.
 // sentry {
 //     autoInstallation {
 //       enabled = false
 //     }
-//     uploadNativeSymbols = true
 //     org = "sentry-sdks"
 //     projectName = "sentry-flutter"
 //     authToken = System.getenv("SENTRY_AUTH_TOKEN")

--- a/packages/flutter/example/android/app/build.gradle
+++ b/packages/flutter/example/android/app/build.gradle
@@ -2,7 +2,10 @@ plugins {
     id "com.android.application"
     id "kotlin-android"
     id "dev.flutter.flutter-gradle-plugin"
-    id "io.sentry.android.gradle"
+    // Disabled by default because symbol upload fails on CI when SENTRY_AUTH_TOKEN
+    // is unavailable (e.g. on fork PRs). Uncomment together with the sentry { } block
+    // below to upload debug symbols to Sentry locally.
+    // id "io.sentry.android.gradle"
 }
 
 def localProperties = new Properties()
@@ -95,12 +98,15 @@ dependencies {
     implementation "androidx.annotation:annotation:1.1.0"
 }
 
-sentry {
-    autoInstallation {
-      enabled = false
-    }
-    uploadNativeSymbols = true
-    org = "sentry-sdks"
-    projectName = "sentry-flutter"
-    authToken = System.getenv("SENTRY_AUTH_TOKEN")
-}
+// Disabled by default because symbol upload fails on CI when SENTRY_AUTH_TOKEN
+// is unavailable (e.g. on fork PRs). Uncomment together with the
+// io.sentry.android.gradle plugin above to upload debug symbols to Sentry locally.
+// sentry {
+//     autoInstallation {
+//       enabled = false
+//     }
+//     uploadNativeSymbols = true
+//     org = "sentry-sdks"
+//     projectName = "sentry-flutter"
+//     authToken = System.getenv("SENTRY_AUTH_TOKEN")
+// }

--- a/packages/flutter/example/lib/screens/events_screen.dart
+++ b/packages/flutter/example/lib/screens/events_screen.dart
@@ -141,18 +141,26 @@ class _EventsScreenState extends State<EventsScreen> {
                         'Shows a custom feedback dialog without an ongoing event that captures and sends user feedback data to Sentry.',
                     buttonTitle: 'Capture Feedback',
                   ),
-                  TextField(
-                    controller: _hangSecondsController,
-                    keyboardType: TextInputType.number,
-                    decoration: const InputDecoration(
-                      labelText: 'App hang duration (seconds)',
-                    ),
-                  ),
-                  TooltipButton(
-                    onPressed: _hangMainIsolate,
-                    text:
-                        'Blocks the main isolate for the given duration to trigger an app-hang event.',
-                    buttonTitle: 'Trigger app hang',
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    spacing: 8,
+                    children: [
+                      Expanded(
+                        child: TextField(
+                          controller: _hangSecondsController,
+                          keyboardType: TextInputType.number,
+                          decoration: const InputDecoration(
+                            labelText: 'ANR / App Hang duration (seconds)',
+                          ),
+                        ),
+                      ),
+                      TooltipButton(
+                        onPressed: _hangMainIsolate,
+                        text:
+                            'Blocks the main isolate for the given duration to trigger an app-hang event.',
+                        buttonTitle: 'Trigger ANR / App Hang',
+                      ),
+                    ],
                   ),
                 ],
               ),

--- a/packages/flutter/example/lib/screens/events_screen.dart
+++ b/packages/flutter/example/lib/screens/events_screen.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:math';
 
 import 'package:feedback/feedback.dart' as feedback;
 import 'package:flutter/material.dart';
@@ -6,8 +7,38 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 
 import '../widgets.dart';
 
-class EventsScreen extends StatelessWidget {
+class EventsScreen extends StatefulWidget {
   const EventsScreen({super.key});
+
+  @override
+  State<EventsScreen> createState() => _EventsScreenState();
+}
+
+class _EventsScreenState extends State<EventsScreen> {
+  static const _defaultHangSeconds = 5;
+
+  final _hangSecondsController =
+      TextEditingController(text: '$_defaultHangSeconds');
+
+  int get _hangSeconds {
+    final seconds = int.tryParse(_hangSecondsController.text);
+    return max(1, seconds ?? _defaultHangSeconds);
+  }
+
+  void _hangMainIsolate() {
+    final duration = Duration(seconds: _hangSeconds);
+    final stopwatch = Stopwatch()..start();
+
+    while (stopwatch.elapsed < duration) {
+      // Intentionally block the main isolate to test app-hang reporting.
+    }
+  }
+
+  @override
+  void dispose() {
+    _hangSecondsController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -109,6 +140,19 @@ class EventsScreen extends StatelessWidget {
                     text:
                         'Shows a custom feedback dialog without an ongoing event that captures and sends user feedback data to Sentry.',
                     buttonTitle: 'Capture Feedback',
+                  ),
+                  TextField(
+                    controller: _hangSecondsController,
+                    keyboardType: TextInputType.number,
+                    decoration: const InputDecoration(
+                      labelText: 'App hang duration (seconds)',
+                    ),
+                  ),
+                  TooltipButton(
+                    onPressed: _hangMainIsolate,
+                    text:
+                        'Blocks the main isolate for the given duration to trigger an app-hang event.',
+                    buttonTitle: 'Trigger app hang',
                   ),
                 ],
               ),


### PR DESCRIPTION
Adds a configurable app-hang trigger to the example app's events screen.

The new "Trigger app hang" button blocks the main isolate for a duration
specified via an accompanying text field (defaulting to 5 seconds), making
it easy to manually verify app-hang reporting in the Flutter SDK.

To support the controller and state, `EventsScreen` is converted from a
`StatelessWidget` to a `StatefulWidget`.

Made with [Cursor](https://cursor.com)