### PR TITLE
fix(replay): Accept Double timestamps in Android network breadcrumb conversion

### DIFF
--- a/packages/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterReplayBreadcrumbConverter.kt
+++ b/packages/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterReplayBreadcrumbConverter.kt
@@ -71,25 +71,32 @@ class SentryFlutterReplayBreadcrumbConverter : DefaultReplayBreadcrumbConverter(
   private fun doubleTimestamp(timestamp: Long) = timestamp / MILLIS_PER_SECOND
 
   private fun convertNetworkBreadcrumb(breadcrumb: Breadcrumb): RRWebEvent? {
-    var rrWebEvent = super.convert(breadcrumb)
-    if (rrWebEvent == null &&
-      breadcrumb.data.containsKey("start_timestamp") &&
-      breadcrumb.data.containsKey("end_timestamp")
-    ) {
-      rrWebEvent =
-        RRWebSpanEvent().apply {
-          op = "resource.http"
-          timestamp = breadcrumb.timestamp.time
-          description = breadcrumb.data["url"] as String
-          startTimestamp = doubleTimestamp(breadcrumb.data["start_timestamp"] as Long)
-          endTimestamp = doubleTimestamp(breadcrumb.data["end_timestamp"] as Long)
-          data =
-            breadcrumb.data
-              .filterKeys { key -> supportedNetworkData.containsKey(key) }
-              .mapKeys { (key, _) -> supportedNetworkData[key] }
-        }
+    val rrWebEvent = super.convert(breadcrumb)
+    if (rrWebEvent != null) {
+      return rrWebEvent
     }
-    return rrWebEvent
+
+    // The timestamps arrive as Long or Double depending on how the breadcrumb
+    // crossed the platform bridge: the JSON-based scope sync deserializes epoch
+    // millis as Double because they overflow Integer.
+    val startTimestampMs = breadcrumb.data["start_timestamp"] as? Number
+    val endTimestampMs = breadcrumb.data["end_timestamp"] as? Number
+    val url = breadcrumb.data["url"] as? String
+    if (startTimestampMs == null || endTimestampMs == null || url == null) {
+      return null
+    }
+
+    return RRWebSpanEvent().apply {
+      op = "resource.http"
+      timestamp = breadcrumb.timestamp.time
+      description = url
+      startTimestamp = doubleTimestamp(startTimestampMs.toLong())
+      endTimestamp = doubleTimestamp(endTimestampMs.toLong())
+      data =
+        breadcrumb.data
+          .filterKeys { key -> supportedNetworkData.containsKey(key) }
+          .mapKeys { (key, _) -> supportedNetworkData[key] }
+    }
   }
 
   private fun getTouchPathMessage(maybePath: Any?): String? {


### PR DESCRIPTION
## :scroll: Description

Fixes Session Replay being broken on Android since `9.21.0`: replays were either missing entirely or uploaded as short glitchy fragments.

`SentryFlutterReplayBreadcrumbConverter.convertNetworkBreadcrumb` cast `start_timestamp` / `end_timestamp` with an unchecked `as Long`. Since #3708, breadcrumbs are synced to Android as JSON bytes and re-parsed by sentry-java's `Breadcrumb.Deserializer`, whose `JsonObjectDeserializer.nextNumber()` tries `nextInt()` → `nextDouble()` → `nextLong()`. Epoch-millisecond values overflow `Integer`, so they are parsed as `Double` and `nextLong()` is never reached. The cast then threw for every `http` breadcrumb:

```
E/Sentry: Failed to execute task SessionCaptureStrategy.add_frame
E/Sentry: java.lang.ClassCastException: java.lang.Double cannot be cast to java.lang.Long
	at io.sentry.flutter.SentryFlutterReplayBreadcrumbConverter.convertNetworkBreadcrumb(SentryFlutterReplayBreadcrumbConverter.kt:84)
	at io.sentry.flutter.SentryFlutterReplayBreadcrumbConverter.convert(SentryFlutterReplayBreadcrumbConverter.kt:30)
	at io.sentry.android.replay.capture.CaptureStrategy$Companion.buildReplay(CaptureStrategy.kt:200)
	at io.sentry.android.replay.capture.CaptureStrategy$Companion.createSegment(CaptureStrategy.kt:113)
```

Because the exception is thrown inside replay segment creation, any segment containing an `http` breadcrumb was dropped — in apps with regular network traffic this effectively disables Session Replay on Android.

This change accepts any `Number` for the timestamps and returns `null` when `url` or the timestamps are missing or mistyped instead of throwing, matching what the iOS converter (`convertNetwork:` in `SentryFlutterReplayBreadcrumbConverter.m`) already does with its `isKindOfClass:` guards.

## :bulb: Motivation and Context

Replay worked on `9.20.0` (typed method-channel scope sync preserved `Long`) and broke on `9.21.0`+ for Android. The same numeric-subtype issue was fixed in sentry-react-native's converter in getsentry/sentry-react-native#6288.

## :green_heart: How did you test it?

- Reproduced the `ClassCastException` against the unmodified converter by invoking `convert()` with an `http` breadcrumb whose `start_timestamp`/`end_timestamp` are `Double` (compiled against `sentry-android 8.47.0`).
- Verified the fixed converter with the same harness:
  - `Double` timestamps → `RRWebSpanEvent` with correct second-precision start/end timestamps
  - `Long` timestamps (pre-9.21 path) → unchanged behavior
  - missing `url` or non-numeric timestamp → returns `null` instead of throwing
- `ktlint` passes.
- Reproduced the problem in the app, then verified that it disappeared with this fix.

## :pencil: Checklist

- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec
- [x] No breaking changes

## :crystal_ball: Next steps

The root cause — sentry-java's `JsonObjectDeserializer.nextNumber()` returning `Double` for any value that overflows `Integer` — may affect other consumers of JSON-synced scope data and could be worth fixing upstream in sentry-java as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
