### PR TITLE
feat(replay): Record segment names on Android

### DIFF
--- a/packages/flutter/lib/src/integrations/replay_telemetry_integration.dart
+++ b/packages/flutter/lib/src/integrations/replay_telemetry_integration.dart
@@ -63,7 +63,7 @@ class ReplayTelemetryIntegration implements Integration<SentryFlutterOptions> {
       }
 
       final span = event.span;
-      if (identical(span, span.segmentSpan) && span.name.isNotEmpty) {
+      if (identical(span, span.segmentSpan)) {
         return _native?.registerSegmentName(span.name);
       }
     };

--- a/packages/flutter/lib/src/integrations/replay_telemetry_integration.dart
+++ b/packages/flutter/lib/src/integrations/replay_telemetry_integration.dart
@@ -61,6 +61,11 @@ class ReplayTelemetryIntegration implements Integration<SentryFlutterOptions> {
       if (attributes != null) {
         event.span.setAttributes(attributes);
       }
+
+      final span = event.span;
+      if (identical(span, span.segmentSpan) && span.name.isNotEmpty) {
+        return _native?.registerSegmentName(span.name);
+      }
     };
 
     _onGenerateNewTrace = (OnGenerateNewTrace event) async {

--- a/packages/flutter/lib/src/native/c/sentry_native.dart
+++ b/packages/flutter/lib/src/native/c/sentry_native.dart
@@ -329,6 +329,11 @@ class SentryNative with SentryNativeSafeInvoker implements SentryNativeBinding {
   FutureOr<void> registerTraceId(SentryId traceId) {
     // No-op. Replay trace ID registration is currently Android-only.
   }
+
+  @override
+  FutureOr<void> registerSegmentName(String segmentName) {
+    // No-op. Replay segment name registration is currently Android-only.
+  }
 }
 
 extension SentryValueExtension on binding.sentry_value_u {

--- a/packages/flutter/lib/src/native/java/sentry_native_java.dart
+++ b/packages/flutter/lib/src/native/java/sentry_native_java.dart
@@ -294,6 +294,22 @@ class SentryNativeJava extends SentryNativeChannel {
       });
     });
   }
+
+  @override
+  void registerSegmentName(String segmentName) {
+    if (segmentName.isEmpty) {
+      return;
+    }
+
+    tryCatchSync('registerSegmentName', () {
+      using((arena) {
+        final jSegmentName = segmentName.toJString()..releasedBy(arena);
+        _nativeReplay ??=
+            native.SentryFlutterPlugin.privateSentryGetReplayIntegration();
+        _nativeReplay?.registerSegmentName(jSegmentName);
+      });
+    });
+  }
 }
 
 // Direct JNI conversion is fine for primitives. Use the Map/List conversion

--- a/packages/flutter/lib/src/native/sentry_native_binding.dart
+++ b/packages/flutter/lib/src/native/sentry_native_binding.dart
@@ -102,4 +102,7 @@ abstract class SentryNativeBinding {
 
   /// Registers the active Dart trace ID with native replay.
   FutureOr<void> registerTraceId(SentryId traceId);
+
+  /// Registers a segment name with native replay for the current replay segment.
+  FutureOr<void> registerSegmentName(String segmentName);
 }

--- a/packages/flutter/lib/src/native/sentry_native_channel.dart
+++ b/packages/flutter/lib/src/native/sentry_native_channel.dart
@@ -445,4 +445,9 @@ class SentryNativeChannel
   FutureOr<void> registerTraceId(SentryId traceId) {
     // No-op. Replay trace ID registration is currently Android-only.
   }
+
+  @override
+  FutureOr<void> registerSegmentName(String segmentName) {
+    // No-op. Replay segment name registration is currently Android-only.
+  }
 }

--- a/packages/flutter/lib/src/web/sentry_web.dart
+++ b/packages/flutter/lib/src/web/sentry_web.dart
@@ -272,6 +272,11 @@ class SentryWeb with SentryNativeSafeInvoker implements SentryNativeBinding {
   }
 
   @override
+  FutureOr<void> registerSegmentName(String segmentName) {
+    // No-op. Replay segment name registration is currently Android-only.
+  }
+
+  @override
   int? startProfiler(SentryId traceId) {
     _logNotSupported('start profiler');
     return null;

--- a/packages/flutter/test/integrations/replay_telemetry_integration_test.dart
+++ b/packages/flutter/test/integrations/replay_telemetry_integration_test.dart
@@ -142,18 +142,6 @@ void main() {
 
         verifyNever(fixture.nativeBinding.registerSegmentName(any));
       });
