### PR TITLE
feat(tracing): Emit segment name source

### DIFF
--- a/packages/dart/lib/src/constants.dart
+++ b/packages/dart/lib/src/constants.dart
@@ -77,10 +77,10 @@ class SentryFeatures {
 abstract class SemanticAttributesConstants {
   SemanticAttributesConstants._();
 
-  /// The source of a span, also referred to as transaction source.
+  /// The source of the segment span name.
   ///
   /// Known values are:  `'custom'`, `'url'`, `'route'`, `'component'`, `'view'`, `'task'`.
-  static const sentrySpanSource = 'sentry.span.source';
+  static const sentrySegmentNameSource = 'sentry.segment.name.source';
 
   /// Attributes that holds the sample rate that was locally applied to a span.
   /// If this attribute is not defined, it means that the span inherited a sampling decision.

--- a/packages/dart/lib/src/telemetry/span/span_capture_pipeline.dart
+++ b/packages/dart/lib/src/telemetry/span/span_capture_pipeline.dart
@@ -47,8 +47,8 @@ class SpanCapturePipeline {
             if (identical(span, span.segmentSpan))
               SemanticAttributesConstants.sentrySegmentNameSource:
                   SentryAttribute.string(
-                    SentryTransactionNameSource.custom.name,
-                  ),
+                SentryTransactionNameSource.custom.name,
+              ),
           });
 
           final beforeSendSpan = _options.beforeSendSpan;

--- a/packages/dart/lib/src/telemetry/span/span_capture_pipeline.dart
+++ b/packages/dart/lib/src/telemetry/span/span_capture_pipeline.dart
@@ -44,6 +44,11 @@ class SpanCapturePipeline {
             SemanticAttributesConstants.sentrySegmentId: SentryAttribute.string(
               span.segmentSpan.spanId.toString(),
             ),
+            if (identical(span, span.segmentSpan))
+              SemanticAttributesConstants.sentrySegmentNameSource:
+                  SentryAttribute.string(
+                    SentryTransactionNameSource.custom.name,
+                  ),
           });
 
           final beforeSendSpan = _options.beforeSendSpan;

--- a/packages/dart/test/telemetry/span/span_capture_pipeline_test.dart
+++ b/packages/dart/test/telemetry/span/span_capture_pipeline_test.dart
@@ -22,53 +22,74 @@ void main() {
         expect(fixture.processor.addedSpans.first, same(span));
       });
 
