### PR TITLE
test(flutter): Fix OnProcessSpan calls missing Hint argument

### DIFF
--- a/packages/flutter/test/integrations/thread_info_integration_test.dart
+++ b/packages/flutter/test/integrations/thread_info_integration_test.dart
@@ -425,7 +425,7 @@ void main() {
           );
 
           await fixture.options.lifecycleRegistry.dispatchCallback(
-            OnProcessSpan(span),
+            OnProcessSpan(span, Hint()),
           );
 
           expect(
@@ -454,7 +454,7 @@ void main() {
           );
 
           await fixture.options.lifecycleRegistry.dispatchCallback(
-            OnProcessSpan(span),
+            OnProcessSpan(span, Hint()),
           );
 
           expect(
@@ -481,7 +481,7 @@ void main() {
           );
 
           await fixture.options.lifecycleRegistry.dispatchCallback(
-            OnProcessSpan(span),
+            OnProcessSpan(span, Hint()),
           );
 
           expect(
@@ -506,7 +506,7 @@ void main() {
         );
 
         await fixture.options.lifecycleRegistry.dispatchCallback(
-          OnProcessSpan(span),
+          OnProcessSpan(span, Hint()),
         );
 
         // sync == false is not synchronous, so blocked_main_thread is not set.
@@ -532,7 +532,7 @@ void main() {
           span.setAttribute('sync', SentryAttribute.bool(true));
 
           await fixture.options.lifecycleRegistry.dispatchCallback(
-            OnProcessSpan(span),
+            OnProcessSpan(span, Hint()),
           );
 
           expect(


### PR DESCRIPTION
Fixes compilation of `thread_info_integration_test.dart` on `v10-branch`, which currently breaks the `analyze` and flutter `js` CI jobs for every PR targeting the branch.

#3847 added a required `hint` parameter to `OnProcessSpan` and updated its call sites, but this test file landed in parallel and still constructs the event with one argument. The five call sites now pass `Hint()`, matching the pattern in `load_contexts_integration_test.dart` and `replay_telemetry_integration_test.dart`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)