-
-      test('does not register empty segment name', () async {
-        fixture.options.replay.sessionSampleRate = 0.5;
-
-        await fixture.getSut().call(fixture.hub, fixture.options);
-        clearInteractions(fixture.nativeBinding);
-        final span = fixture.createTestSpan(name: '');
-        await fixture.options.lifecycleRegistry
-            .dispatchCallback(OnProcessSpan(span));
-
-        verifyNever(fixture.nativeBinding.registerSegmentName(any));
-      });
     });
 
     group('in session mode', () {

--- a/packages/flutter/test/integrations/replay_telemetry_integration_test.dart
+++ b/packages/flutter/test/integrations/replay_telemetry_integration_test.dart
@@ -372,7 +372,7 @@ void main() {
         verifyNever(fixture.nativeBinding.registerTraceId(any));
       });
 
-      test('removes segment name registration on close', () async {
+      test('does not register segment name with native replay', () async {
         fixture.options.replay.sessionSampleRate = 0.5;
 
         final sut = fixture.getSut();

--- a/packages/flutter/test/integrations/replay_telemetry_integration_test.dart
+++ b/packages/flutter/test/integrations/replay_telemetry_integration_test.dart
@@ -117,6 +117,43 @@ void main() {
 
         verifyNever(fixture.nativeBinding.registerTraceId(any));
       });
+
+      test('registers segment name with native replay', () async {
+        fixture.options.replay.sessionSampleRate = 0.5;
+
+        await fixture.getSut().call(fixture.hub, fixture.options);
+        clearInteractions(fixture.nativeBinding);
+        final span = fixture.createTestSpan(name: 'CheckoutScreen');
+        await fixture.options.lifecycleRegistry
+            .dispatchCallback(OnProcessSpan(span));
+
+        verify(fixture.nativeBinding.registerSegmentName('CheckoutScreen'))
+            .called(1);
+      });
+
+      test('does not register segment name for child spans', () async {
+        fixture.options.replay.sessionSampleRate = 0.5;
+
+        await fixture.getSut().call(fixture.hub, fixture.options);
+        clearInteractions(fixture.nativeBinding);
+        final span = fixture.createChildTestSpan();
+        await fixture.options.lifecycleRegistry
+            .dispatchCallback(OnProcessSpan(span));
+
+        verifyNever(fixture.nativeBinding.registerSegmentName(any));
+      });
+
+      test('does not register empty segment name', () async {
+        fixture.options.replay.sessionSampleRate = 0.5;
+
+        await fixture.getSut().call(fixture.hub, fixture.options);
+        clearInteractions(fixture.nativeBinding);
+        final span = fixture.createTestSpan(name: '');
+        await fixture.options.lifecycleRegistry
+            .dispatchCallback(OnProcessSpan(span));
+
+        verifyNever(fixture.nativeBinding.registerSegmentName(any));
+      });
     });
 
     group('in session mode', () {
@@ -346,6 +383,21 @@ void main() {
 
         verifyNever(fixture.nativeBinding.registerTraceId(any));
       });
+
+      test('removes segment name registration on close', () async {
+        fixture.options.replay.sessionSampleRate = 0.5;
+
+        final sut = fixture.getSut();
+        await sut.call(fixture.hub, fixture.options);
+        await sut.close();
+        clearInteractions(fixture.nativeBinding);
+
+        final span = fixture.createTestSpan(name: 'CheckoutScreen');
+        await fixture.options.lifecycleRegistry
+            .dispatchCallback(OnProcessSpan(span));
+
+        verifyNever(fixture.nativeBinding.registerSegmentName(any));
+      });
     });
   });
 }
@@ -370,6 +422,7 @@ class Fixture {
     });
     when(nativeBinding.replayId).thenReturn(null);
     when(nativeBinding.registerTraceId(any)).thenReturn(null);
+    when(nativeBinding.registerSegmentName(any)).thenReturn(null);
   }
 
   SentryLog createTestLog() => SentryLog(
@@ -388,8 +441,9 @@ class Fixture {
         attributes: <String, SentryAttribute>{},
       );
 
-  RecordingSentrySpanV2 createTestSpan() => RecordingSentrySpanV2.root(
-        name: 'test-span',
+  RecordingSentrySpanV2 createTestSpan({String name = 'test-span'}) =>
+      RecordingSentrySpanV2.root(
+        name: name,
         traceId: SentryId.newId(),
         onSpanEnd: (_) async {},
         clock: options.clock,

--- a/packages/flutter/test/mocks.mocks.dart
+++ b/packages/flutter/test/mocks.mocks.dart
@@ -2103,6 +2103,13 @@ class MockSentryNativeBinding extends _i1.Mock
         #registerTraceId,
         [traceId],
       )) as _i12.FutureOr<void>);
+
+  @override
+  _i12.FutureOr<void> registerSegmentName(String? segmentName) =>
+      (super.noSuchMethod(Invocation.method(
+        #registerSegmentName,
+        [segmentName],
+      )) as _i12.FutureOr<void>);
 }
 
 /// A class which mocks [SentryDelayedFramesTracker].


### PR DESCRIPTION
## :scroll: Description

While Android session replay is recording, finishing a streaming segment-root span now registers that span's name with native replay via `ReplayController.registerSegmentName`. Replay events can then carry `segment_names`, so Transaction Summary can find related replays without relying on `sentry.replay.id` alone.

Non-Android platforms get a no-op on the new binding method. Depends on sentry-android 8.49.0 already on main.

## :bulb: Motivation and Context

Under span streaming, buffer-mode replay often leaves `sentry.replay.id` pointing at missing replays, which breaks "query spans by segment name → get replay IDs → fetch replays". Recording `segment_names` on the replay event sidesteps that.

Fixes #3865

Related: getsentry/sentry-java#5763, getsentry/sentry-javascript#21851

## :green_heart: How did you test it?

- Unit tests in `replay_telemetry_integration_test.dart`: segment root registers name; child/empty skip; close removes the hook

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec
- [x] No breaking changes


## :crystal_ball: Next steps

- Cocoa/iOS once a native `registerSegmentName` API exists