### PR TITLE
ref(feedback): Remove deprecated SentryFeedbackWidget

### DIFF
--- a/packages/flutter/lib/sentry_flutter.dart
+++ b/packages/flutter/lib/sentry_flutter.dart
@@ -7,8 +7,6 @@ export 'package:sentry/sentry.dart';
 export 'src/binding_wrapper.dart'
     show BindingWrapper, SentryWidgetsFlutterBinding;
 export 'src/feedback/sentry_feedback_form.dart';
-// ignore: deprecated_member_use_from_same_package
-export 'src/feedback/sentry_feedback_widget.dart' show SentryFeedbackWidget;
 export 'src/flutter_sentry_attachment.dart';
 export 'src/integrations/load_release_integration.dart';
 export 'src/integrations/on_error_integration.dart';

--- a/packages/flutter/lib/src/feedback/sentry_feedback_widget.dart
+++ b/packages/flutter/lib/src/feedback/sentry_feedback_widget.dart
@@ -1,5 +1,0 @@
-import 'sentry_feedback_form.dart';
-
-/// Deprecated alias for [SentryFeedbackForm].
-@Deprecated('Use SentryFeedbackForm instead.')
-typedef SentryFeedbackWidget = SentryFeedbackForm;

--- a/packages/flutter/test/feedback/sentry_feedback_form_test.dart
+++ b/packages/flutter/test/feedback/sentry_feedback_form_test.dart
@@ -1024,33 +1024,6 @@ void main() {
       });
     });
   });
-
-  group('SentryFeedbackWidget deprecated alias', () {
-    tearDown(() {
-      SentryFeedbackForm.pendingAssociatedEventId = null;
-      SentryFeedbackForm.clearPreservedData();
-    });
-
-    test('is a deprecated alias for SentryFeedbackForm', () {
-      expect(SentryFeedbackWidget, SentryFeedbackForm);
-    });
-
-    test('shares static form state with SentryFeedbackForm', () {
-      final associatedEventId = SentryId.fromId(
-        '1988bb1b6f0d4c509e232f0cb9aaeaea',
-      );
-
-      SentryFeedbackWidget.pendingAssociatedEventId = associatedEventId;
-      SentryFeedbackWidget.preservedName = 'fixture-name';
-      SentryFeedbackWidget.preservedEmail = 'fixture@example.com';
-      SentryFeedbackWidget.preservedMessage = 'fixture-message';
-
-      expect(SentryFeedbackForm.pendingAssociatedEventId, associatedEventId);
-      expect(SentryFeedbackForm.preservedName, 'fixture-name');
-      expect(SentryFeedbackForm.preservedEmail, 'fixture@example.com');
-      expect(SentryFeedbackForm.preservedMessage, 'fixture-message');
-    });
-  });
 }
 
 class Fixture {


### PR DESCRIPTION
`SentryFeedbackWidget` is removed. It was a deprecated typedef alias (`typedef SentryFeedbackWidget = SentryFeedbackForm`) left over from the rename to `SentryFeedbackForm`, which is complete.

Removes the alias file, its export from `sentry_flutter.dart`, and the alias-specific test group. No other code referenced it.

Part of the v10 cleanup (#3487).

**Breaking change:** low impact — already deprecated with a documented migration to `SentryFeedbackForm`.

Fixes #3825