### PR TITLE
fix(rate-limiting): Honor span and feedback rate limits

### DIFF
--- a/packages/dart/lib/src/transport/rate_limit_parser.dart
+++ b/packages/dart/lib/src/transport/rate_limit_parser.dart
@@ -81,8 +81,12 @@ extension _DataCategoryExtension on DataCategory {
         return DataCategory.session;
       case 'transaction':
         return DataCategory.transaction;
+      case 'span':
+        return DataCategory.span;
       case 'attachment':
         return DataCategory.attachment;
+      case 'feedback':
+        return DataCategory.feedback;
       case 'security':
         return DataCategory.security;
       case 'metric_bucket':

--- a/packages/dart/test/protocol/rate_limit_parser_test.dart
+++ b/packages/dart/test/protocol/rate_limit_parser_test.dart
@@ -130,6 +130,22 @@ void main() {
       expect(sut[0].category, DataCategory.logByte);
       expect(sut[0].duration.inMilliseconds, 60000);
     });
+
+    test('parse span category', () {
+      final sut = RateLimitParser('60:span').parseRateLimitHeader();
+
+      expect(sut.length, 1);
+      expect(sut[0].category, DataCategory.span);
+      expect(sut[0].duration.inMilliseconds, 60000);
+    });
+
+    test('parse feedback category', () {
+      final sut = RateLimitParser('60:feedback').parseRateLimitHeader();
+
+      expect(sut.length, 1);
+      expect(sut[0].category, DataCategory.feedback);
+      expect(sut[0].duration.inMilliseconds, 60000);
+    });
   });
 
   group('parseRetryAfterHeader', () {


### PR DESCRIPTION
The `X-Sentry-Rate-Limits` header parser did not recognize the `span` and `feedback` categories. A rate limit for either was parsed as `unknown` and discarded by the parser, so the SDK kept sending standalone spans and user feedback while the server had rate limited those categories — risking more important data being dropped downstream once the backoff escalated.

The fix maps both header strings to their existing `DataCategory` values. `DataCategory.span` / `DataCategory.feedback` and the client-report serialization already handled these categories; only `RateLimitParser._fromStringValue` was missing the cases, so the three category lists had drifted apart.

Regression coverage added in `rate_limit_parser_test.dart` for both categories (mirroring the existing `trace_metric` / `log_byte` cases).

Closes #3787