### PR TITLE
feat: Report blocked_main_thread on streaming spans

### DIFF
--- a/packages/dart/lib/src/constants.dart
+++ b/packages/dart/lib/src/constants.dart
@@ -388,6 +388,15 @@ abstract class SemanticAttributesConstants {
   /// For more information see [frames delay](https://develop.sentry.dev/sdk/performance/frames-delay/).
   static const framesDelay = 'frames.delay';
 
+  /// The managed thread ID the span ran on.
+  static const threadId = 'thread.id';
+
+  /// The name of the thread the span ran on (e.g., "main").
+  static const threadName = 'thread.name';
+
+  /// Whether the main thread was blocked by the span.
+  static const blockedMainThread = 'blocked_main_thread';
+
   /// The HTTP request method (e.g., "GET", "POST").
   static const httpRequestMethod = 'http.request.method';
 

--- a/packages/dart/lib/src/span_data_convention.dart
+++ b/packages/dart/lib/src/span_data_convention.dart
@@ -5,6 +5,4 @@ class SpanDataConvention {
   static const slowFrames = 'frames.slow';
   static const frozenFrames = 'frames.frozen';
   static const framesDelay = 'frames.delay';
-
-  // TODO: eventually add other data keys here as well
 }

--- a/packages/dart/lib/src/span_data_convention.dart
+++ b/packages/dart/lib/src/span_data_convention.dart
@@ -6,11 +6,5 @@ class SpanDataConvention {
   static const frozenFrames = 'frames.frozen';
   static const framesDelay = 'frames.delay';
 
-  // Thread/Isolate data keys according to Sentry span data conventions
-  // https://develop.sentry.dev/sdk/telemetry/traces/span-data-conventions/#thread
-  static const threadId = 'thread.id';
-  static const threadName = 'thread.name';
-  static const blockedMainThread = 'blocked_main_thread';
-
   // TODO: eventually add other data keys here as well
 }

--- a/packages/dart/lib/src/tracing/instrumentation/instrumentation.dart
+++ b/packages/dart/lib/src/tracing/instrumentation/instrumentation.dart
@@ -3,3 +3,4 @@ library;
 
 export 'instrumentation_span.dart';
 export 'span_factory.dart';
+export 'synchronous_span_marker.dart';

--- a/packages/dart/lib/src/tracing/instrumentation/instrumentation_span.dart
+++ b/packages/dart/lib/src/tracing/instrumentation/instrumentation_span.dart
@@ -3,41 +3,6 @@ import 'package:meta/meta.dart';
 import '../../../sentry.dart';
 import '../../utils/internal_logger.dart';
 
-/// Data key marking a span as wrapping a synchronous operation.
-///
-/// This is an internal signal between auto-instrumentation (which knows an
-/// operation ran synchronously) and the Flutter `ThreadInfoIntegration` (which
-/// knows the isolate). The integration consumes it to derive
-/// `blocked_main_thread` and strips it, so it is not sent to Sentry.
-const _synchronousAttributeKey = 'sync';
-
-/// Marks a span as wrapping a synchronous operation.
-@internal
-extension SynchronousInstrumentationSpan on InstrumentationSpan {
-  /// Flags this span as a synchronous operation for main-thread detection.
-  void markSynchronous() => setData(_synchronousAttributeKey, true);
-}
-
-/// Reads and clears the synchronous marker on a v1 span.
-@internal
-extension SynchronousSentrySpan on SentrySpan {
-  /// Whether this span was flagged as a synchronous operation.
-  bool get isSynchronous => data[_synchronousAttributeKey] == true;
-
-  /// Removes the synchronous marker so it is not sent to Sentry.
-  void clearSynchronous() => removeData(_synchronousAttributeKey);
-}
-
-/// Reads and clears the synchronous marker on a v2 span.
-@internal
-extension SynchronousSentrySpanV2 on SentrySpanV2 {
-  /// Whether this span was flagged as a synchronous operation.
-  bool get isSynchronous => attributes[_synchronousAttributeKey]?.value == true;
-
-  /// Removes the synchronous marker so it is not sent to Sentry.
-  void clearSynchronous() => removeAttribute(_synchronousAttributeKey);
-}
-
 /// Opaque span handle enabling swappable tracing backends.
 @internal
 abstract class InstrumentationSpan {

--- a/packages/dart/lib/src/tracing/instrumentation/instrumentation_span.dart
+++ b/packages/dart/lib/src/tracing/instrumentation/instrumentation_span.dart
@@ -3,6 +3,41 @@ import 'package:meta/meta.dart';
 import '../../../sentry.dart';
 import '../../utils/internal_logger.dart';
 
+/// Data key marking a span as wrapping a synchronous operation.
+///
+/// This is an internal signal between auto-instrumentation (which knows an
+/// operation ran synchronously) and the Flutter `ThreadInfoIntegration` (which
+/// knows the isolate). The integration consumes it to derive
+/// `blocked_main_thread` and strips it, so it is not sent to Sentry.
+const _synchronousAttributeKey = 'sync';
+
+/// Marks a span as wrapping a synchronous operation.
+@internal
+extension SynchronousInstrumentationSpan on InstrumentationSpan {
+  /// Flags this span as a synchronous operation for main-thread detection.
+  void markSynchronous() => setData(_synchronousAttributeKey, true);
+}
+
+/// Reads and clears the synchronous marker on a v1 span.
+@internal
+extension SynchronousSentrySpan on SentrySpan {
+  /// Whether this span was flagged as a synchronous operation.
+  bool get isSynchronous => data[_synchronousAttributeKey] == true;
+
+  /// Removes the synchronous marker so it is not sent to Sentry.
+  void clearSynchronous() => removeData(_synchronousAttributeKey);
+}
+
+/// Reads and clears the synchronous marker on a v2 span.
+@internal
+extension SynchronousSentrySpanV2 on SentrySpanV2 {
+  /// Whether this span was flagged as a synchronous operation.
+  bool get isSynchronous => attributes[_synchronousAttributeKey]?.value == true;
+
+  /// Removes the synchronous marker so it is not sent to Sentry.
+  void clearSynchronous() => removeAttribute(_synchronousAttributeKey);
+}
+
 /// Opaque span handle enabling swappable tracing backends.
 @internal
 abstract class InstrumentationSpan {

--- a/packages/dart/lib/src/tracing/instrumentation/synchronous_span_marker.dart
+++ b/packages/dart/lib/src/tracing/instrumentation/synchronous_span_marker.dart
@@ -1,0 +1,51 @@
+import 'package:meta/meta.dart';
+
+import '../../../sentry.dart';
+
+/// Data key marking a span as wrapping a synchronous operation.
+///
+/// This is an internal signal between auto-instrumentation (which knows an
+/// operation ran synchronously) and the Flutter `ThreadInfoIntegration` (which
+/// knows the isolate). The integration consumes it to derive
+/// `blocked_main_thread` and strips it, so it is not sent to Sentry.
+const _synchronousAttributeKey = 'sync';
+
+/// Marks a span as wrapping a synchronous operation.
+@internal
+extension SynchronousInstrumentationSpan on InstrumentationSpan {
+  /// Flags this span as a synchronous operation for main-thread detection.
+  void markSynchronous() => setData(_synchronousAttributeKey, true);
+}
+
+/// Reads and clears the synchronous marker on a v1 span.
+@internal
+extension SynchronousSentrySpan on SentrySpan {
+  /// Whether the synchronous marker is present, regardless of its value.
+  ///
+  /// Used to decide whether the marker must be stripped, so a stray non-`true`
+  /// value is never sent to Sentry.
+  bool get hasSynchronousMarker => data.containsKey(_synchronousAttributeKey);
+
+  /// Whether this span was flagged as a synchronous operation.
+  bool get isSynchronous => data[_synchronousAttributeKey] == true;
+
+  /// Removes the synchronous marker so it is not sent to Sentry.
+  void clearSynchronous() => removeData(_synchronousAttributeKey);
+}
+
+/// Reads and clears the synchronous marker on a v2 span.
+@internal
+extension SynchronousSentrySpanV2 on SentrySpanV2 {
+  /// Whether the synchronous marker is present, regardless of its value.
+  ///
+  /// Used to decide whether the marker must be stripped, so a stray non-`true`
+  /// value is never sent to Sentry.
+  bool get hasSynchronousMarker =>
+      attributes.containsKey(_synchronousAttributeKey);
+
+  /// Whether this span was flagged as a synchronous operation.
+  bool get isSynchronous => attributes[_synchronousAttributeKey]?.value == true;
+
+  /// Removes the synchronous marker so it is not sent to Sentry.
+  void clearSynchronous() => removeAttribute(_synchronousAttributeKey);
+}

--- a/packages/file/lib/src/sentry_file.dart
+++ b/packages/file/lib/src/sentry_file.dart
@@ -503,7 +503,7 @@ class SentryFile implements File {
 
     span?.origin = SentryTraceOrigins.autoFile;
     span?.setData('file.async', false);
-    span?.setData('sync', true);
+    span?.markSynchronous();
 
     final Map<String, dynamic> breadcrumbData = {};
     breadcrumbData['file.async'] = false;

--- a/packages/flutter/lib/src/integrations/thread_info_integration.dart
+++ b/packages/flutter/lib/src/integrations/thread_info_integration.dart
@@ -88,13 +88,16 @@ class ThreadInfoIntegration implements Integration<SentryFlutterOptions> {
 
   void _processSyncSpanOnFinish(OnSpanFinish event) {
     final span = event.span;
-    if (span is! SentrySpan || !span.isSynchronous) {
+    if (span is! SentrySpan || !span.hasSynchronousMarker) {
       return;
     }
 
-    if (span.data[SemanticAttributesConstants.threadName] == 'main') {
+    if (span.isSynchronous &&
+        span.data[SemanticAttributesConstants.threadName] == 'main') {
       span.setData(SemanticAttributesConstants.blockedMainThread, true);
     }
+    // Always strip the internal marker so it never leaks to Sentry, even when
+    // it holds a stray non-true value.
     span.clearSynchronous();
   }
 
@@ -120,15 +123,18 @@ class ThreadInfoIntegration implements Integration<SentryFlutterOptions> {
 
   void _processSyncSpanOnProcess(OnProcessSpan event) {
     final span = event.span;
-    if (!span.isSynchronous) {
+    if (!span.hasSynchronousMarker) {
       return;
     }
 
-    if (span.attributes[SemanticAttributesConstants.threadName]?.value ==
-        'main') {
+    if (span.isSynchronous &&
+        span.attributes[SemanticAttributesConstants.threadName]?.value ==
+            'main') {
       span.setAttribute(SemanticAttributesConstants.blockedMainThread,
           SentryAttribute.bool(true));
     }
+    // Always strip the internal marker so it never leaks to Sentry, even when
+    // it holds a stray non-true value.
     span.clearSynchronous();
   }
 }

--- a/packages/flutter/lib/src/integrations/thread_info_integration.dart
+++ b/packages/flutter/lib/src/integrations/thread_info_integration.dart
@@ -32,63 +32,103 @@ class ThreadInfoIntegration implements Integration<SentryFlutterOptions> {
       return;
     }
 
-    options.lifecycleRegistry
-        .registerCallback<OnSpanStart>(_addThreadInfoToSpan);
-    options.lifecycleRegistry
-        .registerCallback<OnSpanFinish>(_processSyncSpanOnFinish);
+    switch (options.traceLifecycle) {
+      case SentryTraceLifecycle.static:
+        options.lifecycleRegistry
+            .registerCallback<OnSpanStart>(_addThreadInfoToSpan);
+        options.lifecycleRegistry
+            .registerCallback<OnSpanFinish>(_processSyncSpanOnFinish);
+      case SentryTraceLifecycle.stream:
+        options.lifecycleRegistry
+            .registerCallback<OnSpanStartV2>(_addThreadInfoToSpanV2);
+        options.lifecycleRegistry
+            .registerCallback<OnProcessSpan>(_processSyncSpanOnProcess);
+    }
 
     options.sdk.addIntegration(integrationName);
   }
 
   @override
   void close() {
-    _hub?.options.lifecycleRegistry
-        .removeCallback<OnSpanStart>(_addThreadInfoToSpan);
-    _hub?.options.lifecycleRegistry
-        .removeCallback<OnSpanFinish>(_processSyncSpanOnFinish);
+    final options = _hub?.options;
+    if (options == null) {
+      return;
+    }
+    switch (options.traceLifecycle) {
+      case SentryTraceLifecycle.static:
+        options.lifecycleRegistry
+            .removeCallback<OnSpanStart>(_addThreadInfoToSpan);
+        options.lifecycleRegistry
+            .removeCallback<OnSpanFinish>(_processSyncSpanOnFinish);
+      case SentryTraceLifecycle.stream:
+        options.lifecycleRegistry
+            .removeCallback<OnSpanStartV2>(_addThreadInfoToSpanV2);
+        options.lifecycleRegistry
+            .removeCallback<OnProcessSpan>(_processSyncSpanOnProcess);
+    }
   }
 
   Future<void> _addThreadInfoToSpan(OnSpanStart event) async {
     final span = event.span;
-    // Check if we're in the root isolate first
     if (_isolateHelper.isRootIsolate()) {
-      // For root isolate, always set thread name as "main"
-      span.setData(SpanDataConvention.threadId, 'main'.hashCode.toString());
-      span.setData(SpanDataConvention.threadName, 'main');
+      span.setData(
+          SemanticAttributesConstants.threadId, 'main'.hashCode.toString());
+      span.setData(SemanticAttributesConstants.threadName, 'main');
       return;
     }
 
-    // For non-root isolates, get thread info dynamically for each span to handle multi-isolate scenarios
+    // Resolve per span so multiple isolates are handled correctly.
     final isolateName = _isolateHelper.getIsolateName();
-
-    // Only set thread info if we have a valid isolate name
     if (isolateName != null && isolateName.isNotEmpty) {
-      final threadName = isolateName;
-      final threadId = isolateName.hashCode.toString();
-
-      span.setData(SpanDataConvention.threadId, threadId);
-      span.setData(SpanDataConvention.threadName, threadName);
+      span.setData(SemanticAttributesConstants.threadId,
+          isolateName.hashCode.toString());
+      span.setData(SemanticAttributesConstants.threadName, isolateName);
     }
   }
 
   void _processSyncSpanOnFinish(OnSpanFinish event) {
     final span = event.span;
-    if (span is! SentrySpan) {
+    if (span is! SentrySpan || !span.isSynchronous) {
       return;
     }
 
-    final data = span.data;
-
-    // Check if this is a sync operation
-    if (data.containsKey('sync')) {
-      // Check if we're on the main isolate by looking at thread name
-      if (data['sync'] == true &&
-          data[SpanDataConvention.threadName] == 'main') {
-        span.setData(SpanDataConvention.blockedMainThread, true);
-      }
-
-      // Always remove the sync flag
-      span.removeData('sync');
+    if (span.data[SemanticAttributesConstants.threadName] == 'main') {
+      span.setData(SemanticAttributesConstants.blockedMainThread, true);
     }
+    span.clearSynchronous();
+  }
+
+  Future<void> _addThreadInfoToSpanV2(OnSpanStartV2 event) async {
+    final span = event.span;
+    if (_isolateHelper.isRootIsolate()) {
+      span.setAttribute(SemanticAttributesConstants.threadId,
+          SentryAttribute.string('main'.hashCode.toString()));
+      span.setAttribute(SemanticAttributesConstants.threadName,
+          SentryAttribute.string('main'));
+      return;
+    }
+
+    // Resolve per span so multiple isolates are handled correctly.
+    final isolateName = _isolateHelper.getIsolateName();
+    if (isolateName != null && isolateName.isNotEmpty) {
+      span.setAttribute(SemanticAttributesConstants.threadId,
+          SentryAttribute.string(isolateName.hashCode.toString()));
+      span.setAttribute(SemanticAttributesConstants.threadName,
+          SentryAttribute.string(isolateName));
+    }
+  }
+
+  void _processSyncSpanOnProcess(OnProcessSpan event) {
+    final span = event.span;
+    if (!span.isSynchronous) {
+      return;
+    }
+
+    if (span.attributes[SemanticAttributesConstants.threadName]?.value ==
+        'main') {
+      span.setAttribute(SemanticAttributesConstants.blockedMainThread,
+          SentryAttribute.bool(true));
+    }
+    span.clearSynchronous();
   }
 }

--- a/packages/flutter/test/integrations/thread_info_integration_test.dart
+++ b/packages/flutter/test/integrations/thread_info_integration_test.dart
@@ -246,10 +246,13 @@ void main() {
       await fixture.options.lifecycleRegistry
           .dispatchCallback(OnSpanFinish(span));
 
-      // sync == false is treated as not synchronous, so nothing is set.
+      // sync == false is not synchronous, so blocked_main_thread is not set.
       final blockedMainThreadCalls = span.setDataCalls.where(
           (call) => call.key == SemanticAttributesConstants.blockedMainThread);
       expect(blockedMainThreadCalls, isEmpty);
+
+      // But the internal marker is still stripped so it never leaks to Sentry.
+      expect(span.removeDataCalls.map((call) => call.key), contains('sync'));
     });
 
     test('does not set blocked_main_thread when sync span has no thread name',
@@ -434,11 +437,14 @@ void main() {
         await fixture.options.lifecycleRegistry
             .dispatchCallback(OnProcessSpan(span));
 
-        // sync == false is treated as not synchronous, so nothing is set.
+        // sync == false is not synchronous, so blocked_main_thread is not set.
         expect(
             span.attributes
                 .containsKey(SemanticAttributesConstants.blockedMainThread),
             isFalse);
+
+        // But the internal marker is still stripped so it never leaks to Sentry.
+        expect(span.attributes.containsKey('sync'), isFalse);
       });
 
       test('does not set blocked_main_thread when sync span has no thread name',

--- a/packages/flutter/test/integrations/thread_info_integration_test.dart
+++ b/packages/flutter/test/integrations/thread_info_integration_test.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: invalid_use_of_internal_member, experimental_member_use
 @TestOn('vm')
 library;
 
@@ -7,6 +8,7 @@ import 'package:sentry_flutter/src/integrations/thread_info_integration.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:sentry_flutter/src/isolate/isolate_helper.dart';
 
+import '../mocks.dart';
 import '../mocks.mocks.dart';
 
 void main() {
@@ -29,17 +31,16 @@ void main() {
       integration.call(hub, fixture.options);
 
       // Dispatch OnSpanStart event through the lifecycle registry
-      // ignore: invalid_use_of_internal_member
       await fixture.options.lifecycleRegistry
           .dispatchCallback(OnSpanStart(span));
 
       final setDataCalls = span.setDataCalls;
       expect(setDataCalls.length, equals(2));
 
-      final threadIdCall = setDataCalls
-          .firstWhere((call) => call.key == SpanDataConvention.threadId);
-      final threadNameCall = setDataCalls
-          .firstWhere((call) => call.key == SpanDataConvention.threadName);
+      final threadIdCall = setDataCalls.firstWhere(
+          (call) => call.key == SemanticAttributesConstants.threadId);
+      final threadNameCall = setDataCalls.firstWhere(
+          (call) => call.key == SemanticAttributesConstants.threadName);
 
       expect(threadIdCall.value, equals('main'.hashCode.toString()));
       expect(threadNameCall.value, equals('main'));
@@ -54,17 +55,16 @@ void main() {
       final span = fixture.createMockSpan();
 
       integration.call(hub, fixture.options);
-      // ignore: invalid_use_of_internal_member
       await fixture.options.lifecycleRegistry
           .dispatchCallback(OnSpanStart(span));
 
       final setDataCalls = span.setDataCalls;
       expect(setDataCalls.length, equals(2));
 
-      final threadIdCall = setDataCalls
-          .firstWhere((call) => call.key == SpanDataConvention.threadId);
-      final threadNameCall = setDataCalls
-          .firstWhere((call) => call.key == SpanDataConvention.threadName);
+      final threadIdCall = setDataCalls.firstWhere(
+          (call) => call.key == SemanticAttributesConstants.threadId);
+      final threadNameCall = setDataCalls.firstWhere(
+          (call) => call.key == SemanticAttributesConstants.threadName);
 
       expect(threadIdCall.value, equals('worker-thread'.hashCode.toString()));
       expect(threadNameCall.value, equals('worker-thread'));
@@ -79,13 +79,11 @@ void main() {
       final span = fixture.createMockSpan();
 
       integration.call(hub, fixture.options);
-      // ignore: invalid_use_of_internal_member
       await fixture.options.lifecycleRegistry
           .dispatchCallback(OnSpanStart(span));
       final firstCallCount = span.setDataCalls.length;
 
       final span2 = fixture.createMockSpan();
-      // ignore: invalid_use_of_internal_member
       await fixture.options.lifecycleRegistry
           .dispatchCallback(OnSpanStart(span2));
 
@@ -103,15 +101,14 @@ void main() {
       final span = fixture.createMockSpan();
 
       integration.call(hub, fixture.options);
-      // ignore: invalid_use_of_internal_member
       await fixture.options.lifecycleRegistry
           .dispatchCallback(OnSpanStart(span));
 
       // Find thread data calls
-      final threadIdCall = span.setDataCalls
-          .firstWhere((call) => call.key == SpanDataConvention.threadId);
-      final threadNameCall = span.setDataCalls
-          .firstWhere((call) => call.key == SpanDataConvention.threadName);
+      final threadIdCall = span.setDataCalls.firstWhere(
+          (call) => call.key == SemanticAttributesConstants.threadId);
+      final threadNameCall = span.setDataCalls.firstWhere(
+          (call) => call.key == SemanticAttributesConstants.threadName);
 
       expect(threadIdCall.value, equals('custom-isolate'.hashCode.toString()));
       expect(threadNameCall.value, equals('custom-isolate'));
@@ -126,7 +123,6 @@ void main() {
       final span = fixture.createMockSpan();
 
       integration.call(hub, fixture.options);
-      // ignore: invalid_use_of_internal_member
       await fixture.options.lifecycleRegistry
           .dispatchCallback(OnSpanStart(span));
 
@@ -143,7 +139,6 @@ void main() {
       final span = fixture.createMockSpan();
 
       integration.call(hub, fixture.options);
-      // ignore: invalid_use_of_internal_member
       await fixture.options.lifecycleRegistry
           .dispatchCallback(OnSpanStart(span));
 
@@ -163,7 +158,6 @@ void main() {
       fixture.options.tracesSampleRate = null;
 
       integration.call(hub, fixture.options);
-      // ignore: invalid_use_of_internal_member
       await fixture.options.lifecycleRegistry
           .dispatchCallback(OnSpanStart(span));
 
@@ -181,11 +175,10 @@ void main() {
       final integration = fixture.getSut();
       final span = fixture.createMockSpanWithData({
         'sync': true,
-        SpanDataConvention.threadName: 'main',
+        SemanticAttributesConstants.threadName: 'main',
       });
 
       integration.call(hub, fixture.options);
-      // ignore: invalid_use_of_internal_member
       await fixture.options.lifecycleRegistry
           .dispatchCallback(OnSpanFinish(span));
 
@@ -193,7 +186,7 @@ void main() {
       expect(setDataCalls.length, equals(1));
 
       final blockedMainThreadCall = setDataCalls.firstWhere(
-          (call) => call.key == SpanDataConvention.blockedMainThread);
+          (call) => call.key == SemanticAttributesConstants.blockedMainThread);
       expect(blockedMainThreadCall.value, equals(true));
 
       // Check that sync was removed
@@ -208,17 +201,16 @@ void main() {
       final integration = fixture.getSut();
       final span = fixture.createMockSpanWithData({
         'sync': true,
-        SpanDataConvention.threadName: 'worker-thread',
+        SemanticAttributesConstants.threadName: 'worker-thread',
       });
 
       integration.call(hub, fixture.options);
-      // ignore: invalid_use_of_internal_member
       await fixture.options.lifecycleRegistry
           .dispatchCallback(OnSpanFinish(span));
 
       // Should not set blocked_main_thread
-      final blockedMainThreadCalls = span.setDataCalls
-          .where((call) => call.key == SpanDataConvention.blockedMainThread);
+      final blockedMainThreadCalls = span.setDataCalls.where(
+          (call) => call.key == SemanticAttributesConstants.blockedMainThread);
       expect(blockedMainThreadCalls, isEmpty);
 
       // But should still remove sync
@@ -230,11 +222,10 @@ void main() {
       final hub = fixture.createHub();
       final integration = fixture.getSut();
       final span = fixture.createMockSpanWithData({
-        SpanDataConvention.threadName: 'main',
+        SemanticAttributesConstants.threadName: 'main',
       });
 
       integration.call(hub, fixture.options);
-      // ignore: invalid_use_of_internal_member
       await fixture.options.lifecycleRegistry
           .dispatchCallback(OnSpanFinish(span));
 
@@ -243,27 +234,22 @@ void main() {
       expect(span.removeDataCalls, isEmpty);
     });
 
-    test('removes sync flag even when sync is false', () async {
+    test('does not set blocked_main_thread when sync is false', () async {
       final hub = fixture.createHub();
       final integration = fixture.getSut();
       final span = fixture.createMockSpanWithData({
         'sync': false,
-        SpanDataConvention.threadName: 'main',
+        SemanticAttributesConstants.threadName: 'main',
       });
 
       integration.call(hub, fixture.options);
-      // ignore: invalid_use_of_internal_member
       await fixture.options.lifecycleRegistry
           .dispatchCallback(OnSpanFinish(span));
 
-      // Should not set blocked_main_thread (sync is false)
-      final blockedMainThreadCalls = span.setDataCalls
-          .where((call) => call.key == SpanDataConvention.blockedMainThread);
+      // sync == false is treated as not synchronous, so nothing is set.
+      final blockedMainThreadCalls = span.setDataCalls.where(
+          (call) => call.key == SemanticAttributesConstants.blockedMainThread);
       expect(blockedMainThreadCalls, isEmpty);
-
-      // But should still remove sync
-      expect(span.removeDataCalls.length, equals(1));
-      expect(span.removeDataCalls.first.key, equals('sync'));
     });
 
     test('does not set blocked_main_thread when sync span has no thread name',
@@ -273,18 +259,206 @@ void main() {
       final span = fixture.createMockSpanWithData({'sync': true});
 
       integration.call(hub, fixture.options);
-      // ignore: invalid_use_of_internal_member
       await fixture.options.lifecycleRegistry
           .dispatchCallback(OnSpanFinish(span));
 
       // Should not set blocked_main_thread (no thread name)
-      final blockedMainThreadCalls = span.setDataCalls
-          .where((call) => call.key == SpanDataConvention.blockedMainThread);
+      final blockedMainThreadCalls = span.setDataCalls.where(
+          (call) => call.key == SemanticAttributesConstants.blockedMainThread);
       expect(blockedMainThreadCalls, isEmpty);
 
       // But should still remove sync
       expect(span.removeDataCalls.length, equals(1));
       expect(span.removeDataCalls.first.key, equals('sync'));
+    });
+  });
+
+  group('$ThreadInfoIntegration with streaming lifecycle', () {
+    setUp(() {
+      fixture.options.dsn = fakeDsn;
+      fixture.options.traceLifecycle = SentryTraceLifecycle.stream;
+    });
+
+    group('when a span starts', () {
+      test('sets main thread name when in root isolate', () async {
+        fixture.mockHelper.setIsRootIsolate(true);
+        fixture.mockHelper.setIsolateName('main(debug)');
+
+        final hub = Hub(fixture.options);
+        final integration = fixture.getSut();
+        integration.call(hub, fixture.options);
+
+        final span = fixture.startStreamingSpan(hub);
+        await fixture.options.lifecycleRegistry
+            .dispatchCallback(OnSpanStartV2(span));
+
+        expect(span.attributes[SemanticAttributesConstants.threadId]?.value,
+            equals('main'.hashCode.toString()));
+        expect(span.attributes[SemanticAttributesConstants.threadName]?.value,
+            equals('main'));
+      });
+
+      test('adds thread information when isolate has name', () async {
+        fixture.mockHelper.setIsRootIsolate(false);
+        fixture.mockHelper.setIsolateName('worker-thread');
+
+        final hub = Hub(fixture.options);
+        final integration = fixture.getSut();
+        integration.call(hub, fixture.options);
+
+        final span = fixture.startStreamingSpan(hub);
+        await fixture.options.lifecycleRegistry
+            .dispatchCallback(OnSpanStartV2(span));
+
+        expect(span.attributes[SemanticAttributesConstants.threadId]?.value,
+            equals('worker-thread'.hashCode.toString()));
+        expect(span.attributes[SemanticAttributesConstants.threadName]?.value,
+            equals('worker-thread'));
+      });
+
+      test('does not set thread info when isolate name is null', () async {
+        fixture.mockHelper.setIsRootIsolate(false);
+        fixture.mockHelper.setIsolateName(null);
+
+        final hub = Hub(fixture.options);
+        final integration = fixture.getSut();
+        integration.call(hub, fixture.options);
+
+        final span = fixture.startStreamingSpan(hub);
+        await fixture.options.lifecycleRegistry
+            .dispatchCallback(OnSpanStartV2(span));
+
+        expect(
+            span.attributes.containsKey(SemanticAttributesConstants.threadId),
+            isFalse);
+        expect(
+            span.attributes.containsKey(SemanticAttributesConstants.threadName),
+            isFalse);
+      });
+
+      test('does not set thread info when isolate name is empty', () async {
+        fixture.mockHelper.setIsRootIsolate(false);
+        fixture.mockHelper.setIsolateName('');
+
+        final hub = Hub(fixture.options);
+        final integration = fixture.getSut();
+        integration.call(hub, fixture.options);
+
+        final span = fixture.startStreamingSpan(hub);
+        await fixture.options.lifecycleRegistry
+            .dispatchCallback(OnSpanStartV2(span));
+
+        expect(
+            span.attributes.containsKey(SemanticAttributesConstants.threadId),
+            isFalse);
+        expect(
+            span.attributes.containsKey(SemanticAttributesConstants.threadName),
+            isFalse);
+      });
+    });
+
+    group('when a span is processed', () {
+      test('sets blocked_main_thread when sync span is on main isolate',
+          () async {
+        final hub = Hub(fixture.options);
+        final integration = fixture.getSut();
+        integration.call(hub, fixture.options);
+
+        final span = fixture.startStreamingSpan(hub);
+        span.setAttribute('sync', SentryAttribute.bool(true));
+        span.setAttribute(SemanticAttributesConstants.threadName,
+            SentryAttribute.string('main'));
+
+        await fixture.options.lifecycleRegistry
+            .dispatchCallback(OnProcessSpan(span));
+
+        expect(
+            span.attributes[SemanticAttributesConstants.blockedMainThread]
+                ?.value,
+            isTrue);
+        // sync marker is stripped, never sent
+        expect(span.attributes.containsKey('sync'), isFalse);
+      });
+
+      test(
+          'does not set blocked_main_thread when sync span is on background isolate',
+          () async {
+        final hub = Hub(fixture.options);
+        final integration = fixture.getSut();
+        integration.call(hub, fixture.options);
+
+        final span = fixture.startStreamingSpan(hub);
+        span.setAttribute('sync', SentryAttribute.bool(true));
+        span.setAttribute(SemanticAttributesConstants.threadName,
+            SentryAttribute.string('worker-thread'));
+
+        await fixture.options.lifecycleRegistry
+            .dispatchCallback(OnProcessSpan(span));
+
+        expect(
+            span.attributes
+                .containsKey(SemanticAttributesConstants.blockedMainThread),
+            isFalse);
+        expect(span.attributes.containsKey('sync'), isFalse);
+      });
+
+      test('does not set blocked_main_thread for spans without sync data',
+          () async {
+        final hub = Hub(fixture.options);
+        final integration = fixture.getSut();
+        integration.call(hub, fixture.options);
+
+        final span = fixture.startStreamingSpan(hub);
+        span.setAttribute(SemanticAttributesConstants.threadName,
+            SentryAttribute.string('main'));
+
+        await fixture.options.lifecycleRegistry
+            .dispatchCallback(OnProcessSpan(span));
+
+        expect(
+            span.attributes
+                .containsKey(SemanticAttributesConstants.blockedMainThread),
+            isFalse);
+      });
+
+      test('does not set blocked_main_thread when sync is false', () async {
+        final hub = Hub(fixture.options);
+        final integration = fixture.getSut();
+        integration.call(hub, fixture.options);
+
+        final span = fixture.startStreamingSpan(hub);
+        span.setAttribute('sync', SentryAttribute.bool(false));
+        span.setAttribute(SemanticAttributesConstants.threadName,
+            SentryAttribute.string('main'));
+
+        await fixture.options.lifecycleRegistry
+            .dispatchCallback(OnProcessSpan(span));
+
+        // sync == false is treated as not synchronous, so nothing is set.
+        expect(
+            span.attributes
+                .containsKey(SemanticAttributesConstants.blockedMainThread),
+            isFalse);
+      });
+
+      test('does not set blocked_main_thread when sync span has no thread name',
+          () async {
+        final hub = Hub(fixture.options);
+        final integration = fixture.getSut();
+        integration.call(hub, fixture.options);
+
+        final span = fixture.startStreamingSpan(hub);
+        span.setAttribute('sync', SentryAttribute.bool(true));
+
+        await fixture.options.lifecycleRegistry
+            .dispatchCallback(OnProcessSpan(span));
+
+        expect(
+            span.attributes
+                .containsKey(SemanticAttributesConstants.blockedMainThread),
+            isFalse);
+        expect(span.attributes.containsKey('sync'), isFalse);
+      });
     });
   });
 }
@@ -312,6 +486,10 @@ class _Fixture {
 
   _MockSpan createMockSpanWithData(Map<String, dynamic> data) {
     return _MockSpan.withData(data);
+  }
+
+  RecordingSentrySpanV2 startStreamingSpan(Hub hub) {
+    return hub.startInactiveSpan('test') as RecordingSentrySpanV2;
   }
 
   MockHub createHub() {

--- a/packages/hive/lib/src/sentry_span_helper.dart
+++ b/packages/hive/lib/src/sentry_span_helper.dart
@@ -84,7 +84,7 @@ class SentrySpanHelper {
         : null;
 
     span?.origin = _origin;
-    span?.setData('sync', true);
+    span?.markSynchronous();
     span?.setData(SentryHiveImpl.dbSystemKey, SentryHiveImpl.dbSystem);
     if (dbName != null) {
       span?.setData(SentryHiveImpl.dbNameKey, dbName);

--- a/packages/isar/lib/src/sentry_span_helper.dart
+++ b/packages/isar/lib/src/sentry_span_helper.dart
@@ -90,7 +90,7 @@ class SentrySpanHelper {
         : null;
 
     span?.origin = _origin;
-    span?.setData('sync', true);
+    span?.markSynchronous();
     span?.setData(SentryIsar.dbSystemKey, SentryIsar.dbSystem);
     if (dbName != null) {
       span?.setData(SentryIsar.dbNameKey, dbName);


### PR DESCRIPTION
`ThreadInfoIntegration` only handled v1 spans (`OnSpanStart`/`OnSpanFinish`), so streaming/v2 spans received no `thread.id`/`thread.name` and never got `blocked_main_thread`. The internal `sync` marker set by the `file`/`hive`/`isar` instrumentation was also written onto v2 spans but never consumed there, so it leaked to Sentry.

This brings v2/streaming spans to parity with v1. `call()`/`close()` branch on `options.traceLifecycle`:

- **static** — `OnSpanStart`/`OnSpanFinish` (unchanged).
- **stream** — `OnSpanStartV2` sets `thread.id`/`thread.name`; `OnProcessSpan` derives `blocked_main_thread` from the sync marker when on the main isolate, then strips the marker.

The responsibilities stay clean: instrumentation states a fact it knows (the op is synchronous), and `ThreadInfoIntegration` — which knows the isolate — is the sole setter of `blocked_main_thread`. The previously raw `'sync'` data key is wrapped in a small set of internal extensions so the key lives in one place:

- `InstrumentationSpan.markSynchronous()` — used by `file`/`hive`/`isar`.
- `SentrySpan.isSynchronous` / `clearSynchronous()` (v1) and `SentrySpanV2.isSynchronous` / `clearSynchronous()` (v2) — used by the integration.

No new state is added to the span classes. Behavior is unchanged on v1.