### PR TITLE
chore: Complete 10.0.0-alpha.2 changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,10 @@
 
 ### Features
 
-- (flutter) Support SwiftPM on Flutter 3.44+ by @buenaflor in [#3784](https://github.com/getsentry/sentry-dart/pull/3784)
 - (telemetry) Align span attributes with Sentry Conventions by @buenaflor in [#3805](https://github.com/getsentry/sentry-dart/pull/3805)
 - Add feature flags to hub span by @denrase in [#3806](https://github.com/getsentry/sentry-dart/pull/3806)
 - (logs) Add Hint to beforeSend for logs, metrics, and spans by @buenaflor in [#3847](https://github.com/getsentry/sentry-dart/pull/3847)
 - (logs) Enable logs by default by @buenaflor in [#3846](https://github.com/getsentry/sentry-dart/pull/3846)
-
-### Dependencies
-
-#### Flutter
-
-- Bump jni to 1.0.0 and jnigen to 0.16.0 in v10 by @buenaflor in [#3765](https://github.com/getsentry/sentry-dart/pull/3765)
-- Bump sentry-cocoa to 9.17.1 in v10 by @buenaflor in [#3764](https://github.com/getsentry/sentry-dart/pull/3764)
 
 ### Internal Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - (flutter) Support SwiftPM on Flutter 3.44+ by @buenaflor in [#3784](https://github.com/getsentry/sentry-dart/pull/3784)
 - (telemetry) Align span attributes with Sentry Conventions by @buenaflor in [#3805](https://github.com/getsentry/sentry-dart/pull/3805)
 - Add feature flags to hub span by @denrase in [#3806](https://github.com/getsentry/sentry-dart/pull/3806)
+- (logs) Add Hint to beforeSend for logs, metrics, and spans by @buenaflor in [#3847](https://github.com/getsentry/sentry-dart/pull/3847)
+- (logs) Enable logs by default by @buenaflor in [#3846](https://github.com/getsentry/sentry-dart/pull/3846)
 
 ### Dependencies
 
@@ -19,6 +21,12 @@
 
 - (logs) Make traceId required on SentryLog by @buenaflor in [#3842](https://github.com/getsentry/sentry-dart/pull/3842)
 - Make clone() internal and remove deprecated protocol clones by @buenaflor in [#3845](https://github.com/getsentry/sentry-dart/pull/3845)
+- (dart) Make feature flags hub/scope-based by @buenaflor in [#3848](https://github.com/getsentry/sentry-dart/pull/3848)
+- (file) Remove file.async attributes from instrumentation by @buenaflor in [#3841](https://github.com/getsentry/sentry-dart/pull/3841)
+- (logs) Make logger methods return void by @buenaflor in [#3852](https://github.com/getsentry/sentry-dart/pull/3852)
+- (logs) Remove deprecated SentryLogAttribute by @buenaflor in [#3843](https://github.com/getsentry/sentry-dart/pull/3843)
+- Remove deprecated performance collectors by @buenaflor in [#3850](https://github.com/getsentry/sentry-dart/pull/3850)
+- (feedback) Remove deprecated SentryFeedbackWidget by @buenaflor in [#3844](https://github.com/getsentry/sentry-dart/pull/3844)
 
 ## 10.0.0-alpha.1
 ## 9.23.0


### PR DESCRIPTION
Reconcile the `10.0.0-alpha.2` changelog section with the commits actually released in it.

**Added** PRs that merged since `10.0.0-alpha.1` but were missing, categorized per `.github/release.yml`:

- **Features** — #3847, #3846
- **Internal Changes** — #3848, #3841, #3852, #3843, #3850, #3844

**Removed** entries that were already published under `9.23.0`: #3784, #3765, #3764. This empties the Dependencies section, so it is dropped too.

`ref!` removals (#3850, #3844) sit under Internal Changes alongside the other refactors rather than a separate Breaking Changes section, matching how the section is organized.