### PR TITLE
feat(tracing): Simplify span v2 status to ok/error

### DIFF
--- a/packages/dart/lib/src/constants.dart
+++ b/packages/dart/lib/src/constants.dart
@@ -104,6 +104,14 @@ abstract class SemanticAttributesConstants {
   /// The operation name of a span.
   static const sentryOp = 'sentry.op';
 
+  /// A human-readable message providing additional context about a span's
+  /// status, e.g. `'deadline_exceeded'` when an idle span hits its final timeout.
+  static const sentryStatusMessage = 'sentry.status.message';
+
+  /// The reason an idle span finished, e.g. `'cancelled'` when the span was
+  /// superseded by a new interaction before it could complete.
+  static const sentryIdleSpanFinishReason = 'sentry.idle_span_finish_reason';
+
   /// Whether the replay is buffering (onErrorSampleRate).
   static const sentryInternalReplayIsBuffering =
       'sentry._internal.replay_is_buffering';

--- a/packages/dart/lib/src/constants.dart
+++ b/packages/dart/lib/src/constants.dart
@@ -41,6 +41,22 @@ class SentrySpanDescriptions {
   static String dbClose({required String dbName}) => 'Close database $dbName';
 }
 
+/// Values for the [SemanticAttributesConstants.sentryStatusMessage] attribute.
+///
+/// These mirror the corresponding `SpanStatus` protocol strings
+/// (e.g. `SpanStatus.deadlineExceeded()`); keep them in sync.
+@internal
+class SentrySpanStatusMessages {
+  static const String deadlineExceeded = 'deadline_exceeded';
+}
+
+/// Values for the [SemanticAttributesConstants.sentryIdleSpanFinishReason]
+/// attribute.
+@internal
+class SentryIdleSpanFinishReasons {
+  static const String cancelled = 'cancelled';
+}
+
 /// Features are SDK metadata to help us query SDK usage and analytics internally.
 @internal
 class SentryFeatures {
@@ -105,11 +121,13 @@ abstract class SemanticAttributesConstants {
   static const sentryOp = 'sentry.op';
 
   /// A human-readable message providing additional context about a span's
-  /// status, e.g. `'deadline_exceeded'` when an idle span hits its final timeout.
+  /// status, e.g. [SentrySpanStatusMessages.deadlineExceeded] when an idle span
+  /// hits its final timeout.
   static const sentryStatusMessage = 'sentry.status.message';
 
-  /// The reason an idle span finished, e.g. `'cancelled'` when the span was
-  /// superseded by a new interaction before it could complete.
+  /// The reason an idle span finished, e.g.
+  /// [SentryIdleSpanFinishReasons.cancelled] when the span was superseded by a
+  /// new interaction before it could complete.
   static const sentryIdleSpanFinishReason = 'sentry.idle_span_finish_reason';
 
   /// Whether the replay is buffering (onErrorSampleRate).

--- a/packages/dart/lib/src/telemetry/span/idle_recording_sentry_span_v2.dart
+++ b/packages/dart/lib/src/telemetry/span/idle_recording_sentry_span_v2.dart
@@ -151,7 +151,7 @@ final class IdleRecordingSentrySpanV2 extends RecordingSentrySpanV2 {
       status = SentrySpanStatusV2.error;
       setAttribute(
         SemanticAttributesConstants.sentryStatusMessage,
-        SentryAttribute.string('deadline_exceeded'),
+        SentryAttribute.string(SentrySpanStatusMessages.deadlineExceeded),
       );
     }
 

--- a/packages/dart/lib/src/telemetry/span/idle_recording_sentry_span_v2.dart
+++ b/packages/dart/lib/src/telemetry/span/idle_recording_sentry_span_v2.dart
@@ -148,7 +148,11 @@ final class IdleRecordingSentrySpanV2 extends RecordingSentrySpanV2 {
     final idleEndTimestamp = _resolveIdleEndTimestamp(requestedEndTimestamp);
 
     if (reason == _IdleSpanFinishReason.finalTimeout) {
-      status = SentrySpanStatusV2.deadlineExceeded;
+      status = SentrySpanStatusV2.error;
+      setAttribute(
+        SemanticAttributesConstants.sentryStatusMessage,
+        SentryAttribute.string('deadline_exceeded'),
+      );
     }
 
     _finishActiveDescendants(idleEndTimestamp);
@@ -172,15 +176,15 @@ final class IdleRecordingSentrySpanV2 extends RecordingSentrySpanV2 {
       if (child.isEnded) continue;
       if (child.startTimestamp.isAfter(idleEndTimestamp)) continue;
 
-      child.status = SentrySpanStatusV2.cancelled;
+      child.status = SentrySpanStatusV2.ok;
       child.end(endTimestamp: idleEndTimestamp);
       // Track explicitly because lifecycle callbacks are already unregistered
       // at this point, so _onSpanEndEvent won't fire for these force-ended children.
       _trackLatestChildEnd(idleEndTimestamp);
 
       internalLogger.debug(
-        () => 'IdleRecordingSentrySpanV2: finished child span "${child.name}" '
-            'with reason: ${SentrySpanStatusV2.cancelled.name}',
+        () => 'IdleRecordingSentrySpanV2: finished still-active child span '
+            '"${child.name}"',
       );
     }
   }

--- a/packages/dart/lib/src/telemetry/span/sentry_span_status_v2.dart
+++ b/packages/dart/lib/src/telemetry/span/sentry_span_status_v2.dart
@@ -1,7 +1,5 @@
 enum SentrySpanStatusV2 {
   error('error'),
-  cancelled('cancelled'),
-  deadlineExceeded('deadline_exceeded'),
   ok('ok');
 
   final String value;

--- a/packages/dart/lib/src/tracing/instrumentation/instrumentation_span.dart
+++ b/packages/dart/lib/src/tracing/instrumentation/instrumentation_span.dart
@@ -203,22 +203,12 @@ class StreamingInstrumentationSpan implements InstrumentationSpan {
         return SpanStatus.ok();
       case SentrySpanStatusV2.error:
         return SpanStatus.unknownError();
-      case SentrySpanStatusV2.cancelled:
-        return SpanStatus.cancelled();
-      case SentrySpanStatusV2.deadlineExceeded:
-        return SpanStatus.deadlineExceeded();
     }
   }
 
   SentrySpanStatusV2 _convertToV2Status(SpanStatus status) {
     if (status == SpanStatus.ok()) {
       return SentrySpanStatusV2.ok;
-    }
-    if (status == SpanStatus.cancelled()) {
-      return SentrySpanStatusV2.cancelled;
-    }
-    if (status == SpanStatus.deadlineExceeded()) {
-      return SentrySpanStatusV2.deadlineExceeded;
     }
     return SentrySpanStatusV2.error;
   }

--- a/packages/dart/test/hub_span_test.dart
+++ b/packages/dart/test/hub_span_test.dart
@@ -1180,12 +1180,12 @@ void main() {
 
         final activeIdleSpan = hub.getActiveSpan() as IdleRecordingSentrySpanV2;
         activeIdleSpan
-          ..status = SentrySpanStatusV2.cancelled
+          ..status = SentrySpanStatusV2.error
           ..end();
         await Future<void>.delayed(Duration.zero);
 
         expect(idleSpan.isEnded, isTrue);
-        expect(idleSpan.status, equals(SentrySpanStatusV2.cancelled));
+        expect(idleSpan.status, equals(SentrySpanStatusV2.error));
         expect(hub.getActiveSpan(), isNull);
       });
 
@@ -1238,14 +1238,37 @@ void main() {
 
         await Future<void>.delayed(Duration(milliseconds: 240));
         expect(idleSpan.isEnded, isTrue);
-        expect(idleSpan.status, equals(SentrySpanStatusV2.deadlineExceeded));
+        expect(idleSpan.status, equals(SentrySpanStatusV2.error));
+        expect(
+          idleSpan.attributes[SemanticAttributesConstants.sentryStatusMessage]
+              ?.value,
+          'deadline_exceeded',
+        );
         expect(childSpan.isEnded, isTrue);
-        expect(childSpan.status, equals(SentrySpanStatusV2.cancelled));
+        expect(childSpan.status, equals(SentrySpanStatusV2.ok));
         expect(childSpan.endTimestamp, isNotNull);
         expect(idleSpan.endTimestamp, isNotNull);
         final endTimestampDelta =
             idleSpan.endTimestamp!.difference(childSpan.endTimestamp!).abs();
         expect(endTimestampDelta, lessThan(Duration(milliseconds: 10)));
+      });
+
+      test('finishes with ok status when idle timeout is reached', () async {
+        final hub = fixture.getSut();
+        final idleSpan = hub.startIdleSpan(
+          'idle-root',
+          idleTimeout: Duration(milliseconds: 60),
+          finalTimeout: Duration(seconds: 2),
+        ) as RecordingSentrySpanV2;
+
+        await Future<void>.delayed(Duration(milliseconds: 120));
+
+        expect(idleSpan.isEnded, isTrue);
+        expect(idleSpan.status, equals(SentrySpanStatusV2.ok));
+        expect(
+          idleSpan.attributes[SemanticAttributesConstants.sentryStatusMessage],
+          isNull,
+        );
       });
 
       test('trims idle span end timestamp to latest finished child', () async {

--- a/packages/flutter/lib/src/navigation/time_to_display_tracker_v2.dart
+++ b/packages/flutter/lib/src/navigation/time_to_display_tracker_v2.dart
@@ -204,7 +204,7 @@ class TimeToDisplayTrackerV2 {
         ..status = SentrySpanStatusV2.ok
         ..setAttribute(
           SemanticAttributesConstants.sentryIdleSpanFinishReason,
-          SentryAttribute.string('cancelled'),
+          SentryAttribute.string(SentryIdleSpanFinishReasons.cancelled),
         )
         ..end();
     }

--- a/packages/flutter/lib/src/navigation/time_to_display_tracker_v2.dart
+++ b/packages/flutter/lib/src/navigation/time_to_display_tracker_v2.dart
@@ -201,7 +201,11 @@ class TimeToDisplayTrackerV2 {
     final activeSpan = _hub.getActiveSpan();
     if (activeSpan is IdleRecordingSentrySpanV2) {
       activeSpan
-        ..status = SentrySpanStatusV2.cancelled
+        ..status = SentrySpanStatusV2.ok
+        ..setAttribute(
+          SemanticAttributesConstants.sentryIdleSpanFinishReason,
+          SentryAttribute.string('cancelled'),
+        )
         ..end();
     }
   }

--- a/packages/flutter/lib/src/user_interaction/sentry_user_interaction_widget.dart
+++ b/packages/flutter/lib/src/user_interaction/sentry_user_interaction_widget.dart
@@ -441,7 +441,11 @@ class _SentryUserInteractionWidgetState
 
         // Different widget tapped — cancel the previous idle span.
         activeSpan
-          ..status = SentrySpanStatusV2.cancelled
+          ..status = SentrySpanStatusV2.ok
+          ..setAttribute(
+            SemanticAttributesConstants.sentryIdleSpanFinishReason,
+            SentryAttribute.string('cancelled'),
+          )
           ..end();
       }
     }

--- a/packages/flutter/lib/src/user_interaction/sentry_user_interaction_widget.dart
+++ b/packages/flutter/lib/src/user_interaction/sentry_user_interaction_widget.dart
@@ -444,7 +444,7 @@ class _SentryUserInteractionWidgetState
           ..status = SentrySpanStatusV2.ok
           ..setAttribute(
             SemanticAttributesConstants.sentryIdleSpanFinishReason,
-            SentryAttribute.string('cancelled'),
+            SentryAttribute.string(SentryIdleSpanFinishReasons.cancelled),
           )
           ..end();
       }

