### PR TITLE
test(flutter): Deflake frames tracking test and report hidden failures

### DIFF
--- a/.github/actions/flutter-test/action.yml
+++ b/.github/actions/flutter-test/action.yml
@@ -73,9 +73,12 @@ runs:
             (map(select(.type == "testStart"))
               | map({(.test.id | tostring): .test.name}) | add // {}) as $names
             | map(select(.type == "error")
-              | "FAILED: \($names[.testID | tostring] // .testID)\n\(.error)\n\(.stackTrace // "")\n")
+              | ($names[.testID | tostring] // (.testID | tostring)) as $name
+              | "FAILED: \($name)\n\(.error)\n\(.stackTrace // "")\n",
+                ("::error title=Test failure::FAILED: \($name)\n\(.error)"
+                  | gsub("%"; "%25") | gsub("\r"; "%0D") | gsub("\n"; "%0A")))
             | .[]
-          ' test-vm.jsonl
+          ' test-vm.jsonl || true
         fi
 
     - name: Install better_test_reporter

--- a/.github/actions/flutter-test/action.yml
+++ b/.github/actions/flutter-test/action.yml
@@ -59,15 +59,15 @@ runs:
           $testCmd --file-reporter json:test-vm.jsonl
         fi
 
+    # Tests that fail after they already completed (async errors) flip the
+    # exit code and failure count without the github reporter printing
+    # which test failed. The JSON report still contains the error events,
+    # so surface every test error here by name.
     - name: Report test failures hidden from the console reporter
       if: ${{ !cancelled() && (matrix.target == 'linux' || matrix.target == 'windows' || matrix.target == 'macos') }}
       working-directory: ${{ inputs.directory }}
       shell: bash
       run: |
-        # Tests that fail after they already completed (async errors) flip the
-        # exit code and failure count without the github reporter printing
-        # which test failed. The JSON report still contains the error events,
-        # so surface every test error here by name.
         if [[ -f test-vm.jsonl ]]; then
           jq -rs '
             (map(select(.type == "testStart"))

--- a/.github/actions/flutter-test/action.yml
+++ b/.github/actions/flutter-test/action.yml
@@ -59,6 +59,25 @@ runs:
           $testCmd --file-reporter json:test-vm.jsonl
         fi
 
+    - name: Report test failures hidden from the console reporter
+      if: ${{ !cancelled() && (matrix.target == 'linux' || matrix.target == 'windows' || matrix.target == 'macos') }}
+      working-directory: ${{ inputs.directory }}
+      shell: bash
+      run: |
+        # Tests that fail after they already completed (async errors) flip the
+        # exit code and failure count without the github reporter printing
+        # which test failed. The JSON report still contains the error events,
+        # so surface every test error here by name.
+        if [[ -f test-vm.jsonl ]]; then
+          jq -rs '
+            (map(select(.type == "testStart"))
+              | map({(.test.id | tostring): .test.name}) | add // {}) as $names
+            | map(select(.type == "error")
+              | "FAILED: \($names[.testID | tostring] // .testID)\n\(.error)\n\(.stackTrace // "")\n")
+            | .[]
+          ' test-vm.jsonl
+        fi
+
     - name: Install better_test_reporter
       if: ${{ !cancelled() && (matrix.target == 'linux' || matrix.target == 'windows' || matrix.target == 'macos') }}
       shell: bash

--- a/packages/flutter/test/frame_tracking/frames_tracking_integration_test.dart
+++ b/packages/flutter/test/frame_tracking/frames_tracking_integration_test.dart
@@ -211,24 +211,24 @@ void main() {
         );
         parentSpan.end();
 
-        expect(
-          childSpan.attributes[SemanticAttributesConstants.framesSlow]?.value,
-          2,
-        );
-        expect(
-          childSpan.attributes[SemanticAttributesConstants.framesFrozen]?.value,
-          1,
-        );
+        // Frames are measured with real wall-clock time, so on a loaded CI
+        // runner a 100ms "slow" frame can stretch past the 700ms frozen
+        // threshold and be reclassified, and extra delayed frames can be
+        // recorded. Assert combined counts and lower bounds instead of an
+        // exact slow/frozen split.
+        final childSlow = childSpan
+            .attributes[SemanticAttributesConstants.framesSlow]?.value as int;
+        final childFrozen = childSpan
+            .attributes[SemanticAttributesConstants.framesFrozen]?.value as int;
+        expect(childSlow + childFrozen, greaterThanOrEqualTo(3));
+        expect(childFrozen, greaterThanOrEqualTo(1));
 
-        expect(
-          parentSpan.attributes[SemanticAttributesConstants.framesSlow]?.value,
-          5,
-        );
-        expect(
-          parentSpan
-              .attributes[SemanticAttributesConstants.framesFrozen]?.value,
-          2,
-        );
+        final parentSlow = parentSpan
+            .attributes[SemanticAttributesConstants.framesSlow]?.value as int;
+        final parentFrozen = parentSpan
+            .attributes[SemanticAttributesConstants.framesFrozen]?.value as int;
+        expect(parentSlow + parentFrozen, greaterThanOrEqualTo(7));
+        expect(parentFrozen, greaterThanOrEqualTo(2));
         expect(
           parentSpan.attributes[SemanticAttributesConstants.framesTotal]?.value,
           greaterThanOrEqualTo(8),
@@ -283,27 +283,35 @@ void main() {
 
         expect(tracer, isNotNull);
 
+        // Frames are measured with real wall-clock time, so on a loaded CI
+        // runner a 100ms "slow" frame can stretch past the 700ms frozen
+        // threshold and be reclassified, and extra delayed frames can be
+        // recorded. Assert combined counts and lower bounds instead of an
+        // exact slow/frozen split.
+
         // Verify child span
         final childSpan = tracer!.children.first;
-        expect(childSpan.data['frames.slow'] as int, 2);
-        expect(childSpan.data['frames.frozen'] as int, 1);
+        final childSlow = childSpan.data['frames.slow'] as int;
+        final childFrozen = childSpan.data['frames.frozen'] as int;
+        expect(childSlow + childFrozen, greaterThanOrEqualTo(3));
+        expect(childFrozen, greaterThanOrEqualTo(1));
 
         // Verify tracer
-        expect(tracer!.data['frames.slow'] as int, 5);
-        expect(tracer!.data['frames.frozen'] as int, 2);
+        final tracerSlow = tracer!.data['frames.slow'] as int;
+        final tracerFrozen = tracer!.data['frames.frozen'] as int;
+        expect(tracerSlow + tracerFrozen, greaterThanOrEqualTo(7));
+        expect(tracerFrozen, greaterThanOrEqualTo(2));
 
         expect(
           (tracer!.measurements['frames_total'] as SentryMeasurement).value,
           greaterThanOrEqualTo(8),
         );
-        expect(
-          (tracer!.measurements['frames_slow'] as SentryMeasurement).value,
-          5,
-        );
-        expect(
-          (tracer!.measurements['frames_frozen'] as SentryMeasurement).value,
-          2,
-        );
+        final measuredSlow =
+            (tracer!.measurements['frames_slow'] as SentryMeasurement).value;
+        final measuredFrozen =
+            (tracer!.measurements['frames_frozen'] as SentryMeasurement).value;
+        expect(measuredSlow + measuredFrozen, greaterThanOrEqualTo(7));
+        expect(measuredFrozen, greaterThanOrEqualTo(2));
         // No delay assertions due to test env timing flakiness.
       });
     });

--- a/packages/flutter/test/frame_tracking/frames_tracking_integration_test.dart
+++ b/packages/flutter/test/frame_tracking/frames_tracking_integration_test.dart
@@ -311,13 +311,12 @@ void main() {
         expect(tracerFrozen, greaterThanOrEqualTo(2));
 
         expect(
-          (tracer!.measurements['frames_total'] as SentryMeasurement).value,
+          tracer!.measurements['frames_total']?.value ?? 0,
           greaterThanOrEqualTo(8),
         );
-        final measuredSlow =
-            (tracer!.measurements['frames_slow'] as SentryMeasurement).value;
+        final measuredSlow = tracer!.measurements['frames_slow']?.value ?? 0;
         final measuredFrozen =
-            (tracer!.measurements['frames_frozen'] as SentryMeasurement).value;
+            tracer!.measurements['frames_frozen']?.value ?? 0;
         expect(measuredSlow + measuredFrozen, greaterThanOrEqualTo(7));
         expect(measuredFrozen, greaterThanOrEqualTo(2));
         // No delay assertions due to test env timing flakiness.

--- a/packages/flutter/test/frame_tracking/frames_tracking_integration_test.dart
+++ b/packages/flutter/test/frame_tracking/frames_tracking_integration_test.dart
@@ -217,16 +217,24 @@ void main() {
         // recorded. Assert combined counts and lower bounds instead of an
         // exact slow/frozen split.
         final childSlow = childSpan
-            .attributes[SemanticAttributesConstants.framesSlow]?.value as int;
+                .attributes[SemanticAttributesConstants.framesSlow]
+                ?.value as int? ??
+            0;
         final childFrozen = childSpan
-            .attributes[SemanticAttributesConstants.framesFrozen]?.value as int;
+                .attributes[SemanticAttributesConstants.framesFrozen]
+                ?.value as int? ??
+            0;
         expect(childSlow + childFrozen, greaterThanOrEqualTo(3));
         expect(childFrozen, greaterThanOrEqualTo(1));
 
         final parentSlow = parentSpan
-            .attributes[SemanticAttributesConstants.framesSlow]?.value as int;
+                .attributes[SemanticAttributesConstants.framesSlow]
+                ?.value as int? ??
+            0;
         final parentFrozen = parentSpan
-            .attributes[SemanticAttributesConstants.framesFrozen]?.value as int;
+                .attributes[SemanticAttributesConstants.framesFrozen]
+                ?.value as int? ??
+            0;
         expect(parentSlow + parentFrozen, greaterThanOrEqualTo(7));
         expect(parentFrozen, greaterThanOrEqualTo(2));
         expect(
@@ -291,14 +299,14 @@ void main() {
 
         // Verify child span
         final childSpan = tracer!.children.first;
-        final childSlow = childSpan.data['frames.slow'] as int;
-        final childFrozen = childSpan.data['frames.frozen'] as int;
+        final childSlow = childSpan.data['frames.slow'] as int? ?? 0;
+        final childFrozen = childSpan.data['frames.frozen'] as int? ?? 0;
         expect(childSlow + childFrozen, greaterThanOrEqualTo(3));
         expect(childFrozen, greaterThanOrEqualTo(1));
 
         // Verify tracer
-        final tracerSlow = tracer!.data['frames.slow'] as int;
-        final tracerFrozen = tracer!.data['frames.frozen'] as int;
+        final tracerSlow = tracer!.data['frames.slow'] as int? ?? 0;
+        final tracerFrozen = tracer!.data['frames.frozen'] as int? ?? 0;
         expect(tracerSlow + tracerFrozen, greaterThanOrEqualTo(7));
         expect(tracerFrozen, greaterThanOrEqualTo(2));
 


### PR DESCRIPTION
Fixes the recurring flaky CI failures where a `sentry_flutter` test job fails with `N tests passed, 1 failed` but the log never shows which test failed (e.g. [this run](https://github.com/getsentry/sentry-dart/actions/runs/27217883555/job/80364516959), and several `macos` jobs on `main`).

**What's going on**

The flaky tests are the two `measures frames` tests in `frames_tracking_integration_test.dart`. They simulate frames with real wall-clock sleeps (100ms "slow", 800ms "frozen") inside `tester.runAsync` and assert exact slow/frozen counts. On a loaded CI runner a 100ms slow frame can stretch past the 700ms frozen threshold and get reclassified, failing the exact-count assertion — a [visible occurrence on Linux](https://github.com/getsentry/sentry-dart/actions/runs/26486511562) shows `Expected: <2> Actual: <1>` for `frames.slow`.

The failure is invisible in the macOS jobs because it's delivered asynchronously via `FlutterError` after the test already completed: the github reporter has already printed ✅ for the test, and when the late error lands at the very end of the run, only the failure count and exit code flip. In all four recent silent macOS failures the printed pass count is exactly `passed + 1` and the frames tests finished within the final seconds of the run. The JUnit conversion only reads `testDone` events, so Codecov test analytics misses these too.

**Changes**

1. The `measures frames` tests now assert combined delayed-frame counts and lower bounds (`slow + frozen >= n`, `frozen >= m`) instead of exact slow/frozen splits. These bounds hold under arbitrary CPU starvation: every simulated frame is always at least delayed, and an 800ms frame can never be classified as slow. Exact classification remains covered by the deterministic unit tests in `sentry_delayed_frames_tracker_test.dart`.
2. The `flutter-test` action gains a step that prints every test error by name from `test-vm.jsonl` after the VM test run — the JSON file reporter does record post-completion failures as `error` events even though `testDone` already said success. The step runs on every matrix job (silent when green, never fails the job), so this PR's own CI run exercises it end to end. If a hidden failure ever recurs, the log will name the test.