### PR TITLE
chore(craft): Add Supabase and gRPC SDKs

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -36,5 +36,5 @@ targets:
       pub:sentry_isar:
       pub:sentry_link:
       pub:sentry_firebase_remote_config:
-      # TODO: after we published supabase we need to add it to the registry repo and then uncomment here
-      # pub:sentry_supabase:
+      pub:sentry_supabase:
+      pub:sentry_grpc:


### PR DESCRIPTION
Craft will now publish sentry_supabase and sentry_grpc releases to the Sentry release registry.