### PR TITLE
feat(flutter): Make native request capture opt-in

### DIFF
--- a/packages/dart/lib/src/sentry_options.dart
+++ b/packages/dart/lib/src/sentry_options.dart
@@ -362,18 +362,17 @@ class SentryOptions {
   ///   because the connection was interrupted.
   /// Use with [SentryHttpClient] or `sentry_dio` integration for this to work
   ///
-  /// If you wish to disable capturing native failed requests on iOS/macOS, use [captureNativeFailedRequests] instead.
-  // TODO(major-v10): do not sync this with native options, instead use captureNativeFailedRequests instead to sync.
+  /// Native failed request capture on iOS/macOS is controlled independently by
+  /// [captureNativeFailedRequests].
   bool captureFailedRequests = true;
 
   /// Whether failed HTTP requests are captured by the native iOS/macOS SDK.
   ///
-  /// This allows controlling native-side HTTP error capturing independently
-  /// from [captureFailedRequests], which controls Dart-side capturing.
+  /// Disabled by default. Set to `true` to opt in.
   ///
-  /// When `null` (the default), falls back to [captureFailedRequests].
-  // TODO(major-v10): it's currently nullable for backwards compatibility, make non-nullable by default.
-  bool? captureNativeFailedRequests;
+  /// This setting is independent from [captureFailedRequests], which controls
+  /// Dart-side capturing.
+  bool captureNativeFailedRequests = false;
 
   /// Whether to records requests as breadcrumbs. This is on by default.
   /// It only has an effect when the SentryHttpClient or dio integration is in

--- a/packages/dart/test/sentry_options_test.dart
+++ b/packages/dart/test/sentry_options_test.dart
@@ -20,12 +20,10 @@ void main() {
     expect(client, options.httpClient);
   });
 
-  group('$SentryOptions', () {
-    test('disables native failed request capture by default', () {
-      final options = defaultTestOptions();
+  test('captureNativeFailedRequests is false by default', () {
+    final options = defaultTestOptions();
 
-      expect(options.captureNativeFailedRequests, false);
-    });
+    expect(options.captureNativeFailedRequests, false);
   });
 
   test('maxBreadcrumbs is 100 by default', () {

--- a/packages/dart/test/sentry_options_test.dart
+++ b/packages/dart/test/sentry_options_test.dart
@@ -20,6 +20,14 @@ void main() {
     expect(client, options.httpClient);
   });
 
+  group('$SentryOptions', () {
+    test('disables native failed request capture by default', () {
+      final options = defaultTestOptions();
+
+      expect(options.captureNativeFailedRequests, false);
+    });
+  });
+
   test('maxBreadcrumbs is 100 by default', () {
     final options = defaultTestOptions();
 

--- a/packages/flutter/lib/src/native/sentry_native_channel.dart
+++ b/packages/flutter/lib/src/native/sentry_native_channel.dart
@@ -71,8 +71,7 @@ class SentryNativeChannel
       'proguardUuid': options.proguardUuid,
       'maxAttachmentSize': options.maxAttachmentSize,
       'recordHttpBreadcrumbs': options.recordHttpBreadcrumbs,
-      'captureFailedRequests':
-          options.captureNativeFailedRequests ?? options.captureFailedRequests,
+      'captureFailedRequests': options.captureNativeFailedRequests,
       'enableAppHangTracking': options.enableAppHangTracking,
       'connectionTimeoutMillis': options.connectionTimeout.inMilliseconds,
       'readTimeoutMillis': options.readTimeout.inMilliseconds,

--- a/packages/flutter/test/sentry_native_channel_test.dart
+++ b/packages/flutter/test/sentry_native_channel_test.dart
@@ -597,12 +597,11 @@ void main() {
     });
 
     test(
-      'defaults native failed request capture to false when Dart capture is disabled',
+      'forwards disabled native failed request capture by default',
       () async {
         final options = defaultTestOptions()
           ..platform = MockPlatform.iOS()
-          ..methodChannel = channel
-          ..captureFailedRequests = false;
+          ..methodChannel = channel;
         sut = createBinding(options);
 
         final args = await callInitAndCaptureArgs(options);
@@ -612,7 +611,7 @@ void main() {
     );
 
     test(
-      'uses captureNativeFailedRequests when explicitly set to true even if captureFailedRequests is false',
+      'forwards enabled native failed request capture independently of Dart capture',
       () async {
         final options = defaultTestOptions()
           ..platform = MockPlatform.iOS()
@@ -628,27 +627,13 @@ void main() {
     );
 
     test(
-      'uses captureNativeFailedRequests when explicitly set to false even if captureFailedRequests is true',
+      'forwards disabled native failed request capture independently of Dart capture',
       () async {
         final options = defaultTestOptions()
           ..platform = MockPlatform.iOS()
           ..methodChannel = channel
           ..captureFailedRequests = true
           ..captureNativeFailedRequests = false;
-        sut = createBinding(options);
-
-        final args = await callInitAndCaptureArgs(options);
-
-        expect(args['captureFailedRequests'], false);
-      },
-    );
-
-    test(
-      'defaults native failed request capture to false when Dart capture is enabled',
-      () async {
-        final options = defaultTestOptions()
-          ..platform = MockPlatform.iOS()
-          ..methodChannel = channel;
         sut = createBinding(options);
 
         final args = await callInitAndCaptureArgs(options);

--- a/packages/flutter/test/sentry_native_channel_test.dart
+++ b/packages/flutter/test/sentry_native_channel_test.dart
@@ -597,13 +597,12 @@ void main() {
     });
 
     test(
-      'uses captureFailedRequests when captureNativeFailedRequests is null (backwards compatibility)',
+      'defaults native failed request capture to false when Dart capture is disabled',
       () async {
         final options = defaultTestOptions()
           ..platform = MockPlatform.iOS()
           ..methodChannel = channel
-          ..captureFailedRequests = false
-          ..captureNativeFailedRequests = null;
+          ..captureFailedRequests = false;
         sut = createBinding(options);
 
         final args = await callInitAndCaptureArgs(options);
@@ -645,18 +644,16 @@ void main() {
     );
 
     test(
-      'defaults to captureFailedRequests value when both use defaults',
+      'defaults native failed request capture to false when Dart capture is enabled',
       () async {
         final options = defaultTestOptions()
           ..platform = MockPlatform.iOS()
           ..methodChannel = channel;
-        // captureFailedRequests defaults to true
-        // captureNativeFailedRequests defaults to null
         sut = createBinding(options);
 
         final args = await callInitAndCaptureArgs(options);
 
-        expect(args['captureFailedRequests'], true);
+        expect(args['captureFailedRequests'], false);
       },
     );
   });


### PR DESCRIPTION
Native failed-request capture on iOS and macOS is now opt-in. `captureNativeFailedRequests` is a non-nullable `bool` that defaults to `false`, and Cocoa initialization no longer falls back to Dart's `captureFailedRequests`.

Apps relying on implicit native HTTP error capture must set `options.captureNativeFailedRequests = true`. Dart-side failed-request capture remains enabled by default and independent.

Fixes getsentry/sentry-dart#3834