-      test('adds default attributes and segment metadata for recording spans',
-          () async {
-        await fixture.scope.setUser(SentryUser(id: 'user-id'));
-        fixture.scope.setAttributes({
-          'scope-key': SentryAttribute.string('scope'),
-          'custom': SentryAttribute.string('scope-custom'),
-        });
+      test(
+        'adds default attributes and segment metadata for recording spans',
+        () async {
+          await fixture.scope.setUser(SentryUser(id: 'user-id'));
+          fixture.scope.setAttributes({
+            'scope-key': SentryAttribute.string('scope'),
+            'custom': SentryAttribute.string('scope-custom'),
+          });
 
-        final segmentSpan = fixture.createRecordingSpan(name: 'root-span');
-        final span = RecordingSentrySpanV2.child(
-          parent: segmentSpan,
-          name: 'child-span',
-          onSpanEnd: (_) async {},
-          clock: fixture.options.clock,
-          dscCreator: (s) => SentryTraceContextHeader(SentryId.newId(), 'key'),
-        );
-        span.setAttributes({
-          'custom': SentryAttribute.string('span-custom'),
-          SemanticAttributesConstants.sentryRelease:
-              SentryAttribute.string('span-release'),
-        });
+          final segmentSpan = fixture.createRecordingSpan(name: 'root-span');
+          final span = RecordingSentrySpanV2.child(
+            parent: segmentSpan,
+            name: 'child-span',
+            onSpanEnd: (_) async {},
+            clock: fixture.options.clock,
+            dscCreator: (s) =>
+                SentryTraceContextHeader(SentryId.newId(), 'key'),
+          );
+          span.setAttributes({
+            'custom': SentryAttribute.string('span-custom'),
+            SemanticAttributesConstants.sentryRelease: SentryAttribute.string(
+              'span-release',
+            ),
+          });
 
-        await fixture.pipeline.captureSpan(span, scope: fixture.scope);
+          await fixture.pipeline.captureSpan(span, scope: fixture.scope);
 
-        final attributes = span.attributes;
-        expect(attributes[SemanticAttributesConstants.sentryEnvironment]?.value,
-            'test-env');
-        expect(attributes[SemanticAttributesConstants.sentryRelease]?.value,
-            'span-release');
-        expect(attributes[SemanticAttributesConstants.sentrySdkName]?.value,
-            fixture.options.sdk.name);
-        expect(attributes[SemanticAttributesConstants.sentrySdkVersion]?.value,
-            fixture.options.sdk.version);
-        expect(
-            attributes[SemanticAttributesConstants.userId]?.value, 'user-id');
-        expect(attributes[SemanticAttributesConstants.sentrySegmentName]?.value,
-            span.segmentSpan.name);
-        expect(attributes[SemanticAttributesConstants.sentryTransaction]?.value,
-            span.segmentSpan.name);
-        expect(attributes[SemanticAttributesConstants.sentrySegmentId]?.value,
-            span.segmentSpan.spanId.toString());
-      });
+          final attributes = span.attributes;
+          expect(
+            attributes[SemanticAttributesConstants.sentryEnvironment]?.value,
+            'test-env',
+          );
+          expect(
+            attributes[SemanticAttributesConstants.sentryRelease]?.value,
+            'span-release',
+          );
+          expect(
+            attributes[SemanticAttributesConstants.sentrySdkName]?.value,
+            fixture.options.sdk.name,
+          );
+          expect(
+            attributes[SemanticAttributesConstants.sentrySdkVersion]?.value,
+            fixture.options.sdk.version,
+          );
+          expect(
+            attributes[SemanticAttributesConstants.userId]?.value,
+            'user-id',
+          );
+          expect(
+            attributes[SemanticAttributesConstants.sentrySegmentName]?.value,
+            span.segmentSpan.name,
+          );
+          expect(
+            attributes[SemanticAttributesConstants.sentryTransaction]?.value,
+            span.segmentSpan.name,
+          );
+          expect(
+            attributes[SemanticAttributesConstants.sentrySegmentId]?.value,
+            span.segmentSpan.spanId.toString(),
+          );
+        },
+      );
 
       test('prefers scope attributes over defaults', () async {
         fixture.scope.setAttributes({
-          SemanticAttributesConstants.sentryEnvironment:
-              SentryAttribute.string('scope-env'),
+          SemanticAttributesConstants.sentryEnvironment: SentryAttribute.string(
+            'scope-env',
+          ),
         });
 
         final span = fixture.createRecordingSpan();
@@ -80,15 +101,20 @@ void main() {
         await fixture.pipeline.captureSpan(span, scope: fixture.scope);
 
         final attributes = span.attributes;
-        expect(attributes[SemanticAttributesConstants.sentryEnvironment]?.value,
-            'scope-env');
-        expect(attributes[SemanticAttributesConstants.sentryRelease]?.value,
-            'test-release');
+        expect(
+          attributes[SemanticAttributesConstants.sentryEnvironment]?.value,
+          'scope-env',
+        );
+        expect(
+          attributes[SemanticAttributesConstants.sentryRelease]?.value,
+          'test-release',
+        );
       });
 
       test('keeps attributes added by lifecycle callbacks', () async {
-        fixture.options.lifecycleRegistry
-            .registerCallback<OnProcessSpan>((event) {
+        fixture.options.lifecycleRegistry.registerCallback<OnProcessSpan>((
+          event,
+        ) {
           event.span.setAttribute(
             'callback-key',
             SentryAttribute.string('callback-value'),
@@ -104,29 +130,35 @@ void main() {
 
         final attributes = span.attributes;
         expect(attributes['callback-key']?.value, 'callback-value');
-        expect(attributes[SemanticAttributesConstants.sentryEnvironment]?.value,
-            'callback-env');
+        expect(
+          attributes[SemanticAttributesConstants.sentryEnvironment]?.value,
+          'callback-env',
+        );
       });
 
       test(
-          'attributes set by lifecycle callbacks are not overridden by default attributes',
-          () async {
-        fixture.options.release = 'random-release';
-        fixture.options.lifecycleRegistry
-            .registerCallback<OnProcessSpan>((event) {
-          event.span.setAttribute(
-            SemanticAttributesConstants.sentryRelease,
-            SentryAttribute.string('release-from-lifecycle-callback'),
+        'attributes set by lifecycle callbacks are not overridden by default attributes',
+        () async {
+          fixture.options.release = 'random-release';
+          fixture.options.lifecycleRegistry.registerCallback<OnProcessSpan>((
+            event,
+          ) {
+            event.span.setAttribute(
+              SemanticAttributesConstants.sentryRelease,
+              SentryAttribute.string('release-from-lifecycle-callback'),
+            );
+          });
+
+          final span = fixture.createRecordingSpan();
+          await fixture.pipeline.captureSpan(span, scope: fixture.scope);
+
+          final attributes = span.attributes;
+          expect(
+            attributes[SemanticAttributesConstants.sentryRelease]?.value,
+            'release-from-lifecycle-callback',
           );
-        });
-
-        final span = fixture.createRecordingSpan();
-        await fixture.pipeline.captureSpan(span, scope: fixture.scope);
-
-        final attributes = span.attributes;
-        expect(attributes[SemanticAttributesConstants.sentryRelease]?.value,
-            'release-from-lifecycle-callback');
-      });
+        },
+      );
 
       test('preserves array attributes on captured spans', () async {
         final span = fixture.createRecordingSpan();
@@ -140,16 +172,69 @@ void main() {
         expect(attr?.value, ['a', 'b']);
       });
 
+      test('adds custom segment name source to segment spans', () async {
+        final span = fixture.createRecordingSpan();
+        await fixture.pipeline.captureSpan(span, scope: fixture.scope);
+
+        expect(
+          span
+              .attributes[SemanticAttributesConstants.sentrySegmentNameSource]
+              ?.value,
+          'custom',
+        );
+      });
+
+      test('preserves explicit segment name source on segment spans', () async {
+        final span = fixture.createRecordingSpan();
+        span.setAttribute(
+          SemanticAttributesConstants.sentrySegmentNameSource,
+          SentryAttribute.string('component'),
+        );
+
+        await fixture.pipeline.captureSpan(span, scope: fixture.scope);
+
+        expect(
+          span
+              .attributes[SemanticAttributesConstants.sentrySegmentNameSource]
+              ?.value,
+          'component',
+        );
+      });
+
+      test('does not add segment name source to child spans', () async {
+        final segmentSpan = fixture.createRecordingSpan();
+        final span = RecordingSentrySpanV2.child(
+          parent: segmentSpan,
+          name: 'child-span',
+          onSpanEnd: (_) async {},
+          clock: fixture.options.clock,
+          dscCreator: (s) => SentryTraceContextHeader(SentryId.newId(), 'key'),
+        );
+
+        await fixture.pipeline.captureSpan(span, scope: fixture.scope);
+
+        expect(
+          span.attributes.containsKey(
+            SemanticAttributesConstants.sentrySegmentNameSource,
+          ),
+          isFalse,
+        );
+      });
+
       test('does not add spans to processor for no-op spans', () async {
-        await fixture.pipeline
-            .captureSpan(const NoOpSentrySpanV2(), scope: fixture.scope);
+        await fixture.pipeline.captureSpan(
+          const NoOpSentrySpanV2(),
+          scope: fixture.scope,
+        );
 
         expect(fixture.processor.addedSpans, isEmpty);
       });
 
       test('does not add spans to processor for unset spans', () async {
-        await fixture.pipeline
-            .captureSpan(const UnsetSentrySpanV2(), scope: fixture.scope);
+        await fixture.pipeline.captureSpan(
+          const UnsetSentrySpanV2(),
+          scope: fixture.scope,
+        );
 
         expect(fixture.processor.addedSpans, isEmpty);
       });
@@ -201,7 +286,9 @@ void main() {
           await Future.delayed(Duration.zero);
           asyncCompleted = true;
           span.setAttribute(
-              'async-attr', SentryAttribute.string('async-value'));
+            'async-attr',
+            SentryAttribute.string('async-value'),
+          );
         };
 
         final span = fixture.createRecordingSpan();
@@ -214,8 +301,9 @@ void main() {
       test('beforeSendSpan is called after lifecycle callbacks', () async {
         final callOrder = <String>[];
 
-        fixture.options.lifecycleRegistry
-            .registerCallback<OnProcessSpan>((event) {
+        fixture.options.lifecycleRegistry.registerCallback<OnProcessSpan>((
+          event,
+        ) {
           callOrder.add('lifecycle');
         });
 
@@ -229,35 +317,42 @@ void main() {
         expect(callOrder, ['lifecycle', 'beforeSendSpan']);
       });
 
-      test('beforeSendSpan is called after default attributes are added',
-          () async {
-        String? envValue;
-        fixture.options.beforeSendSpan = (span) {
-          envValue = span
-              .attributes[SemanticAttributesConstants.sentryEnvironment]
-              ?.value as String?;
-        };
+      test(
+        'beforeSendSpan is called after default attributes are added',
+        () async {
+          String? envValue;
+          fixture.options.beforeSendSpan = (span) {
+            envValue =
+                span
+                        .attributes[SemanticAttributesConstants
+                            .sentryEnvironment]
+                        ?.value
+                    as String?;
+          };
 
-        final span = fixture.createRecordingSpan();
-        await fixture.pipeline.captureSpan(span, scope: fixture.scope);
+          final span = fixture.createRecordingSpan();
+          await fixture.pipeline.captureSpan(span, scope: fixture.scope);
 
-        expect(envValue, 'test-env');
-      });
+          expect(envValue, 'test-env');
+        },
+      );
 
-      test('span is still captured when beforeSendSpan throws exception',
-          () async {
-        fixture.options.automatedTestMode = false;
-        fixture.options.beforeSendSpan = (span) async {
-          await Future.delayed(Duration.zero);
-          throw Exception('async beforeSendSpan callback error');
-        };
+      test(
+        'span is still captured when beforeSendSpan throws exception',
+        () async {
+          fixture.options.automatedTestMode = false;
+          fixture.options.beforeSendSpan = (span) async {
+            await Future.delayed(Duration.zero);
+            throw Exception('async beforeSendSpan callback error');
+          };
 
-        final span = fixture.createRecordingSpan();
-        await fixture.pipeline.captureSpan(span, scope: fixture.scope);
+          final span = fixture.createRecordingSpan();
+          await fixture.pipeline.captureSpan(span, scope: fixture.scope);
 
-        expect(fixture.processor.addedSpans.length, 1);
-        expect(fixture.processor.addedSpans.first, same(span));
-      });
+          expect(fixture.processor.addedSpans.length, 1);
+          expect(fixture.processor.addedSpans.first, same(span));
+        },
+      );
     });
   });
 }

--- a/packages/dart/test/telemetry/span/span_capture_pipeline_test.dart
+++ b/packages/dart/test/telemetry/span/span_capture_pipeline_test.dart
@@ -22,74 +22,53 @@ void main() {
         expect(fixture.processor.addedSpans.first, same(span));
       });
 
-      test(
-        'adds default attributes and segment metadata for recording spans',
-        () async {
-          await fixture.scope.setUser(SentryUser(id: 'user-id'));
-          fixture.scope.setAttributes({
-            'scope-key': SentryAttribute.string('scope'),
-            'custom': SentryAttribute.string('scope-custom'),
-          });
+      test('adds default attributes and segment metadata for recording spans',
+          () async {
+        await fixture.scope.setUser(SentryUser(id: 'user-id'));
+        fixture.scope.setAttributes({
+          'scope-key': SentryAttribute.string('scope'),
+          'custom': SentryAttribute.string('scope-custom'),
+        });
 
-          final segmentSpan = fixture.createRecordingSpan(name: 'root-span');
-          final span = RecordingSentrySpanV2.child(
-            parent: segmentSpan,
-            name: 'child-span',
-            onSpanEnd: (_) async {},
-            clock: fixture.options.clock,
-            dscCreator: (s) =>
-                SentryTraceContextHeader(SentryId.newId(), 'key'),
-          );
-          span.setAttributes({
-            'custom': SentryAttribute.string('span-custom'),
-            SemanticAttributesConstants.sentryRelease: SentryAttribute.string(
-              'span-release',
-            ),
-          });
+        final segmentSpan = fixture.createRecordingSpan(name: 'root-span');
+        final span = RecordingSentrySpanV2.child(
+          parent: segmentSpan,
+          name: 'child-span',
+          onSpanEnd: (_) async {},
+          clock: fixture.options.clock,
+          dscCreator: (s) => SentryTraceContextHeader(SentryId.newId(), 'key'),
+        );
+        span.setAttributes({
+          'custom': SentryAttribute.string('span-custom'),
+          SemanticAttributesConstants.sentryRelease:
+              SentryAttribute.string('span-release'),
+        });
 
-          await fixture.pipeline.captureSpan(span, scope: fixture.scope);
+        await fixture.pipeline.captureSpan(span, scope: fixture.scope);
 
-          final attributes = span.attributes;
-          expect(
-            attributes[SemanticAttributesConstants.sentryEnvironment]?.value,
-            'test-env',
-          );
-          expect(
-            attributes[SemanticAttributesConstants.sentryRelease]?.value,
-            'span-release',
-          );
-          expect(
-            attributes[SemanticAttributesConstants.sentrySdkName]?.value,
-            fixture.options.sdk.name,
-          );
-          expect(
-            attributes[SemanticAttributesConstants.sentrySdkVersion]?.value,
-            fixture.options.sdk.version,
-          );
-          expect(
-            attributes[SemanticAttributesConstants.userId]?.value,
-            'user-id',
-          );
-          expect(
-            attributes[SemanticAttributesConstants.sentrySegmentName]?.value,
-            span.segmentSpan.name,
-          );
-          expect(
-            attributes[SemanticAttributesConstants.sentryTransaction]?.value,
-            span.segmentSpan.name,
-          );
-          expect(
-            attributes[SemanticAttributesConstants.sentrySegmentId]?.value,
-            span.segmentSpan.spanId.toString(),
-          );
-        },
-      );
+        final attributes = span.attributes;
+        expect(attributes[SemanticAttributesConstants.sentryEnvironment]?.value,
+            'test-env');
+        expect(attributes[SemanticAttributesConstants.sentryRelease]?.value,
+            'span-release');
+        expect(attributes[SemanticAttributesConstants.sentrySdkName]?.value,
+            fixture.options.sdk.name);
+        expect(attributes[SemanticAttributesConstants.sentrySdkVersion]?.value,
+            fixture.options.sdk.version);
+        expect(
+            attributes[SemanticAttributesConstants.userId]?.value, 'user-id');
+        expect(attributes[SemanticAttributesConstants.sentrySegmentName]?.value,
+            span.segmentSpan.name);
+        expect(attributes[SemanticAttributesConstants.sentryTransaction]?.value,
+            span.segmentSpan.name);
+        expect(attributes[SemanticAttributesConstants.sentrySegmentId]?.value,
+            span.segmentSpan.spanId.toString());
+      });
 
       test('prefers scope attributes over defaults', () async {
         fixture.scope.setAttributes({
-          SemanticAttributesConstants.sentryEnvironment: SentryAttribute.string(
-            'scope-env',
-          ),
+          SemanticAttributesConstants.sentryEnvironment:
+              SentryAttribute.string('scope-env'),
         });
 
         final span = fixture.createRecordingSpan();
@@ -101,20 +80,15 @@ void main() {
         await fixture.pipeline.captureSpan(span, scope: fixture.scope);
 
         final attributes = span.attributes;
-        expect(
-          attributes[SemanticAttributesConstants.sentryEnvironment]?.value,
-          'scope-env',
-        );
-        expect(
-          attributes[SemanticAttributesConstants.sentryRelease]?.value,
-          'test-release',
-        );
+        expect(attributes[SemanticAttributesConstants.sentryEnvironment]?.value,
+            'scope-env');
+        expect(attributes[SemanticAttributesConstants.sentryRelease]?.value,
+            'test-release');
       });
 
       test('keeps attributes added by lifecycle callbacks', () async {
-        fixture.options.lifecycleRegistry.registerCallback<OnProcessSpan>((
-          event,
-        ) {
+        fixture.options.lifecycleRegistry
+            .registerCallback<OnProcessSpan>((event) {
           event.span.setAttribute(
             'callback-key',
             SentryAttribute.string('callback-value'),
@@ -130,35 +104,29 @@ void main() {
 
         final attributes = span.attributes;
         expect(attributes['callback-key']?.value, 'callback-value');
-        expect(
-          attributes[SemanticAttributesConstants.sentryEnvironment]?.value,
-          'callback-env',
-        );
+        expect(attributes[SemanticAttributesConstants.sentryEnvironment]?.value,
+            'callback-env');
       });
 
       test(
-        'attributes set by lifecycle callbacks are not overridden by default attributes',
-        () async {
-          fixture.options.release = 'random-release';
-          fixture.options.lifecycleRegistry.registerCallback<OnProcessSpan>((
-            event,
-          ) {
-            event.span.setAttribute(
-              SemanticAttributesConstants.sentryRelease,
-              SentryAttribute.string('release-from-lifecycle-callback'),
-            );
-          });
-
-          final span = fixture.createRecordingSpan();
-          await fixture.pipeline.captureSpan(span, scope: fixture.scope);
-
-          final attributes = span.attributes;
-          expect(
-            attributes[SemanticAttributesConstants.sentryRelease]?.value,
-            'release-from-lifecycle-callback',
+          'attributes set by lifecycle callbacks are not overridden by default attributes',
+          () async {
+        fixture.options.release = 'random-release';
+        fixture.options.lifecycleRegistry
+            .registerCallback<OnProcessSpan>((event) {
+          event.span.setAttribute(
+            SemanticAttributesConstants.sentryRelease,
+            SentryAttribute.string('release-from-lifecycle-callback'),
           );
-        },
-      );
+        });
+
+        final span = fixture.createRecordingSpan();
+        await fixture.pipeline.captureSpan(span, scope: fixture.scope);
+
+        final attributes = span.attributes;
+        expect(attributes[SemanticAttributesConstants.sentryRelease]?.value,
+            'release-from-lifecycle-callback');
+      });
 
       test('preserves array attributes on captured spans', () async {
         final span = fixture.createRecordingSpan();
@@ -177,8 +145,7 @@ void main() {
         await fixture.pipeline.captureSpan(span, scope: fixture.scope);
 
         expect(
-          span
-              .attributes[SemanticAttributesConstants.sentrySegmentNameSource]
+          span.attributes[SemanticAttributesConstants.sentrySegmentNameSource]
               ?.value,
           'custom',
         );
@@ -194,8 +161,7 @@ void main() {
         await fixture.pipeline.captureSpan(span, scope: fixture.scope);
 
         expect(
-          span
-              .attributes[SemanticAttributesConstants.sentrySegmentNameSource]
+          span.attributes[SemanticAttributesConstants.sentrySegmentNameSource]
               ?.value,
           'component',
         );
@@ -222,19 +188,15 @@ void main() {
       });
 
       test('does not add spans to processor for no-op spans', () async {
-        await fixture.pipeline.captureSpan(
-          const NoOpSentrySpanV2(),
-          scope: fixture.scope,
-        );
+        await fixture.pipeline
+            .captureSpan(const NoOpSentrySpanV2(), scope: fixture.scope);
 
         expect(fixture.processor.addedSpans, isEmpty);
       });
 
       test('does not add spans to processor for unset spans', () async {
-        await fixture.pipeline.captureSpan(
-          const UnsetSentrySpanV2(),
-          scope: fixture.scope,
-        );
+        await fixture.pipeline
+            .captureSpan(const UnsetSentrySpanV2(), scope: fixture.scope);
 
         expect(fixture.processor.addedSpans, isEmpty);
       });
@@ -286,9 +248,7 @@ void main() {
           await Future.delayed(Duration.zero);
           asyncCompleted = true;
           span.setAttribute(
-            'async-attr',
-            SentryAttribute.string('async-value'),
-          );
+              'async-attr', SentryAttribute.string('async-value'));
         };
 
         final span = fixture.createRecordingSpan();
@@ -301,9 +261,8 @@ void main() {
       test('beforeSendSpan is called after lifecycle callbacks', () async {
         final callOrder = <String>[];
 
-        fixture.options.lifecycleRegistry.registerCallback<OnProcessSpan>((
-          event,
-        ) {
+        fixture.options.lifecycleRegistry
+            .registerCallback<OnProcessSpan>((event) {
           callOrder.add('lifecycle');
         });
 
@@ -317,42 +276,35 @@ void main() {
         expect(callOrder, ['lifecycle', 'beforeSendSpan']);
       });
 
-      test(
-        'beforeSendSpan is called after default attributes are added',
-        () async {
-          String? envValue;
-          fixture.options.beforeSendSpan = (span) {
-            envValue =
-                span
-                        .attributes[SemanticAttributesConstants
-                            .sentryEnvironment]
-                        ?.value
-                    as String?;
-          };
+      test('beforeSendSpan is called after default attributes are added',
+          () async {
+        String? envValue;
+        fixture.options.beforeSendSpan = (span) {
+          envValue = span
+              .attributes[SemanticAttributesConstants.sentryEnvironment]
+              ?.value as String?;
+        };
 
-          final span = fixture.createRecordingSpan();
-          await fixture.pipeline.captureSpan(span, scope: fixture.scope);
+        final span = fixture.createRecordingSpan();
+        await fixture.pipeline.captureSpan(span, scope: fixture.scope);
 
-          expect(envValue, 'test-env');
-        },
-      );
+        expect(envValue, 'test-env');
+      });
 
-      test(
-        'span is still captured when beforeSendSpan throws exception',
-        () async {
-          fixture.options.automatedTestMode = false;
-          fixture.options.beforeSendSpan = (span) async {
-            await Future.delayed(Duration.zero);
-            throw Exception('async beforeSendSpan callback error');
-          };
+      test('span is still captured when beforeSendSpan throws exception',
+          () async {
+        fixture.options.automatedTestMode = false;
+        fixture.options.beforeSendSpan = (span) async {
+          await Future.delayed(Duration.zero);
+          throw Exception('async beforeSendSpan callback error');
+        };
 
-          final span = fixture.createRecordingSpan();
-          await fixture.pipeline.captureSpan(span, scope: fixture.scope);
+        final span = fixture.createRecordingSpan();
+        await fixture.pipeline.captureSpan(span, scope: fixture.scope);
 
-          expect(fixture.processor.addedSpans.length, 1);
-          expect(fixture.processor.addedSpans.first, same(span));
-        },
-      );
+        expect(fixture.processor.addedSpans.length, 1);
+        expect(fixture.processor.addedSpans.first, same(span));
+      });
     });
   });
 }

--- a/packages/flutter/lib/src/integrations/generic_app_start_integration.dart
+++ b/packages/flutter/lib/src/integrations/generic_app_start_integration.dart
@@ -36,6 +36,7 @@ class GenericAppStartIntegration extends Integration<SentryFlutterOptions> {
     final transactionContext = SentryTransactionContext(
       'root /',
       SentrySpanOperations.uiLoad,
+      transactionNameSource: SentryTransactionNameSource.component,
       origin: SentryTraceOrigins.autoUiTimeToDisplay,
     );
 

--- a/packages/flutter/lib/src/integrations/native_app_start_integration.dart
+++ b/packages/flutter/lib/src/integrations/native_app_start_integration.dart
@@ -41,6 +41,7 @@ class NativeAppStartIntegration extends Integration<SentryFlutterOptions> {
       context = SentryTransactionContext(
         'root /',
         SentrySpanOperations.uiLoad,
+        transactionNameSource: SentryTransactionNameSource.component,
         origin: SentryTraceOrigins.autoUiTimeToDisplay,
       );
       options.timeToDisplayTracker.transactionId = context.spanId;

--- a/packages/flutter/lib/src/navigation/time_to_display_tracker_v2.dart
+++ b/packages/flutter/lib/src/navigation/time_to_display_tracker_v2.dart
@@ -19,10 +19,12 @@ class TimeToDisplayTrackerV2 {
   /// Null when no preparation is pending.
   SentrySpanV2? _preparedRootNavigationSpan;
 
-  TimeToDisplayTrackerV2({Hub? hub, FrameCallbackHandler? frameCallbackHandler})
-    : _hub = hub ?? HubAdapter(),
-      _frameCallbackHandler =
-          frameCallbackHandler ?? DefaultFrameCallbackHandler();
+  TimeToDisplayTrackerV2({
+    Hub? hub,
+    FrameCallbackHandler? frameCallbackHandler,
+  })  : _hub = hub ?? HubAdapter(),
+        _frameCallbackHandler =
+            frameCallbackHandler ?? DefaultFrameCallbackHandler();
 
   /// The active TTFD span's ID, used by [SentryFlutter.currentDisplay].
   SpanId? get ttfdSpanId => _ttfdSpan?.spanId;
@@ -34,10 +36,8 @@ class TimeToDisplayTrackerV2 {
   /// [SentryFlutter.currentDisplay] before [trackAppStart] fires.
   /// Timestamps are backdated later in [trackAppStart].
   void prepareAppStart() {
-    assert(
-      _preparedRootNavigationSpan == null,
-      'prepareRootNavigation called while a prepared span is still pending',
-    );
+    assert(_preparedRootNavigationSpan == null,
+        'prepareRootNavigation called while a prepared span is still pending');
 
     cancelCurrentRoute();
 
@@ -70,10 +70,8 @@ class TimeToDisplayTrackerV2 {
         }
         routeSpan = prepared;
       case null:
-        routeSpan = _createRouteSpan(
-          _rootRouteName,
-          startTimestamp: startTimestamp,
-        );
+        routeSpan =
+            _createRouteSpan(_rootRouteName, startTimestamp: startTimestamp);
     }
 
     _trackDisplaySpans(
@@ -91,33 +89,23 @@ class TimeToDisplayTrackerV2 {
   SentrySpanV2 trackRoute(String routeName) {
     cancelCurrentRoute();
 
-    final routeSpan = _createRouteSpan(
-      routeName,
-      segmentNameSource: SentryTransactionNameSource.component,
-    );
+    final routeSpan = _createRouteSpan(routeName);
     _trackDisplaySpans(routeSpan, routeName);
     return routeSpan;
   }
 
-  SentrySpanV2 _createRouteSpan(
-    String routeName, {
-    DateTime? startTimestamp,
-    SentryTransactionNameSource? segmentNameSource,
-  }) => _hub.startIdleSpan(
-    routeName,
-    startTimestamp: startTimestamp,
-    attributes: {
-      SemanticAttributesConstants.sentryOp: SentryAttribute.string(
-        SentrySpanOperations.uiLoad,
-      ),
-      SemanticAttributesConstants.sentryOrigin: SentryAttribute.string(
-        SentryTraceOrigins.autoNavigationRouteObserver,
-      ),
-      if (segmentNameSource != null)
-        SemanticAttributesConstants.sentrySegmentNameSource:
-            SentryAttribute.string(segmentNameSource.name),
-    },
-  );
+  SentrySpanV2 _createRouteSpan(String routeName, {DateTime? startTimestamp}) =>
+      _hub.startIdleSpan(routeName,
+          startTimestamp: startTimestamp,
+          attributes: {
+            SemanticAttributesConstants.sentryOp:
+                SentryAttribute.string(SentrySpanOperations.uiLoad),
+            SemanticAttributesConstants.sentryOrigin: SentryAttribute.string(
+                SentryTraceOrigins.autoNavigationRouteObserver),
+            SemanticAttributesConstants.sentrySegmentNameSource:
+                SentryAttribute.string(
+                    SentryTransactionNameSource.component.name),
+          });
 
   /// Ensures the TTFD span exists, creating it if not already present.
   void _ensureTtfdSpan(
@@ -126,20 +114,17 @@ class TimeToDisplayTrackerV2 {
     DateTime? startTimestamp,
   }) {
     if (_ttfdSpan != null) return;
-    if (_hub.options case SentryFlutterOptions(
-      enableTimeToFullDisplayTracing: true,
-    )) {
+    if (_hub.options
+        case SentryFlutterOptions(enableTimeToFullDisplayTracing: true)) {
       _ttfdSpan = _hub.startInactiveSpan(
         '$routeName full display',
         parentSpan: parentSpan,
         startTimestamp: startTimestamp,
         attributes: {
-          SemanticAttributesConstants.sentryOp: SentryAttribute.string(
-            SentrySpanOperations.uiTimeToFullDisplay,
-          ),
+          SemanticAttributesConstants.sentryOp:
+              SentryAttribute.string(SentrySpanOperations.uiTimeToFullDisplay),
           SemanticAttributesConstants.sentryOrigin: SentryAttribute.string(
-            SentryTraceOrigins.autoNavigationRouteObserver,
-          ),
+              SentryTraceOrigins.autoNavigationRouteObserver),
         },
       );
     }
@@ -159,25 +144,20 @@ class TimeToDisplayTrackerV2 {
       parentSpan: routeSpan,
       startTimestamp: startTimestamp,
       attributes: {
-        SemanticAttributesConstants.sentryOp: SentryAttribute.string(
-          SentrySpanOperations.uiTimeToInitialDisplay,
-        ),
+        SemanticAttributesConstants.sentryOp:
+            SentryAttribute.string(SentrySpanOperations.uiTimeToInitialDisplay),
         SemanticAttributesConstants.sentryOrigin: SentryAttribute.string(
-          SentryTraceOrigins.autoNavigationRouteObserver,
-        ),
+            SentryTraceOrigins.autoNavigationRouteObserver),
       },
     );
     if (ttidEndTimestamp != null) {
       if (startTimestamp != null) {
         ttidSpan.setAttribute(
-          SemanticAttributesConstants.appVitalsTtidValue,
-          SentryAttribute.double(
-            ttidEndTimestamp
+            SemanticAttributesConstants.appVitalsTtidValue,
+            SentryAttribute.double(ttidEndTimestamp
                 .difference(startTimestamp)
                 .inMilliseconds
-                .toDouble(),
-          ),
-        );
+                .toDouble()));
       }
       ttidSpan.end(endTimestamp: ttidEndTimestamp);
     } else {
@@ -185,11 +165,11 @@ class TimeToDisplayTrackerV2 {
         final endTimestamp = DateTime.now();
         if (startTimestamp != null) {
           ttidSpan.setAttribute(
-            SemanticAttributesConstants.appVitalsTtidValue,
-            SentryAttribute.double(
-              endTimestamp.difference(startTimestamp).inMilliseconds.toDouble(),
-            ),
-          );
+              SemanticAttributesConstants.appVitalsTtidValue,
+              SentryAttribute.double(endTimestamp
+                  .difference(startTimestamp)
+                  .inMilliseconds
+                  .toDouble()));
         }
         ttidSpan.end(endTimestamp: endTimestamp);
       });
@@ -207,14 +187,11 @@ class TimeToDisplayTrackerV2 {
     }
     final endTimestamp = DateTime.now();
     ttfdSpan.setAttribute(
-      SemanticAttributesConstants.appVitalsTtfdValue,
-      SentryAttribute.double(
-        endTimestamp
+        SemanticAttributesConstants.appVitalsTtfdValue,
+        SentryAttribute.double(endTimestamp
             .difference(ttfdSpan.startTimestamp)
             .inMilliseconds
-            .toDouble(),
-      ),
-    );
+            .toDouble()));
     ttfdSpan.end(endTimestamp: endTimestamp);
     _ttfdSpan = null;
   }

--- a/packages/flutter/lib/src/navigation/time_to_display_tracker_v2.dart
+++ b/packages/flutter/lib/src/navigation/time_to_display_tracker_v2.dart
@@ -19,12 +19,10 @@ class TimeToDisplayTrackerV2 {
   /// Null when no preparation is pending.
   SentrySpanV2? _preparedRootNavigationSpan;
 
-  TimeToDisplayTrackerV2({
-    Hub? hub,
-    FrameCallbackHandler? frameCallbackHandler,
-  })  : _hub = hub ?? HubAdapter(),
-        _frameCallbackHandler =
-            frameCallbackHandler ?? DefaultFrameCallbackHandler();
+  TimeToDisplayTrackerV2({Hub? hub, FrameCallbackHandler? frameCallbackHandler})
+    : _hub = hub ?? HubAdapter(),
+      _frameCallbackHandler =
+          frameCallbackHandler ?? DefaultFrameCallbackHandler();
 
   /// The active TTFD span's ID, used by [SentryFlutter.currentDisplay].
   SpanId? get ttfdSpanId => _ttfdSpan?.spanId;
@@ -36,8 +34,10 @@ class TimeToDisplayTrackerV2 {
   /// [SentryFlutter.currentDisplay] before [trackAppStart] fires.
   /// Timestamps are backdated later in [trackAppStart].
   void prepareAppStart() {
-    assert(_preparedRootNavigationSpan == null,
-        'prepareRootNavigation called while a prepared span is still pending');
+    assert(
+      _preparedRootNavigationSpan == null,
+      'prepareRootNavigation called while a prepared span is still pending',
+    );
 
     cancelCurrentRoute();
 
@@ -70,8 +70,10 @@ class TimeToDisplayTrackerV2 {
         }
         routeSpan = prepared;
       case null:
-        routeSpan =
-            _createRouteSpan(_rootRouteName, startTimestamp: startTimestamp);
+        routeSpan = _createRouteSpan(
+          _rootRouteName,
+          startTimestamp: startTimestamp,
+        );
     }
 
     _trackDisplaySpans(
@@ -89,20 +91,33 @@ class TimeToDisplayTrackerV2 {
   SentrySpanV2 trackRoute(String routeName) {
     cancelCurrentRoute();
 
-    final routeSpan = _createRouteSpan(routeName);
+    final routeSpan = _createRouteSpan(
+      routeName,
+      segmentNameSource: SentryTransactionNameSource.component,
+    );
     _trackDisplaySpans(routeSpan, routeName);
     return routeSpan;
   }
 
-  SentrySpanV2 _createRouteSpan(String routeName, {DateTime? startTimestamp}) =>
-      _hub.startIdleSpan(routeName,
-          startTimestamp: startTimestamp,
-          attributes: {
-            SemanticAttributesConstants.sentryOp:
-                SentryAttribute.string(SentrySpanOperations.uiLoad),
-            SemanticAttributesConstants.sentryOrigin: SentryAttribute.string(
-                SentryTraceOrigins.autoNavigationRouteObserver),
-          });
+  SentrySpanV2 _createRouteSpan(
+    String routeName, {
+    DateTime? startTimestamp,
+    SentryTransactionNameSource? segmentNameSource,
+  }) => _hub.startIdleSpan(
+    routeName,
+    startTimestamp: startTimestamp,
+    attributes: {
+      SemanticAttributesConstants.sentryOp: SentryAttribute.string(
+        SentrySpanOperations.uiLoad,
+      ),
+      SemanticAttributesConstants.sentryOrigin: SentryAttribute.string(
+        SentryTraceOrigins.autoNavigationRouteObserver,
+      ),
+      if (segmentNameSource != null)
+        SemanticAttributesConstants.sentrySegmentNameSource:
+            SentryAttribute.string(segmentNameSource.name),
+    },
+  );
 
   /// Ensures the TTFD span exists, creating it if not already present.
   void _ensureTtfdSpan(
@@ -111,17 +126,20 @@ class TimeToDisplayTrackerV2 {
     DateTime? startTimestamp,
   }) {
     if (_ttfdSpan != null) return;
-    if (_hub.options
-        case SentryFlutterOptions(enableTimeToFullDisplayTracing: true)) {
+    if (_hub.options case SentryFlutterOptions(
+      enableTimeToFullDisplayTracing: true,
+    )) {
       _ttfdSpan = _hub.startInactiveSpan(
         '$routeName full display',
         parentSpan: parentSpan,
         startTimestamp: startTimestamp,
         attributes: {
-          SemanticAttributesConstants.sentryOp:
-              SentryAttribute.string(SentrySpanOperations.uiTimeToFullDisplay),
+          SemanticAttributesConstants.sentryOp: SentryAttribute.string(
+            SentrySpanOperations.uiTimeToFullDisplay,
+          ),
           SemanticAttributesConstants.sentryOrigin: SentryAttribute.string(
-              SentryTraceOrigins.autoNavigationRouteObserver),
+            SentryTraceOrigins.autoNavigationRouteObserver,
+          ),
         },
       );
     }
@@ -141,20 +159,25 @@ class TimeToDisplayTrackerV2 {
       parentSpan: routeSpan,
       startTimestamp: startTimestamp,
       attributes: {
-        SemanticAttributesConstants.sentryOp:
-            SentryAttribute.string(SentrySpanOperations.uiTimeToInitialDisplay),
+        SemanticAttributesConstants.sentryOp: SentryAttribute.string(
+          SentrySpanOperations.uiTimeToInitialDisplay,
+        ),
         SemanticAttributesConstants.sentryOrigin: SentryAttribute.string(
-            SentryTraceOrigins.autoNavigationRouteObserver),
+          SentryTraceOrigins.autoNavigationRouteObserver,
+        ),
       },
     );
     if (ttidEndTimestamp != null) {
       if (startTimestamp != null) {
         ttidSpan.setAttribute(
-            SemanticAttributesConstants.appVitalsTtidValue,
-            SentryAttribute.double(ttidEndTimestamp
+          SemanticAttributesConstants.appVitalsTtidValue,
+          SentryAttribute.double(
+            ttidEndTimestamp
                 .difference(startTimestamp)
                 .inMilliseconds
-                .toDouble()));
+                .toDouble(),
+          ),
+        );
       }
       ttidSpan.end(endTimestamp: ttidEndTimestamp);
     } else {
@@ -162,11 +185,11 @@ class TimeToDisplayTrackerV2 {
         final endTimestamp = DateTime.now();
         if (startTimestamp != null) {
           ttidSpan.setAttribute(
-              SemanticAttributesConstants.appVitalsTtidValue,
-              SentryAttribute.double(endTimestamp
-                  .difference(startTimestamp)
-                  .inMilliseconds
-                  .toDouble()));
+            SemanticAttributesConstants.appVitalsTtidValue,
+            SentryAttribute.double(
+              endTimestamp.difference(startTimestamp).inMilliseconds.toDouble(),
+            ),
+          );
         }
         ttidSpan.end(endTimestamp: endTimestamp);
       });
@@ -184,11 +207,14 @@ class TimeToDisplayTrackerV2 {
     }
     final endTimestamp = DateTime.now();
     ttfdSpan.setAttribute(
-        SemanticAttributesConstants.appVitalsTtfdValue,
-        SentryAttribute.double(endTimestamp
+      SemanticAttributesConstants.appVitalsTtfdValue,
+      SentryAttribute.double(
+        endTimestamp
             .difference(ttfdSpan.startTimestamp)
             .inMilliseconds
-            .toDouble()));
+            .toDouble(),
+      ),
+    );
     ttfdSpan.end(endTimestamp: endTimestamp);
     _ttfdSpan = null;
   }

--- a/packages/flutter/lib/src/user_interaction/sentry_user_interaction_widget.dart
+++ b/packages/flutter/lib/src/user_interaction/sentry_user_interaction_widget.dart
@@ -362,7 +362,7 @@ class _SentryUserInteractionWidgetState
     final label = _getLabelRecursively(info.element);
     final data = {
       'path': _getTouchPath(info.element),
-      if (label != null) 'label': label,
+      if (label != null) 'label': label
     };
 
     final crumb = Breadcrumb.userInteraction(
@@ -428,8 +428,7 @@ class _SentryUserInteractionWidgetState
 
       if (activeSpan is IdleRecordingSentrySpanV2) {
         final lastElement = _lastTappedWidget?.element;
-        final isSameWidget =
-            _isElementMounted(lastElement) &&
+        final isSameWidget = _isElementMounted(lastElement) &&
             _isElementMounted(info.element) &&
             lastElement?.widget == info.element.widget;
 
@@ -457,12 +456,10 @@ class _SentryUserInteractionWidgetState
       idleTimeout: const Duration(seconds: 1),
       widgetKey,
       attributes: {
-        SemanticAttributesConstants.sentryOp: SentryAttribute.string(
-          SentrySpanOperations.uiActionClick,
-        ),
-        SemanticAttributesConstants.sentryOrigin: SentryAttribute.string(
-          SentryTraceOrigins.autoUiInteraction,
-        ),
+        SemanticAttributesConstants.sentryOp:
+            SentryAttribute.string(SentrySpanOperations.uiActionClick),
+        SemanticAttributesConstants.sentryOrigin:
+            SentryAttribute.string(SentryTraceOrigins.autoUiInteraction),
         SemanticAttributesConstants.sentrySegmentNameSource:
             SentryAttribute.string(SentryTransactionNameSource.component.name),
       },
@@ -569,8 +566,7 @@ class _SentryUserInteractionWidgetState
 
     if (_options?.sendDefaultPii ?? false) {
       final widget = element.widget;
-      final allowText =
-          widget is ButtonStyleButton ||
+      final allowText = widget is ButtonStyleButton ||
           widget is MaterialButton ||
           widget is CupertinoButton;
 
@@ -613,10 +609,8 @@ class _SentryUserInteractionWidgetState
       }
 
       final transform = renderObject.getTransformTo(rootElement.renderObject);
-      final paintBounds = MatrixUtils.transformRect(
-        transform,
-        renderObject.paintBounds,
-      );
+      final paintBounds =
+          MatrixUtils.transformRect(transform, renderObject.paintBounds);
 
       if (!paintBounds.contains(position)) {
         return;
@@ -624,7 +618,10 @@ class _SentryUserInteractionWidgetState
 
       final type = _getElementType(element);
       if (type != null) {
-        tappedWidget = UserInteractionInfo(element: element, type: type);
+        tappedWidget = UserInteractionInfo(
+          element: element,
+          type: type,
+        );
       }
 
       if (tappedWidget == null) {

--- a/packages/flutter/lib/src/user_interaction/sentry_user_interaction_widget.dart
+++ b/packages/flutter/lib/src/user_interaction/sentry_user_interaction_widget.dart
@@ -362,7 +362,7 @@ class _SentryUserInteractionWidgetState
     final label = _getLabelRecursively(info.element);
     final data = {
       'path': _getTouchPath(info.element),
-      if (label != null) 'label': label
+      if (label != null) 'label': label,
     };
 
     final crumb = Breadcrumb.userInteraction(
@@ -428,7 +428,8 @@ class _SentryUserInteractionWidgetState
 
       if (activeSpan is IdleRecordingSentrySpanV2) {
         final lastElement = _lastTappedWidget?.element;
-        final isSameWidget = _isElementMounted(lastElement) &&
+        final isSameWidget =
+            _isElementMounted(lastElement) &&
             _isElementMounted(info.element) &&
             lastElement?.widget == info.element.widget;
 
@@ -456,10 +457,14 @@ class _SentryUserInteractionWidgetState
       idleTimeout: const Duration(seconds: 1),
       widgetKey,
       attributes: {
-        SemanticAttributesConstants.sentryOp:
-            SentryAttribute.string(SentrySpanOperations.uiActionClick),
-        SemanticAttributesConstants.sentryOrigin:
-            SentryAttribute.string(SentryTraceOrigins.autoUiInteraction),
+        SemanticAttributesConstants.sentryOp: SentryAttribute.string(
+          SentrySpanOperations.uiActionClick,
+        ),
+        SemanticAttributesConstants.sentryOrigin: SentryAttribute.string(
+          SentryTraceOrigins.autoUiInteraction,
+        ),
+        SemanticAttributesConstants.sentrySegmentNameSource:
+            SentryAttribute.string(SentryTransactionNameSource.component.name),
       },
     );
   }
@@ -564,7 +569,8 @@ class _SentryUserInteractionWidgetState
 
     if (_options?.sendDefaultPii ?? false) {
       final widget = element.widget;
-      final allowText = widget is ButtonStyleButton ||
+      final allowText =
+          widget is ButtonStyleButton ||
           widget is MaterialButton ||
           widget is CupertinoButton;
 
@@ -607,8 +613,10 @@ class _SentryUserInteractionWidgetState
       }
 
       final transform = renderObject.getTransformTo(rootElement.renderObject);
-      final paintBounds =
-          MatrixUtils.transformRect(transform, renderObject.paintBounds);
+      final paintBounds = MatrixUtils.transformRect(
+        transform,
+        renderObject.paintBounds,
+      );
 
       if (!paintBounds.contains(position)) {
         return;
@@ -616,10 +624,7 @@ class _SentryUserInteractionWidgetState
 
       final type = _getElementType(element);
       if (type != null) {
-        tappedWidget = UserInteractionInfo(
-          element: element,
-          type: type,
-        );
+        tappedWidget = UserInteractionInfo(element: element, type: type);
       }
 
       if (tappedWidget == null) {

--- a/packages/flutter/test/integrations/generic_app_start_integration_test.dart
+++ b/packages/flutter/test/integrations/generic_app_start_integration_test.dart
@@ -64,6 +64,10 @@ void main() {
         expect(tracer!.name, 'root /');
         expect(tracer.context.operation, SentrySpanOperations.uiLoad);
         expect(tracer.origin, SentryTraceOrigins.autoUiTimeToDisplay);
+        expect(
+          tracer.transactionNameSource,
+          SentryTransactionNameSource.component,
+        );
       });
 
       test('tracks time to display when frame callback executes', () async {

--- a/packages/flutter/test/integrations/native_app_start_integration_test.dart
+++ b/packages/flutter/test/integrations/native_app_start_integration_test.dart
@@ -140,6 +140,10 @@ void main() {
         // ignore: invalid_use_of_internal_member
         SentrySpanOperations.uiLoad,
       );
+      expect(
+        fixture.nativeAppStartHandler.context?.transactionNameSource,
+        SentryTransactionNameSource.component,
+      );
 
       expect(
         fixture.options.timeToDisplayTracker.transactionId,

--- a/packages/flutter/test/navigation/time_to_display_tracker_v2_test.dart
+++ b/packages/flutter/test/navigation/time_to_display_tracker_v2_test.dart
@@ -30,8 +30,8 @@ void main() {
         expect(activeSpan.status, SentrySpanStatusV2.ok);
         expect(
           activeSpan
-              .attributes[SemanticAttributesConstants
-                  .sentryIdleSpanFinishReason]
+              .attributes[
+                  SemanticAttributesConstants.sentryIdleSpanFinishReason]
               ?.value,
           'cancelled',
         );
@@ -51,8 +51,7 @@ void main() {
         );
         expect(
           activeSpan
-              .attributes[SemanticAttributesConstants.sentryOrigin]
-              ?.value,
+              .attributes[SemanticAttributesConstants.sentryOrigin]?.value,
           SentryTraceOrigins.autoNavigationRouteObserver,
         );
         expect(
@@ -115,21 +114,20 @@ void main() {
       });
 
       test(
-        'does not create TTFD span when enableTimeToFullDisplayTracing is false',
-        () {
-          fixture.options.enableTimeToFullDisplayTracing = false;
-          final sut = fixture.getSut();
-          final childSpans = fixture.captureChildSpans();
+          'does not create TTFD span when enableTimeToFullDisplayTracing is false',
+          () {
+        fixture.options.enableTimeToFullDisplayTracing = false;
+        final sut = fixture.getSut();
+        final childSpans = fixture.captureChildSpans();
 
-          sut.trackRoute('/test-route');
+        sut.trackRoute('/test-route');
 
-          final ttfdSpans = childSpans.where(
-            (s) => s.name == '/test-route full display',
-          );
-          expect(ttfdSpans, isEmpty);
-          expect(sut.ttfdSpanId, isNull);
-        },
-      );
+        final ttfdSpans = childSpans.where(
+          (s) => s.name == '/test-route full display',
+        );
+        expect(ttfdSpans, isEmpty);
+        expect(sut.ttfdSpanId, isNull);
+      });
 
       test('creates TTFD span with correct op and origin', () {
         final sut = fixture.getSut();
@@ -162,6 +160,18 @@ void main() {
     });
 
     group('when tracking app start', () {
+      test('adds component segment name source', () {
+        final sut = fixture.getSut();
+
+        final span = sut.trackAppStart();
+
+        expect(
+          span.attributes[SemanticAttributesConstants.sentrySegmentNameSource]
+              ?.value,
+          'component',
+        );
+      });
+
       test('returns idle span named root /', () {
         final sut = fixture.getSut();
 
@@ -242,6 +252,20 @@ void main() {
     });
 
     group('when preparing app start', () {
+      test('adds component segment name source', () {
+        final sut = fixture.getSut();
+
+        sut.prepareAppStart();
+
+        expect(
+          fixture.hub
+              .getActiveSpan()
+              ?.attributes[SemanticAttributesConstants.sentrySegmentNameSource]
+              ?.value,
+          'component',
+        );
+      });
+
       test('creates idle span eagerly', () {
         final sut = fixture.getSut();
 
@@ -284,8 +308,8 @@ void main() {
         expect(existingSpan.status, SentrySpanStatusV2.ok);
         expect(
           existingSpan
-              .attributes[SemanticAttributesConstants
-                  .sentryIdleSpanFinishReason]
+              .attributes[
+                  SemanticAttributesConstants.sentryIdleSpanFinishReason]
               ?.value,
           'cancelled',
         );
@@ -434,8 +458,8 @@ void main() {
         expect(activeSpan.status, SentrySpanStatusV2.ok);
         expect(
           activeSpan
-              .attributes[SemanticAttributesConstants
-                  .sentryIdleSpanFinishReason]
+              .attributes[
+                  SemanticAttributesConstants.sentryIdleSpanFinishReason]
               ?.value,
           'cancelled',
         );
@@ -444,9 +468,8 @@ void main() {
       test('cancels an existing idle span not created by the tracker', () {
         final sut = fixture.getSut();
 
-        final externalIdleSpan = fixture.hub.startIdleSpan(
-          'user interaction span',
-        );
+        final externalIdleSpan =
+            fixture.hub.startIdleSpan('user interaction span');
         expect(externalIdleSpan.isEnded, isFalse);
 
         sut.cancelCurrentRoute();
@@ -455,8 +478,8 @@ void main() {
         expect(externalIdleSpan.status, SentrySpanStatusV2.ok);
         expect(
           externalIdleSpan
-              .attributes[SemanticAttributesConstants
-                  .sentryIdleSpanFinishReason]
+              .attributes[
+                  SemanticAttributesConstants.sentryIdleSpanFinishReason]
               ?.value,
           'cancelled',
         );
@@ -475,8 +498,8 @@ void main() {
         expect(preparedSpan.status, SentrySpanStatusV2.ok);
         expect(
           preparedSpan
-              .attributes[SemanticAttributesConstants
-                  .sentryIdleSpanFinishReason]
+              .attributes[
+                  SemanticAttributesConstants.sentryIdleSpanFinishReason]
               ?.value,
           'cancelled',
         );

--- a/packages/flutter/test/navigation/time_to_display_tracker_v2_test.dart
+++ b/packages/flutter/test/navigation/time_to_display_tracker_v2_test.dart
@@ -30,8 +30,8 @@ void main() {
         expect(activeSpan.status, SentrySpanStatusV2.ok);
         expect(
           activeSpan
-              .attributes[
-                  SemanticAttributesConstants.sentryIdleSpanFinishReason]
+              .attributes[SemanticAttributesConstants
+                  .sentryIdleSpanFinishReason]
               ?.value,
           'cancelled',
         );
@@ -51,8 +51,15 @@ void main() {
         );
         expect(
           activeSpan
-              .attributes[SemanticAttributesConstants.sentryOrigin]?.value,
+              .attributes[SemanticAttributesConstants.sentryOrigin]
+              ?.value,
           SentryTraceOrigins.autoNavigationRouteObserver,
+        );
+        expect(
+          activeSpan
+              .attributes[SemanticAttributesConstants.sentrySegmentNameSource]
+              ?.value,
+          'component',
         );
       });
 
@@ -108,20 +115,21 @@ void main() {
       });
 
       test(
-          'does not create TTFD span when enableTimeToFullDisplayTracing is false',
-          () {
-        fixture.options.enableTimeToFullDisplayTracing = false;
-        final sut = fixture.getSut();
-        final childSpans = fixture.captureChildSpans();
+        'does not create TTFD span when enableTimeToFullDisplayTracing is false',
+        () {
+          fixture.options.enableTimeToFullDisplayTracing = false;
+          final sut = fixture.getSut();
+          final childSpans = fixture.captureChildSpans();
 
-        sut.trackRoute('/test-route');
+          sut.trackRoute('/test-route');
 
-        final ttfdSpans = childSpans.where(
-          (s) => s.name == '/test-route full display',
-        );
-        expect(ttfdSpans, isEmpty);
-        expect(sut.ttfdSpanId, isNull);
-      });
+          final ttfdSpans = childSpans.where(
+            (s) => s.name == '/test-route full display',
+          );
+          expect(ttfdSpans, isEmpty);
+          expect(sut.ttfdSpanId, isNull);
+        },
+      );
 
       test('creates TTFD span with correct op and origin', () {
         final sut = fixture.getSut();
@@ -276,8 +284,8 @@ void main() {
         expect(existingSpan.status, SentrySpanStatusV2.ok);
         expect(
           existingSpan
-              .attributes[
-                  SemanticAttributesConstants.sentryIdleSpanFinishReason]
+              .attributes[SemanticAttributesConstants
+                  .sentryIdleSpanFinishReason]
               ?.value,
           'cancelled',
         );
@@ -426,8 +434,8 @@ void main() {
         expect(activeSpan.status, SentrySpanStatusV2.ok);
         expect(
           activeSpan
-              .attributes[
-                  SemanticAttributesConstants.sentryIdleSpanFinishReason]
+              .attributes[SemanticAttributesConstants
+                  .sentryIdleSpanFinishReason]
               ?.value,
           'cancelled',
         );
@@ -436,8 +444,9 @@ void main() {
       test('cancels an existing idle span not created by the tracker', () {
         final sut = fixture.getSut();
 
-        final externalIdleSpan =
-            fixture.hub.startIdleSpan('user interaction span');
+        final externalIdleSpan = fixture.hub.startIdleSpan(
+          'user interaction span',
+        );
         expect(externalIdleSpan.isEnded, isFalse);
 
         sut.cancelCurrentRoute();
@@ -446,8 +455,8 @@ void main() {
         expect(externalIdleSpan.status, SentrySpanStatusV2.ok);
         expect(
           externalIdleSpan
-              .attributes[
-                  SemanticAttributesConstants.sentryIdleSpanFinishReason]
+              .attributes[SemanticAttributesConstants
+                  .sentryIdleSpanFinishReason]
               ?.value,
           'cancelled',
         );
@@ -466,8 +475,8 @@ void main() {
         expect(preparedSpan.status, SentrySpanStatusV2.ok);
         expect(
           preparedSpan
-              .attributes[
-                  SemanticAttributesConstants.sentryIdleSpanFinishReason]
+              .attributes[SemanticAttributesConstants
+                  .sentryIdleSpanFinishReason]
               ?.value,
           'cancelled',
         );

--- a/packages/flutter/test/user_interaction/sentry_user_interaction_widget_test.dart
+++ b/packages/flutter/test/user_interaction/sentry_user_interaction_widget_test.dart
@@ -18,7 +18,7 @@ import '../mocks.mocks.dart';
 // The Scaffold widget tree uses AnimatedBuilder on stable but Builder on beta.
 // Use anyOf to accept either name since this is a framework-internal detail.
 final _animatedBuilderElement = {
-  'element': anyOf('AnimatedBuilder', 'Builder'),
+  'element': anyOf('AnimatedBuilder', 'Builder')
 };
 
 void main() {
@@ -33,7 +33,9 @@ void main() {
     (tester) async {
       await tester.runAsync(() async {
         await tester.pumpWidget(
-          SentryUserInteractionWidget(child: MaterialApp()),
+          SentryUserInteractionWidget(
+            child: MaterialApp(),
+          ),
         );
       });
     },
@@ -116,24 +118,23 @@ void main() {
         await tapMe(tester, sut, 'btn_1');
 
         expect(
-          fixture.getBreadcrumb().data?.replaceHashCodes(),
-          equals({
-            'path': [
-              {'name': 'btn_1', 'element': 'MaterialButton'},
-              {'element': 'Column'},
-              {'element': 'Center'},
-              {'name': '[GlobalKey#00000]', 'element': 'KeyedSubtree'},
-              {'element': 'MediaQuery'},
-              {'name': '_ScaffoldSlot.body', 'element': 'LayoutId'},
-              {'element': 'CustomMultiChildLayout'},
-              {'element': 'Actions'},
-              _animatedBuilderElement,
-              {'element': 'DefaultTextStyle'},
-            ],
-            'view.id': 'btn_1',
-            'view.class': 'MaterialButton',
-          }),
-        );
+            fixture.getBreadcrumb().data?.replaceHashCodes(),
+            equals({
+              'path': [
+                {'name': 'btn_1', 'element': 'MaterialButton'},
+                {'element': 'Column'},
+                {'element': 'Center'},
+                {'name': '[GlobalKey#00000]', 'element': 'KeyedSubtree'},
+                {'element': 'MediaQuery'},
+                {'name': '_ScaffoldSlot.body', 'element': 'LayoutId'},
+                {'element': 'CustomMultiChildLayout'},
+                {'element': 'Actions'},
+                _animatedBuilderElement,
+                {'element': 'DefaultTextStyle'}
+              ],
+              'view.id': 'btn_1',
+              'view.class': 'MaterialButton',
+            }));
       });
     });
 
@@ -144,25 +145,24 @@ void main() {
         await tapMe(tester, sut, 'btn_1');
 
         expect(
-          fixture.getBreadcrumb().data?.replaceHashCodes(),
-          equals({
-            'path': [
-              {'name': 'btn_1', 'element': 'MaterialButton'},
-              {'element': 'Column'},
-              {'element': 'Center'},
-              {'name': '[GlobalKey#00000]', 'element': 'KeyedSubtree'},
-              {'element': 'MediaQuery'},
-              {'name': '_ScaffoldSlot.body', 'element': 'LayoutId'},
-              {'element': 'CustomMultiChildLayout'},
-              {'element': 'Actions'},
-              _animatedBuilderElement,
-              {'element': 'DefaultTextStyle'},
-            ],
-            'label': 'Button 1',
-            'view.id': 'btn_1',
-            'view.class': 'MaterialButton',
-          }),
-        );
+            fixture.getBreadcrumb().data?.replaceHashCodes(),
+            equals({
+              'path': [
+                {'name': 'btn_1', 'element': 'MaterialButton'},
+                {'element': 'Column'},
+                {'element': 'Center'},
+                {'name': '[GlobalKey#00000]', 'element': 'KeyedSubtree'},
+                {'element': 'MediaQuery'},
+                {'name': '_ScaffoldSlot.body', 'element': 'LayoutId'},
+                {'element': 'CustomMultiChildLayout'},
+                {'element': 'Actions'},
+                _animatedBuilderElement,
+                {'element': 'DefaultTextStyle'}
+              ],
+              'label': 'Button 1',
+              'view.id': 'btn_1',
+              'view.class': 'MaterialButton'
+            }));
       });
     });
 
@@ -173,25 +173,24 @@ void main() {
         await tapMe(tester, sut, 'btn_3');
 
         expect(
-          fixture.getBreadcrumb().data?.replaceHashCodes(),
-          equals({
-            'path': [
-              {'name': 'btn_3', 'element': 'IconButton'},
-              {'element': 'Column'},
-              {'element': 'Center'},
-              {'name': '[GlobalKey#00000]', 'element': 'KeyedSubtree'},
-              {'element': 'MediaQuery'},
-              {'name': '_ScaffoldSlot.body', 'element': 'LayoutId'},
-              {'element': 'CustomMultiChildLayout'},
-              {'element': 'Actions'},
-              _animatedBuilderElement,
-              {'element': 'DefaultTextStyle'},
-            ],
-            'label': 'My Icon',
-            'view.id': 'btn_3',
-            'view.class': 'IconButton',
-          }),
-        );
+            fixture.getBreadcrumb().data?.replaceHashCodes(),
+            equals({
+              'path': [
+                {'name': 'btn_3', 'element': 'IconButton'},
+                {'element': 'Column'},
+                {'element': 'Center'},
+                {'name': '[GlobalKey#00000]', 'element': 'KeyedSubtree'},
+                {'element': 'MediaQuery'},
+                {'name': '_ScaffoldSlot.body', 'element': 'LayoutId'},
+                {'element': 'CustomMultiChildLayout'},
+                {'element': 'Actions'},
+                _animatedBuilderElement,
+                {'element': 'DefaultTextStyle'}
+              ],
+              'label': 'My Icon',
+              'view.id': 'btn_3',
+              'view.class': 'IconButton'
+            }));
       });
     });
 
@@ -202,25 +201,24 @@ void main() {
         await tapMe(tester, sut, 'btn_2');
 
         expect(
-          fixture.getBreadcrumb().data?.replaceHashCodes(),
-          equals({
-            'path': [
-              {'name': 'btn_2', 'element': 'CupertinoButton'},
-              {'element': 'Column'},
-              {'element': 'Center'},
-              {'name': '[GlobalKey#00000]', 'element': 'KeyedSubtree'},
-              {'element': 'MediaQuery'},
-              {'name': '_ScaffoldSlot.body', 'element': 'LayoutId'},
-              {'element': 'CustomMultiChildLayout'},
-              {'element': 'Actions'},
-              _animatedBuilderElement,
-              {'element': 'DefaultTextStyle'},
-            ],
-            'label': 'Button 2',
-            'view.id': 'btn_2',
-            'view.class': 'CupertinoButton',
-          }),
-        );
+            fixture.getBreadcrumb().data?.replaceHashCodes(),
+            equals({
+              'path': [
+                {'name': 'btn_2', 'element': 'CupertinoButton'},
+                {'element': 'Column'},
+                {'element': 'Center'},
+                {'name': '[GlobalKey#00000]', 'element': 'KeyedSubtree'},
+                {'element': 'MediaQuery'},
+                {'name': '_ScaffoldSlot.body', 'element': 'LayoutId'},
+                {'element': 'CustomMultiChildLayout'},
+                {'element': 'Actions'},
+                _animatedBuilderElement,
+                {'element': 'DefaultTextStyle'}
+              ],
+              'label': 'Button 2',
+              'view.id': 'btn_2',
+              'view.class': 'CupertinoButton'
+            }));
       });
     });
 
@@ -239,14 +237,14 @@ void main() {
     });
 
     testWidgets(
-      'Add crumb for ElevatedButton within a GestureDetector with label',
-      (tester) async {
-        await tester.runAsync(() async {
-          final sut = fixture.getSut(sendDefaultPii: true);
+        'Add crumb for ElevatedButton within a GestureDetector with label',
+        (tester) async {
+      await tester.runAsync(() async {
+        final sut = fixture.getSut(sendDefaultPii: true);
 
-          await tapMe(tester, sut, 'btn_5');
+        await tapMe(tester, sut, 'btn_5');
 
-          expect(
+        expect(
             fixture.getBreadcrumb().data?.replaceHashCodes(),
             equals({
               'path': [
@@ -259,16 +257,14 @@ void main() {
                 {'element': 'DefaultTextStyle'},
                 {'element': 'AnimatedDefaultTextStyle'},
                 {'element': 'NotificationListener<LayoutChangedNotification>'},
-                {'element': 'CustomPaint'},
+                {'element': 'CustomPaint'}
               ],
               'label': 'Button 5',
               'view.id': 'btn_5',
-              'view.class': 'ButtonStyleButton',
-            }),
-          );
-        });
-      },
-    );
+              'view.class': 'ButtonStyleButton'
+            }));
+      });
+    });
 
     testWidgets('Add crumb for PopupMenuButton', (tester) async {
       await tester.runAsync(() async {
@@ -277,24 +273,23 @@ void main() {
         await tapMe(tester, sut, 'popup_menu_button');
 
         expect(
-          fixture.getBreadcrumb().data?.replaceHashCodes(),
-          equals({
-            'path': [
-              {'name': 'popup_menu_button', 'element': 'PopupMenuButton'},
-              {'element': 'Column'},
-              {'element': 'Center'},
-              {'name': '[GlobalKey#00000]', 'element': 'KeyedSubtree'},
-              {'element': 'MediaQuery'},
-              {'name': '_ScaffoldSlot.body', 'element': 'LayoutId'},
-              {'element': 'CustomMultiChildLayout'},
-              {'element': 'Actions'},
-              _animatedBuilderElement,
-              {'element': 'DefaultTextStyle'},
-            ],
-            'view.id': 'popup_menu_button',
-            'view.class': 'PopupMenuButton',
-          }),
-        );
+            fixture.getBreadcrumb().data?.replaceHashCodes(),
+            equals({
+              'path': [
+                {'name': 'popup_menu_button', 'element': 'PopupMenuButton'},
+                {'element': 'Column'},
+                {'element': 'Center'},
+                {'name': '[GlobalKey#00000]', 'element': 'KeyedSubtree'},
+                {'element': 'MediaQuery'},
+                {'name': '_ScaffoldSlot.body', 'element': 'LayoutId'},
+                {'element': 'CustomMultiChildLayout'},
+                {'element': 'Actions'},
+                _animatedBuilderElement,
+                {'element': 'DefaultTextStyle'}
+              ],
+              'view.id': 'popup_menu_button',
+              'view.class': 'PopupMenuButton'
+            }));
       });
     });
 
@@ -309,27 +304,26 @@ void main() {
         await tapMe(tester, sut, 'popup_menu_item_1');
 
         expect(
-          fixture.getBreadcrumb().data?.replaceHashCodes(),
-          equals({
-            'path': [
-              {'name': 'popup_menu_item_1', 'element': 'PopupMenuItem'},
-              {'name': '[GlobalKey#00000]', 'element': 'FadeTransition'},
-              {'element': 'ListBody'},
-              {'element': 'Padding'},
-              {'name': '[GlobalKey#00000]', 'element': 'IgnorePointer'},
-              {'element': 'Semantics'},
-              {'element': 'Listener'},
-              {
-                'name': '[LabeledGlobalKey<RawGestureDetectorState>#00000]',
-                'element': 'RawGestureDetector',
-              },
-              {'element': 'Listener'},
-              {'element': 'NotificationListener<ScrollMetricsNotification>'},
-            ],
-            'view.id': 'popup_menu_item_1',
-            'view.class': 'PopupMenuItem',
-          }),
-        );
+            fixture.getBreadcrumb().data?.replaceHashCodes(),
+            equals({
+              'path': [
+                {'name': 'popup_menu_item_1', 'element': 'PopupMenuItem'},
+                {'name': '[GlobalKey#00000]', 'element': 'FadeTransition'},
+                {'element': 'ListBody'},
+                {'element': 'Padding'},
+                {'name': '[GlobalKey#00000]', 'element': 'IgnorePointer'},
+                {'element': 'Semantics'},
+                {'element': 'Listener'},
+                {
+                  'name': '[LabeledGlobalKey<RawGestureDetectorState>#00000]',
+                  'element': 'RawGestureDetector'
+                },
+                {'element': 'Listener'},
+                {'element': 'NotificationListener<ScrollMetricsNotification>'}
+              ],
+              'view.id': 'popup_menu_item_1',
+              'view.class': 'PopupMenuItem'
+            }));
       });
     });
 
@@ -346,88 +340,74 @@ void main() {
         expect(data?['label'], equals('Button text'));
         expect(data?['view.id'], equals('tooltip_button'));
         expect(data?['view.class'], equals('ButtonStyleButton'));
+        expect(path?.first,
+            equals({'name': 'tooltip_button', 'element': 'ButtonStyleButton'}));
         expect(
-          path?.first,
-          equals({'name': 'tooltip_button', 'element': 'ButtonStyleButton'}),
-        );
-        expect(
-          path?.any(
-            (element) =>
+            path?.any((element) =>
                 element['element'] == 'Tooltip' &&
-                element['label'] == 'Tooltip message.',
-          ),
-          isTrue,
-        );
+                element['label'] == 'Tooltip message.'),
+            isTrue);
       });
     });
 
     // Regression test for https://github.com/getsentry/sentry-dart/issues/1208
     testWidgets(
-      'Add crumb for button on Page2 not Page1 when pages are stacked',
-      (tester) async {
-        await tester.runAsync(() async {
-          final sut = fixture.getSut();
+        'Add crumb for button on Page2 not Page1 when pages are stacked',
+        (tester) async {
+      await tester.runAsync(() async {
+        final sut = fixture.getSut();
 
-          await tester.pumpWidget(sut);
+        await tester.pumpWidget(sut);
 
-          // Navigate to Page2 (Page1 stays behind in the nav stack).
-          await tester.tap(find.byKey(Key('btn_go_to_page2')));
-          await tester.pumpAndSettle();
+        // Navigate to Page2 (Page1 stays behind in the nav stack).
+        await tester.tap(find.byKey(Key('btn_go_to_page2')));
+        await tester.pumpAndSettle();
 
-          // Page2's btn_page_2 fills the entire screen (SizedBox.expand).
-          // Tap at btn_1's center, which is inside both buttons' bounds.
-          final btn1Center = tester.getCenter(
-            find.byKey(Key('btn_1'), skipOffstage: false),
-          );
-          await tester.tapAt(btn1Center);
+        // Page2's btn_page_2 fills the entire screen (SizedBox.expand).
+        // Tap at btn_1's center, which is inside both buttons' bounds.
+        final btn1Center =
+            tester.getCenter(find.byKey(Key('btn_1'), skipOffstage: false));
+        await tester.tapAt(btn1Center);
 
-          final data = fixture.getBreadcrumb().data;
-          expect(
-            data?['view.id'],
-            equals('btn_page_2'),
-            reason:
-                'Should identify the Page2 button, not the Page1 button '
-                'behind it in the navigation stack',
-          );
-          expect(data?['view.class'], equals('MaterialButton'));
-        });
-      },
-    );
+        final data = fixture.getBreadcrumb().data;
+        expect(data?['view.id'], equals('btn_page_2'),
+            reason: 'Should identify the Page2 button, not the Page1 button '
+                'behind it in the navigation stack');
+        expect(data?['view.class'], equals('MaterialButton'));
+      });
+    });
 
     testWidgets('Add crumb for button without key', (tester) async {
       await tester.runAsync(() async {
         final sut = fixture.getSut(sendDefaultPii: true);
 
         await tester.pumpWidget(sut);
-        await tester.tap(
-          find.byElementPredicate((element) {
-            final widget = element.widget;
-            if (widget is MaterialButton) {
-              return (widget.child as Text).data == 'Button 5';
-            }
-            return false;
-          }),
-        );
+        await tester.tap(find.byElementPredicate((element) {
+          final widget = element.widget;
+          if (widget is MaterialButton) {
+            return (widget.child as Text).data == 'Button 5';
+          }
+          return false;
+        }));
 
         expect(
-          fixture.getBreadcrumb().data?.replaceHashCodes(),
-          equals({
-            'path': [
-              {'element': 'MaterialButton'},
-              {'element': 'Column'},
-              {'element': 'Center'},
-              {'name': '[GlobalKey#00000]', 'element': 'KeyedSubtree'},
-              {'element': 'MediaQuery'},
-              {'name': '_ScaffoldSlot.body', 'element': 'LayoutId'},
-              {'element': 'CustomMultiChildLayout'},
-              {'element': 'Actions'},
-              _animatedBuilderElement,
-              {'element': 'DefaultTextStyle'},
-            ],
-            'label': 'Button 5',
-            'view.class': 'MaterialButton',
-          }),
-        );
+            fixture.getBreadcrumb().data?.replaceHashCodes(),
+            equals({
+              'path': [
+                {'element': 'MaterialButton'},
+                {'element': 'Column'},
+                {'element': 'Center'},
+                {'name': '[GlobalKey#00000]', 'element': 'KeyedSubtree'},
+                {'element': 'MediaQuery'},
+                {'name': '_ScaffoldSlot.body', 'element': 'LayoutId'},
+                {'element': 'CustomMultiChildLayout'},
+                {'element': 'Actions'},
+                _animatedBuilderElement,
+                {'element': 'DefaultTextStyle'}
+              ],
+              'label': 'Button 5',
+              'view.class': 'MaterialButton'
+            }));
       });
     });
   });
@@ -442,16 +422,15 @@ void main() {
     testWidgets('Adds integration if enabled', (tester) async {
       await tester.runAsync(() async {
         final sut = fixture.getSut(
-          enableUserInteractionTracing: true,
-          enableUserInteractionBreadcrumbs: false,
-        );
+            enableUserInteractionTracing: true,
+            enableUserInteractionBreadcrumbs: false);
 
         await tester.pumpWidget(sut);
 
         expect(
-          fixture._options.sdk.integrations.contains('UserInteractionTracing'),
-          true,
-        );
+            fixture._options.sdk.integrations
+                .contains('UserInteractionTracing'),
+            true);
       });
     });
 
@@ -462,18 +441,17 @@ void main() {
         await tester.pumpWidget(sut);
 
         expect(
-          fixture._options.sdk.integrations.contains('UserInteractionTracing'),
-          false,
-        );
+            fixture._options.sdk.integrations
+                .contains('UserInteractionTracing'),
+            false);
       });
     });
 
     testWidgets('Start transaction and set in the scope', (tester) async {
       await tester.runAsync(() async {
         final sut = fixture.getSut(
-          enableUserInteractionTracing: true,
-          enableUserInteractionBreadcrumbs: false,
-        );
+            enableUserInteractionTracing: true,
+            enableUserInteractionBreadcrumbs: false);
 
         await tapMe(tester, sut, 'btn_1');
 
@@ -483,22 +461,18 @@ void main() {
         });
         expect(tracer?.name, 'btn_1');
         expect(tracer?.context.operation, 'ui.action.click');
-        expect(
-          tracer?.transactionNameSource,
-          SentryTransactionNameSource.component,
-        );
+        expect(tracer?.transactionNameSource,
+            SentryTransactionNameSource.component);
         expect(tracer?.autoFinishAfterTimer, isNotNull);
       });
     });
 
-    testWidgets('Start transaction and do not set in the scope if any', (
-      tester,
-    ) async {
+    testWidgets('Start transaction and do not set in the scope if any',
+        (tester) async {
       await tester.runAsync(() async {
         final sut = fixture.getSut(
-          enableUserInteractionTracing: true,
-          enableUserInteractionBreadcrumbs: false,
-        );
+            enableUserInteractionTracing: true,
+            enableUserInteractionBreadcrumbs: false);
 
         fixture.hub.configureScope((scope) {
           scope.span = NoOpSentrySpan();
@@ -515,73 +489,67 @@ void main() {
     });
 
     testWidgets(
-      'Cancel transaction if already started for same widget and start new one',
-      (tester) async {
-        await tester.runAsync(() async {
-          final sut = fixture.getSut(
-            enableUserInteractionTracing: true,
-            enableUserInteractionBreadcrumbs: false,
-          );
-
-          await tapMe(tester, sut, 'btn_1');
-          SentryTracer? initialTracer;
-
-          fixture.hub.configureScope((scope) {
-            initialTracer = (scope.span as SentryTracer);
-          });
-
-          await tapMe(tester, sut, 'btn_1');
-
-          SentryTracer? tracer;
-          fixture.hub.configureScope((scope) {
-            tracer = (scope.span as SentryTracer);
-          });
-          expect(initialTracer?.finished, isTrue);
-          expect(initialTracer?.status, equals(SpanStatus.cancelled()));
-
-          expect(initialTracer, isNot(equals(tracer)));
-        });
-      },
-    );
-
-    testWidgets(
-      'Finish transaction if already started with children for same widget and start new one',
-      (tester) async {
-        await tester.runAsync(() async {
-          final sut = fixture.getSut(
-            enableUserInteractionTracing: true,
-            enableUserInteractionBreadcrumbs: false,
-          );
-
-          await tapMe(tester, sut, 'btn_1');
-          SentryTracer? initialTracer;
-
-          await fixture.hub.configureScope((scope) async {
-            initialTracer = (scope.span as SentryTracer);
-            final child = initialTracer?.startChild("btn_1_child");
-            await child?.finish();
-          });
-
-          await tapMe(tester, sut, 'btn_1');
-
-          SentryTracer? tracer;
-          fixture.hub.configureScope((scope) {
-            tracer = (scope.span as SentryTracer);
-          });
-          expect(initialTracer?.finished, isTrue);
-          expect(initialTracer, isNot(equals(tracer)));
-        });
-      },
-    );
-
-    testWidgets('Finish transaction and start new one if new tap', (
-      tester,
-    ) async {
+        'Cancel transaction if already started for same widget and start new one',
+        (tester) async {
       await tester.runAsync(() async {
         final sut = fixture.getSut(
-          enableUserInteractionTracing: true,
-          enableUserInteractionBreadcrumbs: false,
-        );
+            enableUserInteractionTracing: true,
+            enableUserInteractionBreadcrumbs: false);
+
+        await tapMe(tester, sut, 'btn_1');
+        SentryTracer? initialTracer;
+
+        fixture.hub.configureScope((scope) {
+          initialTracer = (scope.span as SentryTracer);
+        });
+
+        await tapMe(tester, sut, 'btn_1');
+
+        SentryTracer? tracer;
+        fixture.hub.configureScope((scope) {
+          tracer = (scope.span as SentryTracer);
+        });
+        expect(initialTracer?.finished, isTrue);
+        expect(initialTracer?.status, equals(SpanStatus.cancelled()));
+
+        expect(initialTracer, isNot(equals(tracer)));
+      });
+    });
+
+    testWidgets(
+        'Finish transaction if already started with children for same widget and start new one',
+        (tester) async {
+      await tester.runAsync(() async {
+        final sut = fixture.getSut(
+            enableUserInteractionTracing: true,
+            enableUserInteractionBreadcrumbs: false);
+
+        await tapMe(tester, sut, 'btn_1');
+        SentryTracer? initialTracer;
+
+        await fixture.hub.configureScope((scope) async {
+          initialTracer = (scope.span as SentryTracer);
+          final child = initialTracer?.startChild("btn_1_child");
+          await child?.finish();
+        });
+
+        await tapMe(tester, sut, 'btn_1');
+
+        SentryTracer? tracer;
+        fixture.hub.configureScope((scope) {
+          tracer = (scope.span as SentryTracer);
+        });
+        expect(initialTracer?.finished, isTrue);
+        expect(initialTracer, isNot(equals(tracer)));
+      });
+    });
+
+    testWidgets('Finish transaction and start new one if new tap',
+        (tester) async {
+      await tester.runAsync(() async {
+        final sut = fixture.getSut(
+            enableUserInteractionTracing: true,
+            enableUserInteractionBreadcrumbs: false);
 
         await tapMe(tester, sut, 'btn_1');
         SentryTracer? currentTracer;
@@ -634,9 +602,8 @@ void main() {
       });
     });
 
-    testWidgets('does not start idle span when ui.load span is active', (
-      tester,
-    ) async {
+    testWidgets('does not start idle span when ui.load span is active',
+        (tester) async {
       await tester.runAsync(() async {
         final sut = fixture.getSut(
           enableUserInteractionTracing: true,
@@ -648,9 +615,8 @@ void main() {
         fixture.hub.startIdleSpan(
           'ui.load',
           attributes: {
-            SemanticAttributesConstants.sentryOp: SentryAttribute.string(
-              SentrySpanOperations.uiLoad,
-            ),
+            SemanticAttributesConstants.sentryOp:
+                SentryAttribute.string(SentrySpanOperations.uiLoad),
           },
         );
         final loadSpan = fixture.hub.getActiveSpan();
@@ -663,9 +629,8 @@ void main() {
       });
     });
 
-    testWidgets('resets idle timer when same widget is tapped again', (
-      tester,
-    ) async {
+    testWidgets('resets idle timer when same widget is tapped again',
+        (tester) async {
       await tester.runAsync(() async {
         final sut = fixture.getSut(
           enableUserInteractionTracing: true,
@@ -687,44 +652,43 @@ void main() {
     });
 
     testWidgets(
-      'cancels previous idle span when tapping different widget after activity',
-      (tester) async {
-        await tester.runAsync(() async {
-          final sut = fixture.getSut(
-            enableUserInteractionTracing: true,
-            enableUserInteractionBreadcrumbs: false,
-            traceLifecycle: SentryTraceLifecycle.stream,
-          );
+        'cancels previous idle span when tapping different widget after activity',
+        (tester) async {
+      await tester.runAsync(() async {
+        final sut = fixture.getSut(
+          enableUserInteractionTracing: true,
+          enableUserInteractionBreadcrumbs: false,
+          traceLifecycle: SentryTraceLifecycle.stream,
+        );
 
-          await tapMe(tester, sut, 'btn_1');
-          final firstSpan = fixture.hub.getActiveSpan();
-          expect(firstSpan, isA<IdleRecordingSentrySpanV2>());
+        await tapMe(tester, sut, 'btn_1');
+        final firstSpan = fixture.hub.getActiveSpan();
+        expect(firstSpan, isA<IdleRecordingSentrySpanV2>());
 
-          // Simulate descendant activity by starting a child span
-          fixture.hub.startSpanSync('child-work', (_) {});
+        // Simulate descendant activity by starting a child span
+        fixture.hub.startSpanSync('child-work', (_) {});
 
-          await Future<void>.delayed(Duration.zero);
-          // Tap a different widget
-          await tapMe(tester, sut, 'btn_2', pumpWidget: false);
+        await Future<void>.delayed(Duration.zero);
+        // Tap a different widget
+        await tapMe(tester, sut, 'btn_2', pumpWidget: false);
 
-          // First span should be cancelled
-          expect(firstSpan!.isEnded, isTrue);
-          expect(firstSpan.status, SentrySpanStatusV2.ok);
-          expect(
-            firstSpan
-                .attributes[SemanticAttributesConstants
-                    .sentryIdleSpanFinishReason]
-                ?.value,
-            'cancelled',
-          );
+        // First span should be cancelled
+        expect(firstSpan!.isEnded, isTrue);
+        expect(firstSpan.status, SentrySpanStatusV2.ok);
+        expect(
+          firstSpan
+              .attributes[
+                  SemanticAttributesConstants.sentryIdleSpanFinishReason]
+              ?.value,
+          'cancelled',
+        );
 
-          // New idle span should be started for btn_2
-          final newSpan = fixture.hub.getActiveSpan();
-          expect(newSpan, isA<IdleRecordingSentrySpanV2>());
-          expect(newSpan?.name, 'btn_2');
-        });
-      },
-    );
+        // New idle span should be started for btn_2
+        final newSpan = fixture.hub.getActiveSpan();
+        expect(newSpan, isA<IdleRecordingSentrySpanV2>());
+        expect(newSpan?.name, 'btn_2');
+      });
+    });
   });
 
   // Regression tests for https://github.com/getsentry/sentry-dart/issues/3503
@@ -735,22 +699,20 @@ void main() {
         final hitTestPositions = <Offset>[];
         final hitNotifier = ValueNotifier<Offset?>(null);
 
-        await tester.pumpWidget(
-          fixture.getSut(
-            child: MaterialApp(
-              home: Scaffold(
-                body: GestureDetector(
-                  onTap: () {},
-                  child: HitTestTracker(
-                    hitTestPositions: hitTestPositions,
-                    hitNotifier: hitNotifier,
-                    child: const SizedBox.expand(),
-                  ),
+        await tester.pumpWidget(fixture.getSut(
+          child: MaterialApp(
+            home: Scaffold(
+              body: GestureDetector(
+                onTap: () {},
+                child: HitTestTracker(
+                  hitTestPositions: hitTestPositions,
+                  hitNotifier: hitNotifier,
+                  child: const SizedBox.expand(),
                 ),
               ),
             ),
           ),
-        );
+        ));
 
         hitTestPositions.clear();
 
@@ -763,13 +725,9 @@ void main() {
         await gesture.up();
         await tester.pumpAndSettle();
 
-        expect(
-          hitTestPositions.length,
-          equals(hitTestCountAfterDown),
-          reason:
-              'SentryUserInteractionWidget should not re-trigger '
-              'hitTest on pointerUp',
-        );
+        expect(hitTestPositions.length, equals(hitTestCountAfterDown),
+            reason: 'SentryUserInteractionWidget should not re-trigger '
+                'hitTest on pointerUp');
       },
     );
 
@@ -779,22 +737,20 @@ void main() {
         final hitTestPositions = <Offset>[];
         final hitNotifier = ValueNotifier<Offset?>(null);
 
-        await tester.pumpWidget(
-          fixture.getSut(
-            child: MaterialApp(
-              home: Scaffold(
-                body: GestureDetector(
-                  onTap: () {},
-                  child: HitTestTracker(
-                    hitTestPositions: hitTestPositions,
-                    hitNotifier: hitNotifier,
-                    child: const SizedBox.expand(),
-                  ),
+        await tester.pumpWidget(fixture.getSut(
+          child: MaterialApp(
+            home: Scaffold(
+              body: GestureDetector(
+                onTap: () {},
+                child: HitTestTracker(
+                  hitTestPositions: hitTestPositions,
+                  hitNotifier: hitNotifier,
+                  child: const SizedBox.expand(),
                 ),
               ),
             ),
           ),
-        );
+        ));
 
         final center = tester.getCenter(find.byType(SizedBox).last);
         final gesture = await tester.startGesture(center);
@@ -807,13 +763,9 @@ void main() {
         await gesture.up();
         await tester.pumpAndSettle();
 
-        expect(
-          hitNotifier.value,
-          isNull,
-          reason:
-              'SentryUserInteractionWidget should not overwrite '
-              'hitNotifier during pointerUp',
-        );
+        expect(hitNotifier.value, isNull,
+            reason: 'SentryUserInteractionWidget should not overwrite '
+                'hitNotifier during pointerUp');
       },
     );
   });
@@ -859,7 +811,10 @@ class Fixture {
 
     hub = Hub(_options);
 
-    return SentryUserInteractionWidget(hub: hub, child: child ?? MyApp());
+    return SentryUserInteractionWidget(
+      hub: hub,
+      child: child ?? MyApp(),
+    );
   }
 
   Breadcrumb getBreadcrumb() {
@@ -906,7 +861,10 @@ class Page1 extends StatelessWidget {
             IconButton(
               key: Key('btn_3'),
               onPressed: () {},
-              icon: Icon(Icons.dark_mode, semanticLabel: 'My Icon'),
+              icon: Icon(
+                Icons.dark_mode,
+                semanticLabel: 'My Icon',
+              ),
             ),
             Card(
               child: GestureDetector(
@@ -948,7 +906,10 @@ class Page1 extends StatelessWidget {
                 child: Text('Button text'),
               ),
             ),
-            MaterialButton(onPressed: () {}, child: const Text('Button 5')),
+            MaterialButton(
+              onPressed: () {},
+              child: const Text('Button 5'),
+            ),
           ],
         ),
       ),
@@ -979,29 +940,29 @@ extension on String {
 
 extension on Map<dynamic, dynamic> {
   Map<dynamic, dynamic> replaceHashCodes() => map((key, value) {
-    if (value is String) {
-      value = value.replaceHashCodes();
-    } else if (value is Map) {
-      value = value.replaceHashCodes();
-    } else if (value is List) {
-      value = value.replaceHashCodes();
-    }
-    return MapEntry(key, value);
-  });
+        if (value is String) {
+          value = value.replaceHashCodes();
+        } else if (value is Map) {
+          value = value.replaceHashCodes();
+        } else if (value is List) {
+          value = value.replaceHashCodes();
+        }
+        return MapEntry(key, value);
+      });
 }
 
 extension on List<dynamic> {
   Iterable<dynamic> replaceHashCodes() => map((value) {
-    if (value is String) {
-      return value.replaceHashCodes();
-    } else if (value is Map) {
-      return value.replaceHashCodes();
-    } else if (value is List) {
-      return value.replaceHashCodes();
-    } else {
-      return value;
-    }
-  });
+        if (value is String) {
+          return value.replaceHashCodes();
+        } else if (value is Map) {
+          return value.replaceHashCodes();
+        } else if (value is List) {
+          return value.replaceHashCodes();
+        } else {
+          return value;
+        }
+      });
 }
 
 /// A widget whose [RenderBox] records every [hitTest] call and updates a
@@ -1028,9 +989,7 @@ class HitTestTracker extends SingleChildRenderObjectWidget {
 
   @override
   void updateRenderObject(
-    BuildContext context,
-    RenderHitTestTracker renderObject,
-  ) {
+      BuildContext context, RenderHitTestTracker renderObject) {
     renderObject
       ..hitTestPositions = hitTestPositions
       ..hitNotifier = hitNotifier;
@@ -1041,8 +1000,8 @@ class RenderHitTestTracker extends RenderProxyBox {
   RenderHitTestTracker({
     required List<Offset> hitTestPositions,
     required ValueNotifier<Offset?> hitNotifier,
-  }) : _hitTestPositions = hitTestPositions,
-       _hitNotifier = hitNotifier;
+  })  : _hitTestPositions = hitTestPositions,
+        _hitNotifier = hitNotifier;
 
   List<Offset> _hitTestPositions;
   set hitTestPositions(List<Offset> value) => _hitTestPositions = value;

--- a/packages/flutter/test/user_interaction/sentry_user_interaction_widget_test.dart
+++ b/packages/flutter/test/user_interaction/sentry_user_interaction_widget_test.dart
@@ -18,7 +18,7 @@ import '../mocks.mocks.dart';
 // The Scaffold widget tree uses AnimatedBuilder on stable but Builder on beta.
 // Use anyOf to accept either name since this is a framework-internal detail.
 final _animatedBuilderElement = {
-  'element': anyOf('AnimatedBuilder', 'Builder')
+  'element': anyOf('AnimatedBuilder', 'Builder'),
 };
 
 void main() {
@@ -33,9 +33,7 @@ void main() {
     (tester) async {
       await tester.runAsync(() async {
         await tester.pumpWidget(
-          SentryUserInteractionWidget(
-            child: MaterialApp(),
-          ),
+          SentryUserInteractionWidget(child: MaterialApp()),
         );
       });
     },
@@ -118,23 +116,24 @@ void main() {
         await tapMe(tester, sut, 'btn_1');
 
         expect(
-            fixture.getBreadcrumb().data?.replaceHashCodes(),
-            equals({
-              'path': [
-                {'name': 'btn_1', 'element': 'MaterialButton'},
-                {'element': 'Column'},
-                {'element': 'Center'},
-                {'name': '[GlobalKey#00000]', 'element': 'KeyedSubtree'},
-                {'element': 'MediaQuery'},
-                {'name': '_ScaffoldSlot.body', 'element': 'LayoutId'},
-                {'element': 'CustomMultiChildLayout'},
-                {'element': 'Actions'},
-                _animatedBuilderElement,
-                {'element': 'DefaultTextStyle'}
-              ],
-              'view.id': 'btn_1',
-              'view.class': 'MaterialButton',
-            }));
+          fixture.getBreadcrumb().data?.replaceHashCodes(),
+          equals({
+            'path': [
+              {'name': 'btn_1', 'element': 'MaterialButton'},
+              {'element': 'Column'},
+              {'element': 'Center'},
+              {'name': '[GlobalKey#00000]', 'element': 'KeyedSubtree'},
+              {'element': 'MediaQuery'},
+              {'name': '_ScaffoldSlot.body', 'element': 'LayoutId'},
+              {'element': 'CustomMultiChildLayout'},
+              {'element': 'Actions'},
+              _animatedBuilderElement,
+              {'element': 'DefaultTextStyle'},
+            ],
+            'view.id': 'btn_1',
+            'view.class': 'MaterialButton',
+          }),
+        );
       });
     });
 
@@ -145,24 +144,25 @@ void main() {
         await tapMe(tester, sut, 'btn_1');
 
         expect(
-            fixture.getBreadcrumb().data?.replaceHashCodes(),
-            equals({
-              'path': [
-                {'name': 'btn_1', 'element': 'MaterialButton'},
-                {'element': 'Column'},
-                {'element': 'Center'},
-                {'name': '[GlobalKey#00000]', 'element': 'KeyedSubtree'},
-                {'element': 'MediaQuery'},
-                {'name': '_ScaffoldSlot.body', 'element': 'LayoutId'},
-                {'element': 'CustomMultiChildLayout'},
-                {'element': 'Actions'},
-                _animatedBuilderElement,
-                {'element': 'DefaultTextStyle'}
-              ],
-              'label': 'Button 1',
-              'view.id': 'btn_1',
-              'view.class': 'MaterialButton'
-            }));
+          fixture.getBreadcrumb().data?.replaceHashCodes(),
+          equals({
+            'path': [
+              {'name': 'btn_1', 'element': 'MaterialButton'},
+              {'element': 'Column'},
+              {'element': 'Center'},
+              {'name': '[GlobalKey#00000]', 'element': 'KeyedSubtree'},
+              {'element': 'MediaQuery'},
+              {'name': '_ScaffoldSlot.body', 'element': 'LayoutId'},
+              {'element': 'CustomMultiChildLayout'},
+              {'element': 'Actions'},
+              _animatedBuilderElement,
+              {'element': 'DefaultTextStyle'},
+            ],
+            'label': 'Button 1',
+            'view.id': 'btn_1',
+            'view.class': 'MaterialButton',
+          }),
+        );
       });
     });
 
@@ -173,24 +173,25 @@ void main() {
         await tapMe(tester, sut, 'btn_3');
 
         expect(
-            fixture.getBreadcrumb().data?.replaceHashCodes(),
-            equals({
-              'path': [
-                {'name': 'btn_3', 'element': 'IconButton'},
-                {'element': 'Column'},
-                {'element': 'Center'},
-                {'name': '[GlobalKey#00000]', 'element': 'KeyedSubtree'},
-                {'element': 'MediaQuery'},
-                {'name': '_ScaffoldSlot.body', 'element': 'LayoutId'},
-                {'element': 'CustomMultiChildLayout'},
-                {'element': 'Actions'},
-                _animatedBuilderElement,
-                {'element': 'DefaultTextStyle'}
-              ],
-              'label': 'My Icon',
-              'view.id': 'btn_3',
-              'view.class': 'IconButton'
-            }));
+          fixture.getBreadcrumb().data?.replaceHashCodes(),
+          equals({
+            'path': [
+              {'name': 'btn_3', 'element': 'IconButton'},
+              {'element': 'Column'},
+              {'element': 'Center'},
+              {'name': '[GlobalKey#00000]', 'element': 'KeyedSubtree'},
+              {'element': 'MediaQuery'},
+              {'name': '_ScaffoldSlot.body', 'element': 'LayoutId'},
+              {'element': 'CustomMultiChildLayout'},
+              {'element': 'Actions'},
+              _animatedBuilderElement,
+              {'element': 'DefaultTextStyle'},
+            ],
+            'label': 'My Icon',
+            'view.id': 'btn_3',
+            'view.class': 'IconButton',
+          }),
+        );
       });
     });
 
@@ -201,24 +202,25 @@ void main() {
         await tapMe(tester, sut, 'btn_2');
 
         expect(
-            fixture.getBreadcrumb().data?.replaceHashCodes(),
-            equals({
-              'path': [
-                {'name': 'btn_2', 'element': 'CupertinoButton'},
-                {'element': 'Column'},
-                {'element': 'Center'},
-                {'name': '[GlobalKey#00000]', 'element': 'KeyedSubtree'},
-                {'element': 'MediaQuery'},
-                {'name': '_ScaffoldSlot.body', 'element': 'LayoutId'},
-                {'element': 'CustomMultiChildLayout'},
-                {'element': 'Actions'},
-                _animatedBuilderElement,
-                {'element': 'DefaultTextStyle'}
-              ],
-              'label': 'Button 2',
-              'view.id': 'btn_2',
-              'view.class': 'CupertinoButton'
-            }));
+          fixture.getBreadcrumb().data?.replaceHashCodes(),
+          equals({
+            'path': [
+              {'name': 'btn_2', 'element': 'CupertinoButton'},
+              {'element': 'Column'},
+              {'element': 'Center'},
+              {'name': '[GlobalKey#00000]', 'element': 'KeyedSubtree'},
+              {'element': 'MediaQuery'},
+              {'name': '_ScaffoldSlot.body', 'element': 'LayoutId'},
+              {'element': 'CustomMultiChildLayout'},
+              {'element': 'Actions'},
+              _animatedBuilderElement,
+              {'element': 'DefaultTextStyle'},
+            ],
+            'label': 'Button 2',
+            'view.id': 'btn_2',
+            'view.class': 'CupertinoButton',
+          }),
+        );
       });
     });
 
@@ -237,14 +239,14 @@ void main() {
     });
 
     testWidgets(
-        'Add crumb for ElevatedButton within a GestureDetector with label',
-        (tester) async {
-      await tester.runAsync(() async {
-        final sut = fixture.getSut(sendDefaultPii: true);
+      'Add crumb for ElevatedButton within a GestureDetector with label',
+      (tester) async {
+        await tester.runAsync(() async {
+          final sut = fixture.getSut(sendDefaultPii: true);
 
-        await tapMe(tester, sut, 'btn_5');
+          await tapMe(tester, sut, 'btn_5');
 
-        expect(
+          expect(
             fixture.getBreadcrumb().data?.replaceHashCodes(),
             equals({
               'path': [
@@ -257,14 +259,16 @@ void main() {
                 {'element': 'DefaultTextStyle'},
                 {'element': 'AnimatedDefaultTextStyle'},
                 {'element': 'NotificationListener<LayoutChangedNotification>'},
-                {'element': 'CustomPaint'}
+                {'element': 'CustomPaint'},
               ],
               'label': 'Button 5',
               'view.id': 'btn_5',
-              'view.class': 'ButtonStyleButton'
-            }));
-      });
-    });
+              'view.class': 'ButtonStyleButton',
+            }),
+          );
+        });
+      },
+    );
 
     testWidgets('Add crumb for PopupMenuButton', (tester) async {
       await tester.runAsync(() async {
@@ -273,23 +277,24 @@ void main() {
         await tapMe(tester, sut, 'popup_menu_button');
 
         expect(
-            fixture.getBreadcrumb().data?.replaceHashCodes(),
-            equals({
-              'path': [
-                {'name': 'popup_menu_button', 'element': 'PopupMenuButton'},
-                {'element': 'Column'},
-                {'element': 'Center'},
-                {'name': '[GlobalKey#00000]', 'element': 'KeyedSubtree'},
-                {'element': 'MediaQuery'},
-                {'name': '_ScaffoldSlot.body', 'element': 'LayoutId'},
-                {'element': 'CustomMultiChildLayout'},
-                {'element': 'Actions'},
-                _animatedBuilderElement,
-                {'element': 'DefaultTextStyle'}
-              ],
-              'view.id': 'popup_menu_button',
-              'view.class': 'PopupMenuButton'
-            }));
+          fixture.getBreadcrumb().data?.replaceHashCodes(),
+          equals({
+            'path': [
+              {'name': 'popup_menu_button', 'element': 'PopupMenuButton'},
+              {'element': 'Column'},
+              {'element': 'Center'},
+              {'name': '[GlobalKey#00000]', 'element': 'KeyedSubtree'},
+              {'element': 'MediaQuery'},
+              {'name': '_ScaffoldSlot.body', 'element': 'LayoutId'},
+              {'element': 'CustomMultiChildLayout'},
+              {'element': 'Actions'},
+              _animatedBuilderElement,
+              {'element': 'DefaultTextStyle'},
+            ],
+            'view.id': 'popup_menu_button',
+            'view.class': 'PopupMenuButton',
+          }),
+        );
       });
     });
 
@@ -304,26 +309,27 @@ void main() {
         await tapMe(tester, sut, 'popup_menu_item_1');
 
         expect(
-            fixture.getBreadcrumb().data?.replaceHashCodes(),
-            equals({
-              'path': [
-                {'name': 'popup_menu_item_1', 'element': 'PopupMenuItem'},
-                {'name': '[GlobalKey#00000]', 'element': 'FadeTransition'},
-                {'element': 'ListBody'},
-                {'element': 'Padding'},
-                {'name': '[GlobalKey#00000]', 'element': 'IgnorePointer'},
-                {'element': 'Semantics'},
-                {'element': 'Listener'},
-                {
-                  'name': '[LabeledGlobalKey<RawGestureDetectorState>#00000]',
-                  'element': 'RawGestureDetector'
-                },
-                {'element': 'Listener'},
-                {'element': 'NotificationListener<ScrollMetricsNotification>'}
-              ],
-              'view.id': 'popup_menu_item_1',
-              'view.class': 'PopupMenuItem'
-            }));
+          fixture.getBreadcrumb().data?.replaceHashCodes(),
+          equals({
+            'path': [
+              {'name': 'popup_menu_item_1', 'element': 'PopupMenuItem'},
+              {'name': '[GlobalKey#00000]', 'element': 'FadeTransition'},
+              {'element': 'ListBody'},
+              {'element': 'Padding'},
+              {'name': '[GlobalKey#00000]', 'element': 'IgnorePointer'},
+              {'element': 'Semantics'},
+              {'element': 'Listener'},
+              {
+                'name': '[LabeledGlobalKey<RawGestureDetectorState>#00000]',
+                'element': 'RawGestureDetector',
+              },
+              {'element': 'Listener'},
+              {'element': 'NotificationListener<ScrollMetricsNotification>'},
+            ],
+            'view.id': 'popup_menu_item_1',
+            'view.class': 'PopupMenuItem',
+          }),
+        );
       });
     });
 
@@ -340,74 +346,88 @@ void main() {
         expect(data?['label'], equals('Button text'));
         expect(data?['view.id'], equals('tooltip_button'));
         expect(data?['view.class'], equals('ButtonStyleButton'));
-        expect(path?.first,
-            equals({'name': 'tooltip_button', 'element': 'ButtonStyleButton'}));
         expect(
-            path?.any((element) =>
+          path?.first,
+          equals({'name': 'tooltip_button', 'element': 'ButtonStyleButton'}),
+        );
+        expect(
+          path?.any(
+            (element) =>
                 element['element'] == 'Tooltip' &&
-                element['label'] == 'Tooltip message.'),
-            isTrue);
+                element['label'] == 'Tooltip message.',
+          ),
+          isTrue,
+        );
       });
     });
 
     // Regression test for https://github.com/getsentry/sentry-dart/issues/1208
     testWidgets(
-        'Add crumb for button on Page2 not Page1 when pages are stacked',
-        (tester) async {
-      await tester.runAsync(() async {
-        final sut = fixture.getSut();
+      'Add crumb for button on Page2 not Page1 when pages are stacked',
+      (tester) async {
+        await tester.runAsync(() async {
+          final sut = fixture.getSut();
 
-        await tester.pumpWidget(sut);
+          await tester.pumpWidget(sut);
 
-        // Navigate to Page2 (Page1 stays behind in the nav stack).
-        await tester.tap(find.byKey(Key('btn_go_to_page2')));
-        await tester.pumpAndSettle();
+          // Navigate to Page2 (Page1 stays behind in the nav stack).
+          await tester.tap(find.byKey(Key('btn_go_to_page2')));
+          await tester.pumpAndSettle();
 
-        // Page2's btn_page_2 fills the entire screen (SizedBox.expand).
-        // Tap at btn_1's center, which is inside both buttons' bounds.
-        final btn1Center =
-            tester.getCenter(find.byKey(Key('btn_1'), skipOffstage: false));
-        await tester.tapAt(btn1Center);
+          // Page2's btn_page_2 fills the entire screen (SizedBox.expand).
+          // Tap at btn_1's center, which is inside both buttons' bounds.
+          final btn1Center = tester.getCenter(
+            find.byKey(Key('btn_1'), skipOffstage: false),
+          );
+          await tester.tapAt(btn1Center);
 
-        final data = fixture.getBreadcrumb().data;
-        expect(data?['view.id'], equals('btn_page_2'),
-            reason: 'Should identify the Page2 button, not the Page1 button '
-                'behind it in the navigation stack');
-        expect(data?['view.class'], equals('MaterialButton'));
-      });
-    });
+          final data = fixture.getBreadcrumb().data;
+          expect(
+            data?['view.id'],
+            equals('btn_page_2'),
+            reason:
+                'Should identify the Page2 button, not the Page1 button '
+                'behind it in the navigation stack',
+          );
+          expect(data?['view.class'], equals('MaterialButton'));
+        });
+      },
+    );
 
     testWidgets('Add crumb for button without key', (tester) async {
       await tester.runAsync(() async {
         final sut = fixture.getSut(sendDefaultPii: true);
 
         await tester.pumpWidget(sut);
-        await tester.tap(find.byElementPredicate((element) {
-          final widget = element.widget;
-          if (widget is MaterialButton) {
-            return (widget.child as Text).data == 'Button 5';
-          }
-          return false;
-        }));
+        await tester.tap(
+          find.byElementPredicate((element) {
+            final widget = element.widget;
+            if (widget is MaterialButton) {
+              return (widget.child as Text).data == 'Button 5';
+            }
+            return false;
+          }),
+        );
 
         expect(
-            fixture.getBreadcrumb().data?.replaceHashCodes(),
-            equals({
-              'path': [
-                {'element': 'MaterialButton'},
-                {'element': 'Column'},
-                {'element': 'Center'},
-                {'name': '[GlobalKey#00000]', 'element': 'KeyedSubtree'},
-                {'element': 'MediaQuery'},
-                {'name': '_ScaffoldSlot.body', 'element': 'LayoutId'},
-                {'element': 'CustomMultiChildLayout'},
-                {'element': 'Actions'},
-                _animatedBuilderElement,
-                {'element': 'DefaultTextStyle'}
-              ],
-              'label': 'Button 5',
-              'view.class': 'MaterialButton'
-            }));
+          fixture.getBreadcrumb().data?.replaceHashCodes(),
+          equals({
+            'path': [
+              {'element': 'MaterialButton'},
+              {'element': 'Column'},
+              {'element': 'Center'},
+              {'name': '[GlobalKey#00000]', 'element': 'KeyedSubtree'},
+              {'element': 'MediaQuery'},
+              {'name': '_ScaffoldSlot.body', 'element': 'LayoutId'},
+              {'element': 'CustomMultiChildLayout'},
+              {'element': 'Actions'},
+              _animatedBuilderElement,
+              {'element': 'DefaultTextStyle'},
+            ],
+            'label': 'Button 5',
+            'view.class': 'MaterialButton',
+          }),
+        );
       });
     });
   });
