### PR TITLE
enh(flutter): Support int64 values from sentry-native

### DIFF
--- a/packages/flutter/ffi-native.yaml
+++ b/packages/flutter/ffi-native.yaml
@@ -42,6 +42,8 @@ functions:
     - sentry_value_is_true
     - sentry_value_new_null
     - sentry_value_new_int32
+    - sentry_value_new_int64
+    - sentry_value_new_uint64
     - sentry_value_new_double
     - sentry_value_new_string
     - sentry_value_new_list
@@ -49,6 +51,8 @@ functions:
     - sentry_value_new_bool
     - sentry_value_append
     - sentry_value_as_int32
+    - sentry_value_as_int64
+    - sentry_value_as_uint64
     - sentry_value_as_double
     - sentry_value_as_string
     - sentry_value_as_list

--- a/packages/flutter/lib/src/native/c/binding.dart
+++ b/packages/flutter/lib/src/native/c/binding.dart
@@ -63,6 +63,36 @@ class SentryNative {
   late final _value_new_int32 =
       _value_new_int32Ptr.asFunction<sentry_value_u Function(int)>();
 
+  /// Creates a new 64-bit signed integer value.
+  sentry_value_u value_new_int64(
+    int value,
+  ) {
+    return _value_new_int64(
+      value,
+    );
+  }
+
+  late final _value_new_int64Ptr =
+      _lookup<ffi.NativeFunction<sentry_value_u Function(ffi.Int64)>>(
+          'sentry_value_new_int64');
+  late final _value_new_int64 =
+      _value_new_int64Ptr.asFunction<sentry_value_u Function(int)>();
+
+  /// Creates a new 64-bit unsigned integer value.
+  sentry_value_u value_new_uint64(
+    int value,
+  ) {
+    return _value_new_uint64(
+      value,
+    );
+  }
+
+  late final _value_new_uint64Ptr =
+      _lookup<ffi.NativeFunction<sentry_value_u Function(ffi.Uint64)>>(
+          'sentry_value_new_uint64');
+  late final _value_new_uint64 =
+      _value_new_uint64Ptr.asFunction<sentry_value_u Function(int)>();
+
   /// Creates a new double value.
   sentry_value_u value_new_double(
     double value,
@@ -275,6 +305,36 @@ class SentryNative {
           'sentry_value_as_int32');
   late final _value_as_int32 =
       _value_as_int32Ptr.asFunction<int Function(sentry_value_u)>();
+
+  /// Converts a value into a 64bit signed integer.
+  int value_as_int64(
+    sentry_value_u value,
+  ) {
+    return _value_as_int64(
+      value,
+    );
+  }
+
+  late final _value_as_int64Ptr =
+      _lookup<ffi.NativeFunction<ffi.Int64 Function(sentry_value_u)>>(
+          'sentry_value_as_int64');
+  late final _value_as_int64 =
+      _value_as_int64Ptr.asFunction<int Function(sentry_value_u)>();
+
+  /// Converts a value into a 64bit unsigned integer.
+  int value_as_uint64(
+    sentry_value_u value,
+  ) {
+    return _value_as_uint64(
+      value,
+    );
+  }
+
+  late final _value_as_uint64Ptr =
+      _lookup<ffi.NativeFunction<ffi.Uint64 Function(sentry_value_u)>>(
+          'sentry_value_as_uint64');
+  late final _value_as_uint64 =
+      _value_as_uint64Ptr.asFunction<int Function(sentry_value_u)>();
 
   /// Converts a value into a double value.
   double value_as_double(

--- a/packages/flutter/lib/src/native/c/sentry_native.dart
+++ b/packages/flutter/lib/src/native/c/sentry_native.dart
@@ -12,6 +12,7 @@ import 'package:sentry/src/utils/iterable_utils.dart';
 
 import '../../../sentry_flutter.dart';
 import '../../replay/replay_config.dart';
+import '../../utils/internal_logger.dart';
 import '../native_app_start.dart';
 import '../sentry_native_binding.dart';
 import '../sentry_native_invoker.dart';
@@ -39,13 +40,13 @@ class SentryNative with SentryNativeSafeInvoker implements SentryNativeBinding {
 
   SentryNative(this.options);
 
-  void _logNotSupported(String operation) => options.log(
-      SentryLevel.debug, 'SentryNative: $operation is not supported');
+  void _logNotSupported(String operation) =>
+      internalLogger.debug('SentryNative: $operation is not supported');
 
   @override
   FutureOr<void> init(Hub hub) {
     if (!options.enableNativeCrashHandling) {
-      options.log(SentryLevel.info, 'SentryNative crash handling is disabled');
+      internalLogger.info('SentryNative crash handling is disabled');
     } else {
       tryCatchSync("init", () {
         final cOptions = createOptions(options);
@@ -81,15 +82,14 @@ class SentryNative with SentryNativeSafeInvoker implements SentryNativeBinding {
       }
       if (options.proxy != null) {
         // sentry-native expects a single string and it doesn't support different types or authentication
-        options.log(SentryLevel.warning,
+        internalLogger.warning(
             'SentryNative: setting a proxy is currently not supported');
       }
 
       if (crashpadPath != null) {
         native.options_set_handler_path(cOptions, c.str(crashpadPath));
       } else {
-        options.log(
-            SentryLevel.warning, 'SentryNative: could not find crashpad path');
+        internalLogger.warning('SentryNative: could not find crashpad path');
       }
 
       return cOptions;
@@ -126,7 +126,7 @@ class SentryNative with SentryNativeSafeInvoker implements SentryNativeBinding {
       tryCatchSync('remove_user', native.remove_user);
     } else {
       tryCatchSync('set_user', () {
-        var cUser = user.toJson().toNativeValue(options.log);
+        var cUser = user.toJson().toNativeValue();
         native.set_user(cUser);
       });
     }
@@ -135,7 +135,7 @@ class SentryNative with SentryNativeSafeInvoker implements SentryNativeBinding {
   @override
   FutureOr<void> addBreadcrumb(Breadcrumb breadcrumb) {
     tryCatchSync('add_breadcrumb', () {
-      var cBreadcrumb = breadcrumb.toJson().toNativeValue(options.log);
+      var cBreadcrumb = breadcrumb.toJson().toNativeValue();
       native.add_breadcrumb(cBreadcrumb);
     });
   }
@@ -157,13 +157,13 @@ class SentryNative with SentryNativeSafeInvoker implements SentryNativeBinding {
   @override
   FutureOr<void> setContexts(String key, dynamic value) {
     tryCatchSync('set_context', () {
-      final cValue = dynamicToNativeValue(value, options.log);
+      final cValue = dynamicToNativeValue(value);
       if (cValue != null) {
         final cKey = key.toNativeUtf8();
         native.set_context(cKey.cast(), cValue);
         malloc.free(cKey);
       } else {
-        options.log(SentryLevel.warning,
+        internalLogger.warning(
             'SentryNative: failed to set context $key - value couldn\'t be converted to native');
       }
     });
@@ -181,13 +181,13 @@ class SentryNative with SentryNativeSafeInvoker implements SentryNativeBinding {
   @override
   FutureOr<void> setExtra(String key, dynamic value) {
     tryCatchSync('set_extra', () {
-      final cValue = dynamicToNativeValue(value, options.log);
+      final cValue = dynamicToNativeValue(value);
       if (cValue != null) {
         final cKey = key.toNativeUtf8();
         native.set_extra(cKey.cast(), cValue);
         malloc.free(cKey);
       } else {
-        options.log(SentryLevel.warning,
+        internalLogger.warning(
             'SentryNative: failed to set extra $key - value couldn\'t be converted to native');
       }
     });
@@ -253,13 +253,13 @@ class SentryNative with SentryNativeSafeInvoker implements SentryNativeBinding {
               native.value_get_length(cImages), (index) {
             final cImage = native.value_get_by_index(cImages, index);
             return DebugImage(
-              type: cImage.get('type').castPrimitive(options.log) ?? '',
-              imageAddr: cImage.get('image_addr').castPrimitive(options.log),
-              imageSize: cImage.get('image_size').castPrimitive(options.log),
-              codeFile: cImage.get('code_file').castPrimitive(options.log),
-              debugId: cImage.get('debug_id').castPrimitive(options.log),
-              debugFile: cImage.get('debug_file').castPrimitive(options.log),
-              codeId: cImage.get('code_id').castPrimitive(options.log),
+              type: cImage.get('type').castPrimitive() ?? '',
+              imageAddr: cImage.get('image_addr').castPrimitive(),
+              imageSize: cImage.get('image_size').castPrimitive(),
+              codeFile: cImage.get('code_file').castPrimitive(),
+              debugId: cImage.get('debug_id').castPrimitive(),
+              debugFile: cImage.get('debug_file').castPrimitive(),
+              codeId: cImage.get('code_id').castPrimitive(),
             );
           });
           return images;
@@ -346,7 +346,7 @@ extension SentryValueExtension on binding.sentry_value_u {
     }
   }
 
-  T? castPrimitive<T>(SdkLogCallback logger) {
+  T? castPrimitive<T>() {
     if (SentryNative.native.value_is_null(this) == 1) {
       return null;
     }
@@ -361,10 +361,16 @@ extension SentryValueExtension on binding.sentry_value_u {
       case binding.sentry_value_type_t.SENTRY_VALUE_TYPE_INT64:
         return SentryNative.native.value_as_int64(this) as T;
       case binding.sentry_value_type_t.SENTRY_VALUE_TYPE_UINT64:
-        // Dart's int is a signed 64-bit value, so a uint64 above 2^63-1 will
-        // wrap around to a negative number. In practice native values that
-        // reach here (e.g. image_size) are well within the signed range.
-        return SentryNative.native.value_as_uint64(this) as T;
+        // Dart's int is signed 64-bit, so a uint64 above 2^63-1 wraps to a
+        // negative number. Drop it rather than propagate a corrupt value.
+        final value = SentryNative.native.value_as_uint64(this);
+        if (value < 0) {
+          internalLogger.warning(
+              'SentryNative: uint64 value exceeds signed int64 range and '
+              'cannot be represented as a Dart int');
+          return null;
+        }
+        return value as T;
       case binding.sentry_value_type_t.SENTRY_VALUE_TYPE_DOUBLE:
         return SentryNative.native.value_as_double(this) as T;
       case binding.sentry_value_type_t.SENTRY_VALUE_TYPE_STRING:
@@ -373,15 +379,14 @@ extension SentryValueExtension on binding.sentry_value_u {
             .cast<Utf8>()
             .toDartString() as T;
       default:
-        logger(SentryLevel.warning,
-            'SentryNative: cannot read native value type: $type');
+        internalLogger
+            .warning('SentryNative: cannot read native value type: $type');
         return null;
     }
   }
 }
 
-binding.sentry_value_u? dynamicToNativeValue(
-    dynamic value, SdkLogCallback logger) {
+binding.sentry_value_u? dynamicToNativeValue(dynamic value) {
   if (value is String) {
     return value.toNativeValue();
   } else if (value is int) {
@@ -391,13 +396,13 @@ binding.sentry_value_u? dynamicToNativeValue(
   } else if (value is bool) {
     return value.toNativeValue();
   } else if (value is Map<String, dynamic>) {
-    return value.toNativeValue(logger);
+    return value.toNativeValue();
   } else if (value is List) {
-    return value.toNativeValue(logger);
+    return value.toNativeValue();
   } else if (value == null) {
     return SentryNative.native.value_new_null();
   } else {
-    logger(SentryLevel.warning,
+    internalLogger.warning(
         'SentryNative: unsupported data for for conversion: ${value.runtimeType} ($value)');
     return null;
   }
@@ -436,10 +441,10 @@ extension on bool {
 }
 
 extension on Map<String, dynamic> {
-  binding.sentry_value_u toNativeValue(SdkLogCallback logger) {
+  binding.sentry_value_u toNativeValue() {
     final cObject = SentryNative.native.value_new_object();
     for (final entry in entries) {
-      final cValue = dynamicToNativeValue(entry.value, logger);
+      final cValue = dynamicToNativeValue(entry.value);
       cObject.setNativeValue(entry.key, cValue);
     }
     return cObject;
@@ -447,10 +452,10 @@ extension on Map<String, dynamic> {
 }
 
 extension on List<dynamic> {
-  binding.sentry_value_u toNativeValue(SdkLogCallback logger) {
+  binding.sentry_value_u toNativeValue() {
     final cObject = SentryNative.native.value_new_list();
     for (final value in this) {
-      final cValue = dynamicToNativeValue(value, logger);
+      final cValue = dynamicToNativeValue(value);
       if (cValue != null) {
         SentryNative.native.value_append(cObject, cValue);
       }

--- a/packages/flutter/lib/src/native/c/sentry_native.dart
+++ b/packages/flutter/lib/src/native/c/sentry_native.dart
@@ -326,7 +326,7 @@ class SentryNative with SentryNativeSafeInvoker implements SentryNativeBinding {
   }
 }
 
-extension on binding.sentry_value_u {
+extension SentryValueExtension on binding.sentry_value_u {
   void setNativeValue(String key, binding.sentry_value_u? value) {
     final cKey = key.toNativeUtf8();
     if (value == null) {
@@ -358,6 +358,13 @@ extension on binding.sentry_value_u {
         return (SentryNative.native.value_is_true(this) == 1) as T;
       case binding.sentry_value_type_t.SENTRY_VALUE_TYPE_INT32:
         return SentryNative.native.value_as_int32(this) as T;
+      case binding.sentry_value_type_t.SENTRY_VALUE_TYPE_INT64:
+        return SentryNative.native.value_as_int64(this) as T;
+      case binding.sentry_value_type_t.SENTRY_VALUE_TYPE_UINT64:
+        // Dart's int is a signed 64-bit value, so a uint64 above 2^63-1 will
+        // wrap around to a negative number. In practice native values that
+        // reach here (e.g. image_size) are well within the signed range.
+        return SentryNative.native.value_as_uint64(this) as T;
       case binding.sentry_value_type_t.SENTRY_VALUE_TYPE_DOUBLE:
         return SentryNative.native.value_as_double(this) as T;
       case binding.sentry_value_type_t.SENTRY_VALUE_TYPE_STRING:
@@ -405,12 +412,15 @@ extension on String {
   }
 }
 
+const _int32Min = -2147483648; // -(2^31)
+const _int32Max = 2147483647; // 2^31 - 1
+
 extension on int {
   binding.sentry_value_u toNativeValue() {
-    if (this >= -2147483648 && this <= 2147483647) {
+    if (this >= _int32Min && this <= _int32Max) {
       return SentryNative.native.value_new_int32(this);
     } else {
-      return toString().toNativeValue();
+      return SentryNative.native.value_new_int64(this);
     }
   }
 }

--- a/packages/flutter/test/sentry_native/sentry_native_test_ffi.dart
+++ b/packages/flutter/test/sentry_native/sentry_native_test_ffi.dart
@@ -6,6 +6,7 @@ import 'package:ffi/ffi.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sentry/src/platform/platform.dart' as platform;
 import 'package:sentry_flutter/sentry_flutter.dart';
+import 'package:sentry_flutter/src/native/c/binding.dart' as binding;
 import 'package:sentry_flutter/src/native/c/sentry_native.dart';
 import 'package:sentry_flutter/src/native/factory.dart';
 
@@ -191,6 +192,14 @@ void main() {
         );
 
         await sut.setUser(user);
+      });
+
+      test('int64 value round-trips through native', () {
+        const value = 0x7FFFFFFF + 1; // 2147483648, just outside int32 range
+        final cValue = dynamicToNativeValue(value, options.log)!;
+        expect(SentryNative.native.value_get_type(cValue),
+            binding.sentry_value_type_t.SENTRY_VALUE_TYPE_INT64);
+        expect(cValue.castPrimitive<int>(options.log), value);
       });
 
       test('addBreadcrumb', () async {

--- a/packages/flutter/test/sentry_native/sentry_native_test_ffi.dart
+++ b/packages/flutter/test/sentry_native/sentry_native_test_ffi.dart
@@ -196,10 +196,10 @@ void main() {
 
       test('int64 value round-trips through native', () {
         const value = 0x7FFFFFFF + 1; // 2147483648, just outside int32 range
-        final cValue = dynamicToNativeValue(value, options.log)!;
+        final cValue = dynamicToNativeValue(value)!;
         expect(SentryNative.native.value_get_type(cValue),
             binding.sentry_value_type_t.SENTRY_VALUE_TYPE_INT64);
-        expect(cValue.castPrimitive<int>(options.log), value);
+        expect(cValue.castPrimitive<int>(), value);
       });
 
       test('addBreadcrumb', () async {


### PR DESCRIPTION
Native `int64`/`uint64` values from sentry-native are no longer silently dropped, and large Dart `int` values are no longer coerced to strings when sent to native.

Previously, reading a native value typed as `int64` or `uint64` (for example `image_size` on a debug image) fell through to the `default` case in `castPrimitive`, which logged a warning and returned `null`. In the write direction, any Dart `int` outside the int32 range was converted to a string instead of an integer. Both were silent type-fidelity losses.

**Read path**

`castPrimitive` now handles `SENTRY_VALUE_TYPE_INT64` and `SENTRY_VALUE_TYPE_UINT64` via `sentry_value_as_int64`/`sentry_value_as_uint64`. Dart's `int` is signed 64-bit, so a `uint64` above 2^63-1 wraps to a negative number; native values that reach here in practice (e.g. `image_size`) are well within the signed range.

**Write path**

Dart ints outside the int32 range now use `sentry_value_new_int64` instead of `toString()`. Note that values above 2^53 may lose precision once serialized as a JSON number downstream — this matches how other SDKs send large integers.

**FFI bindings**

`sentry_value_new_int64`/`uint64` and `sentry_value_as_int64`/`uint64` are added to `ffi-native.yaml` and `binding.dart`. The `sentry_value_u` extension is now named (`SentryValueExtension`) so the new round-trip test can exercise `castPrimitive`.

The FFI test suite runs on Linux and Windows CI (it is gated by `@TestOn('vm && (windows || linux)')` and cannot run on macOS, which uses sentry-cocoa).

Fixes GH-3669