### PR TITLE
fix(flutter): Add replay IDs to span telemetry

### DIFF
--- a/packages/dart/lib/src/telemetry/processing/processor_integration.dart
+++ b/packages/dart/lib/src/telemetry/processing/processor_integration.dart
@@ -52,7 +52,14 @@ class InMemoryTelemetryProcessorIntegration extends Integration<SentryOptions> {
               utf8JsonEncoder.convert(item.toJson()),
           onFlush: (items) {
             final futures = items.values.map((itemData) {
-              final dsc = itemData.$2.resolveDsc();
+              final span = itemData.$2;
+              final dsc = span.resolveDsc();
+              final replayId = span
+                  .attributes[SemanticAttributesConstants.sentryReplayId]
+                  ?.value;
+              if (replayId is String) {
+                dsc.replayId = SentryId.fromId(replayId);
+              }
               final envelope = SentryEnvelope.fromSpansData(
                   itemData.$1, options.sdk,
                   traceContext: dsc);

--- a/packages/dart/test/telemetry/processing/processor_integration_test.dart
+++ b/packages/dart/test/telemetry/processing/processor_integration_test.dart
@@ -119,6 +119,46 @@ void main() {
 
         expect(fixture.transport.envelopes, hasLength(1));
       });
+
+      test('adds span replay_id attribute to envelope DSC', () async {
+        final options = fixture.options;
+        fixture.getSut().call(fixture.hub, options);
+
+        final processor =
+            options.telemetryProcessor as DefaultTelemetryProcessor;
+        final span = fixture.createSpan()
+          ..setAttribute(
+            SemanticAttributesConstants.sentryReplayId,
+            SentryAttribute.string('42'),
+          );
+        span.end();
+        processor.addSpan(span);
+        await processor.flush();
+
+        expect(fixture.transport.envelopes.first.header.traceContext?.replayId,
+            SentryId.fromId('42'));
+      });
+
+      test('adds span replay_id attribute to frozen envelope DSC', () async {
+        final options = fixture.options;
+        fixture.getSut().call(fixture.hub, options);
+
+        final processor =
+            options.telemetryProcessor as DefaultTelemetryProcessor;
+        final span = fixture.createSpan();
+        final dsc = span.resolveDsc();
+        span.setAttribute(
+          SemanticAttributesConstants.sentryReplayId,
+          SentryAttribute.string('42'),
+        );
+        span.end();
+        processor.addSpan(span);
+        await processor.flush();
+
+        expect(dsc.replayId, SentryId.fromId('42'));
+        expect(fixture.transport.envelopes.first.header.traceContext?.replayId,
+            SentryId.fromId('42'));
+      });
     });
   });
 }

--- a/packages/flutter/lib/src/integrations/replay_telemetry_integration.dart
+++ b/packages/flutter/lib/src/integrations/replay_telemetry_integration.dart
@@ -5,7 +5,7 @@ import 'package:sentry/sentry.dart';
 import '../sentry_flutter_options.dart';
 import '../native/sentry_native_binding.dart';
 
