### PR TITLE
fix(metrics): Add missing metric byte outcomes

### DIFF
--- a/packages/dart/lib/src/client_reports/client_report_recorder.dart
+++ b/packages/dart/lib/src/client_reports/client_report_recorder.dart
@@ -37,7 +37,7 @@ class ClientReportRecorder {
   /// Records dropped metrics as a [DataCategory.metric] count and, when the
   /// size is known, an additional [DataCategory.metricByte] outcome.
   ///
-  /// Pass a null [bytes] when the size cannot be determined. The byte outcome
+  /// Pass null [bytes] when the size cannot be determined. The byte outcome
   /// is then omitted rather than reported as zero.
   void recordLostMetric(final DiscardReason reason,
       {int count = 1, int? bytes}) {

--- a/packages/dart/lib/src/client_reports/client_report_recorder.dart
+++ b/packages/dart/lib/src/client_reports/client_report_recorder.dart
@@ -34,6 +34,19 @@ class ClientReportRecorder {
     }
   }
 
+  /// Records dropped metrics as a [DataCategory.metric] count and, when the
+  /// size is known, an additional [DataCategory.metricByte] outcome.
+  ///
+  /// Pass a null [bytes] when the size cannot be determined. The byte outcome
+  /// is then omitted rather than reported as zero.
+  void recordLostMetric(final DiscardReason reason,
+      {int count = 1, int? bytes}) {
+    recordLostEvent(reason, DataCategory.metric, count: count);
+    if (bytes != null) {
+      recordLostEvent(reason, DataCategory.metricByte, count: bytes);
+    }
+  }
+
   ClientReport? flush() {
     if (_quantities.isEmpty) {
       return null;

--- a/packages/dart/lib/src/client_reports/discarded_event.dart
+++ b/packages/dart/lib/src/client_reports/discarded_event.dart
@@ -78,6 +78,8 @@ extension _DataCategoryExtension on DataCategory {
         return 'metric_bucket';
       case DataCategory.metric:
         return 'trace_metric';
+      case DataCategory.metricByte:
+        return 'trace_metric_byte';
     }
   }
 }

--- a/packages/dart/lib/src/client_reports/noop_client_report_recorder.dart
+++ b/packages/dart/lib/src/client_reports/noop_client_report_recorder.dart
@@ -20,4 +20,7 @@ class NoOpClientReportRecorder implements ClientReportRecorder {
 
   @override
   void recordLostLog(DiscardReason reason, {int count = 1, int? bytes}) {}
+
+  @override
+  void recordLostMetric(DiscardReason reason, {int count = 1, int? bytes}) {}
 }

--- a/packages/dart/lib/src/telemetry/metric/metric_capture_pipeline.dart
+++ b/packages/dart/lib/src/telemetry/metric/metric_capture_pipeline.dart
@@ -2,7 +2,6 @@ import 'package:meta/meta.dart';
 
 import '../../../sentry.dart';
 import '../../client_reports/discard_reason.dart';
-import '../../transport/data_category.dart';
 import '../../utils/internal_logger.dart';
 import '../default_attributes.dart';
 
@@ -36,10 +35,9 @@ class MetricCapturePipeline {
         try {
           processedMetric = await beforeSendMetric(metric);
         } catch (exception, stackTrace) {
-          _options.log(
-            SentryLevel.error,
+          internalLogger.error(
             'The beforeSendMetric callback threw an exception',
-            exception: exception,
+            error: exception,
             stackTrace: stackTrace,
           );
           if (_options.automatedTestMode) {
@@ -48,8 +46,10 @@ class MetricCapturePipeline {
         }
       }
       if (processedMetric == null) {
-        _options.recorder
-            .recordLostEvent(DiscardReason.beforeSend, DataCategory.metric);
+        _options.recorder.recordLostMetric(
+          DiscardReason.beforeSend,
+          bytes: _approximateMetricBytes(metric),
+        );
         internalLogger.debug(
             '$MetricCapturePipeline: Metric ${metric.name} dropped by beforeSendMetric');
         return;
@@ -59,6 +59,10 @@ class MetricCapturePipeline {
       internalLogger.debug(
           '$MetricCapturePipeline: Metric ${processedMetric.name} (${processedMetric.type}) captured');
     } catch (exception, stackTrace) {
+      _options.recorder.recordLostMetric(
+        DiscardReason.internalSdkError,
+        bytes: _approximateMetricBytes(metric),
+      );
       internalLogger.error(
         'Error capturing metric ${metric.name}',
         error: exception,
@@ -68,5 +72,18 @@ class MetricCapturePipeline {
         rethrow;
       }
     }
+  }
+}
+
+int? _approximateMetricBytes(SentryMetric metric) {
+  try {
+    return utf8JsonEncoder.convert(metric.toJson()).length;
+  } catch (exception, stackTrace) {
+    internalLogger.warning(
+      'Failed to estimate dropped metric size',
+      error: exception,
+      stackTrace: stackTrace,
+    );
+    return null;
   }
 }

--- a/packages/dart/lib/src/telemetry/processing/processor_integration.dart
+++ b/packages/dart/lib/src/telemetry/processing/processor_integration.dart
@@ -2,6 +2,7 @@ import 'package:meta/meta.dart';
 
 import '../../../sentry.dart';
 import '../../client_reports/discard_reason.dart';
+import '../../transport/data_category.dart';
 import '../../utils/internal_logger.dart';
 import 'in_memory_buffer.dart';
 import 'processor.dart';
@@ -95,6 +96,20 @@ class InMemoryTelemetryProcessorIntegration extends Integration<SentryOptions> {
   ) =>
       InMemoryTelemetryBuffer(
         encoder: (SentryMetric item) => utf8JsonEncoder.convert(item.toJson()),
+        onDrop: (item, {required cause, bytes}) {
+          switch (cause) {
+            case BufferDropCause.encodeFailed:
+              options.recorder.recordLostEvent(
+                DiscardReason.internalSdkError,
+                DataCategory.metric,
+              );
+            case BufferDropCause.tooLarge:
+              options.recorder.recordLostEvent(
+                DiscardReason.bufferOverflow,
+                DataCategory.metric,
+              );
+          }
+        },
         onFlush: (items) {
           final envelope = SentryEnvelope.fromMetricsData(
             items.map((item) => item).toList(),

--- a/packages/dart/lib/src/telemetry/processing/processor_integration.dart
+++ b/packages/dart/lib/src/telemetry/processing/processor_integration.dart
@@ -2,7 +2,6 @@ import 'package:meta/meta.dart';
 
 import '../../../sentry.dart';
 import '../../client_reports/discard_reason.dart';
-import '../../transport/data_category.dart';
 import '../../utils/internal_logger.dart';
 import 'in_memory_buffer.dart';
 import 'processor.dart';
@@ -101,22 +100,14 @@ class InMemoryTelemetryProcessorIntegration extends Integration<SentryOptions> {
             case BufferDropCause.encodeFailed:
               // No encoded bytes available, so the trace_metric_byte size is
               // unknown.
-              options.recorder.recordLostEvent(
+              options.recorder.recordLostMetric(
                 DiscardReason.internalSdkError,
-                DataCategory.metric,
               );
             case BufferDropCause.tooLarge:
-              options.recorder.recordLostEvent(
+              options.recorder.recordLostMetric(
                 DiscardReason.bufferOverflow,
-                DataCategory.metric,
+                bytes: bytes,
               );
-              if (bytes != null) {
-                options.recorder.recordLostEvent(
-                  DiscardReason.bufferOverflow,
-                  DataCategory.metricByte,
-                  count: bytes,
-                );
-              }
           }
         },
         onFlush: (items) {

--- a/packages/dart/lib/src/telemetry/processing/processor_integration.dart
+++ b/packages/dart/lib/src/telemetry/processing/processor_integration.dart
@@ -99,6 +99,8 @@ class InMemoryTelemetryProcessorIntegration extends Integration<SentryOptions> {
         onDrop: (item, {required cause, bytes}) {
           switch (cause) {
             case BufferDropCause.encodeFailed:
+              // No encoded bytes available, so the trace_metric_byte size is
+              // unknown.
               options.recorder.recordLostEvent(
                 DiscardReason.internalSdkError,
                 DataCategory.metric,
@@ -108,6 +110,13 @@ class InMemoryTelemetryProcessorIntegration extends Integration<SentryOptions> {
                 DiscardReason.bufferOverflow,
                 DataCategory.metric,
               );
+              if (bytes != null) {
+                options.recorder.recordLostEvent(
+                  DiscardReason.bufferOverflow,
+                  DataCategory.metricByte,
+                  count: bytes,
+                );
+              }
           }
         },
         onFlush: (items) {

--- a/packages/dart/lib/src/transport/data_category.dart
+++ b/packages/dart/lib/src/transport/data_category.dart
@@ -13,6 +13,7 @@ enum DataCategory {
   logByte,
   feedback,
   metric,
+  metricByte,
   unknown;
 
   static DataCategory fromItemType(String itemType) {

--- a/packages/dart/lib/src/transport/rate_limit_parser.dart
+++ b/packages/dart/lib/src/transport/rate_limit_parser.dart
@@ -97,6 +97,8 @@ extension _DataCategoryExtension on DataCategory {
         return DataCategory.logByte;
       case 'trace_metric':
         return DataCategory.metric;
+      case 'trace_metric_byte':
+        return DataCategory.metricByte;
     }
     return DataCategory.unknown;
   }

--- a/packages/dart/lib/src/transport/rate_limiter.dart
+++ b/packages/dart/lib/src/transport/rate_limiter.dart
@@ -30,6 +30,12 @@ class RateLimiter {
             item,
             DiscardReason.rateLimitBackoff,
           );
+        } else if (category == DataCategory.metric) {
+          TransportUtils.recordLostMetricItem(
+            _options,
+            item,
+            DiscardReason.rateLimitBackoff,
+          );
         } else {
           _options.recorder.recordLostEvent(
             DiscardReason.rateLimitBackoff,
@@ -133,6 +139,15 @@ class RateLimiter {
     if (dataCategory == DataCategory.logItem) {
       final dateLogByte = _rateLimitedUntil[DataCategory.logByte];
       if (dateLogByte != null && !currentDate.isAfter(dateLogByte)) {
+        return true;
+      }
+    }
+
+    // Metric envelope items map to `metric`, but Relay can rate limit their
+    // byte category independently. Honor that limit for metric items too.
+    if (dataCategory == DataCategory.metric) {
+      final dateMetricByte = _rateLimitedUntil[DataCategory.metricByte];
+      if (dateMetricByte != null && !currentDate.isAfter(dateMetricByte)) {
         return true;
       }
     }

--- a/packages/dart/lib/src/utils/transport_utils.dart
+++ b/packages/dart/lib/src/utils/transport_utils.dart
@@ -28,6 +28,8 @@ class TransportUtils {
       final category = DataCategory.fromItemType(item.header.type);
       if (category == DataCategory.logItem) {
         recordLostLogItem(options, item, reason);
+      } else if (category == DataCategory.metric) {
+        recordLostMetricItem(options, item, reason);
       } else {
         options.recorder.recordLostEvent(reason, category);
       }
@@ -65,6 +67,34 @@ class TransportUtils {
     }
 
     options.recorder.recordLostLog(
+      reason,
+      count: item.header.itemCount ?? 1,
+      bytes: bytes,
+    );
+  }
+
+  /// Records a dropped metric envelope item, reporting the metric count and,
+  /// when it can be determined, a best-effort byte size.
+  static void recordLostMetricItem(
+    SentryOptions options,
+    SentryEnvelopeItem item,
+    DiscardReason reason,
+  ) {
+    int? bytes;
+    try {
+      final data = item.dataFactory();
+      if (data is List<int>) {
+        bytes = data.length;
+      }
+    } catch (exception, stackTrace) {
+      internalLogger.warning(
+        'Failed to estimate dropped metric item size',
+        error: exception,
+        stackTrace: stackTrace,
+      );
+    }
+
+    options.recorder.recordLostMetric(
       reason,
       count: item.header.itemCount ?? 1,
       bytes: bytes,

--- a/packages/dart/test/client_reports/client_report_recorder_test.dart
+++ b/packages/dart/test/client_reports/client_report_recorder_test.dart
@@ -86,6 +86,23 @@ void main() {
       expect(logByte?.quantity, 42);
     });
 
+    test('records metric item and byte outcomes separately', () {
+      final sut = fixture.getSut();
+
+      sut.recordLostMetric(DiscardReason.beforeSend, bytes: 42);
+
+      final clientReport = sut.flush();
+
+      final metric = clientReport?.discardedEvents
+          .firstWhere((event) => event.category == DataCategory.metric);
+      final metricByte = clientReport?.discardedEvents
+          .firstWhere((event) => event.category == DataCategory.metricByte);
+
+      expect(metric?.quantity, 1);
+      expect(metricByte?.quantity, 42);
+      expect(metricByte?.toJson()['category'], 'trace_metric_byte');
+    });
+
     test('calling flush multiple times returns null', () {
       final sut = fixture.getSut();
 

--- a/packages/dart/test/mocks/mock_client_report_recorder.dart
+++ b/packages/dart/test/mocks/mock_client_report_recorder.dart
@@ -7,6 +7,7 @@ import 'package:sentry/src/transport/data_category.dart';
 class MockClientReportRecorder implements ClientReportRecorder {
   List<DiscardedEvent> discardedEvents = [];
   List<({DiscardReason reason, int count, int? bytes})> lostLogs = [];
+  List<({DiscardReason reason, int count, int? bytes})> lostMetrics = [];
 
   ClientReport? clientReport;
 
@@ -27,5 +28,10 @@ class MockClientReportRecorder implements ClientReportRecorder {
   @override
   void recordLostLog(DiscardReason reason, {int count = 1, int? bytes}) {
     lostLogs.add((reason: reason, count: count, bytes: bytes));
+  }
+
+  @override
+  void recordLostMetric(DiscardReason reason, {int count = 1, int? bytes}) {
+    lostMetrics.add((reason: reason, count: count, bytes: bytes));
   }
 }

--- a/packages/dart/test/mocks/mock_telemetry_processor.dart
+++ b/packages/dart/test/mocks/mock_telemetry_processor.dart
@@ -11,6 +11,9 @@ class MockTelemetryProcessor implements TelemetryProcessor {
   /// When set, [addLog] throws this error instead of recording the log.
   Object? addLogError;
 
+  /// When set, [addMetric] throws this error instead of recording the metric.
+  Object? addMetricError;
+
   @override
   void addSpan(RecordingSentrySpanV2 span) {
     addedSpans.add(span);
@@ -27,6 +30,10 @@ class MockTelemetryProcessor implements TelemetryProcessor {
 
   @override
   void addMetric(SentryMetric metric) {
+    final error = addMetricError;
+    if (error != null) {
+      throw error;
+    }
     addedMetrics.add(metric);
   }
 

--- a/packages/dart/test/protocol/rate_limit_parser_test.dart
+++ b/packages/dart/test/protocol/rate_limit_parser_test.dart
@@ -123,6 +123,15 @@ void main() {
       expect(sut[0].duration.inMilliseconds, 60000);
     });
 
+    test('parse trace_metric_byte category', () {
+      final sut =
+          RateLimitParser('60:trace_metric_byte').parseRateLimitHeader();
+
+      expect(sut.length, 1);
+      expect(sut[0].category, DataCategory.metricByte);
+      expect(sut[0].duration.inMilliseconds, 60000);
+    });
+
     test('parse log_byte category', () {
       final sut = RateLimitParser('60:log_byte').parseRateLimitHeader();
 

--- a/packages/dart/test/protocol/rate_limiter_test.dart
+++ b/packages/dart/test/protocol/rate_limiter_test.dart
@@ -282,6 +282,55 @@ void main() {
       expect(result, isNull);
     });
 
+    test('metric', () {
+      final rateLimiter = fixture.getSut();
+      fixture.dateTimeToReturn = 0;
+
+      final metrics = [
+        [1, 2, 3],
+        [4, 5],
+      ];
+      final envelope = SentryEnvelope.fromMetricsData(
+        metrics,
+        SdkVersion(name: 'test', version: 'test'),
+      );
+
+      rateLimiter.updateRetryAfterLimits(
+          '1:trace_metric:key, 5:trace_metric:organization', null, 1);
+
+      final result = rateLimiter.filter(envelope);
+      expect(result, isNull);
+
+      final lostMetric = fixture.mockRecorder.lostMetrics.single;
+      expect(lostMetric.reason, DiscardReason.rateLimitBackoff);
+      expect(lostMetric.count, metrics.length);
+      expect(lostMetric.bytes, greaterThan(0));
+    });
+
+    test('trace_metric_byte limit applies to metric items', () {
+      final rateLimiter = fixture.getSut();
+      fixture.dateTimeToReturn = 0;
+
+      final metrics = [
+        [1, 2, 3],
+      ];
+      final envelope = SentryEnvelope.fromMetricsData(
+        metrics,
+        SdkVersion(name: 'test', version: 'test'),
+      );
+
+      rateLimiter.updateRetryAfterLimits(
+          '1:trace_metric_byte:key, 5:trace_metric_byte:organization', null, 1);
+
+      final result = rateLimiter.filter(envelope);
+      expect(result, isNull);
+
+      final lostMetric = fixture.mockRecorder.lostMetrics.single;
+      expect(lostMetric.reason, DiscardReason.rateLimitBackoff);
+      expect(lostMetric.count, metrics.length);
+      expect(lostMetric.bytes, greaterThan(0));
+    });
+
     test('log', () {
       final rateLimiter = fixture.getSut();
       fixture.dateTimeToReturn = 0;

--- a/packages/dart/test/telemetry/metric/metric_capture_pipeline_test.dart
+++ b/packages/dart/test/telemetry/metric/metric_capture_pipeline_test.dart
@@ -1,7 +1,6 @@
 import 'package:sentry/sentry.dart';
 import 'package:sentry/src/client_reports/discard_reason.dart';
 import 'package:sentry/src/telemetry/metric/metric_capture_pipeline.dart';
-import 'package:sentry/src/transport/data_category.dart';
 import 'package:test/test.dart';
 
 import '../../mocks/mock_client_report_recorder.dart';
@@ -143,18 +142,31 @@ void main() {
         expect(fixture.processor.addedMetrics, isEmpty);
       });
 
-      test('returning null records lost event in client report', () async {
+      test('returning null records metric count and bytes', () async {
         fixture.options.beforeSendMetric = (_) => null;
 
         final metric = fixture.createMetric();
 
         await fixture.pipeline.captureMetric(metric, scope: fixture.scope);
 
-        expect(fixture.recorder.discardedEvents.length, 1);
-        expect(fixture.recorder.discardedEvents.first.reason,
-            DiscardReason.beforeSend);
-        expect(fixture.recorder.discardedEvents.first.category,
-            DataCategory.metric);
+        final lostMetric = fixture.recorder.lostMetrics.single;
+        expect(lostMetric.reason, DiscardReason.beforeSend);
+        expect(lostMetric.count, 1);
+        expect(lostMetric.bytes, greaterThan(0));
+      });
+
+      test('returning null omits bytes when size estimation fails', () async {
+        fixture.options.beforeSendMetric = (_) => null;
+
+        await fixture.pipeline.captureMetric(
+          fixture.createUnencodableMetric(),
+          scope: fixture.scope,
+        );
+
+        final lostMetric = fixture.recorder.lostMetrics.single;
+        expect(lostMetric.reason, DiscardReason.beforeSend);
+        expect(lostMetric.count, 1);
+        expect(lostMetric.bytes, isNull);
       });
 
       test('can mutate the metric', () async {
@@ -172,6 +184,23 @@ void main() {
         final captured = fixture.processor.addedMetrics.first;
         expect(captured.name, 'modified-name');
         expect(captured.attributes['added-key']?.value, 'added');
+      });
+    });
+
+    group('when capturing fails unexpectedly', () {
+      test('records lost metric as internal SDK error', () async {
+        fixture.options.automatedTestMode = false;
+        fixture.processor.addMetricError = StateError('boom');
+
+        await fixture.pipeline.captureMetric(
+          fixture.createMetric(),
+          scope: fixture.scope,
+        );
+
+        final lostMetric = fixture.recorder.lostMetrics.single;
+        expect(lostMetric.reason, DiscardReason.internalSdkError);
+        expect(lostMetric.count, 1);
+        expect(lostMetric.bytes, greaterThan(0));
       });
     });
   });
@@ -204,4 +233,19 @@ class Fixture {
       traceId: SentryId.newId(),
     );
   }
+
+  SentryMetric createUnencodableMetric() {
+    return _UnencodableMetric(
+      timestamp: DateTime.now().toUtc(),
+      traceId: SentryId.newId(),
+    );
+  }
+}
+
+final class _UnencodableMetric extends SentryMetric {
+  _UnencodableMetric({required super.timestamp, required super.traceId})
+      : super(type: 'counter', name: 'test metric', value: 1);
+
+  @override
+  Map<String, dynamic> toJson() => throw StateError('Encoding failed');
 }

--- a/packages/dart/test/telemetry/processing/processor_integration_test.dart
+++ b/packages/dart/test/telemetry/processing/processor_integration_test.dart
@@ -3,6 +3,7 @@ import 'package:sentry/src/client_reports/discard_reason.dart';
 import 'package:sentry/src/telemetry/processing/in_memory_buffer.dart';
 import 'package:sentry/src/telemetry/processing/processor.dart';
 import 'package:sentry/src/telemetry/processing/processor_integration.dart';
+import 'package:sentry/src/transport/data_category.dart';
 import 'package:test/test.dart';
 
 import '../../mocks/mock_hub.dart';
@@ -124,6 +125,40 @@ void main() {
         expect(lostLog.bytes, greaterThan(1024 * 1024));
       });
 
+      test('oversized metric records buffer overflow client report', () {
+        final options = fixture.options;
+        fixture.getSut().call(fixture.hub, options);
+
+        final processor =
+            options.telemetryProcessor as DefaultTelemetryProcessor;
+        processor.addMetric(
+          fixture.createMetric(name: 'x' * (1024 * 1024)),
+        );
+
+        expect(fixture.transport.envelopes, isEmpty);
+
+        final discardedEvent = fixture.recorder.discardedEvents.single;
+        expect(discardedEvent.reason, DiscardReason.bufferOverflow);
+        expect(discardedEvent.category, DataCategory.metric);
+        expect(discardedEvent.quantity, 1);
+      });
+
+      test('unencodable metric records internal SDK error client report', () {
+        final options = fixture.options;
+        fixture.getSut().call(fixture.hub, options);
+
+        final processor =
+            options.telemetryProcessor as DefaultTelemetryProcessor;
+        processor.addMetric(fixture.createUnencodableMetric());
+
+        expect(fixture.transport.envelopes, isEmpty);
+
+        final discardedEvent = fixture.recorder.discardedEvents.single;
+        expect(discardedEvent.reason, DiscardReason.internalSdkError);
+        expect(discardedEvent.category, DataCategory.metric);
+        expect(discardedEvent.quantity, 1);
+      });
+
       test('span reaches transport as envelope', () async {
         final options = fixture.options;
         fixture.getSut().call(fixture.hub, options);
@@ -232,6 +267,22 @@ class _Fixture {
     );
   }
 
+  SentryMetric createMetric({String name = 'test metric', num value = 1}) {
+    return SentryCounterMetric(
+      timestamp: DateTime.now().toUtc(),
+      traceId: SentryId.newId(),
+      name: name,
+      value: value,
+    );
+  }
+
+  SentryMetric createUnencodableMetric() {
+    return _UnencodableMetric(
+      timestamp: DateTime.now().toUtc(),
+      traceId: SentryId.newId(),
+    );
+  }
+
   RecordingSentrySpanV2 createSpan() {
     return RecordingSentrySpanV2.root(
       name: 'test-span',
@@ -243,4 +294,12 @@ class _Fixture {
       samplingDecision: SentryTracesSamplingDecision(true),
     );
   }
+}
+
+final class _UnencodableMetric extends SentryMetric {
+  _UnencodableMetric({required super.timestamp, required super.traceId})
+      : super(type: 'counter', name: 'test metric', value: 1);
+
+  @override
+  Map<String, dynamic> toJson() => throw StateError('Encoding failed');
 }

--- a/packages/dart/test/telemetry/processing/processor_integration_test.dart
+++ b/packages/dart/test/telemetry/processing/processor_integration_test.dart
@@ -137,10 +137,19 @@ void main() {
 
         expect(fixture.transport.envelopes, isEmpty);
 
-        final discardedEvent = fixture.recorder.discardedEvents.single;
-        expect(discardedEvent.reason, DiscardReason.bufferOverflow);
-        expect(discardedEvent.category, DataCategory.metric);
-        expect(discardedEvent.quantity, 1);
+        expect(fixture.recorder.discardedEvents, hasLength(2));
+
+        final metricCount = fixture.recorder.discardedEvents.firstWhere(
+          (event) => event.category == DataCategory.metric,
+        );
+        expect(metricCount.reason, DiscardReason.bufferOverflow);
+        expect(metricCount.quantity, 1);
+
+        final metricBytes = fixture.recorder.discardedEvents.firstWhere(
+          (event) => event.toJson()['category'] == 'trace_metric_byte',
+        );
+        expect(metricBytes.reason, DiscardReason.bufferOverflow);
+        expect(metricBytes.quantity, greaterThan(1024 * 1024));
       });
 
       test('unencodable metric records internal SDK error client report', () {

--- a/packages/dart/test/telemetry/processing/processor_integration_test.dart
+++ b/packages/dart/test/telemetry/processing/processor_integration_test.dart
@@ -3,7 +3,6 @@ import 'package:sentry/src/client_reports/discard_reason.dart';
 import 'package:sentry/src/telemetry/processing/in_memory_buffer.dart';
 import 'package:sentry/src/telemetry/processing/processor.dart';
 import 'package:sentry/src/telemetry/processing/processor_integration.dart';
-import 'package:sentry/src/transport/data_category.dart';
 import 'package:test/test.dart';
 
 import '../../mocks/mock_hub.dart';
@@ -137,19 +136,10 @@ void main() {
 
         expect(fixture.transport.envelopes, isEmpty);
 
-        expect(fixture.recorder.discardedEvents, hasLength(2));
-
-        final metricCount = fixture.recorder.discardedEvents.firstWhere(
-          (event) => event.category == DataCategory.metric,
-        );
-        expect(metricCount.reason, DiscardReason.bufferOverflow);
-        expect(metricCount.quantity, 1);
-
-        final metricBytes = fixture.recorder.discardedEvents.firstWhere(
-          (event) => event.toJson()['category'] == 'trace_metric_byte',
-        );
-        expect(metricBytes.reason, DiscardReason.bufferOverflow);
-        expect(metricBytes.quantity, greaterThan(1024 * 1024));
+        final lostMetric = fixture.recorder.lostMetrics.single;
+        expect(lostMetric.reason, DiscardReason.bufferOverflow);
+        expect(lostMetric.count, 1);
+        expect(lostMetric.bytes, greaterThan(1024 * 1024));
       });
 
       test('unencodable metric records internal SDK error client report', () {
@@ -162,10 +152,10 @@ void main() {
 
         expect(fixture.transport.envelopes, isEmpty);
 
-        final discardedEvent = fixture.recorder.discardedEvents.single;
-        expect(discardedEvent.reason, DiscardReason.internalSdkError);
-        expect(discardedEvent.category, DataCategory.metric);
-        expect(discardedEvent.quantity, 1);
+        final lostMetric = fixture.recorder.lostMetrics.single;
+        expect(lostMetric.reason, DiscardReason.internalSdkError);
+        expect(lostMetric.count, 1);
+        expect(lostMetric.bytes, isNull);
       });
 
       test('span reaches transport as envelope', () async {

--- a/packages/dart/test/transport/http_transport_test.dart
+++ b/packages/dart/test/transport/http_transport_test.dart
@@ -118,6 +118,31 @@ void main() {
       expect(lostLog.bytes, greaterThan(0));
     });
 
+    test('records lost metric count and bytes when client throws exception',
+        () async {
+      final httpMock = MockClient((http.Request request) async {
+        throw http.ClientException(
+            'Connection closed before full header was received');
+      });
+
+      fixture.options.automatedTestMode = false;
+      final sut = fixture.getSut(httpMock, MockRateLimiter());
+
+      final metrics = [
+        [1, 2, 3],
+        [4, 5],
+      ];
+      final envelope =
+          SentryEnvelope.fromMetricsData(metrics, fixture.options.sdk);
+
+      await sut.send(envelope);
+
+      final lostMetric = fixture.clientReportRecorder.lostMetrics.single;
+      expect(lostMetric.reason, DiscardReason.networkError);
+      expect(lostMetric.count, metrics.length);
+      expect(lostMetric.bytes, greaterThan(0));
+    });
+
     test('records lost transaction and spans when client throws exception',
         () async {
       final httpMock = MockClient((http.Request request) async {


### PR DESCRIPTION
## 📜 Description

Discarded metrics now record paired `trace_metric` count and `trace_metric_byte` size outcomes wherever the SDK can determine the encoded size. This covers `beforeSendMetric`, unexpected capture failures, telemetry buffer overflow, rate-limit filtering, and transport failures.

`trace_metric_byte` response-header limits are parsed and applied to metric envelope items. Encoding failures still record the metric count but omit the byte outcome because no encoded size is available.

## 💡 Motivation and Context

Metric drops previously reported only item counts, or no outcome at all for telemetry buffer rejection. This left discarded metric volume invisible and did not honor byte-category rate limits. The shared metric recorder now mirrors the existing log count/byte behavior across the same SDK paths.

Fixes getsentry/sentry-dart#3752

## 💚 How did you test it?

* `fvm dart test test/client_reports test/telemetry/metric test/telemetry/processing test/protocol/rate_limit_parser_test.dart test/protocol/rate_limiter_test.dart test/transport/http_transport_test.dart`
* Focused `fvm dart analyze` for all modified files

## :pencil: Checklist

- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [X] All tests passing
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](<https://develop.sentry.dev/>) spec
- [X] No breaking changes

## 🔮 Next steps

None.