### PR TITLE
feat(logs): Enable logs by default

### DIFF
--- a/packages/dart/lib/src/sentry_options.dart
+++ b/packages/dart/lib/src/sentry_options.dart
@@ -586,8 +586,11 @@ class SentryOptions {
 
   /// Enable to capture and send logs to Sentry.
   ///
-  /// Disabled by default.
-  bool enableLogs = false;
+  /// Enabled by default. Logs are only sent when they are emitted, either by
+  /// calling a [SentryLogger] method via `Sentry.logger`, or by explicitly
+  /// adding an integration that emits logs (e.g. `LoggingIntegration` from
+  /// the `sentry_logging` package).
+  bool enableLogs = true;
 
   /// Enable to capture and send metrics to Sentry.
   ///

--- a/packages/dart/test/sentry_options_test.dart
+++ b/packages/dart/test/sentry_options_test.dart
@@ -189,4 +189,10 @@ void main() {
 
     expect(options.enableMetrics, true);
   });
+
+  test('enableLogs is true by default', () {
+    final options = defaultTestOptions();
+
+    expect(options.enableLogs, true);
+  });
 }

--- a/packages/flutter/test/integrations/load_contexts_integration_test.dart
+++ b/packages/flutter/test/integrations/load_contexts_integration_test.dart
@@ -869,6 +869,7 @@ void main() {
     group('metrics', () {
       test('adds device attributes to metric when metrics enabled', () async {
         fixture.options.enableMetrics = true;
+        fixture.options.enableLogs = false;
         mockLoadContexts();
         await fixture.registerIntegration();
 
@@ -903,6 +904,7 @@ void main() {
 
       test('does not register callback when metrics disabled', () async {
         fixture.options.enableMetrics = false;
+        fixture.options.enableLogs = false;
         await fixture.registerIntegration();
 
         expect(fixture.options.lifecycleRegistry.lifecycleCallbacks.length, 0);
@@ -1033,6 +1035,7 @@ void main() {
     group('close', () {
       test('removes metric callback from lifecycle registry', () async {
         fixture.options.enableMetrics = true;
+        fixture.options.enableLogs = false;
         mockLoadContexts();
         await fixture.registerIntegration();
 

--- a/packages/logging/lib/src/logging_integration.dart
+++ b/packages/logging/lib/src/logging_integration.dart
@@ -11,6 +11,10 @@ import 'version.dart';
 
 /// An [Integration] which listens to all messages of the
 /// [logging](https://pub.dev/packages/logging) package.
+///
+/// Adding this integration opts into emitting Sentry logs: log records are
+/// forwarded as structured Sentry logs whenever [SentryOptions.enableLogs]
+/// is `true` (the default).
 class LoggingIntegration implements Integration<SentryOptions> {
   /// Creates the [LoggingIntegration].
   ///
@@ -19,7 +23,7 @@ class LoggingIntegration implements Integration<SentryOptions> {
   /// - All log events equal or higher than [minEventLevel] are recorded as a
   /// [SentryEvent].
   /// - All log events equal or higher than [minSentryLogLevel] are logged to
-  /// Sentry, if [SentryOptions.enableLogs] is true.
+  /// Sentry, unless [SentryOptions.enableLogs] is set to `false`.
   ///
   /// Log levels are mapped to the following Sentry log levels methods:
   ///


### PR DESCRIPTION
`SentryOptions.enableLogs` now defaults to `true`, matching `enableMetrics`, so calling `Sentry.logger.*` works without any configuration.

Flipping the default sends nothing by itself: logs only flow when the user emits them — by calling `Sentry.logger.*` or by explicitly adding a log-emitting integration. Per the [develop spec](https://develop.sentry.dev/sdk/telemetry/logs/), integrations that auto-emit logs must be opt-in; the audit for #3833 confirmed `LoggingIntegration` (`sentry_logging`) is the only such integration in this repo and is never auto-registered, so explicitly adding it is the opt-in and no integration-level toggle is needed. Doc comments on `enableLogs` and `LoggingIntegration` now spell out that contract.

Behavior change for existing users: apps that already add `LoggingIntegration` (or call `Sentry.logger.*`) without setting `enableLogs = true` will start sending logs after upgrading; setting `enableLogs = false` restores the old behavior.

Fixes #3682
Fixes #3833