-/// Integration that adds replay-related information to logs and metrics
+/// Integration that adds replay-related information to telemetry
 /// using lifecycle callbacks.
 @internal
 class ReplayTelemetryIntegration implements Integration<SentryFlutterOptions> {
@@ -17,6 +17,7 @@ class ReplayTelemetryIntegration implements Integration<SentryFlutterOptions> {
   SentryFlutterOptions? _options;
   SdkLifecycleCallback<OnProcessLog>? _onProcessLog;
   SdkLifecycleCallback<OnProcessMetric>? _onProcessMetric;
+  SdkLifecycleCallback<OnProcessSpan>? _onProcessSpan;
 
   @override
   Future<void> call(Hub hub, SentryFlutterOptions options) async {
@@ -29,32 +30,47 @@ class ReplayTelemetryIntegration implements Integration<SentryFlutterOptions> {
     _options = options;
 
     _onProcessLog = (OnProcessLog event) {
-      _addReplayAttributes(
+      final attributes = _replayAttributes(
         hub.scope.replayId,
-        event.log.attributes,
         sessionSampleRate: sessionSampleRate,
         onErrorSampleRate: onErrorSampleRate,
       );
+      if (attributes != null) {
+        event.log.attributes.addAll(attributes);
+      }
     };
 
     _onProcessMetric = (OnProcessMetric event) {
-      _addReplayAttributes(
+      final attributes = _replayAttributes(
         hub.scope.replayId,
-        event.metric.attributes,
         sessionSampleRate: sessionSampleRate,
         onErrorSampleRate: onErrorSampleRate,
       );
+      if (attributes != null) {
+        event.metric.attributes.addAll(attributes);
+      }
+    };
+
+    _onProcessSpan = (OnProcessSpan event) {
+      final attributes = _replayAttributes(
+        hub.scope.replayId,
+        sessionSampleRate: sessionSampleRate,
+        onErrorSampleRate: onErrorSampleRate,
+      );
+      if (attributes != null) {
+        event.span.setAttributes(attributes);
+      }
     };
 
     options.lifecycleRegistry.registerCallback<OnProcessLog>(_onProcessLog!);
     options.lifecycleRegistry
         .registerCallback<OnProcessMetric>(_onProcessMetric!);
+    options.lifecycleRegistry.registerCallback<OnProcessSpan>(_onProcessSpan!);
     options.sdk.addIntegration(integrationName);
   }
 
-  void _addReplayAttributes(
-    SentryId? scopeReplayId,
-    Map<String, SentryAttribute> attributes, {
+  ({SentryId replayId, bool replayIsBuffering})? _replayContext(
+    SentryId? scopeReplayId, {
     required double sessionSampleRate,
     required double onErrorSampleRate,
   }) {
@@ -62,14 +78,34 @@ class ReplayTelemetryIntegration implements Integration<SentryFlutterOptions> {
     final replayIsBuffering = replayId != null && scopeReplayId == null;
 
     if (sessionSampleRate > 0 && replayId != null && !replayIsBuffering) {
-      attributes[SemanticAttributesConstants.sentryReplayId] =
-          SentryAttribute.string(scopeReplayId.toString());
+      return (replayId: replayId, replayIsBuffering: replayIsBuffering);
     } else if (onErrorSampleRate > 0 && replayId != null && replayIsBuffering) {
-      attributes[SemanticAttributesConstants.sentryReplayId] =
-          SentryAttribute.string(replayId.toString());
-      attributes[SemanticAttributesConstants.sentryInternalReplayIsBuffering] =
-          SentryAttribute.bool(true);
+      return (replayId: replayId, replayIsBuffering: replayIsBuffering);
     }
+    return null;
+  }
+
+  Map<String, SentryAttribute>? _replayAttributes(
+    SentryId? scopeReplayId, {
+    required double sessionSampleRate,
+    required double onErrorSampleRate,
+  }) {
+    final replayContext = _replayContext(
+      scopeReplayId,
+      sessionSampleRate: sessionSampleRate,
+      onErrorSampleRate: onErrorSampleRate,
+    );
+    if (replayContext == null) {
+      return null;
+    }
+
+    return {
+      SemanticAttributesConstants.sentryReplayId:
+          SentryAttribute.string(replayContext.replayId.toString()),
+      if (replayContext.replayIsBuffering)
+        SemanticAttributesConstants.sentryInternalReplayIsBuffering:
+            SentryAttribute.bool(true),
+    };
   }
 
   @override
@@ -77,6 +113,7 @@ class ReplayTelemetryIntegration implements Integration<SentryFlutterOptions> {
     final options = _options;
     final onProcessLog = _onProcessLog;
     final onProcessMetric = _onProcessMetric;
+    final onProcessSpan = _onProcessSpan;
 
     if (options != null) {
       if (onProcessLog != null) {
@@ -86,10 +123,14 @@ class ReplayTelemetryIntegration implements Integration<SentryFlutterOptions> {
         options.lifecycleRegistry
             .removeCallback<OnProcessMetric>(onProcessMetric);
       }
+      if (onProcessSpan != null) {
+        options.lifecycleRegistry.removeCallback<OnProcessSpan>(onProcessSpan);
+      }
     }
 
     _options = null;
     _onProcessLog = null;
     _onProcessMetric = null;
+    _onProcessSpan = null;
   }
 }

--- a/packages/flutter/test/integrations/replay_telemetry_integration_test.dart
+++ b/packages/flutter/test/integrations/replay_telemetry_integration_test.dart
@@ -66,6 +66,16 @@ void main() {
         expect(metric.attributes[_replayId]?.value, 'testreplayid');
       });
 
+      test('adds replay_id to spans', () async {
+        await fixture.getSut().call(fixture.hub, fixture.options);
+
+        final span = fixture.createTestSpan();
+        await fixture.options.lifecycleRegistry
+            .dispatchCallback(OnProcessSpan(span));
+
+        expect(span.attributes[_replayId]?.value, 'testreplayid');
+      });
+
       test('does not add buffering flag', () async {
         await fixture.getSut().call(fixture.hub, fixture.options);
 
@@ -102,6 +112,16 @@ void main() {
         expect(metric.attributes[_replayId]?.value, 'testreplayid');
       });
 
+      test('adds replay_id to spans', () async {
+        await fixture.getSut().call(fixture.hub, fixture.options);
+
+        final span = fixture.createTestSpan();
+        await fixture.options.lifecycleRegistry
+            .dispatchCallback(OnProcessSpan(span));
+
+        expect(span.attributes[_replayId]?.value, 'testreplayid');
+      });
+
       test('adds buffering flag', () async {
         await fixture.getSut().call(fixture.hub, fixture.options);
 
@@ -109,6 +129,16 @@ void main() {
         await fixture.hub.captureLog(log);
 
         expect(log.attributes[_replayIsBuffering]?.value, true);
+      });
+
+      test('adds buffering flag to spans', () async {
+        await fixture.getSut().call(fixture.hub, fixture.options);
+
+        final span = fixture.createTestSpan();
+        await fixture.options.lifecycleRegistry
+            .dispatchCallback(OnProcessSpan(span));
+
+        expect(span.attributes[_replayIsBuffering]?.value, true);
       });
     });
 
@@ -128,6 +158,21 @@ void main() {
           expect(log.attributes.containsKey(_replayId), false);
         });
 
+        test('ignores scope replayId for spans when sessionSampleRate is $rate',
+            () async {
+          fixture.options.replay.sessionSampleRate = rate;
+          fixture.options.replay.onErrorSampleRate = 0.5;
+          fixture.hub.scope.replayId = SentryId.fromId('test-replay-id');
+
+          await fixture.getSut().call(fixture.hub, fixture.options);
+
+          final span = fixture.createTestSpan();
+          await fixture.options.lifecycleRegistry
+              .dispatchCallback(OnProcessSpan(span));
+
+          expect(span.attributes.containsKey(_replayId), false);
+        });
+
         test('ignores native replayId when onErrorSampleRate is $rate',
             () async {
           fixture.options.replay.sessionSampleRate = 0.5;
@@ -141,6 +186,23 @@ void main() {
           await fixture.hub.captureLog(log);
 
           expect(log.attributes.containsKey(_replayId), false);
+        });
+
+        test(
+            'ignores native replayId for spans when onErrorSampleRate is $rate',
+            () async {
+          fixture.options.replay.sessionSampleRate = 0.5;
+          fixture.options.replay.onErrorSampleRate = rate;
+          when(fixture.nativeBinding.replayId)
+              .thenReturn(SentryId.fromId('test-replay-id'));
+
+          await fixture.getSut().call(fixture.hub, fixture.options);
+
+          final span = fixture.createTestSpan();
+          await fixture.options.lifecycleRegistry
+              .dispatchCallback(OnProcessSpan(span));
+
+          expect(span.attributes.containsKey(_replayId), false);
         });
       }
     });
@@ -173,6 +235,21 @@ void main() {
             .dispatchCallback(OnProcessMetric(metric));
 
         expect(metric.attributes.containsKey(_replayId), false);
+      });
+
+      test('removes span callback', () async {
+        fixture.options.replay.sessionSampleRate = 0.5;
+        fixture.hub.scope.replayId = SentryId.fromId('test-replay-id');
+
+        final sut = fixture.getSut();
+        await sut.call(fixture.hub, fixture.options);
+        await sut.close();
+
+        final span = fixture.createTestSpan();
+        await fixture.options.lifecycleRegistry
+            .dispatchCallback(OnProcessSpan(span));
+
+        expect(span.attributes.containsKey(_replayId), false);
       });
     });
   });
