### PR TITLE
ci: Skip e2e when auth token is missing

### DIFF
--- a/.github/workflows/e2e_dart.yml
+++ b/.github/workflows/e2e_dart.yml
@@ -23,6 +23,9 @@ env:
 jobs:
   build:
     name: E2E
+    # Fork PRs do not receive secrets. Skip the live sentry.io round-trip
+    # instead of failing. First-party CI still runs and must have the token.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: 'ubuntu-latest'
     timeout-minutes: 30
     defaults:
@@ -33,12 +36,18 @@ jobs:
       matrix:
         sdk: [stable, beta]
     steps:
+      - name: Require E2E auth token
+        working-directory: ${{ github.workspace }}
+        run: |
+          if [ -z "$SENTRY_AUTH_TOKEN_E2E" ]; then
+            echo "::error::SENTRY_AUTH_TOKEN_E2E is required for first-party CI"
+            exit 1
+          fi
       - uses: dart-lang/setup-dart@7654d458321ee25acccccfdb86cd48bd95768ff1 # pin@v1.8.0
         with:
           sdk: ${{ matrix.sdk }}
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Run
-        if: env.SENTRY_AUTH_TOKEN != null
         run: |
           dart pub get
           dart run --define=SENTRY_ENVIRONMENT=e2e

--- a/.github/workflows/e2e_dart.yml
+++ b/.github/workflows/e2e_dart.yml
@@ -25,7 +25,9 @@ jobs:
     name: E2E
     # Fork PRs do not receive secrets. Skip the live sentry.io round-trip
     # instead of failing. First-party CI still runs and must have the token.
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    # Allowlist push / same-repo pull_request so other events (e.g.
+    # pull_request_target) cannot be treated as first-party.
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: 'ubuntu-latest'
     timeout-minutes: 30
     defaults:

--- a/.github/workflows/flutter_test.yml
+++ b/.github/workflows/flutter_test.yml
@@ -34,6 +34,17 @@ jobs:
       - name: checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # Fork PRs do not receive secrets; the e2e test skips when the token is
+      # empty. First-party CI must still fail if the secret is missing.
+      - name: Require E2E auth token on first-party CI
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        working-directory: ${{ github.workspace }}
+        run: |
+          if [ -z "$SENTRY_AUTH_TOKEN_E2E" ]; then
+            echo "::error::SENTRY_AUTH_TOKEN_E2E is required for first-party CI"
+            exit 1
+          fi
+
       - name: Enable KVM group perms
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
@@ -94,6 +105,17 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Fork PRs do not receive secrets; the e2e test skips when the token is
+      # empty. First-party CI must still fail if the secret is missing.
+      - name: Require E2E auth token on first-party CI
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        working-directory: ${{ github.workspace }}
+        run: |
+          if [ -z "$SENTRY_AUTH_TOKEN_E2E" ]; then
+            echo "::error::SENTRY_AUTH_TOKEN_E2E is required for first-party CI"
+            exit 1
+          fi
 
       # QuickFix for failing iOS 18.0 builds https://github.com/actions/runner-images/issues/12758#issuecomment-3187115656
       - name: Switch to Xcode 16.4 for iOS 18.5

--- a/.github/workflows/flutter_test.yml
+++ b/.github/workflows/flutter_test.yml
@@ -36,8 +36,10 @@ jobs:
 
       # Fork PRs do not receive secrets; the e2e test skips when the token is
       # empty. First-party CI must still fail if the secret is missing.
+      # Allowlist push / same-repo pull_request so other events (e.g.
+      # pull_request_target) cannot be treated as first-party.
       - name: Require E2E auth token on first-party CI
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
         working-directory: ${{ github.workspace }}
         run: |
           if [ -z "$SENTRY_AUTH_TOKEN_E2E" ]; then
@@ -108,8 +110,10 @@ jobs:
 
       # Fork PRs do not receive secrets; the e2e test skips when the token is
       # empty. First-party CI must still fail if the secret is missing.
+      # Allowlist push / same-repo pull_request so other events (e.g.
+      # pull_request_target) cannot be treated as first-party.
       - name: Require E2E auth token on first-party CI
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
         working-directory: ${{ github.workspace }}
         run: |
           if [ -z "$SENTRY_AUTH_TOKEN_E2E" ]; then

--- a/packages/flutter/example/integration_test/integration_test.dart
+++ b/packages/flutter/example/integration_test/integration_test.dart
@@ -1230,7 +1230,7 @@ void main() {
       final environment =
           tags.firstWhere((element) => element['key'] == 'environment');
       expect('integration', environment['value']);
-    });
+    }, skip: authToken.isEmpty);
   });
 }
 

--- a/packages/flutter/example/integration_test/integration_test.dart
+++ b/packages/flutter/example/integration_test/integration_test.dart
@@ -1230,8 +1230,11 @@ void main() {
       final environment =
           tags.firstWhere((element) => element['key'] == 'environment');
       expect('integration', environment['value']);
-    }, skip: authToken.isEmpty);
-  });
+    });
+  },
+      skip: authToken.isEmpty
+          ? 'SENTRY_AUTH_TOKEN_E2E not provided (fork PRs)'
+          : false);
 }
 
 class Fixture {

--- a/packages/flutter/example/integration_test/integration_test.dart
+++ b/packages/flutter/example/integration_test/integration_test.dart
@@ -1231,10 +1231,7 @@ void main() {
           tags.firstWhere((element) => element['key'] == 'environment');
       expect('integration', environment['value']);
     });
-  },
-      skip: authToken.isEmpty
-          ? 'SENTRY_AUTH_TOKEN_E2E not provided (fork PRs)'
-          : false);
+  }, skip: authToken.isEmpty ? 'SENTRY_AUTH_TOKEN_E2E not provided' : false);
 }
 
 class Fixture {


### PR DESCRIPTION
Fork PRs and local `flutter test` runs do not have `SENTRY_AUTH_TOKEN_E2E` (GitHub withholds secrets from forks; `String.fromEnvironment` is empty without `--dart-define`). The live sentry.io round-trip was failing in those cases. The rest of the Flutter integration suite uses a fake DSN and should still run.

The Flutter `e2e` group now skips when the token is empty. First-party CI still requires the secret, so a missing token cannot go green.

The Dart `e2e-sentry-dart` job is skipped on fork PRs. On first-party CI it actually runs: the old `if: env.SENTRY_AUTH_TOKEN != null` checked the wrong name, so the Run step has been skipped even on `main`.

Do not use `pull_request_target` to give forks the token.