### PR TITLE
feat(logs): Add Hint to beforeSend for logs, metrics, and spans

### DIFF
--- a/packages/dart/lib/src/sdk_lifecycle_hooks.dart
+++ b/packages/dart/lib/src/sdk_lifecycle_hooks.dart
@@ -68,9 +68,10 @@ class SdkLifecycleRegistry {
 
 @internal
 class OnProcessLog extends SdkLifecycleEvent {
-  OnProcessLog(this.log);
+  OnProcessLog(this.log, this.hint);
 
   final SentryLog log;
+  final Hint hint;
 }
 
 @internal
@@ -120,8 +121,9 @@ class OnSpanEndV2 extends SdkLifecycleEvent {
 @internal
 class OnProcessSpan extends SdkLifecycleEvent {
   final RecordingSentrySpanV2 span;
+  final Hint hint;
 
-  OnProcessSpan(this.span);
+  OnProcessSpan(this.span, this.hint);
 }
 
 /// Dispatched when a metric has been captured and is ready for processing (before default enrichment)
@@ -129,8 +131,9 @@ class OnProcessSpan extends SdkLifecycleEvent {
 @internal
 class OnProcessMetric extends SdkLifecycleEvent {
   final SentryMetric metric;
+  final Hint hint;
 
-  OnProcessMetric(this.metric);
+  OnProcessMetric(this.metric, this.hint);
 }
 
 /// Dispatched when a new trace is generated via [Hub.generateNewTrace].

--- a/packages/dart/lib/src/sentry_options.dart
+++ b/packages/dart/lib/src/sentry_options.dart
@@ -780,15 +780,23 @@ typedef BeforeBreadcrumbCallback = Breadcrumb? Function(
 
 /// This function is called right before a log is about to be sent.
 /// Can return a modified log or null to drop the log.
-typedef BeforeSendLogCallback = FutureOr<SentryLog?> Function(SentryLog log);
+typedef BeforeSendLogCallback = FutureOr<SentryLog?> Function(
+  SentryLog log,
+  Hint hint,
+);
 
 /// This function is called right before a metric is about to be emitted.
 /// Can return true to emit the metric, or false to drop it.
 typedef BeforeSendMetricCallback = FutureOr<SentryMetric?> Function(
-    SentryMetric metric);
+  SentryMetric metric,
+  Hint hint,
+);
 
 /// This function is called right before a span is about to be sent.
-typedef BeforeSendSpanCallback = FutureOr<void> Function(SentrySpanV2 span);
+typedef BeforeSendSpanCallback = FutureOr<void> Function(
+  SentrySpanV2 span,
+  Hint hint,
+);
 
 /// Used to provide timestamp for logging.
 typedef ClockProvider = DateTime Function();

--- a/packages/dart/lib/src/sentry_options.dart
+++ b/packages/dart/lib/src/sentry_options.dart
@@ -786,7 +786,7 @@ typedef BeforeSendLogCallback = FutureOr<SentryLog?> Function(
 );
 
 /// This function is called right before a metric is about to be emitted.
-/// Can return true to emit the metric, or false to drop it.
+/// Can return a modified metric or null to drop the metric.
 typedef BeforeSendMetricCallback = FutureOr<SentryMetric?> Function(
   SentryMetric metric,
   Hint hint,

--- a/packages/dart/lib/src/telemetry/log/log_capture_pipeline.dart
+++ b/packages/dart/lib/src/telemetry/log/log_capture_pipeline.dart
@@ -30,8 +30,10 @@ class LogCapturePipeline {
         log.attributes.addAllIfAbsent(scope.attributes);
       }
 
+      final hint = Hint();
+
       await _options.lifecycleRegistry
-          .dispatchCallback<OnProcessLog>(OnProcessLog(log));
+          .dispatchCallback<OnProcessLog>(OnProcessLog(log, hint));
 
       log.attributes.addAllIfAbsent(defaultAttributes(_options, scope: scope));
 
@@ -39,7 +41,7 @@ class LogCapturePipeline {
       SentryLog? processedLog = log;
       if (beforeSendLog != null) {
         try {
-          final callbackResult = beforeSendLog(log);
+          final callbackResult = beforeSendLog(log, hint);
 
           if (callbackResult is Future<SentryLog?>) {
             processedLog = await callbackResult;

--- a/packages/dart/lib/src/telemetry/metric/metric_capture_pipeline.dart
+++ b/packages/dart/lib/src/telemetry/metric/metric_capture_pipeline.dart
@@ -24,8 +24,10 @@ class MetricCapturePipeline {
         metric.attributes.addAllIfAbsent(scope.attributes);
       }
 
+      final hint = Hint();
+
       await _options.lifecycleRegistry
-          .dispatchCallback<OnProcessMetric>(OnProcessMetric(metric));
+          .dispatchCallback<OnProcessMetric>(OnProcessMetric(metric, hint));
 
       metric.attributes
           .addAllIfAbsent(defaultAttributes(_options, scope: scope));
@@ -34,12 +36,11 @@ class MetricCapturePipeline {
       SentryMetric? processedMetric = metric;
       if (beforeSendMetric != null) {
         try {
-          processedMetric = await beforeSendMetric(metric);
+          processedMetric = await beforeSendMetric(metric, hint);
         } catch (exception, stackTrace) {
-          _options.log(
-            SentryLevel.error,
+          internalLogger.error(
             'The beforeSendMetric callback threw an exception',
-            exception: exception,
+            error: exception,
             stackTrace: stackTrace,
           );
           if (_options.automatedTestMode) {

--- a/packages/dart/lib/src/telemetry/span/span_capture_pipeline.dart
+++ b/packages/dart/lib/src/telemetry/span/span_capture_pipeline.dart
@@ -31,8 +31,10 @@ class SpanCapturePipeline {
             span.addAttributesIfAbsent(scope.attributes);
           }
 
+          final hint = Hint();
+
           await _options.lifecycleRegistry.dispatchCallback<OnProcessSpan>(
-            OnProcessSpan(span),
+            OnProcessSpan(span, hint),
           );
 
           span.addAttributesIfAbsent(defaultAttributes(_options, scope: scope));
@@ -49,7 +51,7 @@ class SpanCapturePipeline {
           final beforeSendSpan = _options.beforeSendSpan;
           if (beforeSendSpan != null) {
             try {
-              await beforeSendSpan(span);
+              await beforeSendSpan(span, hint);
             } catch (exception, stackTrace) {
               internalLogger.error(
                 'The beforeSendSpan callback threw an exception',

--- a/packages/dart/test/event_processor/enricher/enricher_integration_test.dart
+++ b/packages/dart/test/event_processor/enricher/enricher_integration_test.dart
@@ -45,7 +45,7 @@ void main() {
         final log = fixture.givenLog();
 
         await fixture.options.lifecycleRegistry
-            .dispatchCallback(OnProcessLog(log));
+            .dispatchCallback(OnProcessLog(log, Hint()));
 
         expect(log.attributes['device.brand']?.value, 'enricher-brand');
         expect(log.attributes['device.model']?.value, 'enricher-model');
@@ -58,7 +58,7 @@ void main() {
         final log = fixture.givenLog();
 
         await fixture.options.lifecycleRegistry
-            .dispatchCallback(OnProcessLog(log));
+            .dispatchCallback(OnProcessLog(log, Hint()));
 
         expect(log.attributes.containsKey('app.version'), isFalse);
       });
@@ -69,7 +69,7 @@ void main() {
         log.attributes['device.brand'] = SentryAttribute.string('existing');
 
         await fixture.options.lifecycleRegistry
-            .dispatchCallback(OnProcessLog(log));
+            .dispatchCallback(OnProcessLog(log, Hint()));
 
         expect(log.attributes['device.brand']?.value, 'existing');
       });
@@ -100,7 +100,7 @@ void main() {
         final metric = fixture.givenMetric();
 
         await fixture.options.lifecycleRegistry
-            .dispatchCallback(OnProcessMetric(metric));
+            .dispatchCallback(OnProcessMetric(metric, Hint()));
 
         expect(metric.attributes['device.brand']?.value, 'enricher-brand');
         expect(metric.attributes['device.model']?.value, 'enricher-model');
@@ -135,7 +135,7 @@ void main() {
         final childSpan = fixture.createRecordingSpan(parent: segmentSpan);
 
         await fixture.options.lifecycleRegistry
-            .dispatchCallback(OnProcessSpan(childSpan));
+            .dispatchCallback(OnProcessSpan(childSpan, Hint()));
 
         final attributes = childSpan.attributes;
         expect(attributes['device.brand']?.value, 'enricher-brand');
@@ -150,7 +150,7 @@ void main() {
         final segmentSpan = fixture.createRecordingSpan();
 
         await fixture.options.lifecycleRegistry
-            .dispatchCallback(OnProcessSpan(segmentSpan));
+            .dispatchCallback(OnProcessSpan(segmentSpan, Hint()));
 
         final attributes = segmentSpan.attributes;
         expect(attributes['device.brand']?.value, 'enricher-brand');
@@ -165,7 +165,7 @@ void main() {
             'device.brand', SentryAttribute.string('existing'));
 
         await fixture.options.lifecycleRegistry
-            .dispatchCallback(OnProcessSpan(segmentSpan));
+            .dispatchCallback(OnProcessSpan(segmentSpan, Hint()));
 
         expect(segmentSpan.attributes['device.brand']?.value, 'existing');
       });

--- a/packages/dart/test/telemetry/log/log_capture_pipeline_test.dart
+++ b/packages/dart/test/telemetry/log/log_capture_pipeline_test.dart
@@ -97,7 +97,7 @@ void main() {
               event.log.attributes.containsKey('scope-attr');
         });
 
-        fixture.options.beforeSendLog = (log) {
+        fixture.options.beforeSendLog = (log, hint) {
           operations.add('beforeSendLog');
           return log;
         };
@@ -143,8 +143,28 @@ void main() {
     });
 
     group('when beforeSendLog is configured', () {
+      test('receives the same hint instance dispatched to OnProcessLog',
+          () async {
+        Hint? lifecycleHint;
+        Hint? callbackHint;
+
+        fixture.options.lifecycleRegistry
+            .registerCallback<OnProcessLog>((event) {
+          lifecycleHint = event.hint;
+        });
+        fixture.options.beforeSendLog = (log, hint) {
+          callbackHint = hint;
+          return log;
+        };
+
+        await fixture.pipeline.captureLog(givenLog(), scope: fixture.scope);
+
+        expect(callbackHint, isNotNull);
+        expect(callbackHint, same(lifecycleHint));
+      });
+
       test('returning null drops the log', () async {
-        fixture.options.beforeSendLog = (_) => null;
+        fixture.options.beforeSendLog = (_, __) => null;
 
         final log = givenLog();
 
@@ -154,7 +174,7 @@ void main() {
       });
 
       test('returning null records lost event in client report', () async {
-        fixture.options.beforeSendLog = (_) => null;
+        fixture.options.beforeSendLog = (_, __) => null;
 
         final log = givenLog();
 
@@ -169,7 +189,7 @@ void main() {
       test(
           'returning null records log item but omits log byte if size estimation fails',
           () async {
-        fixture.options.beforeSendLog = (_) => null;
+        fixture.options.beforeSendLog = (_, __) => null;
 
         final log = givenLog()
           ..attributes['unserializable'] =
@@ -184,7 +204,7 @@ void main() {
       });
 
       test('can mutate the log', () async {
-        fixture.options.beforeSendLog = (log) {
+        fixture.options.beforeSendLog = (log, hint) {
           log.body = 'modified-body';
           log.attributes['added-key'] = SentryAttribute.string('added');
           return log;
@@ -201,7 +221,7 @@ void main() {
       });
 
       test('async callback is awaited', () async {
-        fixture.options.beforeSendLog = (log) async {
+        fixture.options.beforeSendLog = (log, hint) async {
           await Future.delayed(Duration(milliseconds: 10));
           log.body = 'async-modified';
           return log;
@@ -219,7 +239,7 @@ void main() {
       test('exception in callback is caught and log is still captured',
           () async {
         fixture.options.automatedTestMode = false;
-        fixture.options.beforeSendLog = (log) {
+        fixture.options.beforeSendLog = (log, hint) {
           throw Exception('test');
         };
 

--- a/packages/dart/test/telemetry/metric/metric_capture_pipeline_test.dart
+++ b/packages/dart/test/telemetry/metric/metric_capture_pipeline_test.dart
@@ -86,7 +86,7 @@ void main() {
               event.metric.attributes.containsKey('scope-attr');
         });
 
-        fixture.options.beforeSendMetric = (metric) {
+        fixture.options.beforeSendMetric = (metric, hint) {
           operations.add('beforeSendMetric');
           return metric;
         };
@@ -133,8 +133,29 @@ void main() {
     });
 
     group('when beforeSendMetric is configured', () {
+      test('receives the same hint instance dispatched to OnProcessMetric',
+          () async {
+        Hint? lifecycleHint;
+        Hint? callbackHint;
+
+        fixture.options.lifecycleRegistry
+            .registerCallback<OnProcessMetric>((event) {
+          lifecycleHint = event.hint;
+        });
+        fixture.options.beforeSendMetric = (metric, hint) {
+          callbackHint = hint;
+          return metric;
+        };
+
+        await fixture.pipeline
+            .captureMetric(fixture.createMetric(), scope: fixture.scope);
+
+        expect(callbackHint, isNotNull);
+        expect(callbackHint, same(lifecycleHint));
+      });
+
       test('returning null drops the metric', () async {
-        fixture.options.beforeSendMetric = (_) => null;
+        fixture.options.beforeSendMetric = (_, __) => null;
 
         final metric = fixture.createMetric();
 
@@ -144,7 +165,7 @@ void main() {
       });
 
       test('returning null records lost event in client report', () async {
-        fixture.options.beforeSendMetric = (_) => null;
+        fixture.options.beforeSendMetric = (_, __) => null;
 
         final metric = fixture.createMetric();
 
@@ -158,7 +179,7 @@ void main() {
       });
 
       test('can mutate the metric', () async {
-        fixture.options.beforeSendMetric = (metric) {
+        fixture.options.beforeSendMetric = (metric, hint) {
           metric.name = 'modified-name';
           metric.attributes['added-key'] = SentryAttribute.string('added');
           return metric;

--- a/packages/dart/test/telemetry/span/span_capture_pipeline_test.dart
+++ b/packages/dart/test/telemetry/span/span_capture_pipeline_test.dart
@@ -156,7 +156,7 @@ void main() {
 
       test('calls beforeSendSpan callback with span', () async {
         SentrySpanV2? receivedSpan;
-        fixture.options.beforeSendSpan = (span) {
+        fixture.options.beforeSendSpan = (span, hint) {
           receivedSpan = span;
         };
 
@@ -167,8 +167,28 @@ void main() {
         expect(fixture.processor.addedSpans.length, 1);
       });
 
+      test('receives the same hint instance dispatched to OnProcessSpan',
+          () async {
+        Hint? lifecycleHint;
+        Hint? callbackHint;
+
+        fixture.options.lifecycleRegistry
+            .registerCallback<OnProcessSpan>((event) {
+          lifecycleHint = event.hint;
+        });
+        fixture.options.beforeSendSpan = (span, hint) {
+          callbackHint = hint;
+        };
+
+        await fixture.pipeline
+            .captureSpan(fixture.createRecordingSpan(), scope: fixture.scope);
+
+        expect(callbackHint, isNotNull);
+        expect(callbackHint, same(lifecycleHint));
+      });
+
       test('beforeSendSpan callback can modify span attributes', () async {
-        fixture.options.beforeSendSpan = (span) {
+        fixture.options.beforeSendSpan = (span, hint) {
           span.setAttribute('modified-by-callback', SentryAttribute.bool(true));
           span.name = 'modified-span-name';
         };
@@ -181,7 +201,7 @@ void main() {
       });
 
       test('beforeSendSpan callback can remove sensitive attributes', () async {
-        fixture.options.beforeSendSpan = (span) {
+        fixture.options.beforeSendSpan = (span, hint) {
           span.removeAttribute('sensitive-data');
         };
 
@@ -197,7 +217,7 @@ void main() {
 
       test('beforeSendSpan callback supports async operations', () async {
         var asyncCompleted = false;
-        fixture.options.beforeSendSpan = (span) async {
+        fixture.options.beforeSendSpan = (span, hint) async {
           await Future.delayed(Duration.zero);
           asyncCompleted = true;
           span.setAttribute(
@@ -219,7 +239,7 @@ void main() {
           callOrder.add('lifecycle');
         });
 
-        fixture.options.beforeSendSpan = (span) {
+        fixture.options.beforeSendSpan = (span, hint) {
           callOrder.add('beforeSendSpan');
         };
 
@@ -232,7 +252,7 @@ void main() {
       test('beforeSendSpan is called after default attributes are added',
           () async {
         String? envValue;
-        fixture.options.beforeSendSpan = (span) {
+        fixture.options.beforeSendSpan = (span, hint) {
           envValue = span
               .attributes[SemanticAttributesConstants.sentryEnvironment]
               ?.value as String?;
@@ -247,7 +267,7 @@ void main() {
       test('span is still captured when beforeSendSpan throws exception',
           () async {
         fixture.options.automatedTestMode = false;
-        fixture.options.beforeSendSpan = (span) async {
+        fixture.options.beforeSendSpan = (span, hint) async {
           await Future.delayed(Duration.zero);
           throw Exception('async beforeSendSpan callback error');
         };

--- a/packages/dart/test/track_before_send_usage_integration_test.dart
+++ b/packages/dart/test/track_before_send_usage_integration_test.dart
@@ -49,7 +49,7 @@ void main() {
     });
 
     test('adds beforeSendLog feature when configured', () {
-      fixture.options.beforeSendLog = (log) => log;
+      fixture.options.beforeSendLog = (log, hint) => log;
 
       fixture.getSut().call(fixture.hub, fixture.options);
 
@@ -58,7 +58,7 @@ void main() {
     });
 
     test('adds beforeSendMetric feature when configured', () {
-      fixture.options.beforeSendMetric = (metric) => metric;
+      fixture.options.beforeSendMetric = (metric, hint) => metric;
 
       fixture.getSut().call(fixture.hub, fixture.options);
 

--- a/packages/flutter/example/lib/main.dart
+++ b/packages/flutter/example/lib/main.dart
@@ -70,7 +70,7 @@ Future<void> setupSentry(
 
       options.enableLogs = true;
 
-      options.beforeSendMetric = (metric) {
+      options.beforeSendMetric = (metric, hint) {
         if (metric.name == 'drop-metric') {
           return null;
         }
@@ -85,7 +85,7 @@ Future<void> setupSentry(
       ];
 
       // Example: Scrub sensitive data from spans before sending
-      options.beforeSendSpan = (span) {
+      options.beforeSendSpan = (span, hint) {
         final sensitiveAttributes = span.attributes.entries
             .where((entry) =>
                 entry.value.value is String &&

--- a/packages/flutter/test/integrations/load_contexts_integration_test.dart
+++ b/packages/flutter/test/integrations/load_contexts_integration_test.dart
@@ -882,7 +882,7 @@ void main() {
         );
 
         await fixture.options.lifecycleRegistry.dispatchCallback(
-          OnProcessMetric(metric),
+          OnProcessMetric(metric, Hint()),
         );
 
         verify(fixture.binding.loadContexts()).called(1);
@@ -935,7 +935,7 @@ void main() {
 
           final span = givenSpan();
           await fixture.options.lifecycleRegistry.dispatchCallback(
-            OnProcessSpan(span),
+            OnProcessSpan(span, Hint()),
           );
 
           verify(fixture.binding.loadContexts()).called(1);
@@ -975,7 +975,7 @@ void main() {
         );
 
         await fixture.options.lifecycleRegistry.dispatchCallback(
-          OnProcessSpan(span),
+          OnProcessSpan(span, Hint()),
         );
 
         final attributes = span.attributes;
@@ -1011,7 +1011,7 @@ void main() {
 
         final span = givenSpan();
         await fixture.options.lifecycleRegistry.dispatchCallback(
-          OnProcessSpan(span),
+          OnProcessSpan(span, Hint()),
         );
 
         // Attributes should remain unchanged (empty or just what was set before)
@@ -1121,7 +1121,7 @@ void main() {
         );
 
         await fixture.options.lifecycleRegistry.dispatchCallback(
-          OnProcessMetric(metric),
+          OnProcessMetric(metric, Hint()),
         );
 
         verifyNever(fixture.binding.loadContexts());
@@ -1145,7 +1145,7 @@ void main() {
         );
 
         await fixture.options.lifecycleRegistry.dispatchCallback(
-          OnProcessSpan(span),
+          OnProcessSpan(span, Hint()),
         );
 
         verifyNever(fixture.binding.loadContexts());

--- a/packages/flutter/test/integrations/replay_telemetry_integration_test.dart
+++ b/packages/flutter/test/integrations/replay_telemetry_integration_test.dart
@@ -112,7 +112,7 @@ void main() {
           clearInteractions(fixture.nativeBinding);
           final span = fixture.createTestSpan();
           await fixture.options.lifecycleRegistry.dispatchCallback(
-            OnProcessSpan(span),
+            OnProcessSpan(span, Hint()),
           );
 
           verifyNever(fixture.nativeBinding.registerTraceId(any));
@@ -128,7 +128,7 @@ void main() {
           clearInteractions(fixture.nativeBinding);
           final span = fixture.createChildTestSpan();
           await fixture.options.lifecycleRegistry.dispatchCallback(
-            OnProcessSpan(span),
+            OnProcessSpan(span, Hint()),
           );
 
           verifyNever(fixture.nativeBinding.registerTraceId(any));
@@ -156,7 +156,7 @@ void main() {
 
         final metric = fixture.createTestMetric();
         await fixture.options.lifecycleRegistry.dispatchCallback(
-          OnProcessMetric(metric),
+          OnProcessMetric(metric, Hint()),
         );
 
         expect(metric.attributes[_replayId]?.value, 'testreplayid');
@@ -167,7 +167,7 @@ void main() {
 
         final span = fixture.createTestSpan();
         await fixture.options.lifecycleRegistry.dispatchCallback(
-          OnProcessSpan(span),
+          OnProcessSpan(span, Hint()),
         );
 
         expect(span.attributes[_replayId]?.value, 'testreplayid');
@@ -205,7 +205,7 @@ void main() {
 
         final metric = fixture.createTestMetric();
         await fixture.options.lifecycleRegistry.dispatchCallback(
-          OnProcessMetric(metric),
+          OnProcessMetric(metric, Hint()),
         );
 
         expect(metric.attributes[_replayId]?.value, 'testreplayid');
@@ -216,7 +216,7 @@ void main() {
 
         final span = fixture.createTestSpan();
         await fixture.options.lifecycleRegistry.dispatchCallback(
-          OnProcessSpan(span),
+          OnProcessSpan(span, Hint()),
         );
 
         expect(span.attributes[_replayId]?.value, 'testreplayid');
@@ -236,7 +236,7 @@ void main() {
 
         final span = fixture.createTestSpan();
         await fixture.options.lifecycleRegistry.dispatchCallback(
-          OnProcessSpan(span),
+          OnProcessSpan(span, Hint()),
         );
 
         expect(span.attributes[_replayIsBuffering]?.value, true);
@@ -272,7 +272,7 @@ void main() {
 
             final span = fixture.createTestSpan();
             await fixture.options.lifecycleRegistry.dispatchCallback(
-              OnProcessSpan(span),
+              OnProcessSpan(span, Hint()),
             );
 
             expect(span.attributes.containsKey(_replayId), false);
@@ -310,7 +310,7 @@ void main() {
 
             final span = fixture.createTestSpan();
             await fixture.options.lifecycleRegistry.dispatchCallback(
-              OnProcessSpan(span),
+              OnProcessSpan(span, Hint()),
             );
 
             expect(span.attributes.containsKey(_replayId), false);
@@ -344,7 +344,7 @@ void main() {
 
         final metric = fixture.createTestMetric();
         await fixture.options.lifecycleRegistry.dispatchCallback(
-          OnProcessMetric(metric),
+          OnProcessMetric(metric, Hint()),
         );
 
         expect(metric.attributes.containsKey(_replayId), false);
@@ -360,7 +360,7 @@ void main() {
 
         final span = fixture.createTestSpan();
         await fixture.options.lifecycleRegistry.dispatchCallback(
-          OnProcessSpan(span),
+          OnProcessSpan(span, Hint()),
         );
 
         expect(span.attributes.containsKey(_replayId), false);
@@ -401,7 +401,9 @@ class Fixture {
     when(hub.scope).thenReturn(scope);
     when(hub.captureLog(any)).thenAnswer((invocation) async {
       final log = invocation.positionalArguments.first as SentryLog;
-      await options.lifecycleRegistry.dispatchCallback(OnProcessLog(log));
+      await options.lifecycleRegistry.dispatchCallback(
+        OnProcessLog(log, Hint()),
+      );
     });
     when(nativeBinding.replayId).thenReturn(null);
     when(nativeBinding.registerTraceId(any)).thenReturn(null);


### PR DESCRIPTION
`beforeSendLog`, `beforeSendMetric`, and `beforeSendSpan` now receive a `Hint` as their second argument, matching `beforeSend` and `beforeSendTransaction`. This is a breaking change: user-defined callbacks must add the parameter.

```dart
// before
options.beforeSendLog = (log) { ...; return log; };
// after
options.beforeSendLog = (log, hint) { ...; return log; };
```

Each capture pipeline creates a single `Hint` and threads that same instance through the `OnProcessLog`/`OnProcessMetric`/`OnProcessSpan` lifecycle event and then into the callback. That's the mechanism that makes the hint useful: an SDK-side lifecycle callback can enrich the hint before `beforeSend*` reads it, since both hold the same instance.

```dart
// SDK/integration side (lifecycle callbacks are @internal)
options.lifecycleRegistry.registerCallback<OnProcessSpan>((event) {
  if (event.span.name == 'db.query') {
    event.hint.set('raw_statement', stmt);
  }
});
// user callback receives the same populated hint
options.beforeSendSpan = (span, hint) => hint.get('raw_statement');
```

Scope notes for reviewers:

- Public capture APIs (`captureLog`/`captureMetric`/`captureSpan` on `Hub`/`Client`) are intentionally **unchanged** — nobody emits through them directly, so a `hint` parameter there would have no caller. The hint is created in the pipeline.
- An **emit-time** seam for populating the hint from user code (e.g. `Sentry.logger.info(hint:)`, or a hint carried on a live span) is deliberately deferred. It's a non-breaking addition and there's no populator today; the breaking signature change is what has to land in v10.
- Also migrates the metric pipeline's callback-error log from the deprecated `options.log` to `internalLogger`.

Each pipeline gains a test asserting the callback receives the *same* `Hint` instance dispatched to its `OnProcess*` event, so the threading can't silently regress.

Fixes #3836