@@ -213,6 +290,16 @@ class Fixture {
         value: 1,
         traceId: SentryId.newId(),
         attributes: <String, SentryAttribute>{},
+      );
+
+  RecordingSentrySpanV2 createTestSpan() => RecordingSentrySpanV2.root(
+        name: 'test-span',
+        traceId: SentryId.newId(),
+        onSpanEnd: (_) async {},
+        clock: options.clock,
+        dscCreator: (span) =>
+            SentryTraceContextHeader(span.traceId, 'publicKey'),
+        samplingDecision: SentryTracesSamplingDecision(true),
       );
 
   ReplayTelemetryIntegration getSut() =>


### PR DESCRIPTION
## :scroll: Description
Adds replay correlation to span v2 telemetry by attaching `sentry.replay_id` to Flutter replay span attributes and copying that attribute into the span envelope DSC.

## :bulb: Motivation and Context
Span-first telemetry could miss replay correlation because `ReplayEventProcessor` only runs for errors, feedback, and transactions. This keeps replay IDs available on span v2 payloads and their DSC.

Closes #3716

## :green_heart: How did you test it?
- `fvm dart test test/telemetry/span/span_test.dart`
- `fvm dart test test/telemetry/processing/processor_integration_test.dart`
- `fvm flutter test test/integrations/replay_telemetry_integration_test.dart`
- `fvm dart analyze lib/src/telemetry/processing/processor_integration.dart test/telemetry/processing/processor_integration_test.dart`
- `fvm flutter analyze lib/src/integrations/replay_telemetry_integration.dart test/integrations/replay_telemetry_integration_test.dart`

## :pencil: Checklist
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

Made with [Cursor](https://cursor.com)