### PR TITLE
chore(deps): update Cocoa SDK to v9.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 
 #### Deps
 
-- chore(deps): update Cocoa SDK to v8.58.3 by @github-actions in [#3726](https://github.com/getsentry/sentry-dart/pull/3726)
+- chore(deps): update Cocoa SDK to v9.9.0 by @github-actions in [#3726](https://github.com/getsentry/sentry-dart/pull/3726)
 - chore(deps): update Android SDK to v8.43.0 by @github-actions in [#3727](https://github.com/getsentry/sentry-dart/pull/3727)
 
 ### Internal Changes

--- a/docs/sdk-versions.md
+++ b/docs/sdk-versions.md
@@ -6,7 +6,7 @@ This document shows which version of the various Sentry SDKs are used in which S
 
 | Sentry Flutter SDK | Sentry Android SDK | Sentry Cocoa SDK | Sentry JavaScript SDK | Sentry Native SDK |
 | ------------------ | ------------------ | ---------------- | --------------------- | ----------------- |
-| 9.21.0 | 8.43.0 | 8.58.3 | 10.38.0 | 0.13.8 |
+| 9.21.0 | 8.43.0 | 9.9.0 | 10.38.0 | 0.13.8 |
 | 9.20.0 | 8.41.0 | 8.58.2 | 10.38.0 | 0.13.8 |
 | 9.19.0 | 8.39.1 | 8.58.1 | 10.38.0 | 0.13.7 |
 | 9.18.0 | 8.38.0 | 8.58.1 | 10.38.0 | 0.13.7 |

--- a/packages/flutter/ios/sentry_flutter.podspec
+++ b/packages/flutter/ios/sentry_flutter.podspec
@@ -16,7 +16,7 @@ Sentry SDK for Flutter with support to native through sentry-cocoa.
                          :tag => s.version.to_s }
   s.source_files     = 'sentry_flutter/Sources/**/*'
   s.public_header_files = 'sentry_flutter/Sources/**/*.h'
-  s.dependency 'Sentry/HybridSDK', '8.58.3'
+  s.dependency 'Sentry/HybridSDK', '9.9.0'
   s.ios.dependency 'Flutter'
   s.osx.dependency 'FlutterMacOS'
   s.ios.deployment_target = '12.0'

--- a/packages/flutter/ios/sentry_flutter/Package.swift
+++ b/packages/flutter/ios/sentry_flutter/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .library(name: "sentry-flutter", targets: ["sentry_flutter", "sentry_flutter_objc"])
     ],
     dependencies: [
-      .package(url: "https://github.com/getsentry/sentry-cocoa", exact: "8.58.3")
+      .package(url: "https://github.com/getsentry/sentry-cocoa", exact: "9.9.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
Bumps the Cocoa SDK from 8.58.3 to 9.9.0 to pick up fixes for:
- Fix mismatch of in_foreground app context (getsentry/sentry-cocoa#7188)
- Align app lifecycle breadcrumb state values with in_foreground/is_active app context (getsentry/sentry-cocoa#7703)

This resolves the inconsistency where Sentry events could show in_foreground=true while breadcrumbs indicated a background state (e.g. during WatchdogTermination events).

Refs: getsentry/sentry-cocoa#7188, getsentry/sentry-cocoa#7703