### PR TITLE
feat(dart): Mark span streaming API as non-experimental

### DIFF
--- a/packages/dart/lib/src/sentry.dart
+++ b/packages/dart/lib/src/sentry.dart
@@ -432,7 +432,6 @@ class Sentry {
   ///   return orderService.create(cart, payment);
   /// });
   /// ```
-  @experimental
   static Future<T> startSpan<T>(
     String name,
     Future<T> Function(SentrySpanV2 span) callback, {
@@ -466,7 +465,6 @@ class Sentry {
   /// By default, the span is created as a child of the currently active span.
   /// Pass a [SentrySpanV2] as [parentSpan] to override the parent, or pass
   /// `null` to create a root span.
-  @experimental
   static T startSpanSync<T>(
     String name,
     T Function(SentrySpanV2 span) callback, {

--- a/packages/dart/lib/src/sentry_options.dart
+++ b/packages/dart/lib/src/sentry_options.dart
@@ -254,7 +254,6 @@ class SentryOptions {
   /// Integrations automatically switch to the correct API based on this setting.
   ///
   /// Defaults to [SentryTraceLifecycle.static].
-  @experimental
   SentryTraceLifecycle traceLifecycle = SentryTraceLifecycle.static;
 
   /// The ignoreErrors tells the SDK which errors should be not sent to the sentry server.


### PR DESCRIPTION
Remove the `@experimental` annotation from the span-first streaming API now that it has stabilized. Users of `Sentry.startSpan`, `Sentry.startSpanSync`, and `SentryOptions.traceLifecycle` no longer get experimental-use analyzer warnings.

No behavior change — the API surface, signatures, and defaults (`traceLifecycle` still defaults to `SentryTraceLifecycle.static`) are untouched.

**Scope**

Only the streaming span API is affected. Other experimental APIs (database integrations, replay privacy options, screenshot masking) keep their `@experimental` markers, so the existing `experimental_member_use` ignores in downstream packages remain valid.