### PR TITLE
feat: Add sentry.trace_lifecycle span attribute

### DIFF
--- a/packages/dart/lib/src/constants.dart
+++ b/packages/dart/lib/src/constants.dart
@@ -85,6 +85,9 @@ abstract class SemanticAttributesConstants {
   /// The operation name of a span.
   static const sentryOp = 'sentry.op';
 
+  /// The chosen trace lifecycle mode of the SDK ("stream" or "static").
+  static const sentryTraceLifecycle = 'sentry.trace_lifecycle';
+
   /// Whether the replay is buffering (onErrorSampleRate).
   static const sentryInternalReplayIsBuffering =
       'sentry._internal.replay_is_buffering';

--- a/packages/dart/lib/src/sentry_tracer.dart
+++ b/packages/dart/lib/src/sentry_tracer.dart
@@ -156,6 +156,16 @@ class SentryTracer extends ISentrySpan {
       final transaction = SentryTransaction(this);
       transaction.measurements.addAll(_measurements);
 
+      final trace = transaction.contexts.trace;
+      if (trace != null &&
+          _hub.options.traceLifecycle == SentryTraceLifecycle.static) {
+        trace.data = {
+          ...?trace.data,
+          SemanticAttributesConstants.sentryTraceLifecycle:
+              SentryTraceLifecycle.static.name,
+        };
+      }
+
       profileInfo = (status == null || status == SpanStatus.ok())
           ? await profiler?.finishFor(transaction)
           : null;
@@ -266,6 +276,13 @@ class SentryTracer extends ISentrySpan {
       startTimestamp: startTimestamp,
       finishedCallback: _finishedCallback,
     );
+
+    if (_hub.options.traceLifecycle == SentryTraceLifecycle.static) {
+      child.setData(
+        SemanticAttributesConstants.sentryTraceLifecycle,
+        SentryTraceLifecycle.static.name,
+      );
+    }
 
     _children.add(child);
 

--- a/packages/dart/lib/src/telemetry/span/span_capture_pipeline.dart
+++ b/packages/dart/lib/src/telemetry/span/span_capture_pipeline.dart
@@ -37,6 +37,8 @@ class SpanCapturePipeline {
 
           span.addAttributesIfAbsent(defaultAttributes(_options, scope: scope));
           span.addAttributesIfAbsent({
+            SemanticAttributesConstants.sentryTraceLifecycle:
+                SentryAttribute.string(SentryTraceLifecycle.stream.name),
             SemanticAttributesConstants.sentrySegmentName:
                 SentryAttribute.string(span.segmentSpan.name),
             SemanticAttributesConstants.sentryTransaction:

--- a/packages/dart/test/sentry_tracer_test.dart
+++ b/packages/dart/test/sentry_tracer_test.dart
@@ -121,6 +121,34 @@ void main() {
       expect(tr.transaction.extra?['test'], {'key': 'value'});
     });
 
+    test('sets sentry.trace_lifecycle to static on trace context', () async {
+      final sut = fixture.getSut();
+
+      await sut.finish();
+
+      final tr = fixture.hub.captureTransactionCalls.first;
+      expect(
+        tr.transaction.contexts.trace
+            ?.data?[SemanticAttributesConstants.sentryTraceLifecycle],
+        'static',
+      );
+    });
+
+    test('sets sentry.trace_lifecycle to static on child spans', () async {
+      final sut = fixture.getSut();
+      final child = sut.startChild('operation');
+      await child.finish();
+
+      await sut.finish();
+
+      final tr = fixture.hub.captureTransactionCalls.first;
+      expect(
+        tr.transaction.spans.first
+            .data[SemanticAttributesConstants.sentryTraceLifecycle],
+        'static',
+      );
+    });
+
     test('tracer starts child', () async {
       final sut = fixture.getSut();
 

--- a/packages/dart/test/telemetry/span/span_capture_pipeline_test.dart
+++ b/packages/dart/test/telemetry/span/span_capture_pipeline_test.dart
@@ -140,6 +140,17 @@ void main() {
         expect(attr?.value, ['a', 'b']);
       });
 
+      test('adds sentry.trace_lifecycle stream attribute', () async {
+        final span = fixture.createRecordingSpan();
+        await fixture.pipeline.captureSpan(span, scope: fixture.scope);
+
+        expect(
+          span.attributes[SemanticAttributesConstants.sentryTraceLifecycle]
+              ?.value,
+          'stream',
+        );
+      });
+
       test('does not add spans to processor for no-op spans', () async {
         await fixture.pipeline
             .captureSpan(const NoOpSentrySpanV2(), scope: fixture.scope);


### PR DESCRIPTION
Spans carry no indication of whether they were sent as a streamed span or inside a transaction, so the product can't distinguish the two or measure streaming adoption. This adds the `sentry.trace_lifecycle` attribute defined in [sentry-conventions#442](https://github.com/getsentry/sentry-conventions/pull/442), with value `stream` or `static`.

The value follows the SDK's configured `SentryOptions.traceLifecycle`:

- **stream**: set to `"stream"` on every streamed span in `SpanCapturePipeline`, alongside the existing default/segment attributes. Uses `addAttributesIfAbsent`, so a user-set value or `beforeSendSpan` override wins.
- **static**: the v1 transaction model has no per-span attribute map, so the equivalent surfaces are used — `"static"` is written to the transaction's `contexts.trace.data` (segment level) and to each child span's `data`. Both happen at creation time because `setData` is a no-op once a span is finished.

Every span carries the attribute in both modes, so it queries consistently. The value derives from `SentryTraceLifecycle.<mode>.name`, which serializes exactly to the convention strings.

Closes #3788