--- a/packages/flutter/test/navigation/time_to_display_tracker_v2_test.dart
+++ b/packages/flutter/test/navigation/time_to_display_tracker_v2_test.dart
@@ -27,7 +27,14 @@ void main() {
         sut.trackRoute('/new-route');
 
         expect(activeSpan.isEnded, isTrue);
-        expect(activeSpan.status, SentrySpanStatusV2.cancelled);
+        expect(activeSpan.status, SentrySpanStatusV2.ok);
+        expect(
+          activeSpan
+              .attributes[
+                  SemanticAttributesConstants.sentryIdleSpanFinishReason]
+              ?.value,
+          'cancelled',
+        );
       });
 
       test('starts idle root span with ui.load op and correct origin', () {
@@ -266,7 +273,14 @@ void main() {
         sut.prepareAppStart();
 
         expect(existingSpan.isEnded, isTrue);
-        expect(existingSpan.status, SentrySpanStatusV2.cancelled);
+        expect(existingSpan.status, SentrySpanStatusV2.ok);
+        expect(
+          existingSpan
+              .attributes[
+                  SemanticAttributesConstants.sentryIdleSpanFinishReason]
+              ?.value,
+          'cancelled',
+        );
       });
     });
 
@@ -397,7 +411,7 @@ void main() {
         expect(sut.ttfdSpanId, isNull);
       });
 
