### PR TITLE
chore(skills): Expand test-guidelines and drop stale deps

### DIFF
--- a/.agents/skills/test-guidelines/SKILL.md
+++ b/.agents/skills/test-guidelines/SKILL.md
@@ -266,6 +266,7 @@ group('$Client', () {
 - Use `expect()` with matchers from `package:test`.
 - Prefer specific matchers (`throwsArgumentError`, `isA<SentryException>()`) over generic ones (`throwsException`, `isA<Exception>()`).
 - One logical assertion per test. Multiple `expect()` calls are fine if they verify a single behavior.
+- Assert the literal expected value, not the same constant the production code uses to produce it. Sharing one constant across production and test makes the assertion tautological — it still passes if the constant holds the wrong value. Using the constant as the lookup *key* is fine; pin the expected *value* as a literal.
 
 ```dart
 // GOOD: Specific matchers, single logical assertion
@@ -281,6 +282,14 @@ test('captures exception', () {
   expect(event.exceptions!.first, isA<Object>()); // too generic
   expect(event.breadcrumbs, isEmpty); // unrelated assertion
 });
+```
+
+```dart
+// GOOD: pin the expected value as a literal
+expect(span.data[SentryDatabase.dbSystemKey], 'sqlite');
+
+// AVOID: asserting against the same constant the production code uses to set it
+expect(span.data[SentryDatabase.dbSystemKey], SentryDatabase.dbSystem);
 ```
 
 ## Async

--- a/.agents/skills/test-guidelines/SKILL.md
+++ b/.agents/skills/test-guidelines/SKILL.md
@@ -261,6 +261,41 @@ group('$Client', () {
 });
 ```
 
+## What to Test
+
+Test the behavior owned by your change.
+
+Prefer tests that would fail if your change's intended contract were broken: user-visible behavior, public API behavior, meaningful branching logic, data transformations, integration wiring, precedence rules, error handling, and regressions your change could realistically introduce.
+
+Avoid tests that merely re-prove guarantees owned somewhere else, such as a shared helper, base class, framework, serializer, collection type, generated model, or value object that already has focused coverage. A caller test should not exist just to show that its dependencies still work.
+
+Before adding a test, ask:
+
+- What behavior would fail if my change were wrong?
+- Is this contract owned by this code, or by something it delegates to?
+- Would this test catch a plausible regression in this change?
+- Is this asserting an outcome, or just mirroring implementation details?
+
+Do test delegated behavior when the delegation is load-bearing for your change's own contract. For example, preserving user input, choosing precedence between sources, wiring the correct helper, enforcing a public API promise, or covering a past regression can all deserve caller-level tests even if a helper implements part of the behavior.
+
+Good tests make the intended contract harder to break. Noisy tests make refactors harder without improving confidence.
+
+```dart
+// GOOD: asserts the new behavior this code path introduces
+test('adds sentry.trace_lifecycle stream attribute', () async {
+  final span = fixture.createRecordingSpan();
+  await fixture.pipeline.captureSpan(span, scope: fixture.scope);
+  expect(span.attributes[SemanticAttributesConstants.sentryTraceLifecycle]?.value, 'stream');
+});
+
+// AVOID in this feature's tests: re-proves that SentryAttribute.string
+// stores its value, which is the value object's own contract
+test('SentryAttribute.string stores its value', () {
+  final attribute = SentryAttribute.string('value');
+  expect(attribute.value, 'value');
+});
+```
+
 ## Assertions
 
 - Use `expect()` with matchers from `package:test`.

--- a/agents.toml
+++ b/agents.toml
@@ -24,10 +24,6 @@ name = "pr-writer"
 source = "getsentry/skills"
 
 [[skills]]
-name = "create-pr"
-source = "getsentry/skills"
-
-[[skills]]
 name = "create-branch"
 source = "getsentry/skills"
 
@@ -53,10 +49,6 @@ source = "getsentry/skills"
 
 [[skills]]
 name = "skill-writer"
-source = "getsentry/skills"
-
-[[skills]]
-name = "skill-creator"
 source = "getsentry/skills"
 
 [[skills]]


### PR DESCRIPTION
Two small skill-maintenance changes.

**`test-guidelines`** gains two rules, each with a GOOD/AVOID example:

- *Assertions* — assert the literal expected value, not the same constant the production code uses to set it. A shared constant makes the assertion tautological: it keeps passing even if the constant holds the wrong value. Using the constant as the lookup *key* is fine; pin the expected *value* as a literal.
- *What to Test* — test the behavior your change owns, not guarantees already owned and covered by a shared helper, type, serializer, or framework. Includes the caveat that delegated behavior still deserves a caller-level test when it is load-bearing for your change's own contract (precedence, preserving user input, public API promises, regressions).

**`agents.toml`** drops two redundant entries — `create-pr` and `skill-creator` — which are aliases of the `pr-writer` and `skill-writer` skills already listed.