### PR TITLE
ci: Fix Dependabot pub paths and pin GitHub Action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,48 +1,25 @@
 version: 2
 updates:
+  # Covers every package under packages/ (dart, flutter, dio, drift, file,
+  # firebase_remote_config, hive, isar, link, logging, sqflite, supabase, ...).
+  # Uses a glob so newly added packages are picked up automatically and the
+  # config does not silently break when packages are moved or renamed.
   - package-ecosystem: pub
-    directory: /dart
+    directories:
+      - /packages/*
     schedule:
       interval: weekly
-    open-pull-requests-limit: 2
-    versioning-strategy: increase-if-necessary
-
-  - package-ecosystem: pub
-    directory: /flutter
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 2
-    versioning-strategy: increase-if-necessary
-
-  - package-ecosystem: pub
-    directory: /dio
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 2
-    versioning-strategy: increase-if-necessary
-
-  - package-ecosystem: pub
-    directory: /file
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 2
-    versioning-strategy: increase-if-necessary
-
-  - package-ecosystem: pub
-    directory: /logging
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 2
-    versioning-strategy: increase-if-necessary
-
-  - package-ecosystem: pub
-    directory: /sqflite
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 5
     versioning-strategy: increase-if-necessary
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
-        interval: weekly
+      interval: weekly
+
+  - package-ecosystem: bundler
+    directories:
+      - /metrics
+      - /packages/flutter/example/ios
+    schedule:
+      interval: weekly

--- a/.github/workflows/release-comment-issues.yml
+++ b/.github/workflows/release-comment-issues.yml
@@ -33,7 +33,7 @@ jobs:
           && !contains(steps.get_version.outputs.version, '-alpha.')
           && !contains(steps.get_version.outputs.version, '-rc.')
 
-        uses: getsentry/release-comment-issues-gh-action@v1
+        uses: getsentry/release-comment-issues-gh-action@52e08022ca721e701515ede89edd224b63b180eb # v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           version: ${{ steps.get_version.outputs.version }}


### PR DESCRIPTION
Dependabot's pub entries pointed at `/dart`, `/flutter`, etc., but packages moved under `packages/` after the config was added (#1670), so those paths no longer exist and no pub updates have been opened since. Several integration packages were never listed at all.

Replaces the per-package entries with a `/packages/*` glob so every current and future package is covered. Also adds a `bundler` entry for the two committed `Gemfile`s and SHA-pins the last unpinned Action (`getsentry/release-comment-issues-gh-action` → `52e0802`).

Part of the mobile SDK dependency-pinning audit. Out of scope: the unpinned `isar_flutter_libs` git dep in the Flutter example, and adding a CI audit gate.