### PR TITLE
chore(skills): Add workflow pipeline and sharpen guidelines

### DIFF
--- a/.agents/skills/code-guidelines/SKILL.md
+++ b/.agents/skills/code-guidelines/SKILL.md
@@ -7,7 +7,7 @@ Apply these guidelines to all new and modified code across every package in this
 
 Use only language features available in the Dart/Flutter versions specified in `AGENTS.md`.
 
-When writing or modifying tests as part of implementation, also load the **test-guidelines** skill.
+For non-trivial work — a new feature or integration, a public barrel-file change, or a cross-package/native-interop change — load the **design-first** skill to shape the modules and seams before writing code. When writing or modifying tests as part of implementation, also load the **test-guidelines** skill.
 
 ## SDK Development Rules
 
@@ -16,10 +16,20 @@ When writing or modifying tests as part of implementation, also load the **test-
 Encapsulate SDK features as `Integration` classes that implement `call()` and `close()`:
 
 - Check feature flags and prerequisites early, log and return if disabled
-- Register the integration via `options.sdk.addIntegration(name)`
+- Mark the integration as active for usage tracking — see **Usage Tracking** below
 - Clean up resources in `close()` if needed
 - See `packages/flutter/lib/src/integrations/` for examples
 - Integrations should be order-independent; if yours requires running before/after another, reconsider the design
+
+### Usage Tracking
+
+Record which integrations and features an app actually uses, so usage can be tracked internally. This metadata lives on `options.sdk` and is serialized onto events as `sdk.integrations` / `sdk.features`.
+
+- **`options.sdk.addIntegration('IntegrationName')`** — mark an integration as active. Call it from the integration's `call()`. Do not confuse it with `options.addIntegration(integration)`, which *registers an integration to run* — `options.sdk.addIntegration` only attaches the name as metadata.
+- **`options.sdk.addFeature(SentryFeatures.x)`** — mark a feature as used, gated on whether it is actually configured (e.g. a `beforeSend*` callback is set, a privacy option is enabled).
+- Use named constants from `SentryFeatures` (`packages/dart/lib/src/constants.dart`, `@internal`) — never inline string literals — so the analytics vocabulary stays consistent. Add a constant there when introducing a new feature.
+- Both calls dedupe, so calling them more than once is safe.
+- Canonical example: `TrackBeforeSendUsageIntegration` (`packages/dart/lib/src/track_before_send_usage_integration.dart`).
 
 ### Logging
 
@@ -71,120 +81,50 @@ internalLogger.debug(() => 'Envelope size: ${envelope.computeSize()}');
 
 ### File Organization
 
-- Prefer grouping related files by feature in sub-directories (e.g., `metrics/`)
-- Avoid flat structures with many unrelated files in one directory
+`lib/src/` mixes two organizing axes: **by-kind layer dirs** (`protocol/`, `event_processor/`, `integrations/`, `native/`, `transport/`) and **by-feature concept dirs** (`replay/`, `frames_tracking/`, `navigation/`, `tracing/`, `telemetry/span/`). The repo facts:
 