-      test('ends active idle route span with cancelled status', () {
+      test('ends active idle route span with cancelled finish reason', () {
         final sut = fixture.getSut();
 
         sut.trackRoute('/test-route');
@@ -409,7 +423,14 @@ void main() {
         sut.cancelCurrentRoute();
 
         expect(activeSpan.isEnded, isTrue);
-        expect(activeSpan.status, SentrySpanStatusV2.cancelled);
+        expect(activeSpan.status, SentrySpanStatusV2.ok);
+        expect(
+          activeSpan
+              .attributes[
+                  SemanticAttributesConstants.sentryIdleSpanFinishReason]
+              ?.value,
+          'cancelled',
+        );
       });
 
       test('cancels an existing idle span not created by the tracker', () {
@@ -422,7 +443,14 @@ void main() {
         sut.cancelCurrentRoute();
 
         expect(externalIdleSpan.isEnded, isTrue);
-        expect(externalIdleSpan.status, SentrySpanStatusV2.cancelled);
+        expect(externalIdleSpan.status, SentrySpanStatusV2.ok);
+        expect(
+          externalIdleSpan
+              .attributes[
+                  SemanticAttributesConstants.sentryIdleSpanFinishReason]
+              ?.value,
+          'cancelled',
+        );
       });
 
       test('clears prepared app start span', () {
@@ -435,7 +463,14 @@ void main() {
         sut.cancelCurrentRoute();
 
         expect(preparedSpan.isEnded, isTrue);
-        expect(preparedSpan.status, SentrySpanStatusV2.cancelled);
+        expect(preparedSpan.status, SentrySpanStatusV2.ok);
+        expect(
+          preparedSpan
+              .attributes[
+                  SemanticAttributesConstants.sentryIdleSpanFinishReason]
+              ?.value,
+          'cancelled',
+        );
       });
     });
   });

--- a/packages/flutter/test/user_interaction/sentry_user_interaction_widget_test.dart
+++ b/packages/flutter/test/user_interaction/sentry_user_interaction_widget_test.dart
@@ -668,7 +668,14 @@ void main() {
 
         // First span should be cancelled
         expect(firstSpan!.isEnded, isTrue);
-        expect(firstSpan.status, SentrySpanStatusV2.cancelled);
+        expect(firstSpan.status, SentrySpanStatusV2.ok);
+        expect(
+          firstSpan
+              .attributes[
+                  SemanticAttributesConstants.sentryIdleSpanFinishReason]
+              ?.value,
+          'cancelled',
+        );
 
         // New idle span should be started for btn_2
         final newSpan = fixture.hub.getActiveSpan();


### PR DESCRIPTION
Closes #3839

`SentrySpanStatusV2` now only distinguishes `ok` from `error`. The `cancelled` and `deadlineExceeded` values are removed, and the finer-grained outcome of a v2 idle span moves onto semantic attributes set when the span finishes:

| Scenario | Status | Attribute |
|---|---|---|
| Final timeout | `error` | `sentry.status.message` = `deadline_exceeded` |
| Idle timeout | `ok` | — |
| Still-active children force-finished on timeout | `ok` | — |
| External cancel (navigation route change, user-interaction different-widget tap) | `ok` | `sentry.idle_span_finish_reason` = `cancelled` |

`sentry.idle_span_finish_reason` mirrors the JS SDK's `browserTracingIntegration`. Two new `@internal` `SemanticAttributesConstants` back these attributes: `sentryStatusMessage` and `sentryIdleSpanFinishReason`.

`SentrySpanStatusV2` is `@internal` and not exported from any public barrel, so SDK users are unaffected. The v1 `SpanStatus` (`cancelled()` / `deadlineExceeded()`) is a separate protocol type and is left untouched — its use in gRPC and the v1 navigation trackers is unchanged.