@@ -422,15 +442,16 @@ void main() {
     testWidgets('Adds integration if enabled', (tester) async {
       await tester.runAsync(() async {
         final sut = fixture.getSut(
-            enableUserInteractionTracing: true,
-            enableUserInteractionBreadcrumbs: false);
+          enableUserInteractionTracing: true,
+          enableUserInteractionBreadcrumbs: false,
+        );
 
         await tester.pumpWidget(sut);
 
         expect(
-            fixture._options.sdk.integrations
-                .contains('UserInteractionTracing'),
-            true);
+          fixture._options.sdk.integrations.contains('UserInteractionTracing'),
+          true,
+        );
       });
     });
 
@@ -441,17 +462,18 @@ void main() {
         await tester.pumpWidget(sut);
 
         expect(
-            fixture._options.sdk.integrations
-                .contains('UserInteractionTracing'),
-            false);
+          fixture._options.sdk.integrations.contains('UserInteractionTracing'),
+          false,
+        );
       });
     });
 
     testWidgets('Start transaction and set in the scope', (tester) async {
       await tester.runAsync(() async {
         final sut = fixture.getSut(
-            enableUserInteractionTracing: true,
-            enableUserInteractionBreadcrumbs: false);
+          enableUserInteractionTracing: true,
+          enableUserInteractionBreadcrumbs: false,
+        );
 
         await tapMe(tester, sut, 'btn_1');
 
@@ -461,18 +483,22 @@ void main() {
         });
         expect(tracer?.name, 'btn_1');
         expect(tracer?.context.operation, 'ui.action.click');
-        expect(tracer?.transactionNameSource,
-            SentryTransactionNameSource.component);
+        expect(
+          tracer?.transactionNameSource,
+          SentryTransactionNameSource.component,
+        );
         expect(tracer?.autoFinishAfterTimer, isNotNull);
       });
     });
 