-## Modern Dart Features
+- **Group by concept, not by kind.** A feature-owned processor/integration goes with its feature (a replay processor in `replay/`). A cross-cutting one (enrichment, exceptions, dedup) is still a concept and earns its own concept dir too — core's `enricher/` and `exception/`. `event_processor/` / `integrations/` are by-kind names; they justify a directory only for the **shared machinery** (the runner `run_event_processors.dart`, the base contracts), not as a bucket where concepts land because they share a type. Whether the cross-cutting concept dirs sit top-level or nest under that machinery is a locality call (see design-first). Feature-specific processors sitting loose in the buckets (e.g. `replay_event_processor`, `screenshot_event_processor`) are scatter to steer away from, like the loose tier. (The `Integration` interface itself sits at the `src/` root, e.g. `integration.dart`.)
+- **`native/` is the standing seam exception** — native interop has its own rules (memory, can't be faked; see `packages/flutter/AGENTS.md`), so native adapters group by that seam even when they belong to a concept.
+- The top of `src/` mixes **core primitives** (`hub.dart`, `scope.dart`, `sentry_client.dart`, the `sentry.dart` barrel) with **legacy scatter** (e.g. the v1 span/tracer files). Don't add new feature code to that loose tier — put it in a concept or layer dir.
+- The example to match is `telemetry/span/` (v2 span: a cohesive subsystem in one dir), not the v1 span scattered across `protocol/`, `tracing/`, and loose root files.
 
-Prefer modern Dart language features (Dart 3.5+) when they improve clarity and reduce boilerplate:
+*Where* a given piece goes is a locality judgment — see **design-first** (Shape the modules).
 
-- **Sealed Classes** - Exhaustive pattern matching with restricted hierarchies
-- **Extension Types** - Zero-cost wrappers around existing types
-- **Records** - Lightweight multi-value returns: `(String, int)` or `({String name, int age})`
-- **Pattern Matching** - Destructuring in `switch`, `if-case`, variable declarations
-- **Switch Expressions** - Expression-based switches returning values
-- **Class Modifiers** - `final`, `base`, `interface`, `mixin` class modifiers
-- **Enhanced Enums** - Enums with fields, constructors, and methods
-- **If-Case Expressions** - Pattern matching in if statements
-- **Null-Aware Elements** - `?maybeNull` in collection literals
+## Modern Dart
 
-## Semantic Naming Guidelines
+Prefer modern Dart (3.5+) where it improves clarity — sealed classes for exhaustive matching, records for multi-value returns, pattern matching and switch expressions, extension types for zero-cost wrappers, enhanced enums, and class modifiers (`final` / `base` / `interface`). Don't force them where plain code reads better.
 
-### General Naming
+## API & Dart Style
 
-- [DO use terms consistently.](https://dart.dev/effective-dart/design#do-use-terms-consistently)
-- [AVOID abbreviations.](https://dart.dev/effective-dart/design#avoid-abbreviations)
-- [PREFER putting the most descriptive noun last.](https://dart.dev/effective-dart/design#prefer-putting-the-most-descriptive-noun-last)
-- [CONSIDER making the code read like a sentence.](https://dart.dev/effective-dart/design#consider-making-the-code-read-like-a-sentence)
+Shape the public surface deliberately — see **design-first** for module shape. These habits matter more in an SDK than in app code, and several are easy to get wrong:
 
-### Properties and Variables
+- **Private by default.** Keep declarations private; widen to public only when a type is genuinely part of the SDK's API. Every public symbol is a maintenance burden and a breaking-change liability — see `packages/dart/AGENTS.md` on the barrel-file cascade.
+- **Control extension with class modifiers.** Use `final` / `base` / `interface` / `sealed` to declare whether a public class may be extended or implemented — without them every public class is implicitly both, and you can't evolve it without breaking consumers.
+- **No public `late final` field without an initializer.** It silently defines a public *setter*, leaking API surface — use a normal field or an explicit getter instead.
+- **Prefer a function to a one-member abstract class**, and avoid classes of only static members.
+- **Keep imports inside `lib`.** Never let an import cross the `lib` boundary (`../lib/...`, or into another package's `src/`) — relative imports that escape `lib` create duplicate library instances Dart treats as unrelated.
+- **Re-raise with `rethrow`, never `throw e`.** `throw e` resets the stack trace to the rethrow site; `rethrow` preserves the origin — and stack-trace fidelity is the product.
 
-- [PREFER a noun phrase for a non-boolean property or variable.](https://dart.dev/effective-dart/design#prefer-a-noun-phrase-for-a-non-boolean-property-or-variable)
-- [PREFER a non-imperative verb phrase for a boolean property or variable.](https://dart.dev/effective-dart/design#prefer-a-non-imperative-verb-phrase-for-a-boolean-property-or-variable)
-- [CONSIDER omitting the verb for a named boolean _parameter_.](https://dart.dev/effective-dart/design#consider-omitting-the-verb-for-a-named-boolean-parameter)
-- [PREFER the "positive" name for a boolean property or variable.](https://dart.dev/effective-dart/design#prefer-the-positive-name-for-a-boolean-property-or-variable)
+For everything else — naming, asynchrony, nullability, parameters, equality — follow **Effective Dart**; a frontier model and `dart analyze` already apply most of it, so it isn't restated here. The full checklist (and the standard the `review` skill cites) is in [references/effective-dart.md](references/effective-dart.md).
 
-### Methods and Functions
+## Documentation Comments
 
-- [PREFER an imperative verb phrase for a function or method whose main purpose is a side effect.](https://dart.dev/effective-dart/design#prefer-an-imperative-verb-phrase-for-a-function-or-method-whose-main-purpose-is-a-side-effect)
-- [PREFER a noun phrase or non-imperative verb phrase for a function or method if returning a value is its primary purpose.](https://dart.dev/effective-dart/design#prefer-a-noun-phrase-or-non-imperative-verb-phrase-for-a-function-or-method-if-returning-a-value-is-its-primary-purpose)
-- [CONSIDER an imperative verb phrase for a function or method if you want to draw attention to the work it performs.](https://dart.dev/effective-dart/design#consider-an-imperative-verb-phrase-for-a-function-or-method-if-you-want-to-draw-attention-to-the-work-it-performs)
-- [AVOID starting a method name with `get`.](https://dart.dev/effective-dart/design#avoid-starting-a-method-name-with-get)
-- [PREFER naming a method `to___()` if it copies the object's state to a new object.](https://dart.dev/effective-dart/design#prefer-naming-a-method-to___-if-it-copies-the-objects-state-to-a-new-object)
-- [PREFER naming a method `as___()` if it returns a different representation backed by the original object.](https://dart.dev/effective-dart/design#prefer-naming-a-method-as___-if-it-returns-a-different-representation-backed-by-the-original-object)
-- [AVOID describing the parameters in the function's or method's name.](https://dart.dev/effective-dart/design#avoid-describing-the-parameters-in-the-functions-or-methods-name)
+Prefer self-documenting code — clear names and structure so comments become unnecessary.
 
-### Type Parameters
+**Comment when:**
 
-- [DO follow existing mnemonic conventions when naming type parameters.](https://dart.dev/effective-dart/design#do-follow-existing-mnemonic-conventions-when-naming-type-parameters)
+- **Public APIs** — document for users who can't see the implementation.
+- **Non-obvious *why*** — reasoning not clear from the code (workarounds, edge cases, constraints).
 
-## Dart Code Design
+**Don't comment when:**
 
-### Classes and Abstractions
+- **Obvious behavior** — don't describe what the code plainly does.
+- **Inline play-by-play** — don't narrate every step of a method.
 
-- [AVOID defining a one-member abstract class when a simple function will do.](https://dart.dev/effective-dart/design#avoid-defining-a-one-member-abstract-class-when-a-simple-function-will-do)
-- [AVOID defining a class that contains only static members.](https://dart.dev/effective-dart/design#avoid-defining-a-class-that-contains-only-static-members)
-- [DO use class modifiers to control if your class can be extended.](https://dart.dev/effective-dart/design#do-use-class-modifiers-to-control-if-your-class-can-be-extended)
-- [DO use class modifiers to control if your class can be an interface.](https://dart.dev/effective-dart/design#do-use-class-modifiers-to-control-if-your-class-can-be-an-interface)
-- [PREFER defining a pure `mixin` or pure `class` to a `mixin class`.](https://dart.dev/effective-dart/design#prefer-defining-a-pure-mixin-or-pure-class-to-a-mixin-class)
-- [PREFER making declarations private.](https://dart.dev/effective-dart/design#prefer-making-declarations-private)
+**`dart doc` gotchas** (tooling behavior, not taste):
 
-### Asynchrony
+- Document a getter *or* its setter, never both — `dart doc` merges the pair and discards the setter's comment.
+- The first sentence becomes the summary in API listings — keep it standalone in its own paragraph.
+- Put doc comments *before* annotations (`@override`, `@internal`); placed after, `dart doc` won't associate them with the declaration.
 
-- [PREFER async/await over using raw futures.](https://dart.dev/effective-dart/usage#prefer-asyncawait-over-using-raw-futures)
-- [CONSIDER using higher-order methods to transform a stream.](https://dart.dev/effective-dart/usage#consider-using-higher-order-methods-to-transform-a-stream)
-- [AVOID using Completer directly.](https://dart.dev/effective-dart/usage#avoid-using-completer-directly)
-
-### Types and Nullability
-
-- [AVOID `late` variables if you need to check whether they are initialized.](https://dart.dev/effective-dart/usage#avoid-late-variables-if-you-need-to-check-whether-they-are-initialized)
-- [CONSIDER type promotion or null-check patterns for using nullable types.](https://dart.dev/effective-dart/usage#consider-type-promotion-or-null-check-patterns-for-using-nullable-types)
-- [DO use `Future<void>` as the return type of asynchronous members that do not produce values.](https://dart.dev/effective-dart/design#do-use-futurevoid-as-the-return-type-of-asynchronous-members-that-do-not-produce-values)
-- [AVOID returning nullable `Future`, `Stream`, and collection types.](https://dart.dev/effective-dart/design#avoid-returning-nullable-future-stream-and-collection-types)
-
-### Parameters
-
-- [AVOID positional boolean parameters.](https://dart.dev/effective-dart/design#avoid-positional-boolean-parameters)
-- [AVOID optional positional parameters if the user may want to omit earlier parameters.](https://dart.dev/effective-dart/design#avoid-optional-positional-parameters-if-the-user-may-want-to-omit-earlier-parameters)
-- [AVOID mandatory parameters that accept a special "no argument" value.](https://dart.dev/effective-dart/design#avoid-mandatory-parameters-that-accept-a-special-no-argument-value)
-- [DO use inclusive start and exclusive end parameters to accept a range.](https://dart.dev/effective-dart/design#do-use-inclusive-start-and-exclusive-end-parameters-to-accept-a-range)
-
-### Equality
-
-- [DO override `hashCode` if you override `==`.](https://dart.dev/effective-dart/design#do-override-hashcode-if-you-override)
-- [DO make your `==` operator obey the mathematical rules of equality.](https://dart.dev/effective-dart/design#do-make-your-operator-obey-the-mathematical-rules-of-equality)
-- [AVOID defining custom equality for mutable classes.](https://dart.dev/effective-dart/design#avoid-defining-custom-equality-for-mutable-classes)
-
-### Documentation Comments
-
-Prefer self-documenting code—use clear names and structure so comments become unnecessary.
-
-#### Do Write Comment When
-
-- Public APIs—document for users who can't see the implementation
-- Non-obvious "why" — explain reasoning not clear from code (workarounds, edge cases, constraints)
-
-#### Do Not Write Comment When
-
-- Obvious behavior — don't describe what code clearly does
-- Inline play-by-play — avoid commenting every step in a method
-
-#### Style Rules
-
-- [AVOID redundancy with the surrounding context.](https://dart.dev/effective-dart/documentation#avoid-redundancy-with-the-surrounding-context)
-- [DO use `///` doc comments to document members and types.](https://dart.dev/effective-dart/documentation#do-use-doc-comments-to-document-members-and-types)
-- [PREFER writing doc comments for public APIs.](https://dart.dev/effective-dart/documentation#prefer-writing-doc-comments-for-public-apis)
-- [CONSIDER writing a library-level doc comment.](https://dart.dev/effective-dart/documentation#consider-writing-a-library-level-doc-comment)
-- [CONSIDER writing doc comments for private APIs.](https://dart.dev/effective-dart/documentation#consider-writing-doc-comments-for-private-apis)
-- [DO start doc comments with a single-sentence summary.](https://dart.dev/effective-dart/documentation#do-start-doc-comments-with-a-single-sentence-summary)
-- [DO separate the first sentence of a doc comment into its own paragraph.](https://dart.dev/effective-dart/documentation#do-separate-the-first-sentence-of-a-doc-comment-into-its-own-paragraph)
-- [PREFER starting comments of a function or method with third-person verbs if its main purpose is a side effect.](https://dart.dev/effective-dart/documentation#prefer-starting-comments-of-a-function-or-method-with-third-person-verbs-if-its-main-purpose-is-a-side-effect)
-- [PREFER starting a non-boolean variable or property comment with a noun phrase.](https://dart.dev/effective-dart/documentation#prefer-starting-a-non-boolean-variable-or-property-comment-with-a-noun-phrase)
-- [PREFER starting a boolean variable or property comment with "Whether" followed by a noun or gerund phrase.](https://dart.dev/effective-dart/documentation#prefer-starting-a-boolean-variable-or-property-comment-with-whether-followed-by-a-noun-or-gerund-phrase)
-- [PREFER a noun phrase or non-imperative verb phrase for a function or method if returning a value is its primary purpose.](https://dart.dev/effective-dart/documentation#prefer-a-noun-phrase-or-non-imperative-verb-phrase-for-a-function-or-method-if-returning-a-value-is-its-primary-purpose)
-- [DON'T write documentation for both the getter and setter of a property.](https://dart.dev/effective-dart/documentation#dont-write-documentation-for-both-the-getter-and-setter-of-a-property)
-- [PREFER starting library or type comments with noun phrases.](https://dart.dev/effective-dart/documentation#prefer-starting-library-or-type-comments-with-noun-phrases)
-- [CONSIDER including code samples in doc comments.](https://dart.dev/effective-dart/documentation#consider-including-code-samples-in-doc-comments)
-- [DO use square brackets in doc comments to refer to in-scope identifiers.](https://dart.dev/effective-dart/documentation#do-use-square-brackets-in-doc-comments-to-refer-to-in-scope-identifiers)
-- [DO use prose to explain parameters, return values, and exceptions.](https://dart.dev/effective-dart/documentation#do-use-prose-to-explain-parameters-return-values-and-exceptions)
-- [DO put doc comments before metadata annotations.](https://dart.dev/effective-dart/documentation#do-put-doc-comments-before-metadata-annotations)
+Remaining doc-comment style (`///`, `[bracket]` references) is standard Effective Dart — see [references/effective-dart.md](references/effective-dart.md).

--- a/.agents/skills/code-guidelines/SKILL.md
+++ b/.agents/skills/code-guidelines/SKILL.md
@@ -81,12 +81,12 @@ internalLogger.debug(() => 'Envelope size: ${envelope.computeSize()}');
 
 ### File Organization
 
-`lib/src/` mixes two organizing axes: **by-kind layer dirs** (`protocol/`, `event_processor/`, `integrations/`, `native/`, `transport/`) and **by-feature concept dirs** (`replay/`, `frames_tracking/`, `navigation/`, `tracing/`, `telemetry/span/`). The repo facts:
+**Group by feature, not by type.** A processor or integration a feature owns lives in that feature's dir (a replay processor in `replay/`); a cross-cutting one earns its own top-level concept dir (`exception/`, `enricher/`). Cohesive subsystems already do this — `transport/`, `telemetry/span/`, and `native/` (the binding boundary to the platform SDKs; features *call* it rather than embed native code). Native interop is special for testing and memory, not for placement — see design-first and the **Native Code (JNI/FFI)** rules above.
 
-- **Group by concept, not by kind.** A feature-owned processor/integration goes with its feature (a replay processor in `replay/`). A cross-cutting one (enrichment, exceptions, dedup) is still a concept and earns its own concept dir too — core's `enricher/` and `exception/`. `event_processor/` / `integrations/` are by-kind names; they justify a directory only for the **shared machinery** (the runner `run_event_processors.dart`, the base contracts), not as a bucket where concepts land because they share a type. Whether the cross-cutting concept dirs sit top-level or nest under that machinery is a locality call (see design-first). Feature-specific processors sitting loose in the buckets (e.g. `replay_event_processor`, `screenshot_event_processor`) are scatter to steer away from, like the loose tier. (The `Integration` interface itself sits at the `src/` root, e.g. `integration.dart`.)
-- **`native/` is the standing seam exception** — native interop has its own rules (memory, can't be faked; see `packages/flutter/AGENTS.md`), so native adapters group by that seam even when they belong to a concept.
-- The top of `src/` mixes **core primitives** (`hub.dart`, `scope.dart`, `sentry_client.dart`, the `sentry.dart` barrel) with **legacy scatter** (e.g. the v1 span/tracer files). Don't add new feature code to that loose tier — put it in a concept or layer dir.
-- The example to match is `telemetry/span/` (v2 span: a cohesive subsystem in one dir), not the v1 span scattered across `protocol/`, `tracing/`, and loose root files.
+Two shapes are **scatter** — grow neither, and don't read the repo's current use of them as the target:
+
+- **Type-buckets** (`event_processor/`, `integrations/`) collect classes for sharing a base type. A bucket legitimately holds only its runner (`run_event_processors.dart`); the base contract belongs at `src/` root (`event_processor.dart`, beside `integration.dart`). The repo hasn't finished migrating — enrichment, exceptions, and dedup still sit under `event_processor/`, and flutter has loose `replay_event_processor`/`screenshot_event_processor`.
+- **The loose `src/` root.** Core primitives (`hub.dart`, `scope.dart`, `sentry_client.dart`, the `sentry.dart` barrel) belong there; feature code does not. The v1 span/tracer files strewn across the root, `protocol/`, and `tracing/` are the counter-example to `telemetry/span/`, which keeps the whole v2 subsystem in one dir.
 
 *Where* a given piece goes is a locality judgment — see **design-first** (Shape the modules).
 

--- a/.agents/skills/code-guidelines/references/effective-dart.md
+++ b/.agents/skills/code-guidelines/references/effective-dart.md
@@ -1,0 +1,89 @@
+# Effective Dart — full checklist
+
+A frontier model and the analyzer already apply most of these by default; [SKILL.md](../SKILL.md) keeps only the SDK-specific rules inline. This is the full list, kept for human contributors and as the citable standard for the `review` skill's Standards axis. Skip anything `dart analyze` / lints already enforce.
+
+## Semantic Naming
+
+### General
+
+- [DO use terms consistently.](https://dart.dev/effective-dart/design#do-use-terms-consistently)
+- [AVOID abbreviations.](https://dart.dev/effective-dart/design#avoid-abbreviations)
+- [PREFER putting the most descriptive noun last.](https://dart.dev/effective-dart/design#prefer-putting-the-most-descriptive-noun-last)
+- [CONSIDER making the code read like a sentence.](https://dart.dev/effective-dart/design#consider-making-the-code-read-like-a-sentence)
+
+### Properties and Variables
+
+- [PREFER a noun phrase for a non-boolean property or variable.](https://dart.dev/effective-dart/design#prefer-a-noun-phrase-for-a-non-boolean-property-or-variable)
+- [PREFER a non-imperative verb phrase for a boolean property or variable.](https://dart.dev/effective-dart/design#prefer-a-non-imperative-verb-phrase-for-a-boolean-property-or-variable)
+- [CONSIDER omitting the verb for a named boolean _parameter_.](https://dart.dev/effective-dart/design#consider-omitting-the-verb-for-a-named-boolean-parameter)
+- [PREFER the "positive" name for a boolean property or variable.](https://dart.dev/effective-dart/design#prefer-the-positive-name-for-a-boolean-property-or-variable)
+
+### Methods and Functions
+
+- [PREFER an imperative verb phrase for a function or method whose main purpose is a side effect.](https://dart.dev/effective-dart/design#prefer-an-imperative-verb-phrase-for-a-function-or-method-whose-main-purpose-is-a-side-effect)
+- [PREFER a noun phrase or non-imperative verb phrase for a function or method if returning a value is its primary purpose.](https://dart.dev/effective-dart/design#prefer-a-noun-phrase-or-non-imperative-verb-phrase-for-a-function-or-method-if-returning-a-value-is-its-primary-purpose)
+- [CONSIDER an imperative verb phrase for a function or method if you want to draw attention to the work it performs.](https://dart.dev/effective-dart/design#consider-an-imperative-verb-phrase-for-a-function-or-method-if-you-want-to-draw-attention-to-the-work-it-performs)
+- [AVOID starting a method name with `get`.](https://dart.dev/effective-dart/design#avoid-starting-a-method-name-with-get)
+- [PREFER naming a method `to___()` if it copies the object's state to a new object.](https://dart.dev/effective-dart/design#prefer-naming-a-method-to___-if-it-copies-the-objects-state-to-a-new-object)
+- [PREFER naming a method `as___()` if it returns a different representation backed by the original object.](https://dart.dev/effective-dart/design#prefer-naming-a-method-as___-if-it-returns-a-different-representation-backed-by-the-original-object)
+- [AVOID describing the parameters in the function's or method's name.](https://dart.dev/effective-dart/design#avoid-describing-the-parameters-in-the-functions-or-methods-name)
+
+### Type Parameters
+
+- [DO follow existing mnemonic conventions when naming type parameters.](https://dart.dev/effective-dart/design#do-follow-existing-mnemonic-conventions-when-naming-type-parameters)
+
+## Dart Code Design
+
+### Classes and Abstractions
+
+- [AVOID defining a one-member abstract class when a simple function will do.](https://dart.dev/effective-dart/design#avoid-defining-a-one-member-abstract-class-when-a-simple-function-will-do)
+- [AVOID defining a class that contains only static members.](https://dart.dev/effective-dart/design#avoid-defining-a-class-that-contains-only-static-members)
+- [DO use class modifiers to control if your class can be extended.](https://dart.dev/effective-dart/design#do-use-class-modifiers-to-control-if-your-class-can-be-extended)
+- [DO use class modifiers to control if your class can be an interface.](https://dart.dev/effective-dart/design#do-use-class-modifiers-to-control-if-your-class-can-be-an-interface)
+- [PREFER defining a pure `mixin` or pure `class` to a `mixin class`.](https://dart.dev/effective-dart/design#prefer-defining-a-pure-mixin-or-pure-class-to-a-mixin-class)
+- [PREFER making declarations private.](https://dart.dev/effective-dart/design#prefer-making-declarations-private)
+
+### Asynchrony
+
+- [PREFER async/await over using raw futures.](https://dart.dev/effective-dart/usage#prefer-asyncawait-over-using-raw-futures)
+- [CONSIDER using higher-order methods to transform a stream.](https://dart.dev/effective-dart/usage#consider-using-higher-order-methods-to-transform-a-stream)
+- [AVOID using Completer directly.](https://dart.dev/effective-dart/usage#avoid-using-completer-directly)
+
+### Types and Nullability
+
+- [AVOID `late` variables if you need to check whether they are initialized.](https://dart.dev/effective-dart/usage#avoid-late-variables-if-you-need-to-check-whether-they-are-initialized)
+- [CONSIDER type promotion or null-check patterns for using nullable types.](https://dart.dev/effective-dart/usage#consider-type-promotion-or-null-check-patterns-for-using-nullable-types)
+- [DO use `Future<void>` as the return type of asynchronous members that do not produce values.](https://dart.dev/effective-dart/design#do-use-futurevoid-as-the-return-type-of-asynchronous-members-that-do-not-produce-values)
+- [AVOID returning nullable `Future`, `Stream`, and collection types.](https://dart.dev/effective-dart/design#avoid-returning-nullable-future-stream-and-collection-types)
+
+### Parameters
+
+- [AVOID positional boolean parameters.](https://dart.dev/effective-dart/design#avoid-positional-boolean-parameters)
+- [AVOID optional positional parameters if the user may want to omit earlier parameters.](https://dart.dev/effective-dart/design#avoid-optional-positional-parameters-if-the-user-may-want-to-omit-earlier-parameters)
+- [AVOID mandatory parameters that accept a special "no argument" value.](https://dart.dev/effective-dart/design#avoid-mandatory-parameters-that-accept-a-special-no-argument-value)
+- [DO use inclusive start and exclusive end parameters to accept a range.](https://dart.dev/effective-dart/design#do-use-inclusive-start-and-exclusive-end-parameters-to-accept-a-range)
+
+### Equality
+
+- [DO override `hashCode` if you override `==`.](https://dart.dev/effective-dart/design#do-override-hashcode-if-you-override)
+- [DO make your `==` operator obey the mathematical rules of equality.](https://dart.dev/effective-dart/design#do-make-your-operator-obey-the-mathematical-rules-of-equality)
+- [AVOID defining custom equality for mutable classes.](https://dart.dev/effective-dart/design#avoid-defining-custom-equality-for-mutable-classes)
+
+## Documentation Comment Style
+
+- [AVOID redundancy with the surrounding context.](https://dart.dev/effective-dart/documentation#avoid-redundancy-with-the-surrounding-context)
+- [DO use `///` doc comments to document members and types.](https://dart.dev/effective-dart/documentation#do-use-doc-comments-to-document-members-and-types)
+- [PREFER writing doc comments for public APIs.](https://dart.dev/effective-dart/documentation#prefer-writing-doc-comments-for-public-apis)
+- [CONSIDER writing a library-level doc comment.](https://dart.dev/effective-dart/documentation#consider-writing-a-library-level-doc-comment)
+- [CONSIDER writing doc comments for private APIs.](https://dart.dev/effective-dart/documentation#consider-writing-doc-comments-for-private-apis)
+- [DO start doc comments with a single-sentence summary.](https://dart.dev/effective-dart/documentation#do-start-doc-comments-with-a-single-sentence-summary)
+- [DO separate the first sentence of a doc comment into its own paragraph.](https://dart.dev/effective-dart/documentation#do-separate-the-first-sentence-of-a-doc-comment-into-its-own-paragraph)
+- [PREFER starting comments of a function or method with third-person verbs if its main purpose is a side effect.](https://dart.dev/effective-dart/documentation#prefer-starting-comments-of-a-function-or-method-with-third-person-verbs-if-its-main-purpose-is-a-side-effect)
+- [PREFER starting a non-boolean variable or property comment with a noun phrase.](https://dart.dev/effective-dart/documentation#prefer-starting-a-non-boolean-variable-or-property-comment-with-a-noun-phrase)
+- [PREFER starting a boolean variable or property comment with "Whether" followed by a noun or gerund phrase.](https://dart.dev/effective-dart/documentation#prefer-starting-a-boolean-variable-or-property-comment-with-whether-followed-by-a-noun-or-gerund-phrase)
+- [DON'T write documentation for both the getter and setter of a property.](https://dart.dev/effective-dart/documentation#dont-write-documentation-for-both-the-getter-and-setter-of-a-property)
+- [PREFER starting library or type comments with noun phrases.](https://dart.dev/effective-dart/documentation#prefer-starting-library-or-type-comments-with-noun-phrases)
+- [CONSIDER including code samples in doc comments.](https://dart.dev/effective-dart/documentation#consider-including-code-samples-in-doc-comments)
+- [DO use square brackets in doc comments to refer to in-scope identifiers.](https://dart.dev/effective-dart/documentation#do-use-square-brackets-in-doc-comments-to-refer-to-in-scope-identifiers)
+- [DO use prose to explain parameters, return values, and exceptions.](https://dart.dev/effective-dart/documentation#do-use-prose-to-explain-parameters-return-values-and-exceptions)
+- [DO put doc comments before metadata annotations.](https://dart.dev/effective-dart/documentation#do-put-doc-comments-before-metadata-annotations)

--- a/.agents/skills/design-first/SKILL.md
+++ b/.agents/skills/design-first/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: design-first
+description: Shape non-trivial work before writing it — decide the modules, the seams, and the public API surface up front. Use when starting a feature, adding an integration, changing a public barrel file, crossing a package or native-interop boundary, or deciding where a seam should go. Produces a design sketch to approve before implementation, then hands off to code-guidelines and test-guidelines.
+---
+
+Design the shape before writing the code. The pass ends in a **design sketch** the user approves; implementation does not start until it does. Aim for **deep modules** placed at clean **seams** — so callers get leverage, maintainers get locality, and tests get a surface to push against.
+
+This is a design pass, not an implementation plan. Decide *what shape the code takes and why*; leave the line-level rules to code-guidelines and the test structure to test-guidelines.
+
+## When to run
+
+Run for work where the shape is a real decision:
+
+- A new feature or a new `Integration`
+- A change to a public barrel file (`lib/sentry.dart`, `lib/sentry_flutter.dart`) — it cascades to every downstream package and user
+- Work that crosses a package boundary or the native-interop (JNI/FFI) boundary
+- Any moment you are choosing where a seam goes, or how a module is shaped to be testable
+
+Skip it — and say you are skipping it — for one-line fixes, localized bug fixes with obvious placement, and refactors that change no interface.
+
+## Vocabulary
+
+Use these terms exactly in the sketch and the discussion — consistent language is what makes the design legible across sessions. Don't substitute "component," "service," "layer," or "boundary."
+
+- **Module** — anything with an interface and an implementation: a function, class, or package.
+- **Interface** — everything a caller must know to use it correctly: the signature, plus invariants, ordering, error modes, and required config.
+- **Deep module** — a lot of behavior behind a small interface. The goal. A **shallow** module has an interface nearly as complex as its implementation — avoid it.
+- **Seam** — the place where you can swap behavior without editing in that place. Where a module's interface lives, and where a test double crosses.
+- **Adapter** — a concrete thing satisfying an interface at a seam.
+
+Two checks settle most design questions:
+
+- **The deletion test.** Imagine deleting the module. If complexity vanishes, it was a pass-through — don't build it. If complexity reappears across N callers, it earns its keep.
+- **The interface is the test surface.** Callers and tests cross the same seam. If you need to test *past* the interface, the module is the wrong shape — and per test-guidelines, tests through a clean interface survive refactors.
+
+## The design pass
+
+### 1. Frame the change
+
+State the behavior the change introduces, in the domain's own words. Name the package(s) it lands in. Read the relevant `AGENTS.md` (root, `packages/dart/`, `packages/flutter/`) for the area you're touching.
+
+**Find the nearest well-shaped precedent and align to it.** The codebase has almost certainly solved something adjacent; locate its *best* current example and match it — or improve on it deliberately, noting why. The repo's own best-organized case is a stronger guide than any rule (e.g. follow `telemetry/span/` v2, not the v1 span scatter). This auto-updates as the codebase evolves.
+
+### 2. Shape the modules
+
+Decide the modules and where their seams go. Prefer fewer, deeper modules over many shallow ones. For each module, name its interface — not just the signature, but the invariants and error modes a caller must know. Run the deletion test on anything you suspect is a pass-through.
+
+Decide where the code lives as part of shaping it — a **locality** call: co-locate what changes together so one change stays directory-local. The discriminator is **shared vs owned**:
+
+- A cohesive subsystem owns its model, lifecycle, and pipeline as one **concept** — group it together, sized to the change (a big subsystem earns its own dir; a small addition matches the surrounding convention).
+- Peel a piece into a **shared** module only when it has its own lifecycle *and* more than one consumer — the deletion test decides it (would extracting it concentrate complexity, or just move it?).
+- **If you can't name the concern a piece serves, that's a smell** — it's doing two things, or belongs to a concept you haven't named yet. A cross-cutting concern (enrichment, exceptions) is still a concept with a home; a truly nameless one means the design is off.
+
+For the repo's concrete layout — which dirs are layer vs concept, the `native/` seam exception, the legacy loose tier — see code-guidelines' **File Organization**.
+
+### 3. Design for testability
+
+A seam exists so a test can cross it. For each module, name the seam its tests will cross and what fake injects there (test-guidelines builds these via `Fixture` + `getSut()`). Three rules make that possible:
+
+- **Accept dependencies, don't create them.** A module that constructs its own transport or client can't be faked; one that receives it can.
+- **Return results, don't bury side effects.** A function that returns a value is testable; one that only mutates shared state is not.
+- **Keep the surface small.** Fewer methods and params mean less test setup.
+
+Native interop is special: **JNI/FFI cannot be faked or mocked** (see `packages/flutter/AGENTS.md`). Put the seam at the Dart boundary *above* native so the logic is unit-testable, and plan an integration test for the native path itself.
+
+### 4. Check the SDK constraints
+
+Resolve these before sketching — each has a canonical home; consult it rather than guessing:
+
+- **Public API surface.** Does this add or change exports in a barrel file? Keep new types in `src/` unless they're meant for SDK users. See `packages/dart/AGENTS.md`.
+- **Integration shape.** If the feature is an `Integration`, it implements `call()`/`close()`, gates on its prerequisites early, and stays order-independent. See code-guidelines.
+- **Package boundary.** Core behavior belongs in `packages/dart/`; integration-specific behavior in its own package. A new dependency in core cascades everywhere.
+
+### 5. Write the design sketch and get approval
+
+Write a short sketch — prose or bullets, not code — and present it. **Do not start implementing until the user approves it.**
+
+The sketch is complete when it states, for the change:
+
+- [ ] Each module, its interface, and whether it's new or modified
+- [ ] The seam each module's tests cross, and the fake that injects there (or "integration test" where native)
+- [ ] The public-API-surface impact (barrel-file exports added/changed, or "none")
+- [ ] One alternative shape you considered and why you rejected it
+
+If the solution space is wide and the best interface isn't obvious, design it twice before sketching — see [references/design-it-twice.md](references/design-it-twice.md).
+
+### 6. Hand off
+
+On approval, implement under code-guidelines, and write tests under test-guidelines at the seams this sketch named.

--- a/.agents/skills/design-first/references/design-it-twice.md
+++ b/.agents/skills/design-first/references/design-it-twice.md
@@ -15,9 +15,11 @@ For most cases, write the contrasting interfaces in the sketch itself:
    - **Common-case-first** — the default call is trivial; rarer needs cost more.
 3. **Compare on depth, locality, and seam placement**, then recommend one. Propose a hybrid if pieces combine well. Be opinionated.
 
-## Parallel sub-agents — for genuinely large surfaces
+## Parallel sub-agents — optional
 
-When the surface is large enough that exploring it inline would crowd the design pass, spawn the explorations concurrently:
+Reach for this **only when both hold**: the `Agent` tool is actually available to you, *and* the surface is large enough that exploring it inline would crowd the design pass. **Default to inline** — it produces the identical output and comparison, just using more of your working context. If the user has said they prefer not to use sub-agents, treat this section as off.
+
+When it applies, spawn the explorations concurrently:
 
 - Spawn 3+ agents with the `Agent` tool, each given one of the constraints above plus a technical brief (file paths, coupling, what sits behind the seam, the dependency it injects).
 - Each returns: the interface (types, methods, params, invariants, error modes), a caller usage example, what the implementation hides, the fake its tests inject, and trade-offs.

--- a/.agents/skills/design-first/references/design-it-twice.md
+++ b/.agents/skills/design-first/references/design-it-twice.md
@@ -1,0 +1,34 @@
+# Design It Twice
+
+When the best interface for a module isn't obvious, design it more than one way before committing. Your first idea is rarely the best (Ousterhout). Uses the vocabulary from [SKILL.md](../SKILL.md) — **module**, **interface**, **seam**, **adapter**, deep vs shallow.
+
+Two ways to run it, by how wide the space is.
+
+## Inline — sketch two or three interfaces yourself
+
+For most cases, write the contrasting interfaces in the sketch itself:
+
+1. **Frame the constraints** the interface must satisfy — invariants, the callers it serves, the seam its tests cross, the dependencies behind it.
+2. **Write 2–3 genuinely different interfaces** under those constraints. Make them diverge, not rephrase:
+   - **Minimal** — 1–3 entry points, maximum leverage each.
+   - **Flexible** — supports more callers and extension.
+   - **Common-case-first** — the default call is trivial; rarer needs cost more.
+3. **Compare on depth, locality, and seam placement**, then recommend one. Propose a hybrid if pieces combine well. Be opinionated.
+
+## Parallel sub-agents — for genuinely large surfaces
+
+When the surface is large enough that exploring it inline would crowd the design pass, spawn the explorations concurrently:
+
+- Spawn 3+ agents with the `Agent` tool, each given one of the constraints above plus a technical brief (file paths, coupling, what sits behind the seam, the dependency it injects).
+- Each returns: the interface (types, methods, params, invariants, error modes), a caller usage example, what the implementation hides, the fake its tests inject, and trade-offs.
+- Present them sequentially, compare in prose on **depth** / **locality** / **seam placement**, and give a recommendation.
+
+## Dependencies, for this SDK
+
+Classify what a module depends on — it decides how the module is tested across its seam:
+
+- **In-process** — pure computation, in-memory state. No adapter; test through the interface directly.
+- **Injected Dart dependency** — transport, HTTP client, clock, a third-party Dart client (e.g. a DB driver in an integration package). Inject it as an interface; tests pass a fake (test-guidelines' `Fixture`).
+- **Native (JNI/FFI)** — cannot be faked. Put the seam at the Dart boundary above native so the logic is unit-testable; cover the native path with an integration test (see `packages/flutter/AGENTS.md`).
+
+One adapter means a hypothetical seam; two means a real one (typically production + test). Don't introduce a seam unless something actually varies across it — a single-adapter seam is just indirection.

--- a/.agents/skills/diagnosing-bugs/SKILL.md
+++ b/.agents/skills/diagnosing-bugs/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: diagnosing-bugs
+description: A discipline for hard bugs, flaky tests, CI hangs, and performance regressions in this SDK. Use when the user says "diagnose" or "debug this", reports something broken/throwing/failing/hanging/slow, or a test is flaky. Builds a tight, red-capable feedback loop before hypothesizing.
+---
+
+A discipline for hard bugs. Skip a phase only when you can say why.
+
+**The whole skill is Phase 1: get a loop that goes red on this bug.** Everything after is mechanical once you have it. If you catch yourself reading code to form a theory before that loop exists, stop — jumping to a hypothesis without a red-capable loop is the exact failure this prevents.
+
+For trivial bugs with an obvious fix and an obvious test, skip this and just write the failing test — this skill is for the bugs that resist.
+
+## Phase 1 — Build a feedback loop
+
+A **tight** loop is fast, deterministic, and goes **red** on *this* bug. Build one and the bug is 90% solved; bisection, hypothesis-testing, and instrumentation all just consume it. Be aggressive and creative here — spend disproportionate effort.
+
+### Ways to construct one — try roughly in this order
+
+1. **Failing test at the seam** — `dart test path/to/test.dart` or `flutter test`, unit or widget, at whatever seam reaches the bug. Tightest loop there is.
+2. **`fakeAsync` harness** — for timer, microtask, and timing-dependent bugs (most flakes). Pin the clock via `options.clock`, elapse time deterministically.
+3. **`testWidgets` harness** — for Flutter UI bugs: pump the widget tree, drive the gesture, assert on the tree (e.g. a hit-test or navigation regression).
+4. **Integration test** — `flutter test integration_test/...` when the bug crosses the native (JNI/FFI) boundary, which cannot be faked (see `packages/flutter/AGENTS.md`).
+5. **Replay a captured payload** — save a real envelope / event / span / network payload to disk and replay it through the code path in isolation.
+6. **Throwaway harness** — a minimal `void main()` that exercises the bug path with one call and mocked deps.
+7. **Stress/repetition loop** — for non-deterministic bugs: run the trigger 100×, parallelise, narrow timing windows, inject delays. The goal is a higher reproduction rate, not a clean repro.
+8. **Differential loop** — run the same input through two versions or two configs (e.g. before/after a dependency bump) and diff the output. For regressions that "appeared after X".
+9. **Bisection harness** — if it appeared between two commits, script the red/green check and `git bisect run` it.
+
+### Tighten the loop
+
+Once you have *a* loop, treat it as a product and tighten it:
+
+- **Faster** — narrow the test scope, skip unrelated init.
+- **Sharper** — assert the exact symptom the user described, not "didn't crash".
+- **More deterministic** — pin the clock (`options.clock`), use `fakeAsync`, seed any randomness, avoid real network/filesystem (per test-guidelines). A 2-second deterministic loop beats a 30-second flaky one.
+
+For **non-deterministic** bugs the goal is a *high enough* reproduction rate to debug against — a 50% flake is debuggable, 1% is not. Keep raising the rate.
+
+### Completion criterion
+
+Phase 1 is done when you can name **one command** — a test invocation or script path — that you have **already run at least once** (paste the invocation and its output), and that is:
+
+- [ ] **Red-capable** — drives the actual bug path and asserts the user's exact symptom, so it goes red now and green once fixed
+- [ ] **Deterministic** — same verdict every run (flaky bugs: a pinned, high reproduction rate)
+- [ ] **Fast** — seconds, not minutes
+
+No red-capable command, no Phase 2.
+
+### When you genuinely cannot build a loop
+
+Say so explicitly, list what you tried, and ask the user for: access to an environment that reproduces it, a captured artifact (envelope dump, log, CI run, screen recording with timestamps), or permission for temporary instrumentation. Do **not** hypothesise without a loop.
+
+## Phase 2 — Reproduce and minimise
+
+Run the loop, watch it go red. Confirm it produces the failure mode the **user** described — not a nearby one (wrong bug = wrong fix). Then shrink the repro to the smallest scenario that still goes red: cut inputs, callers, config, and steps **one at a time**, re-running after each cut. Done when every remaining element is load-bearing — removing any one turns it green. The minimal repro shrinks the hypothesis space and becomes the regression test.
+
+## Phase 3 — Hypothesise
+
+Generate **3–5 ranked, falsifiable hypotheses** before testing any — a single hypothesis anchors you on the first plausible idea. Each must state its prediction: "If X is the cause, then changing Y makes the bug vanish." If you can't state the prediction, it's a vibe — sharpen or discard it. Show the ranked list to the user before testing; they often re-rank it instantly ("we just changed #3"). Don't block on it if they're away.
+
+## Phase 4 — Instrument
+
+Each probe maps to one prediction from Phase 3. **Change one variable at a time.**
+
+- Prefer a debugger / breakpoint over logs where the env supports it. One breakpoint beats ten logs.
+- Otherwise add targeted logs at the boundaries that distinguish hypotheses — never "log everything and grep".
+- **Tag every debug log** with a unique prefix like `[DEBUG-a4f2]` so cleanup is one grep.
+- **Performance regressions**: logs are the wrong tool. Establish a baseline measurement (`Stopwatch`, a timing harness, DevTools, the observatory), then bisect. Measure first, fix second.
+
+## Phase 5 — Fix and regression test
+
+Write the regression test **before** the fix — but only at a **correct seam**, one that exercises the real bug pattern as it occurs at the call site (per test-guidelines). A too-shallow seam (a unit test that can't replicate the chain that triggered it) gives false confidence. If no correct seam exists, **that is itself the finding** — note it; the architecture is preventing the bug from being locked down.
+
+With a correct seam: turn the minimised repro into a failing test, watch it fail, apply the fix, watch it pass, then re-run the Phase 1 loop against the original un-minimised scenario.
+
+## Phase 6 — Cleanup and post-mortem
+
+Before declaring done:
+
+- [ ] Original repro no longer reproduces (re-run the Phase 1 loop)
+- [ ] Regression test passes (or the absence of a seam is documented)
+- [ ] All `[DEBUG-…]` instrumentation removed (grep the prefix)
+- [ ] Throwaway harnesses deleted
+- [ ] The correct hypothesis is stated in the commit / PR message, so the next debugger learns
+
+Then ask: **what would have prevented this bug?** If the answer is architectural — no good test seam, tangled callers, a shallow module hiding the real bug behind it — hand off to the **design-first** skill with the specifics. Make that call *after* the fix is in, when you know the most.

--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: review
+description: Three-axis review of the branch diff — Standards (this repo's documented standards + public API surface), Spec (the originating Linear issue / PR), and Correctness (runtime bugs + the SDK threat model — PII, native leaks, buffers, serialization, concurrency). Runs the axes as parallel sub-agents and reports them side by side. Use when reviewing a branch, a PR, or work-in-progress changes before opening or merging, or "review since X".
+---
+
+Review the diff between `HEAD` and a base, on three axes:
+
+- **Standards** — does the diff conform to this repo's documented standards?
+- **Spec** — does it faithfully implement the originating issue / PR?
+- **Correctness** — will it actually work, and is it safe?
+
+Run the axes as **parallel sub-agents** so none pollutes another's context, then aggregate. Report them side by side, and **never rerank across axes** — keeping them separate is the whole point (see *Why separate axes*).
+
+This is the every-PR pass. It complements `security-review` (deeper security audit) and `span-convention-review` (tracing-span conventions) — invoke those for depth. It is *not* a debugger: when a bug is already known and reproducing, use `diagnosing-bugs` instead.
+
+## 1. Pin the base
+
+Use whatever base the user named — a commit, branch, tag, or `HEAD~N`. If they named none, default to the merge-base with the default branch (`git merge-base HEAD origin/main`). Capture once:
+
+- `git diff <base>...HEAD` (three-dot, so it compares against the merge-base)
+- `git log <base>..HEAD --oneline`
+
+Confirm the ref resolves (`git rev-parse <base>`) and the diff is non-empty. A bad ref or empty diff fails **here** — not inside parallel sub-agents.
+
+## 2. Identify the spec source
+
+Look for the originating spec, in order:
+
+1. Linear issue references in commit messages or the PR (fetch the issue via the Linear tools).
+2. The PR description (motivation / what it does).
+3. A path the user passed.
+
+If none is found, ask. If there genuinely is no spec, the Spec sub-agent skips and reports "no spec available".
+
+## 3. Spawn the sub-agents in parallel
+
+Send one message with three `Agent` tool calls (general-purpose subagent for each). Give each the diff command and the commit list, plus its brief:
+
+**Standards sub-agent:**
+
+> Read `.agents/skills/code-guidelines/SKILL.md` and `.agents/skills/test-guidelines/SKILL.md`, then review the diff against them.
+> **Top priority — public API surface:** for any change to a barrel file (`lib/sentry.dart`, `lib/sentry_flutter.dart`, or an integration package's barrel), classify each exported symbol as added / removed / signature-changed / behavior-changed. Flag every removal or incompatible change as a **breaking change** (semver-major) and check it carries a deprecation path (per code-guidelines).
+> Then report, per file/hunk, every place the diff violates a documented standard — cite the rule. For areas the docs don't cover, apply the smell baseline in `.agents/skills/review/references/smell-baseline.md` as judgement calls. Distinguish hard violations from judgement calls; a documented standard overrides the baseline. Skip anything `dart analyze` / `dart format` / lints enforce. Under 400 words.
+
+**Spec sub-agent** (skip and note if no spec):
+
+> Report: (a) requirements the spec asked for that are missing or partial; (b) behavior in the diff that wasn't asked for (scope creep); (c) requirements that look implemented but wrong. Quote the spec line for each finding. Under 400 words.
+
+**Correctness sub-agent:**
+
+> Find bugs and unsafe code the diff introduces — not style, which Standards owns. Check, per file/hunk:
+> - **Runtime bugs** — unawaited / fire-and-forget futures, uncancelled stream subscriptions, `late` used before init, null/empty edge cases, swallowed errors, missing cleanup in `close()` / `dispose()`, races / TOCTOU.
+> - **SDK threat model** — PII collected without gating on `options.sendDefaultPii`; sensitive data leaking into breadcrumbs, logs, or event payloads; native memory not released (JNI local refs, `malloc`) or a native exception that could crash the host app; unbounded buffers / queues / caches (memory growth); serialization correctness (`toJson`/`fromJson` round-trip, null handling); isolate / thread safety; rate-limiter or retry correctness.
+> For each finding give file:line, a one-line severity (critical/high/medium/low), why it's real (not already handled, no covering test), and a concrete fix. Skip anything the analyzer or existing tests already catch. Under 400 words.
+
+## 4. Aggregate
+
+Present the reports under `## Standards`, `## Spec`, and `## Correctness` headings, verbatim or lightly cleaned. Do **not** merge or rerank findings across axes.
+
+End with a one-line summary per axis: total findings, and the worst issue *within that axis*. Don't pick a single winner across axes — that's the reranking the separation exists to prevent.
+
+## Why separate axes
+
+A change can pass on one axis and fail on another, and a merged list lets one mask the others:
+
+- Follows every standard but implements the wrong thing → **Standards pass, Spec fail.**
+- Does what the issue asked but breaks conventions → **Spec pass, Standards fail.**
+- Clean and on-spec but leaks a native ref or drops a `sendDefaultPii` check → **Standards & Spec pass, Correctness fail.**
+
+Reporting them separately stops any one axis from hiding another.

--- a/.agents/skills/review/references/smell-baseline.md
+++ b/.agents/skills/review/references/smell-baseline.md
@@ -1,0 +1,21 @@
+# Smell Baseline
+
+A fallback set of code smells (Fowler, _Refactoring_ ch.3) for the Standards axis to apply **only in areas the repo doesn't document**. Two rules bind it:
+
+- **The repo overrides.** A documented standard in `code-guidelines` / `test-guidelines` always wins; where it endorses something this baseline would flag, suppress the smell.
+- **Always a judgement call.** Each smell is a labelled heuristic ("possible Feature Envy"), never a hard violation — and skip anything `dart analyze` / `dart format` / lints already enforce.
+
+Each reads *what it is* → *how to fix*; match against the diff.
+
+- **Mysterious Name** — a name that doesn't reveal what it does or holds. → rename; if no honest name comes, the design is murky.
+- **Duplicated Code** — the same logic shape in more than one hunk or file in the change. → extract the shared shape, call it from both.
+- **Feature Envy** — a method that reaches into another object's data more than its own. → move it onto the data it envies.
+- **Data Clumps** — the same few fields/params keep travelling together. → bundle them into one type, pass that.
+- **Primitive Obsession** — a primitive or string standing in for a domain concept that deserves its own type. → give the concept a small type (a Dart extension type or value class).
+- **Repeated Switches** — the same `switch`/`if`-cascade on the same type recurs across the change. → replace with polymorphism, sealed-class exhaustiveness, or one shared map.
+- **Shotgun Surgery** — one logical change forces scattered edits across many files. → gather what changes together into one module.
+- **Divergent Change** — one file edited for several unrelated reasons. → split so each module changes for one reason.
+- **Speculative Generality** — abstraction, params, or hooks added for needs the spec doesn't have. → delete it; inline until a real need shows.
+- **Message Chains** — long `a.b().c().d()` navigation the caller shouldn't depend on. → hide the walk behind one method on the first object.
+- **Middle Man** — a class or function that mostly just delegates onward. → cut it, call the real target directly.
+- **Shallow Module** — an interface nearly as complex as its implementation (per design-first). → deepen or merge; apply the deletion test.

--- a/.agents/skills/spec/SKILL.md
+++ b/.agents/skills/spec/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: spec
+description: Produce a verified spec — problem, desired outcome, and acceptance criteria — before building. Use when given a GitHub/Linear issue link, when starting from a fuzzy in-conversation idea, or asked to "figure out what to do" / "scope this" / "what should I build" — whenever the *what* isn't yet pinned down. Grills the ambiguities, checks the premise against the code, and produces acceptance criteria you sign off on — then hands to design-first.
+---
+
+Settle *what* to build and *why* — with verifiable acceptance criteria — before any design or code. This is the front of the pipeline: **spec** (what) → **design-first** (how) → **code-guidelines** + **test-guidelines** (build) → **review** (which verifies the result against this spec).
+
+Run it for a tracked issue or a fuzzy ask. Skip it — and say so — when the ask is already a precise, verifiable instruction.
+
+## 1. Establish the source
+
+Get the raw intent from wherever it lives:
+
+- **From a tracked issue** (a GitHub/Linear link) — fetch it, don't work from the link text or your memory of it:
+  - **GitHub:** `gh issue view <url-or-number> --json title,body,comments,labels,state`, plus any linked PRs.
+  - **Linear:** the Linear tools — the issue and its comments.
+  - Read the full body, **every comment**, labels, and linked issues/PRs. The real decision is often buried in a comment, not the title.
+- **From an in-conversation idea** — start from what the user said, in their words. If a tracked issue might already exist for it, ask for the link; otherwise proceed — the spec itself is the source of truth.
+
+Either way you now hold the raw intent — which is usually vague wherever it came from. Sharpen it in the steps below.
+
+## 2. Reconstruct the real intent
+
+The raw ask usually names a symptom; the real need is underneath. State, in the domain's own words: the problem this solves, who it's for, and what "done" looks like. Separate the *reported symptom* from the *underlying need* — they're often not the same fix.
+
+## 3. Check the premise against the code
+
+The ask — especially from a tracked issue — may be stale, partial, or simply wrong. Investigate before believing it:
+
+- Does the described behavior actually exist / reproduce? For a bug, find the code path — and if it's non-trivial, build the repro loop now (see **diagnosing-bugs**).
+- Is part of it already implemented, or made moot by a later change?
+- Does the codebase contradict the issue's assumptions?
+
+Surface any contradiction to the user before going further — a spec built on a false premise wastes the whole pipeline.
+
+## 4. Grill the gaps
+
+Interview relentlessly until the intent is unambiguous. **One question at a time**, waiting for the answer before the next — batching questions is bewildering. Give your **recommended answer** with each question. If a question can be answered by reading the code, read it instead of asking. Drive out scope, edge cases, and the in-vs-out boundary.
+
+## 5. Write the spec and get sign-off
+
+Produce, in the conversation:
+
+- **Problem** — what's wrong or missing, and why it matters.
+- **Outcome** — the desired end state, in the domain's words.
+- **Acceptance criteria** — verifiable, observable conditions (e.g. "capturing an event with X attaches Y"; "the N+1 is gone — one query"). This is the bar `review`'s Spec axis will check against.
+- **Non-goals** — what's explicitly out of scope.
+- **Open questions** — anything still unresolved.
+
+Done when the user **signs off on the acceptance criteria** — explicit agreement that meeting them means the work is complete. Not "looks reasonable"; agreement on the bar.
+
+## 6. Hand off
+
+The *what* is now settled. This spec becomes the PR description's problem / outcome / acceptance at ship time (`pr-writer` formats it; `review`'s Spec axis verifies against it). Hand off to **design-first** to shape the *how*.

--- a/.agents/skills/test-guidelines/SKILL.md
+++ b/.agents/skills/test-guidelines/SKILL.md
@@ -1,9 +1,19 @@
 ---
 name: test-guidelines
-description: Enforce Sentry Dart/Flutter SDK test conventions for naming, structure, and fixtures. Use when writing tests, adding tests, modifying tests, reviewing test code, fixing failing tests, adding test coverage, TDD, reproducing bugs with tests, regression tests, or test refactoring in any package in this Melos monorepo.
+description: Enforce Sentry Dart/Flutter SDK test conventions for naming, structure, and fixtures. Use when writing tests, adding tests, modifying tests, reviewing test code, fixing failing tests, adding test coverage, TDD, test-first / red-green, reproducing bugs with tests, regression tests, or test refactoring in any package in this Melos monorepo.
 ---
 
 Apply these conventions to all new and modified tests across every package in this monorepo. Existing tests may not follow these conventions — do not refactor them unless asked.
+
+Tests are easiest to write against code designed to accept its dependencies — when implementing the code under test, load **design-first** (where the seams go) and **code-guidelines** (the rules).
+
+## Test-First Loop
+
+Work in **vertical slices**, not horizontal ones. One failing test → the minimal code that makes it pass → repeat. Each test is a **tracer bullet**: it proves one thin path end-to-end, and what you learn from it shapes the next.
+
+Do **not** write all the tests first and then all the implementation. That **horizontal slicing** produces tests of *imagined* behavior — they assert the shape you guessed at, pass when the real behavior breaks, and commit you to a structure before you understand it. Write one test at a time, against behavior you can already reason about.
+
+Fixing a bug? Reproduce it with a failing test first — see **diagnosing-bugs** for the loop.
 
 ## File Structure
 
@@ -156,12 +166,11 @@ group('$Client', () {
 });
 ```
 
-## Fixture Pattern
+## Fixtures and Setup
 
-Define a `Fixture` class at the bottom of each test file to encapsulate setup:
+Encapsulate setup in a `Fixture` class at the bottom of each test file, exposing a `getSut()` that builds the System Under Test with configurable, injectable dependencies. Initialize it in `setUp()` within the narrowest group that needs it. Always build options via `defaultTestOptions()` from `test_utils.dart` — never construct `SentryOptions` directly.
 
 ```dart
-// GOOD: Fixture class with getSut() and configurable options
 class Fixture {
   final transport = MockTransport();
   final options = defaultTestOptions();
@@ -172,94 +181,9 @@ class Fixture {
     return SentryClient(options);
   }
 }
-
-// Usage in tests:
-late Fixture fixture;
-
-setUp(() {
-  fixture = Fixture();
-});
-
-test('captures event', () {
-  final sut = fixture.getSut();
-  // ...
-});
 ```
 
-```dart
-// AVOID: Inline setup without Fixture, duplicated across tests
-test('captures event', () {
-  final options = SentryOptions(dsn: fakeDsn);
-  final transport = MockTransport();
-  options.transport = transport;
-  final client = SentryClient(options);
-  // ...
-});
-```
-
-Rules:
-- Place `Fixture` at the bottom of the test file.
-- Use `getSut()` to create the System Under Test with configurable options.
-- Initialize the fixture in `setUp()` for each test group.
-- When setup steps are shared, use the top-most shared group to set up the fixture.
-
-## Test Options
-
-Always use `defaultTestOptions()` from `test_utils.dart` to create options — never construct `SentryOptions` directly in tests.
-
-```dart
-// GOOD: Use defaultTestOptions()
-final options = defaultTestOptions();
-options.dsn = fakeDsn;
-
-// AVOID: Constructing SentryOptions directly
-final options = SentryOptions(dsn: fakeDsn);
-```
-
-## Setup and Teardown
-
-- Place `setUp()` / `tearDown()` inside the narrowest group they apply to.
-- Prefer `late` variables initialized in `setUp()` over inline construction in each test.
-- Use `setUpAll()` / `tearDownAll()` only for genuinely expensive shared resources.
-
-```dart
-// GOOD: late + setUp in narrowest group, fixture reset per test
-group('$Client', () {
-  late Fixture fixture;
-  setUp(() {
-    fixture = Fixture();
-  });
-
-  group('when capturing', () {
-    test('sends event to transport', () {
-      final sut = fixture.getSut();
-      // ...
-    });
-  });
-});
-
-// AVOID: setUp at top level when only one group needs it
-group('$Client', () {
-  late Fixture fixture;
-  late SomeExpensiveResource resource;
-
-  // Wrong: setUpAll for cheap objects
-  setUpAll(() {
-    fixture = Fixture();
-    resource = SomeExpensiveResource();
-  });
-
-  // Wrong: setUp in a deeper group when all sibling groups share it
-  group('when capturing', () {
-    setUp(() { fixture = Fixture(); });
-    test('sends event', () { });
-  });
-  group('when closing', () {
-    setUp(() { fixture = Fixture(); }); // duplicated
-    test('flushes transport', () { });
-  });
-});
-```
+Full rules — `Fixture` placement, `setUp`/`tearDown` scoping, `setUpAll` caveats, and the `defaultTestOptions()` rule — in [references/fixtures.md](references/fixtures.md).
 
 ## What to Test
 
@@ -301,7 +225,7 @@ test('SentryAttribute.string stores its value', () {
 - Use `expect()` with matchers from `package:test`.
 - Prefer specific matchers (`throwsArgumentError`, `isA<SentryException>()`) over generic ones (`throwsException`, `isA<Exception>()`).
 - One logical assertion per test. Multiple `expect()` calls are fine if they verify a single behavior.
-- Assert the literal expected value, not the same constant the production code uses to produce it. Sharing one constant across production and test makes the assertion tautological — it still passes if the constant holds the wrong value. Using the constant as the lookup *key* is fine; pin the expected *value* as a literal.
+- **Avoid the tautological test.** Assert the literal expected value, not the same constant the production code uses to produce it — a test whose expected value is computed the way the code computes it passes by construction and can never disagree with the code. Sharing one constant across production and test makes the assertion tautological: it still passes if the constant holds the wrong value. Using the constant as the lookup *key* is fine; pin the expected *value* as a literal.
 
 ```dart
 // GOOD: Specific matchers, single logical assertion
@@ -323,66 +247,19 @@ test('captures exception', () {
 // GOOD: pin the expected value as a literal
 expect(span.data[SentryDatabase.dbSystemKey], 'sqlite');
 
-// AVOID: asserting against the same constant the production code uses to set it
+// AVOID (tautological): asserting against the same constant the production code uses to set it
 expect(span.data[SentryDatabase.dbSystemKey], SentryDatabase.dbSystem);
-```
-
-## Async
-
-- Return the `Future` or mark the test callback as `async`. Never fire-and-forget.
-- Use `expectLater` with stream matchers (`emitsInOrder`, `emitsError`) for stream assertions.
-- Use `fakeAsync` for timer and microtask-dependent code.
-
-```dart
-// GOOD: async test, awaited future
-test('sends event asynchronously', () async {
-  await sut.captureEvent(event);
-  expect(fixture.transport.events, hasLength(1));
-});
-
-// GOOD: fakeAsync for timer-dependent code
-test('flushes after timeout', () {
-  fakeAsync((async) {
-    sut.startTimer();
-    async.elapse(Duration(seconds: 5));
-    expect(fixture.transport.flushed, isTrue);
-  });
-});
-
-// AVOID: Fire-and-forget future
-test('sends event', () {
-  sut.captureEvent(event); // missing await!
-  expect(fixture.transport.events, hasLength(1));
-});
 ```
 
 ## Mocking
 
-- **Prefer fakes over mocks.** Fakes are hand-written implementations that capture state, making tests resilient to refactoring and readable as documentation. Use them as the default for test doubles.
-- Only reach for mocks when faking is impractical, e.g. a large
-  third-party interface where writing a full fake isn't worth the effort.
-- Use test doubles already defined in the project.
-- When creating a new fake, implement the interface directly and keep it minimal — only the methods the tests actually exercise.
-- Existing mocks are typically found in `mocks.dart` files.
+**Prefer fakes over mocks** — hand-written implementations that capture state, resilient to refactoring and readable as documentation. Reach for a mock only when faking a large third-party interface isn't worth it. A test that's hard to fake usually signals the code under test should accept its dependencies rather than construct them (a **design-first** concern).
 
-```dart
-// GOOD: Hand-written fake that captures state
-class FakeTransport implements Transport {
-  final List<SentryEnvelope> envelopes = [];
+Full guidance, including **designing for mockability** (dependency injection, SDK-style interfaces, mocking only at real boundaries), in [references/mocking.md](references/mocking.md).
 
-  @override
-  Future<SentryId> send(SentryEnvelope envelope) async {
-    envelopes.add(envelope);
-    return envelope.header.eventId ?? SentryId.empty();
-  }
-}
+## Async
 
-// AVOID: Mock with verification-heavy assertions
-final transport = MockTransport();
-when(transport.send(any)).thenAnswer((_) async => SentryId.newId());
-// ... later
-verify(transport.send(any)).called(1);
-```
+Never fire-and-forget: return the `Future` or mark the callback `async`. Use `expectLater` with stream matchers for streams, and `fakeAsync` for timer/microtask-dependent code. Examples in [references/async.md](references/async.md).
 
 ## General
 

--- a/.agents/skills/test-guidelines/references/async.md
+++ b/.agents/skills/test-guidelines/references/async.md
@@ -1,0 +1,30 @@
+# Async Tests
+
+The full guidance behind the one-line summary in [SKILL.md](../SKILL.md).
+
+- Return the `Future` or mark the test callback as `async`. Never fire-and-forget.
+- Use `expectLater` with stream matchers (`emitsInOrder`, `emitsError`) for stream assertions.
+- Use `fakeAsync` for timer and microtask-dependent code.
+
+```dart
+// GOOD: async test, awaited future
+test('sends event asynchronously', () async {
+  await sut.captureEvent(event);
+  expect(fixture.transport.events, hasLength(1));
+});
+
+// GOOD: fakeAsync for timer-dependent code
+test('flushes after timeout', () {
+  fakeAsync((async) {
+    sut.startTimer();
+    async.elapse(Duration(seconds: 5));
+    expect(fixture.transport.flushed, isTrue);
+  });
+});
+
+// AVOID: Fire-and-forget future
+test('sends event', () {
+  sut.captureEvent(event); // missing await!
+  expect(fixture.transport.events, hasLength(1));
+});
+```

--- a/.agents/skills/test-guidelines/references/fixtures.md
+++ b/.agents/skills/test-guidelines/references/fixtures.md
@@ -1,0 +1,108 @@
+# Fixtures, Test Options, Setup & Teardown
+
+The full rules behind the one-line summary in [SKILL.md](../SKILL.md). All of these concern how a test assembles and resets its System Under Test.
+
+## Fixture Pattern
+
+Define a `Fixture` class at the bottom of each test file to encapsulate setup:
+
+```dart
+// GOOD: Fixture class with getSut() and configurable options
+class Fixture {
+  final transport = MockTransport();
+  final options = defaultTestOptions();
+
+  SentryClient getSut({bool attachStacktrace = true}) {
+    options.attachStacktrace = attachStacktrace;
+    options.transport = transport;
+    return SentryClient(options);
+  }
+}
+
+// Usage in tests:
+late Fixture fixture;
+
+setUp(() {
+  fixture = Fixture();
+});
+
+test('captures event', () {
+  final sut = fixture.getSut();
+  // ...
+});
+```
+
+```dart
+// AVOID: Inline setup without Fixture, duplicated across tests
+test('captures event', () {
+  final options = SentryOptions(dsn: fakeDsn);
+  final transport = MockTransport();
+  options.transport = transport;
+  final client = SentryClient(options);
+  // ...
+});
+```
+
+Rules:
+- Place `Fixture` at the bottom of the test file.
+- Use `getSut()` to create the System Under Test with configurable options.
+- Initialize the fixture in `setUp()` for each test group.
+- When setup steps are shared, use the top-most shared group to set up the fixture.
+
+## Test Options
+
+Always use `defaultTestOptions()` from `test_utils.dart` to create options — never construct `SentryOptions` directly in tests.
+
+```dart
+// GOOD: Use defaultTestOptions()
+final options = defaultTestOptions();
+options.dsn = fakeDsn;
+
+// AVOID: Constructing SentryOptions directly
+final options = SentryOptions(dsn: fakeDsn);
+```
+
+## Setup and Teardown
+
+- Place `setUp()` / `tearDown()` inside the narrowest group they apply to.
+- Prefer `late` variables initialized in `setUp()` over inline construction in each test.
+- Use `setUpAll()` / `tearDownAll()` only for genuinely expensive shared resources.
+
+```dart
+// GOOD: late + setUp in narrowest group, fixture reset per test
+group('$Client', () {
+  late Fixture fixture;
+  setUp(() {
+    fixture = Fixture();
+  });
+
+  group('when capturing', () {
+    test('sends event to transport', () {
+      final sut = fixture.getSut();
+      // ...
+    });
+  });
+});
+
+// AVOID: setUp at top level when only one group needs it
+group('$Client', () {
+  late Fixture fixture;
+  late SomeExpensiveResource resource;
+
+  // Wrong: setUpAll for cheap objects
+  setUpAll(() {
+    fixture = Fixture();
+    resource = SomeExpensiveResource();
+  });
+
+  // Wrong: setUp in a deeper group when all sibling groups share it
+  group('when capturing', () {
+    setUp(() { fixture = Fixture(); });
+    test('sends event', () { });
+  });
+  group('when closing', () {
+    setUp(() { fixture = Fixture(); }); // duplicated
+    test('flushes transport', () { });
+  });
+});
+```

--- a/.agents/skills/test-guidelines/references/mocking.md
+++ b/.agents/skills/test-guidelines/references/mocking.md
@@ -1,0 +1,48 @@
+# Mocking and Designing for Mockability
+
+The full guidance behind the one-line summary in [SKILL.md](../SKILL.md).
+
+## Prefer fakes over mocks
+
+- **Prefer fakes over mocks.** Fakes are hand-written implementations that capture state, making tests resilient to refactoring and readable as documentation. Use them as the default for test doubles.
+- Only reach for mocks when faking is impractical, e.g. a large third-party interface where writing a full fake isn't worth the effort.
+- Use test doubles already defined in the project.
+- When creating a new fake, implement the interface directly and keep it minimal — only the methods the tests actually exercise.
+- Existing mocks are typically found in `mocks.dart` files.
+
+```dart
+// GOOD: Hand-written fake that captures state
+class FakeTransport implements Transport {
+  final List<SentryEnvelope> envelopes = [];
+
+  @override
+  Future<SentryId> send(SentryEnvelope envelope) async {
+    envelopes.add(envelope);
+    return envelope.header.eventId ?? SentryId.empty();
+  }
+}
+
+// AVOID: Mock with verification-heavy assertions
+final transport = MockTransport();
+when(transport.send(any)).thenAnswer((_) async => SentryId.newId());
+// ... later
+verify(transport.send(any)).called(1);
+```
+
+## Designing for mockability
+
+A test double can only be substituted at a seam the code actually exposes. If a test is hard to fake, the code under test is usually the problem — fix the design, not the test. (This is the testability side of **design-first**; shape the code there, verify it here.)
+
+- **The code must accept its dependencies for a fake to substitute.** This is the testability trio that **design-first** owns (accept deps, return results, small surface) — here it's just the test-side consequence: a class that receives its transport/client/clock can be faked in `Fixture.getSut()`; one that constructs them internally cannot.
+
+  ```dart
+  // GOOD: dependency injected → fake it in getSut()
+  SentryClient(this._options); // _options.transport is set by the test
+
+  // HARD TO TEST: dependency constructed internally
+  SentryClient() : _transport = HttpTransport(); // test can't replace it
+  ```
+
+- **Prefer SDK-style interfaces over one generic call.** A double for `getUser()` / `sendEnvelope()` returns one known shape; a double for a single generic `request(endpoint, options)` needs conditional logic inside the fake to decide what to return. Specific per-operation methods keep fakes trivial and make it obvious which operations a test exercises.
+
+- **Mock only at real boundaries** — transport, native interop, the clock, randomness, the filesystem. Don't fake your own in-process collaborators; test through them.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,8 @@ Run from within the package directory (e.g., `cd packages/dart/`):
 | Fix | `dart fix --apply` | `dart fix --apply` |
 | Web test | — | `flutter test -d chrome path/to/test.dart` |
 
+> **Format version footgun:** CI's `analyze` gate (`.github/workflows/analyze.yml`) runs `dart format --set-exit-if-changed ./` using the dart set up for that job's `sdk` input — `setup-dart` for **dart** packages, `flutter-action`'s **Flutter-bundled dart** (stable channel) for **flutter** packages — *not* the package's `environment:` constraint. `dart_style` differs between Dart minor versions, so formatting with a local dart of a different version can leave the gate red. This has bitten `packages/flutter` (Flutter-bundled Dart 3.12 joined a line that system Dart 3.10 didn't). Before pushing format changes to a flutter package, format with the Flutter SDK's bundled dart — its `bin/cache/dart-sdk/bin/dart` (reachable via `fvm flutter` if you use fvm) — and verify with `--output=none --set-exit-if-changed`.
+
 ## Conventions
 
 - Ask clarifying questions and/or propose a plan before implementation
@@ -86,15 +88,29 @@ Use the right AGENTS.md for the area you're working in:
 
 ## Skills
 
-- **test-guidelines** — Writing or modifying tests
-- **code-guidelines** — Implementing features, refactoring, or reviewing code
+These form a workflow pipeline — each is model-invoked (the agent reaches for it on its triggers) and hands off to the next:
+
+**spec** → **design-first** → **code-guidelines** + **test-guidelines** → **diagnosing-bugs** → **review**
+
+- **spec** — Turn an issue link or a fuzzy ask into a verified spec (acceptance criteria) before design — the *what*
+- **design-first** — Shape non-trivial work before writing it: modules, seams, public API surface — the *how*
+- **code-guidelines** — Implement / refactor / review against the SDK's rules and constraints
+- **test-guidelines** — Write or modify tests
+- **diagnosing-bugs** — Hard bugs, flaky tests, CI hangs, performance regressions
+- **review** — Three-axis branch review: Standards (our docs + public API surface), Spec (vs the spec above), Correctness (runtime bugs + SDK threat model)
+
+**With plan mode:** plan mode enforces read-only + the approval gate; these skills supply the content. Plan with `spec` (the *what*) and `design-first` (the *how*) — their acceptance criteria + design sketch *are* the plan, and `ExitPlanMode` is the single sign-off (don't run a separate approval). `code-guidelines` is the constraint set the design must satisfy, not the driver. After approval, implement under `code-guidelines` / `test-guidelines`.
 
 ## Maintaining Agent Docs
 
 When you hit a wall that an instruction would have prevented, a documented command/path is wrong, or a convention has changed — propose an update to the relevant file:
 
 - `AGENTS.md` — commands, environment, package structure, conventions
-- `.agents/skills/test-guidelines/SKILL.md` — Writing or modifying tests
+- `.agents/skills/spec/SKILL.md` — Turning an issue link or a fuzzy ask into a verified spec before design
+- `.agents/skills/design-first/SKILL.md` — Shaping non-trivial work before writing it
 - `.agents/skills/code-guidelines/SKILL.md` — Implementing features, refactoring, or reviewing code
+- `.agents/skills/test-guidelines/SKILL.md` — Writing or modifying tests
+- `.agents/skills/diagnosing-bugs/SKILL.md` — Hard bugs, flaky tests, CI hangs, performance regressions
+- `.agents/skills/review/SKILL.md` — Three-axis branch review (Standards + Spec + Correctness)
 
 Do NOT add task-specific fixes, things discoverable from code, or duplicates of what linters enforce. Always propose changes — do not silently edit these files.

--- a/agents.toml
+++ b/agents.toml
@@ -32,15 +32,7 @@ name = "iterate-pr"
 source = "getsentry/skills"
 
 [[skills]]
-name = "code-review"
-source = "getsentry/skills"
-
-[[skills]]
 name = "code-simplifier"
-source = "getsentry/skills"
-
-[[skills]]
-name = "find-bugs"
 source = "getsentry/skills"
 
 [[skills]]
@@ -95,3 +87,27 @@ source = "getsentry/sdk-skills"
 [[skills]]
 name = "contributing-md"
 source = "getsentry/sdk-skills"
+
+[[skills]]
+name = "code-guidelines"
+source = "path:.agents/skills/code-guidelines"
+
+[[skills]]
+name = "design-first"
+source = "path:.agents/skills/design-first"
+
+[[skills]]
+name = "diagnosing-bugs"
+source = "path:.agents/skills/diagnosing-bugs"
+
+[[skills]]
+name = "review"
+source = "path:.agents/skills/review"
+
+[[skills]]
+name = "test-guidelines"
+source = "path:.agents/skills/test-guidelines"
+
+[[skills]]
+name = "spec"
+source = "path:.agents/skills/spec"

--- a/packages/flutter/AGENTS.md
+++ b/packages/flutter/AGENTS.md
@@ -17,8 +17,6 @@ Flutter SDK with native integrations across all platforms.
 | Linux | C++ | `linux/` |
 | Windows | C++ | `windows/` |
 
-- Release all native memory (JNI local refs, malloc allocations)
-- Handle native exceptions gracefully — never crash the host app
 - JNI bindings use `package:jni`; FFI bindings use `dart:ffi`
 - JNI should pass primitives directly. Small, controlled `Map`/`List` payloads may use direct conversion; arbitrary or large payloads should cross as UTF-8 JSON bytes and deserialize on Kotlin/Java.
 - JNI and FFI can currently only be tested through integration test since they cannot be injected / mocked or faked.

--- a/warden.toml
+++ b/warden.toml
@@ -4,17 +4,9 @@ version = 1
 failOn = "high"
 reportOn = "medium"
 
+# Local three-axis review (Standards + Spec + Correctness) — see .agents/skills/review/
 [[skills]]
-name = "code-review"
-remote = "getsentry/skills"
-
-[[skills.triggers]]
-type = "pull_request"
-actions = ["opened", "synchronize", "reopened"]
-
-[[skills]]
-name = "find-bugs"
-remote = "getsentry/skills"
+name = "review"
 
 [[skills.triggers]]
 type = "pull_request"


### PR DESCRIPTION
Adds a set of locally-authored agent skills (`.agents/skills/`, declared in `agents.toml` as local `path:` skills) that form an end-to-end development workflow for this repo, and sharpens the two existing ones.

The pipeline:

`spec` → `design-first` → `code-guidelines` + `test-guidelines` → `diagnosing-bugs` → `review`

**New:**
- **spec** — turn a GitHub/Linear issue or a fuzzy ask into a verified spec (acceptance criteria) before design.
- **design-first** — shape modules, seams, and public-API impact before writing code.
- **diagnosing-bugs** — feedback-loop-first debugging for hard bugs, flaky tests, and CI hangs.
- **review** — three-axis branch review (Standards / Spec / Correctness) that runs on PRs via warden.

`code-guidelines` and `test-guidelines` are sharpened with the writing-great-skills lens: the tautological-test and horizontal-slicing anti-patterns are named, design-for-mockability is added, and the Effective Dart checklist plus setup/mocking/async detail move behind `references/` files so only the SDK-specific, non-default rules stay inline.

On the tooling side, the vendored `code-review` (wrong language stack) and `find-bugs` (web-app threat model) are removed from `agents.toml` and `warden.toml`; warden now runs the local `review`, whose Correctness axis carries the SDK threat model those covered. `AGENTS.md` documents the pipeline and how it composes with plan mode, and the native-memory rules duplicated in `packages/flutter/AGENTS.md` (now owned by `code-guidelines`) are dropped.

No runtime SDK code changes.

Where to start: `AGENTS.md` for the pipeline overview, then the individual `SKILL.md` files.