### PR TITLE
ref(logs): Make logger methods return void

### DIFF
--- a/packages/dart/lib/src/hub.dart
+++ b/packages/dart/lib/src/hub.dart
@@ -292,7 +292,7 @@ class Hub {
     return sentryId;
   }
 
-  FutureOr<void> captureLog(SentryLog log) async {
+  Future<void> captureLog(SentryLog log) async {
     if (!_isEnabled) {
       _options.log(
         SentryLevel.warning,

--- a/packages/dart/lib/src/hub_adapter.dart
+++ b/packages/dart/lib/src/hub_adapter.dart
@@ -214,7 +214,7 @@ class HubAdapter implements Hub {
       );
 
   @override
-  FutureOr<void> captureLog(SentryLog log) => Sentry.currentHub.captureLog(log);
+  Future<void> captureLog(SentryLog log) => Sentry.currentHub.captureLog(log);
 
   @override
   Future<void> captureMetric(SentryMetric metric) =>

--- a/packages/dart/lib/src/noop_hub.dart
+++ b/packages/dart/lib/src/noop_hub.dart
@@ -97,7 +97,7 @@ class NoOpHub implements Hub {
       SentryId.empty();
 
   @override
-  FutureOr<void> captureLog(SentryLog log) async {}
+  Future<void> captureLog(SentryLog log) async {}
 
   @override
   Future<void> captureMetric(SentryMetric metric) async {}

--- a/packages/dart/lib/src/noop_sentry_client.dart
+++ b/packages/dart/lib/src/noop_sentry_client.dart
@@ -70,7 +70,7 @@ class NoOpSentryClient implements SentryClient {
       SentryId.empty();
 
   @override
-  FutureOr<void> captureLog(SentryLog log, {Scope? scope}) async {}
+  Future<void> captureLog(SentryLog log, {Scope? scope}) async {}
 
   @override
   Future<void> captureMetric(SentryMetric metric, {Scope? scope}) async {}

--- a/packages/dart/lib/src/sentry_client.dart
+++ b/packages/dart/lib/src/sentry_client.dart
@@ -514,7 +514,7 @@ class SentryClient {
       _spanCapturePipeline.captureSpan(span, scope: scope);
 
   @internal
-  FutureOr<void> captureLog(SentryLog log, {Scope? scope}) =>
+  Future<void> captureLog(SentryLog log, {Scope? scope}) =>
       _logCapturePipeline.captureLog(log, scope: scope);
 
   Future<void> captureMetric(SentryMetric metric, {Scope? scope}) =>

--- a/packages/dart/lib/src/telemetry/log/default_logger.dart
+++ b/packages/dart/lib/src/telemetry/log/default_logger.dart
@@ -4,7 +4,7 @@ import '../../../sentry.dart';
 import '../../sentry_template_string.dart';
 import '../../utils/internal_logger.dart';
 
-typedef CaptureLogCallback = FutureOr<void> Function(SentryLog log);
+typedef CaptureLogCallback = Future<void> Function(SentryLog log);
 typedef ScopeProvider = Scope Function();
 
 final class DefaultSentryLogger implements SentryLogger {
@@ -24,51 +24,51 @@ final class DefaultSentryLogger implements SentryLogger {
         _scopeProvider = scopeProvider;
 
   @override
-  FutureOr<void> trace(
+  void trace(
     String body, {
     Map<String, SentryAttribute>? attributes,
   }) {
-    return _captureLog(SentryLogLevel.trace, body, attributes: attributes);
+    _captureLog(SentryLogLevel.trace, body, attributes: attributes);
   }
 
   @override
-  FutureOr<void> debug(
+  void debug(
     String body, {
     Map<String, SentryAttribute>? attributes,
   }) {
-    return _captureLog(SentryLogLevel.debug, body, attributes: attributes);
+    _captureLog(SentryLogLevel.debug, body, attributes: attributes);
   }
 
   @override
-  FutureOr<void> info(
+  void info(
     String body, {
     Map<String, SentryAttribute>? attributes,
   }) {
-    return _captureLog(SentryLogLevel.info, body, attributes: attributes);
+    _captureLog(SentryLogLevel.info, body, attributes: attributes);
   }
 
   @override
-  FutureOr<void> warn(
+  void warn(
     String body, {
     Map<String, SentryAttribute>? attributes,
   }) {
-    return _captureLog(SentryLogLevel.warn, body, attributes: attributes);
+    _captureLog(SentryLogLevel.warn, body, attributes: attributes);
   }
 
   @override
-  FutureOr<void> error(
+  void error(
     String body, {
     Map<String, SentryAttribute>? attributes,
   }) {
-    return _captureLog(SentryLogLevel.error, body, attributes: attributes);
+    _captureLog(SentryLogLevel.error, body, attributes: attributes);
   }
 
   @override
-  FutureOr<void> fatal(
+  void fatal(
     String body, {
     Map<String, SentryAttribute>? attributes,
   }) {
-    return _captureLog(SentryLogLevel.fatal, body, attributes: attributes);
+    _captureLog(SentryLogLevel.fatal, body, attributes: attributes);
   }
 
   @override
@@ -76,7 +76,7 @@ final class DefaultSentryLogger implements SentryLogger {
 
   // Helpers
 
-  FutureOr<void> _captureLog(
+  void _captureLog(
     SentryLogLevel level,
     String body, {
     Map<String, SentryAttribute>? attributes,
@@ -93,7 +93,7 @@ final class DefaultSentryLogger implements SentryLogger {
       attributes: attributes ?? {},
     );
 
-    return _captureLogCallback(log);
+    unawaited(_captureLogCallback(log));
   }
 
   String _formatAttributes(Map<String, SentryAttribute>? attributes) {
@@ -108,108 +108,108 @@ final class _DefaultSentryLoggerFormatter implements SentryLoggerFormatter {
   final DefaultSentryLogger _logger;
 
   @override
-  FutureOr<void> trace(
+  void trace(
     String templateBody,
     List<dynamic> arguments, {
     Map<String, SentryAttribute>? attributes,
   }) {
-    return _format(
+    _format(
       templateBody,
       arguments,
       attributes,
       (formattedBody, allAttributes) {
-        return _logger.trace(formattedBody, attributes: allAttributes);
+        _logger.trace(formattedBody, attributes: allAttributes);
       },
     );
   }
 
   @override
-  FutureOr<void> debug(
+  void debug(
     String templateBody,
     List<dynamic> arguments, {
     Map<String, SentryAttribute>? attributes,
   }) {
-    return _format(
+    _format(
       templateBody,
       arguments,
       attributes,
       (formattedBody, allAttributes) {
-        return _logger.debug(formattedBody, attributes: allAttributes);
+        _logger.debug(formattedBody, attributes: allAttributes);
       },
     );
   }
 
   @override
-  FutureOr<void> info(
+  void info(
     String templateBody,
     List<dynamic> arguments, {
     Map<String, SentryAttribute>? attributes,
   }) {
-    return _format(
+    _format(
       templateBody,
       arguments,
       attributes,
       (formattedBody, allAttributes) {
-        return _logger.info(formattedBody, attributes: allAttributes);
+        _logger.info(formattedBody, attributes: allAttributes);
       },
     );
   }
 
   @override
-  FutureOr<void> warn(
+  void warn(
     String templateBody,
     List<dynamic> arguments, {
     Map<String, SentryAttribute>? attributes,
   }) {
-    return _format(
+    _format(
       templateBody,
       arguments,
       attributes,
       (formattedBody, allAttributes) {
-        return _logger.warn(formattedBody, attributes: allAttributes);
+        _logger.warn(formattedBody, attributes: allAttributes);
       },
     );
   }
 
   @override
-  FutureOr<void> error(
+  void error(
     String templateBody,
     List<dynamic> arguments, {
     Map<String, SentryAttribute>? attributes,
   }) {
-    return _format(
+    _format(
       templateBody,
       arguments,
       attributes,
       (formattedBody, allAttributes) {
-        return _logger.error(formattedBody, attributes: allAttributes);
+        _logger.error(formattedBody, attributes: allAttributes);
       },
     );
   }
 
   @override
-  FutureOr<void> fatal(
+  void fatal(
     String templateBody,
     List<dynamic> arguments, {
     Map<String, SentryAttribute>? attributes,
   }) {
-    return _format(
+    _format(
       templateBody,
       arguments,
       attributes,
       (formattedBody, allAttributes) {
-        return _logger.fatal(formattedBody, attributes: allAttributes);
+        _logger.fatal(formattedBody, attributes: allAttributes);
       },
     );
   }
 
   // Helper
 
-  FutureOr<void> _format(
+  void _format(
     String templateBody,
     List<dynamic> arguments,
     Map<String, SentryAttribute>? attributes,
-    FutureOr<void> Function(String, Map<String, SentryAttribute>) callback,
+    void Function(String, Map<String, SentryAttribute>) callback,
   ) {
     String formattedBody;
     Map<String, SentryAttribute> templateAttributes;
@@ -228,7 +228,7 @@ final class _DefaultSentryLoggerFormatter implements SentryLoggerFormatter {
     if (attributes != null) {
       templateAttributes.addAll(attributes);
     }
-    return callback(formattedBody, templateAttributes);
+    callback(formattedBody, templateAttributes);
   }
 
   Map<String, SentryAttribute> _getAllAttributes(

--- a/packages/dart/lib/src/telemetry/log/log_capture_pipeline.dart
+++ b/packages/dart/lib/src/telemetry/log/log_capture_pipeline.dart
@@ -13,7 +13,7 @@ class LogCapturePipeline {
 
   LogCapturePipeline(this._options);
 
-  FutureOr<void> captureLog(SentryLog log, {Scope? scope}) async {
+  Future<void> captureLog(SentryLog log, {Scope? scope}) async {
     if (!_options.enableLogs) {
       internalLogger
           .debug('$LogCapturePipeline: Logs disabled, dropping ${log.body}');

--- a/packages/dart/lib/src/telemetry/log/logger.dart
+++ b/packages/dart/lib/src/telemetry/log/logger.dart
@@ -1,45 +1,41 @@
-import 'dart:async';
-
 import '../../../sentry.dart';
-
-// TODO(major-v10): refactor FutureOr to void
 
 /// Interface for emitting custom logs to Sentry.
 ///
 /// Access via [Sentry.logger].
 abstract interface class SentryLogger {
   /// Logs a message at TRACE level.
-  FutureOr<void> trace(
+  void trace(
     String body, {
     Map<String, SentryAttribute>? attributes,
   });
 
   /// Logs a message at DEBUG level.
-  FutureOr<void> debug(
+  void debug(
     String body, {
     Map<String, SentryAttribute>? attributes,
   });
 
   /// Logs a message at INFO level.
-  FutureOr<void> info(
+  void info(
     String body, {
     Map<String, SentryAttribute>? attributes,
   });
 
   /// Logs a message at WARN level.
-  FutureOr<void> warn(
+  void warn(
     String body, {
     Map<String, SentryAttribute>? attributes,
   });
 
   /// Logs a message at ERROR level.
-  FutureOr<void> error(
+  void error(
     String body, {
     Map<String, SentryAttribute>? attributes,
   });
 
   /// Logs a message at FATAL level.
-  FutureOr<void> fatal(
+  void fatal(
     String body, {
     Map<String, SentryAttribute>? attributes,
   });
@@ -53,42 +49,42 @@ abstract interface class SentryLogger {
 /// Access via [SentryLogger.fmt].
 abstract interface class SentryLoggerFormatter {
   /// Logs a formatted message at TRACE level.
-  FutureOr<void> trace(
+  void trace(
     String templateBody,
     List<dynamic> arguments, {
     Map<String, SentryAttribute>? attributes,
   });
 
   /// Logs a formatted message at DEBUG level.
-  FutureOr<void> debug(
+  void debug(
     String templateBody,
     List<dynamic> arguments, {
     Map<String, SentryAttribute>? attributes,
   });
 
   /// Logs a formatted message at INFO level.
-  FutureOr<void> info(
+  void info(
     String templateBody,
     List<dynamic> arguments, {
     Map<String, SentryAttribute>? attributes,
   });
 
   /// Logs a formatted message at WARN level.
-  FutureOr<void> warn(
+  void warn(
     String templateBody,
     List<dynamic> arguments, {
     Map<String, SentryAttribute>? attributes,
   });
 
   /// Logs a formatted message at ERROR level.
-  FutureOr<void> error(
+  void error(
     String templateBody,
     List<dynamic> arguments, {
     Map<String, SentryAttribute>? attributes,
   });
 
   /// Logs a formatted message at FATAL level.
-  FutureOr<void> fatal(
+  void fatal(
     String templateBody,
     List<dynamic> arguments, {
     Map<String, SentryAttribute>? attributes,

--- a/packages/dart/lib/src/telemetry/log/noop_logger.dart
+++ b/packages/dart/lib/src/telemetry/log/noop_logger.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import '../../protocol/sentry_attribute.dart';
 import 'logger.dart';
 
@@ -9,37 +7,37 @@ final class NoOpSentryLogger implements SentryLogger {
   static const _formatter = _NoOpSentryLoggerFormatter();
 
   @override
-  FutureOr<void> trace(
+  void trace(
     String body, {
     Map<String, SentryAttribute>? attributes,
   }) {}
 
   @override
-  FutureOr<void> debug(
+  void debug(
     String body, {
     Map<String, SentryAttribute>? attributes,
   }) {}
 
   @override
-  FutureOr<void> info(
+  void info(
     String body, {
     Map<String, SentryAttribute>? attributes,
   }) {}
 
   @override
-  FutureOr<void> warn(
+  void warn(
     String body, {
     Map<String, SentryAttribute>? attributes,
   }) {}
 
   @override
-  FutureOr<void> error(
+  void error(
     String body, {
     Map<String, SentryAttribute>? attributes,
   }) {}
 
   @override
-  FutureOr<void> fatal(
+  void fatal(
     String body, {
     Map<String, SentryAttribute>? attributes,
   }) {}
@@ -52,42 +50,42 @@ final class _NoOpSentryLoggerFormatter implements SentryLoggerFormatter {
   const _NoOpSentryLoggerFormatter();
 
   @override
-  FutureOr<void> trace(
+  void trace(
     String templateBody,
     List<dynamic> arguments, {
     Map<String, SentryAttribute>? attributes,
   }) {}
 
   @override
-  FutureOr<void> debug(
+  void debug(
     String templateBody,
     List<dynamic> arguments, {
     Map<String, SentryAttribute>? attributes,
   }) {}
 
   @override
-  FutureOr<void> info(
+  void info(
     String templateBody,
     List<dynamic> arguments, {
     Map<String, SentryAttribute>? attributes,
   }) {}
 
   @override
-  FutureOr<void> warn(
+  void warn(
     String templateBody,
     List<dynamic> arguments, {
     Map<String, SentryAttribute>? attributes,
   }) {}
 
   @override
-  FutureOr<void> error(
+  void error(
     String templateBody,
     List<dynamic> arguments, {
     Map<String, SentryAttribute>? attributes,
   }) {}
 
   @override
-  FutureOr<void> fatal(
+  void fatal(
     String templateBody,
     List<dynamic> arguments, {
     Map<String, SentryAttribute>? attributes,

--- a/packages/dart/test/mocks/mock_hub.dart
+++ b/packages/dart/test/mocks/mock_hub.dart
@@ -112,7 +112,7 @@ class MockHub with NoSuchMethodProvider implements Hub {
   }
 
   @override
-  FutureOr<void> captureLog(SentryLog log, {Scope? scope}) async {
+  Future<void> captureLog(SentryLog log, {Scope? scope}) async {
     captureLogCalls.add(CaptureLogCall(log, scope));
   }
 

--- a/packages/dart/test/mocks/mock_log_capture_pipeline.dart
+++ b/packages/dart/test/mocks/mock_log_capture_pipeline.dart
@@ -13,7 +13,7 @@ class MockLogCapturePipeline extends LogCapturePipeline {
   int get callCount => captureLogCalls.length;
 
   @override
-  FutureOr<void> captureLog(SentryLog log, {Scope? scope}) async {
+  Future<void> captureLog(SentryLog log, {Scope? scope}) async {
     captureLogCalls.add(CaptureLogCall(log, scope));
   }
 }

--- a/packages/dart/test/mocks/mock_sentry_client.dart
+++ b/packages/dart/test/mocks/mock_sentry_client.dart
@@ -88,7 +88,7 @@ class MockSentryClient with NoSuchMethodProvider implements SentryClient {
   }
 
   @override
-  FutureOr<void> captureLog(SentryLog log, {Scope? scope}) async {
+  Future<void> captureLog(SentryLog log, {Scope? scope}) async {
     captureLogCalls.add(CaptureLogCall(log, scope));
   }
 

--- a/packages/dart/test/telemetry/log/logger_formatter_test.dart
+++ b/packages/dart/test/telemetry/log/logger_formatter_test.dart
@@ -44,7 +44,7 @@ void main() {
 
     group('format basic template', () {
       test('for trace', () async {
-        await fixture.logger.fmt.trace(
+        fixture.logger.fmt.trace(
           "Hello, %s!",
           ["World"],
           attributes: {'foo': SentryAttribute.string('bar')},
@@ -55,7 +55,7 @@ void main() {
       });
 
       test('for debug', () async {
-        await fixture.logger.fmt.debug(
+        fixture.logger.fmt.debug(
           "Hello, %s!",
           ["World"],
           attributes: {'foo': SentryAttribute.string('bar')},
@@ -66,7 +66,7 @@ void main() {
       });
 
       test('for info', () async {
-        await fixture.logger.fmt.info(
+        fixture.logger.fmt.info(
           "Hello, %s!",
           ["World"],
           attributes: {'foo': SentryAttribute.string('bar')},
@@ -77,7 +77,7 @@ void main() {
       });
 
       test('for warn', () async {
-        await fixture.logger.fmt.warn(
+        fixture.logger.fmt.warn(
           "Hello, %s!",
           ["World"],
           attributes: {'foo': SentryAttribute.string('bar')},
@@ -88,7 +88,7 @@ void main() {
       });
 
       test('for error', () async {
-        await fixture.logger.fmt.error(
+        fixture.logger.fmt.error(
           "Hello, %s!",
           ["World"],
           attributes: {'foo': SentryAttribute.string('bar')},
@@ -99,7 +99,7 @@ void main() {
       });
 
       test('for fatal', () async {
-        await fixture.logger.fmt.fatal(
+        fixture.logger.fmt.fatal(
           "Hello, %s!",
           ["World"],
           attributes: {'foo': SentryAttribute.string('bar')},
@@ -112,7 +112,7 @@ void main() {
 
     group('template with multiple arguments', () {
       test('for trace', () async {
-        await fixture.logger.fmt.trace(
+        fixture.logger.fmt.trace(
           "Name: %s, Age: %s, Active: %s, Score: %s",
           ['Alice', 30, true, 95.5],
           attributes: {'foo': SentryAttribute.string('bar')},
@@ -123,7 +123,7 @@ void main() {
       });
 
       test('for debug', () async {
-        await fixture.logger.fmt.debug(
+        fixture.logger.fmt.debug(
           "Name: %s, Age: %s, Active: %s, Score: %s",
           ['Alice', 30, true, 95.5],
           attributes: {'foo': SentryAttribute.string('bar')},
@@ -134,7 +134,7 @@ void main() {
       });
 
       test('for info', () async {
-        await fixture.logger.fmt.info(
+        fixture.logger.fmt.info(
           "Name: %s, Age: %s, Active: %s, Score: %s",
           ['Alice', 30, true, 95.5],
           attributes: {'foo': SentryAttribute.string('bar')},
@@ -145,7 +145,7 @@ void main() {
       });
 
       test('for warn', () async {
-        await fixture.logger.fmt.warn(
+        fixture.logger.fmt.warn(
           "Name: %s, Age: %s, Active: %s, Score: %s",
           ['Alice', 30, true, 95.5],
           attributes: {'foo': SentryAttribute.string('bar')},
@@ -156,7 +156,7 @@ void main() {
       });
 
       test('for error', () async {
-        await fixture.logger.fmt.error(
+        fixture.logger.fmt.error(
           "Name: %s, Age: %s, Active: %s, Score: %s",
           ['Alice', 30, true, 95.5],
           attributes: {'foo': SentryAttribute.string('bar')},
@@ -167,7 +167,7 @@ void main() {
       });
 
       test('for fatal', () async {
-        await fixture.logger.fmt.fatal(
+        fixture.logger.fmt.fatal(
           "Name: %s, Age: %s, Active: %s, Score: %s",
           ['Alice', 30, true, 95.5],
           attributes: {'foo': SentryAttribute.string('bar')},
@@ -180,7 +180,7 @@ void main() {
 
     group('template with no arguments', () {
       test('for trace', () async {
-        await fixture.logger.fmt.trace(
+        fixture.logger.fmt.trace(
           "Hello, World!",
           [],
           attributes: {'foo': SentryAttribute.string('bar')},
@@ -195,7 +195,7 @@ void main() {
       });
 
       test('for debug', () async {
-        await fixture.logger.fmt.debug(
+        fixture.logger.fmt.debug(
           "Hello, World!",
           [],
           attributes: {'foo': SentryAttribute.string('bar')},
@@ -210,7 +210,7 @@ void main() {
       });
 
       test('for info', () async {
-        await fixture.logger.fmt.info(
+        fixture.logger.fmt.info(
           "Hello, World!",
           [],
           attributes: {'foo': SentryAttribute.string('bar')},
@@ -225,7 +225,7 @@ void main() {
       });
 
       test('for warn', () async {
-        await fixture.logger.fmt.warn(
+        fixture.logger.fmt.warn(
           "Hello, World!",
           [],
           attributes: {'foo': SentryAttribute.string('bar')},
@@ -240,7 +240,7 @@ void main() {
       });
 
       test('for error', () async {
-        await fixture.logger.fmt.error(
+        fixture.logger.fmt.error(
           "Hello, World!",
           [],
           attributes: {'foo': SentryAttribute.string('bar')},
@@ -255,7 +255,7 @@ void main() {
       });
 
       test('for fatal', () async {
-        await fixture.logger.fmt.fatal(
+        fixture.logger.fmt.fatal(
           "Hello, World!",
           [],
           attributes: {'foo': SentryAttribute.string('bar')},
@@ -285,7 +285,7 @@ class Fixture {
   Fixture() {
     scope = Scope(options);
     logger = DefaultSentryLogger(
-      captureLogCallback: (log, {scope}) {
+      captureLogCallback: (log) async {
         capturedLogs.add(log);
       },
       clockProvider: () => DateTime.now(),

--- a/packages/dart/test/telemetry/log/logger_setup_integration_test.dart
+++ b/packages/dart/test/telemetry/log/logger_setup_integration_test.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:sentry/sentry.dart';
 import 'package:sentry/src/telemetry/log/default_logger.dart';
 import 'package:sentry/src/telemetry/log/logger_setup_integration.dart';
@@ -84,37 +82,37 @@ class Fixture {
 
 class _CustomSentryLogger implements SentryLogger {
   @override
-  FutureOr<void> trace(
+  void trace(
     String body, {
     Map<String, SentryAttribute>? attributes,
   }) {}
 
   @override
-  FutureOr<void> debug(
+  void debug(
     String body, {
     Map<String, SentryAttribute>? attributes,
   }) {}
 
   @override
-  FutureOr<void> info(
+  void info(
     String body, {
     Map<String, SentryAttribute>? attributes,
   }) {}
 
   @override
-  FutureOr<void> warn(
+  void warn(
     String body, {
     Map<String, SentryAttribute>? attributes,
   }) {}
 
   @override
-  FutureOr<void> error(
+  void error(
     String body, {
     Map<String, SentryAttribute>? attributes,
   }) {}
 
   @override
-  FutureOr<void> fatal(
+  void fatal(
     String body, {
     Map<String, SentryAttribute>? attributes,
   }) {}
@@ -125,42 +123,42 @@ class _CustomSentryLogger implements SentryLogger {
 
 class _CustomSentryLoggerFormatter implements SentryLoggerFormatter {
   @override
-  FutureOr<void> trace(
+  void trace(
     String templateBody,
     List<dynamic> arguments, {
     Map<String, SentryAttribute>? attributes,
   }) {}
 
   @override
-  FutureOr<void> debug(
+  void debug(
     String templateBody,
     List<dynamic> arguments, {
     Map<String, SentryAttribute>? attributes,
   }) {}
 
   @override
-  FutureOr<void> info(
+  void info(
     String templateBody,
     List<dynamic> arguments, {
     Map<String, SentryAttribute>? attributes,
   }) {}
 
   @override
-  FutureOr<void> warn(
+  void warn(
     String templateBody,
     List<dynamic> arguments, {
     Map<String, SentryAttribute>? attributes,
   }) {}
 
   @override
-  FutureOr<void> error(
+  void error(
     String templateBody,
     List<dynamic> arguments, {
     Map<String, SentryAttribute>? attributes,
   }) {}
 
   @override
-  FutureOr<void> fatal(
+  void fatal(
     String templateBody,
     List<dynamic> arguments, {
     Map<String, SentryAttribute>? attributes,

--- a/packages/dart/test/telemetry/log/logger_test.dart
+++ b/packages/dart/test/telemetry/log/logger_test.dart
@@ -22,60 +22,59 @@ void main() {
       expect(capturedLog.attributes['string']?.value, 'string');
     }
 
-    test('info', () async {
+    test('info', () {
       final logger = fixture.getSut();
 
-      await logger.info('test', attributes: fixture.attributes);
+      logger.info('test', attributes: fixture.attributes);
 
       verifyCaptureLog(SentryLogLevel.info);
     });
 
-    test('trace', () async {
+    test('trace', () {
       final logger = fixture.getSut();
 
-      await logger.trace('test', attributes: fixture.attributes);
+      logger.trace('test', attributes: fixture.attributes);
 
       verifyCaptureLog(SentryLogLevel.trace);
     });
 
-    test('debug', () async {
+    test('debug', () {
       final logger = fixture.getSut();
 
-      await logger.debug('test', attributes: fixture.attributes);
+      logger.debug('test', attributes: fixture.attributes);
 
       verifyCaptureLog(SentryLogLevel.debug);
     });
 
-    test('warn', () async {
+    test('warn', () {
       final logger = fixture.getSut();
 
-      await logger.warn('test', attributes: fixture.attributes);
+      logger.warn('test', attributes: fixture.attributes);
 
       verifyCaptureLog(SentryLogLevel.warn);
     });
 
-    test('error', () async {
+    test('error', () {
       final logger = fixture.getSut();
 
-      await logger.error('test', attributes: fixture.attributes);
+      logger.error('test', attributes: fixture.attributes);
 
       verifyCaptureLog(SentryLogLevel.error);
     });
 
-    test('fatal', () async {
+    test('fatal', () {
       final logger = fixture.getSut();
 
-      await logger.fatal('test', attributes: fixture.attributes);
+      logger.fatal('test', attributes: fixture.attributes);
 
       verifyCaptureLog(SentryLogLevel.fatal);
     });
 
     // This is mostly an edge case but let's cover it just in case
-    test('per-log attributes override fmt template attributes on same key',
-        () async {
+    test('per-log attributes override fmt template attributes on same key', () {
       final logger = fixture.getSut();
 
-      await logger.fmt.info(
+      logger.fmt.info(
         'Hello, %s!',
         ['World'],
         attributes: {
@@ -89,44 +88,43 @@ void main() {
       expect(attrs['sentry.message.parameter.0']?.value, 'Earth');
     });
 
-    test('sets trace id from default scope propagation context', () async {
+    test('sets trace id from default scope propagation context', () {
       final logger = fixture.getSut();
 
-      await logger.info('test');
+      logger.info('test');
 
       expect(fixture.capturedLogs.length, 1);
       final capturedLog = fixture.capturedLogs[0];
       expect(capturedLog.traceId, fixture.scope.propagationContext.traceId);
     });
 
-    test('sets span id when span is active on default scope', () async {
+    test('sets span id when span is active on default scope', () {
       final span = _MockSpan();
       fixture.scope.span = span;
 
       final logger = fixture.getSut();
 
-      await logger.info('test');
+      logger.info('test');
 
       expect(fixture.capturedLogs.length, 1);
       final capturedLog = fixture.capturedLogs[0];
       expect(capturedLog.spanId, span.context.spanId);
     });
 
-    test('sets timestamp from clock provider', () async {
+    test('sets timestamp from clock provider', () {
       final logger = fixture.getSut();
 
-      await logger.info('test');
+      logger.info('test');
 
       expect(fixture.capturedLogs.length, 1);
       final capturedLog = fixture.capturedLogs[0];
       expect(capturedLog.timestamp, fixture.timestamp);
     });
 
-    test('includes attributes when provided', () async {
+    test('includes attributes when provided', () {
       final logger = fixture.getSut();
 
-      await logger
-          .info('test', attributes: {'key': SentryAttribute.string('value')});
+      logger.info('test', attributes: {'key': SentryAttribute.string('value')});
 
       expect(fixture.capturedLogs.length, 1);
       final capturedLog = fixture.capturedLogs[0];
@@ -158,7 +156,7 @@ class Fixture {
 
   SentryLogger getSut() {
     return DefaultSentryLogger(
-      captureLogCallback: (log, {scope}) {
+      captureLogCallback: (log) async {
         capturedLogs.add(log);
       },
       clockProvider: () => timestamp,

--- a/packages/firebase_remote_config/test/mocks/mocks.mocks.dart
+++ b/packages/firebase_remote_config/test/mocks/mocks.mocks.dart
@@ -322,11 +322,11 @@ class MockHub extends _i1.Mock implements _i2.Hub {
       ) as _i5.Future<_i2.SentryId>);
 
   @override
-  _i5.FutureOr<void> captureLog(_i2.SentryLog? log) =>
+  _i5.Future<void> captureLog(_i2.SentryLog? log) =>
       (super.noSuchMethod(Invocation.method(
         #captureLog,
         [log],
-      )) as _i5.FutureOr<void>);
+      )) as _i5.Future<void>);
 
   @override
   _i5.Future<void> addBreadcrumb(

--- a/packages/firebase_remote_config/test/mocks/mocks.mocks.dart
+++ b/packages/firebase_remote_config/test/mocks/mocks.mocks.dart
@@ -322,11 +322,14 @@ class MockHub extends _i1.Mock implements _i2.Hub {
       ) as _i5.Future<_i2.SentryId>);
 
   @override
-  _i5.Future<void> captureLog(_i2.SentryLog? log) =>
-      (super.noSuchMethod(Invocation.method(
-        #captureLog,
-        [log],
-      )) as _i5.Future<void>);
+  _i5.Future<void> captureLog(_i2.SentryLog? log) => (super.noSuchMethod(
+        Invocation.method(
+          #captureLog,
+          [log],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
   _i5.Future<void> addBreadcrumb(

--- a/packages/flutter/test/mocks.mocks.dart
+++ b/packages/flutter/test/mocks.mocks.dart
@@ -1298,11 +1298,13 @@ class MockSentryClient extends _i1.Mock implements _i2.SentryClient {
           as _i12.Future<void>);
 
   @override
-  _i12.FutureOr<void> captureLog(_i2.SentryLog? log, {_i2.Scope? scope}) =>
+  _i12.Future<void> captureLog(_i2.SentryLog? log, {_i2.Scope? scope}) =>
       (super.noSuchMethod(
             Invocation.method(#captureLog, [log], {#scope: scope}),
+            returnValue: _i12.Future<void>.value(),
+            returnValueForMissingStub: _i12.Future<void>.value(),
           )
-          as _i12.FutureOr<void>);
+          as _i12.Future<void>);
 
   @override
   _i12.Future<void> captureMetric(
@@ -3351,9 +3353,13 @@ class MockHub extends _i1.Mock implements _i2.Hub {
           as _i12.Future<_i2.SentryId>);
 
   @override
-  _i12.FutureOr<void> captureLog(_i2.SentryLog? log) =>
-      (super.noSuchMethod(Invocation.method(#captureLog, [log]))
-          as _i12.FutureOr<void>);
+  _i12.Future<void> captureLog(_i2.SentryLog? log) =>
+      (super.noSuchMethod(
+            Invocation.method(#captureLog, [log]),
+            returnValue: _i12.Future<void>.value(),
+            returnValueForMissingStub: _i12.Future<void>.value(),
+          )
+          as _i12.Future<void>);
 
   @override
   _i12.Future<void> captureMetric(_i2.SentryMetric? metric) =>

--- a/packages/logging/lib/src/logging_integration.dart
+++ b/packages/logging/lib/src/logging_integration.dart
@@ -112,21 +112,21 @@ class LoggingIntegration implements Integration<SentryOptions> {
       final levelValue = record.level.value;
       if (levelValue >= Level.SEVERE.value) {
         // >= 1000 → error
-        await _options.logger.error(record.message, attributes: attributes);
+        _options.logger.error(record.message, attributes: attributes);
       } else if (levelValue >= Level.WARNING.value) {
         // >= 900 → warn
-        await _options.logger.warn(record.message, attributes: attributes);
+        _options.logger.warn(record.message, attributes: attributes);
       } else if (levelValue >= Level.INFO.value) {
         // >= 800 → info
-        await _options.logger.info(record.message, attributes: attributes);
+        _options.logger.info(record.message, attributes: attributes);
       } else if (levelValue >= Level.CONFIG.value ||
           levelValue == Level.FINE.value ||
           levelValue == Level.ALL.value) {
         // >= 700 || 500 || 0 → debug
-        await _options.logger.debug(record.message, attributes: attributes);
+        _options.logger.debug(record.message, attributes: attributes);
       } else {
         // < 700 → trace
-        await _options.logger.trace(record.message, attributes: attributes);
+        _options.logger.trace(record.message, attributes: attributes);
       }
     }
   }


### PR DESCRIPTION
`SentryLogger` and `SentryLoggerFormatter` methods (`trace`/`debug`/`info`/`warn`/`error`/`fatal`) now return `void` instead of `FutureOr<void>`. These calls were always fire-and-forget in practice — the internal capture pipeline already handles its own errors, so nothing ever awaited the result.

`DefaultSentryLogger` fires its capture callback with `unawaited()`, mirroring `DefaultSentryMetrics`, which already had this shape. The internal capture chain it delegates through (`Hub.captureLog`, `SentryClient.captureLog`, `HubAdapter.captureLog`, `LogCapturePipeline.captureLog`, and the Noop variants) narrows from `FutureOr<void>` to `Future<void>` for the same reason the equivalent metrics pipeline already uses `Future<void>` — these are declared `async` and always return a real `Future`, so this is a type-precision fix with no behavior change; existing `await` call sites are unaffected.

`sentry_logging`'s `LoggingIntegration` no longer awaits the now-void logger calls.

BREAKING CHANGE: `SentryLogger`/`SentryLoggerFormatter` methods return `void` instead of `FutureOr<void>`. Code that awaited or chained a `Sentry.logger.*` call will no longer compile.

Fixes #3851