-    testWidgets('Start transaction and do not set in the scope if any',
-        (tester) async {
+    testWidgets('Start transaction and do not set in the scope if any', (
+      tester,
+    ) async {
       await tester.runAsync(() async {
         final sut = fixture.getSut(
-            enableUserInteractionTracing: true,
-            enableUserInteractionBreadcrumbs: false);
+          enableUserInteractionTracing: true,
+          enableUserInteractionBreadcrumbs: false,
+        );
 
         fixture.hub.configureScope((scope) {
           scope.span = NoOpSentrySpan();
@@ -489,67 +515,73 @@ void main() {
     });
 
     testWidgets(
-        'Cancel transaction if already started for same widget and start new one',
-        (tester) async {
-      await tester.runAsync(() async {
-        final sut = fixture.getSut(
+      'Cancel transaction if already started for same widget and start new one',
+      (tester) async {
+        await tester.runAsync(() async {
+          final sut = fixture.getSut(
             enableUserInteractionTracing: true,
-            enableUserInteractionBreadcrumbs: false);
+            enableUserInteractionBreadcrumbs: false,
+          );
 
-        await tapMe(tester, sut, 'btn_1');
-        SentryTracer? initialTracer;
+          await tapMe(tester, sut, 'btn_1');
+          SentryTracer? initialTracer;
 
-        fixture.hub.configureScope((scope) {
-          initialTracer = (scope.span as SentryTracer);
+          fixture.hub.configureScope((scope) {
+            initialTracer = (scope.span as SentryTracer);
+          });
+
+          await tapMe(tester, sut, 'btn_1');
+
+          SentryTracer? tracer;
+          fixture.hub.configureScope((scope) {
+            tracer = (scope.span as SentryTracer);
+          });
+          expect(initialTracer?.finished, isTrue);
+          expect(initialTracer?.status, equals(SpanStatus.cancelled()));
+
+          expect(initialTracer, isNot(equals(tracer)));
         });
-
-        await tapMe(tester, sut, 'btn_1');
-
-        SentryTracer? tracer;
-        fixture.hub.configureScope((scope) {
-          tracer = (scope.span as SentryTracer);
-        });
-        expect(initialTracer?.finished, isTrue);
-        expect(initialTracer?.status, equals(SpanStatus.cancelled()));
-
-        expect(initialTracer, isNot(equals(tracer)));
-      });
-    });
+      },
+    );
 
     testWidgets(
-        'Finish transaction if already started with children for same widget and start new one',
-        (tester) async {
+      'Finish transaction if already started with children for same widget and start new one',
+      (tester) async {
+        await tester.runAsync(() async {
+          final sut = fixture.getSut(
+            enableUserInteractionTracing: true,
+            enableUserInteractionBreadcrumbs: false,
+          );
+
+          await tapMe(tester, sut, 'btn_1');
+          SentryTracer? initialTracer;
+
+          await fixture.hub.configureScope((scope) async {
+            initialTracer = (scope.span as SentryTracer);
+            final child = initialTracer?.startChild("btn_1_child");
+            await child?.finish();
+          });
+
+          await tapMe(tester, sut, 'btn_1');
+
+          SentryTracer? tracer;
+          fixture.hub.configureScope((scope) {
+            tracer = (scope.span as SentryTracer);
+          });
+          expect(initialTracer?.finished, isTrue);
+          expect(initialTracer, isNot(equals(tracer)));
+        });
+      },
+    );
+
+    testWidgets('Finish transaction and start new one if new tap', (
+      tester,
+    ) async {
       await tester.runAsync(() async {
         final sut = fixture.getSut(
-            enableUserInteractionTracing: true,
-            enableUserInteractionBreadcrumbs: false);
-
-        await tapMe(tester, sut, 'btn_1');
-        SentryTracer? initialTracer;
-
-        await fixture.hub.configureScope((scope) async {
-          initialTracer = (scope.span as SentryTracer);
-          final child = initialTracer?.startChild("btn_1_child");
-          await child?.finish();
-        });
-
-        await tapMe(tester, sut, 'btn_1');
-
-        SentryTracer? tracer;
-        fixture.hub.configureScope((scope) {
-          tracer = (scope.span as SentryTracer);
-        });
-        expect(initialTracer?.finished, isTrue);
-        expect(initialTracer, isNot(equals(tracer)));
-      });
-    });
-
-    testWidgets('Finish transaction and start new one if new tap',
-        (tester) async {
-      await tester.runAsync(() async {
-        final sut = fixture.getSut(
-            enableUserInteractionTracing: true,
-            enableUserInteractionBreadcrumbs: false);
+          enableUserInteractionTracing: true,
+          enableUserInteractionBreadcrumbs: false,
+        );
 
         await tapMe(tester, sut, 'btn_1');
         SentryTracer? currentTracer;
@@ -593,11 +625,18 @@ void main() {
           activeSpan?.attributes[SemanticAttributesConstants.sentryOp]?.value,
           SentrySpanOperations.uiActionClick,
         );
+        expect(
+          activeSpan
+              ?.attributes[SemanticAttributesConstants.sentrySegmentNameSource]
+              ?.value,
+          'component',
+        );
       });
     });
 
-    testWidgets('does not start idle span when ui.load span is active',
-        (tester) async {
+    testWidgets('does not start idle span when ui.load span is active', (
+      tester,
+    ) async {
       await tester.runAsync(() async {
         final sut = fixture.getSut(
           enableUserInteractionTracing: true,
@@ -609,8 +648,9 @@ void main() {
         fixture.hub.startIdleSpan(
           'ui.load',
           attributes: {
-            SemanticAttributesConstants.sentryOp:
-                SentryAttribute.string(SentrySpanOperations.uiLoad),
+            SemanticAttributesConstants.sentryOp: SentryAttribute.string(
+              SentrySpanOperations.uiLoad,
+            ),
           },
         );
         final loadSpan = fixture.hub.getActiveSpan();
@@ -623,8 +663,9 @@ void main() {
       });
     });
 
-    testWidgets('resets idle timer when same widget is tapped again',
-        (tester) async {
+    testWidgets('resets idle timer when same widget is tapped again', (
+      tester,
+    ) async {
       await tester.runAsync(() async {
         final sut = fixture.getSut(
           enableUserInteractionTracing: true,
@@ -646,43 +687,44 @@ void main() {
     });
 
     testWidgets(
-        'cancels previous idle span when tapping different widget after activity',
-        (tester) async {
-      await tester.runAsync(() async {
-        final sut = fixture.getSut(
-          enableUserInteractionTracing: true,
-          enableUserInteractionBreadcrumbs: false,
-          traceLifecycle: SentryTraceLifecycle.stream,
-        );
+      'cancels previous idle span when tapping different widget after activity',
+      (tester) async {
+        await tester.runAsync(() async {
+          final sut = fixture.getSut(
+            enableUserInteractionTracing: true,
+            enableUserInteractionBreadcrumbs: false,
+            traceLifecycle: SentryTraceLifecycle.stream,
+          );
 
-        await tapMe(tester, sut, 'btn_1');
-        final firstSpan = fixture.hub.getActiveSpan();
-        expect(firstSpan, isA<IdleRecordingSentrySpanV2>());
+          await tapMe(tester, sut, 'btn_1');
+          final firstSpan = fixture.hub.getActiveSpan();
+          expect(firstSpan, isA<IdleRecordingSentrySpanV2>());
 
-        // Simulate descendant activity by starting a child span
-        fixture.hub.startSpanSync('child-work', (_) {});
+          // Simulate descendant activity by starting a child span
+          fixture.hub.startSpanSync('child-work', (_) {});
 
-        await Future<void>.delayed(Duration.zero);
-        // Tap a different widget
-        await tapMe(tester, sut, 'btn_2', pumpWidget: false);
+          await Future<void>.delayed(Duration.zero);
+          // Tap a different widget
+          await tapMe(tester, sut, 'btn_2', pumpWidget: false);
 
-        // First span should be cancelled
-        expect(firstSpan!.isEnded, isTrue);
-        expect(firstSpan.status, SentrySpanStatusV2.ok);
-        expect(
-          firstSpan
-              .attributes[
-                  SemanticAttributesConstants.sentryIdleSpanFinishReason]
-              ?.value,
-          'cancelled',
-        );
+          // First span should be cancelled
+          expect(firstSpan!.isEnded, isTrue);
+          expect(firstSpan.status, SentrySpanStatusV2.ok);
+          expect(
+            firstSpan
+                .attributes[SemanticAttributesConstants
+                    .sentryIdleSpanFinishReason]
+                ?.value,
+            'cancelled',
+          );
 
-        // New idle span should be started for btn_2
-        final newSpan = fixture.hub.getActiveSpan();
-        expect(newSpan, isA<IdleRecordingSentrySpanV2>());
-        expect(newSpan?.name, 'btn_2');
-      });
-    });
+          // New idle span should be started for btn_2
+          final newSpan = fixture.hub.getActiveSpan();
+          expect(newSpan, isA<IdleRecordingSentrySpanV2>());
+          expect(newSpan?.name, 'btn_2');
+        });
+      },
+    );
   });
 
   // Regression tests for https://github.com/getsentry/sentry-dart/issues/3503
@@ -693,20 +735,22 @@ void main() {
         final hitTestPositions = <Offset>[];
         final hitNotifier = ValueNotifier<Offset?>(null);
 
-        await tester.pumpWidget(fixture.getSut(
-          child: MaterialApp(
-            home: Scaffold(
-              body: GestureDetector(
-                onTap: () {},
-                child: HitTestTracker(
-                  hitTestPositions: hitTestPositions,
-                  hitNotifier: hitNotifier,
-                  child: const SizedBox.expand(),
+        await tester.pumpWidget(
+          fixture.getSut(
+            child: MaterialApp(
+              home: Scaffold(
+                body: GestureDetector(
+                  onTap: () {},
+                  child: HitTestTracker(
+                    hitTestPositions: hitTestPositions,
+                    hitNotifier: hitNotifier,
+                    child: const SizedBox.expand(),
+                  ),
                 ),
               ),
             ),
           ),
-        ));
+        );
 
         hitTestPositions.clear();
 
@@ -719,9 +763,13 @@ void main() {
         await gesture.up();
         await tester.pumpAndSettle();
 
-        expect(hitTestPositions.length, equals(hitTestCountAfterDown),
-            reason: 'SentryUserInteractionWidget should not re-trigger '
-                'hitTest on pointerUp');
+        expect(
+          hitTestPositions.length,
+          equals(hitTestCountAfterDown),
+          reason:
+              'SentryUserInteractionWidget should not re-trigger '
+              'hitTest on pointerUp',
+        );
       },
     );
 
@@ -731,20 +779,22 @@ void main() {
         final hitTestPositions = <Offset>[];
         final hitNotifier = ValueNotifier<Offset?>(null);
 
-        await tester.pumpWidget(fixture.getSut(
-          child: MaterialApp(
-            home: Scaffold(
-              body: GestureDetector(
-                onTap: () {},
-                child: HitTestTracker(
-                  hitTestPositions: hitTestPositions,
-                  hitNotifier: hitNotifier,
-                  child: const SizedBox.expand(),
+        await tester.pumpWidget(
+          fixture.getSut(
+            child: MaterialApp(
+              home: Scaffold(
+                body: GestureDetector(
+                  onTap: () {},
+                  child: HitTestTracker(
+                    hitTestPositions: hitTestPositions,
+                    hitNotifier: hitNotifier,
+                    child: const SizedBox.expand(),
+                  ),
                 ),
               ),
             ),
           ),
-        ));
+        );
 
         final center = tester.getCenter(find.byType(SizedBox).last);
         final gesture = await tester.startGesture(center);
@@ -757,9 +807,13 @@ void main() {
         await gesture.up();
         await tester.pumpAndSettle();
 
-        expect(hitNotifier.value, isNull,
-            reason: 'SentryUserInteractionWidget should not overwrite '
-                'hitNotifier during pointerUp');
+        expect(
+          hitNotifier.value,
+          isNull,
+          reason:
+              'SentryUserInteractionWidget should not overwrite '
+              'hitNotifier during pointerUp',
+        );
       },
     );
   });
@@ -805,10 +859,7 @@ class Fixture {
 
     hub = Hub(_options);
 
-    return SentryUserInteractionWidget(
-      hub: hub,
-      child: child ?? MyApp(),
-    );
+    return SentryUserInteractionWidget(hub: hub, child: child ?? MyApp());
   }
 
   Breadcrumb getBreadcrumb() {
@@ -855,10 +906,7 @@ class Page1 extends StatelessWidget {
             IconButton(
               key: Key('btn_3'),
               onPressed: () {},
-              icon: Icon(
-                Icons.dark_mode,
-                semanticLabel: 'My Icon',
-              ),
+              icon: Icon(Icons.dark_mode, semanticLabel: 'My Icon'),
             ),
             Card(
               child: GestureDetector(
@@ -900,10 +948,7 @@ class Page1 extends StatelessWidget {
                 child: Text('Button text'),
               ),
             ),
-            MaterialButton(
-              onPressed: () {},
-              child: const Text('Button 5'),
-            ),
+            MaterialButton(onPressed: () {}, child: const Text('Button 5')),
           ],
         ),
       ),
@@ -934,29 +979,29 @@ extension on String {
 
 extension on Map<dynamic, dynamic> {
   Map<dynamic, dynamic> replaceHashCodes() => map((key, value) {
-        if (value is String) {
-          value = value.replaceHashCodes();
-        } else if (value is Map) {
-          value = value.replaceHashCodes();
-        } else if (value is List) {
-          value = value.replaceHashCodes();
-        }
-        return MapEntry(key, value);
-      });
+    if (value is String) {
+      value = value.replaceHashCodes();
+    } else if (value is Map) {
+      value = value.replaceHashCodes();
+    } else if (value is List) {
+      value = value.replaceHashCodes();
+    }
+    return MapEntry(key, value);
+  });
 }
 
 extension on List<dynamic> {
   Iterable<dynamic> replaceHashCodes() => map((value) {
-        if (value is String) {
-          return value.replaceHashCodes();
-        } else if (value is Map) {
-          return value.replaceHashCodes();
-        } else if (value is List) {
-          return value.replaceHashCodes();
-        } else {
-          return value;
-        }
-      });
+    if (value is String) {
+      return value.replaceHashCodes();
+    } else if (value is Map) {
+      return value.replaceHashCodes();
+    } else if (value is List) {
+      return value.replaceHashCodes();
+    } else {
+      return value;
+    }
+  });
 }
 
 /// A widget whose [RenderBox] records every [hitTest] call and updates a
@@ -983,7 +1028,9 @@ class HitTestTracker extends SingleChildRenderObjectWidget {
 
   @override
   void updateRenderObject(
-      BuildContext context, RenderHitTestTracker renderObject) {
+    BuildContext context,
+    RenderHitTestTracker renderObject,
+  ) {
     renderObject
       ..hitTestPositions = hitTestPositions
       ..hitNotifier = hitNotifier;
@@ -994,8 +1041,8 @@ class RenderHitTestTracker extends RenderProxyBox {
   RenderHitTestTracker({
     required List<Offset> hitTestPositions,
     required ValueNotifier<Offset?> hitNotifier,
-  })  : _hitTestPositions = hitTestPositions,
-        _hitNotifier = hitNotifier;
+  }) : _hitTestPositions = hitTestPositions,
+       _hitNotifier = hitNotifier;
 
   List<Offset> _hitTestPositions;
   set hitTestPositions(List<Offset> value) => _hitTestPositions = value;


### PR DESCRIPTION
## :scroll: Description

Streamed segment spans now emit `sentry.segment.name.source`. Segment spans
default to `custom`, while Flutter route-change, app-start, and
user-interaction segments use `component`. The static generic and native
app-start transaction contexts use `component` as well. Child spans do not
receive the attribute, and an explicitly provided segment name source is
preserved.

## :bulb: Motivation and Context

This provides the streamed-span equivalent of `transaction_info.source` so
segment-name clustering can distinguish name sources.

Fixes #3901

## :green_heart: How did you test it?

- `fvm dart test test/telemetry/span/span_capture_pipeline_test.dart`
- `fvm flutter test test/navigation/time_to_display_tracker_v2_test.dart test/user_interaction/sentry_user_interaction_widget_test.dart test/integrations/generic_app_start_integration_test.dart test/integrations/native_app_start_integration_test.dart`
- File-scoped Dart and Flutter analysis

## :pencil: Checklist

- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec
- [x] No breaking changes

## :crystal_ball: Next steps

None.
