### PR TITLE
fix(flutter): Guard script completion

### DIFF
--- a/packages/flutter/lib/src/web/script_loader/web_script_dom_api.dart
+++ b/packages/flutter/lib/src/web/script_loader/web_script_dom_api.dart
@@ -12,8 +12,16 @@ Future<void> loadScript(String src, SentryOptions options,
   final completer = Completer<void>();
   final script = HTMLScriptElement()
     ..crossOrigin = 'anonymous'
-    ..onLoad.listen((_) => completer.complete())
-    ..onError.listen((event) => completer.completeError('Failed to load $src'));
+    ..onLoad.listen((_) {
+      if (!completer.isCompleted) {
+        completer.complete();
+      }
+    })
+    ..onError.listen((event) {
+      if (!completer.isCompleted) {
+        completer.completeError('Failed to load $src');
+      }
+    });
 
   TrustedScriptURL? trustedUrl;
   if (!window.trustedTypes.isUndefinedOrNull) {

--- a/packages/flutter/lib/src/web/script_loader/web_script_dom_api.dart
+++ b/packages/flutter/lib/src/web/script_loader/web_script_dom_api.dart
@@ -10,18 +10,28 @@ Future<void> loadScript(String src, SentryOptions options,
     {String? integrity,
     String trustedTypePolicyName = defaultTrustedPolicyName}) {
   final completer = Completer<void>();
-  final script = HTMLScriptElement()
-    ..crossOrigin = 'anonymous'
-    ..onLoad.listen((_) {
-      if (!completer.isCompleted) {
-        completer.complete();
-      }
-    })
-    ..onError.listen((event) {
-      if (!completer.isCompleted) {
-        completer.completeError('Failed to load $src');
-      }
-    });
+  final script = HTMLScriptElement()..crossOrigin = 'anonymous';
+
+  late final StreamSubscription<Event> loadSubscription;
+  late final StreamSubscription<Event> errorSubscription;
+
+  void cancelSubscriptions() {
+    unawaited(loadSubscription.cancel());
+    unawaited(errorSubscription.cancel());
+  }
+
+  loadSubscription = script.onLoad.listen((_) {
+    if (!completer.isCompleted) {
+      completer.complete();
+      cancelSubscriptions();
+    }
+  });
+  errorSubscription = script.onError.listen((_) {
+    if (!completer.isCompleted) {
+      completer.completeError('Failed to load $src');
+      cancelSubscriptions();
+    }
+  });
 
   TrustedScriptURL? trustedUrl;
   if (!window.trustedTypes.isUndefinedOrNull) {

--- a/packages/flutter/test/web/sentry_script_loader_test.dart
+++ b/packages/flutter/test/web/sentry_script_loader_test.dart
@@ -113,9 +113,9 @@ void main() {
     test('ignores terminal events after the script has loaded', () async {
       final loadFuture = loadScript('https://invalid', fixture.options);
 
-      dispatchFirstScriptEvent('load');
+      dispatchScriptEvent('load');
 
-      expect(() => dispatchFirstScriptEvent('error'), returnsNormally);
+      expect(() => dispatchScriptEvent('error'), returnsNormally);
       await loadFuture;
     });
 
@@ -126,9 +126,9 @@ void main() {
         throwsA('Failed to load https://invalid'),
       );
 
-      dispatchFirstScriptEvent('error');
+      dispatchScriptEvent('error');
 
-      expect(() => dispatchFirstScriptEvent('load'), returnsNormally);
+      expect(() => dispatchScriptEvent('load'), returnsNormally);
       await errorExpectation;
     });
 

--- a/packages/flutter/test/web/sentry_script_loader_test.dart
+++ b/packages/flutter/test/web/sentry_script_loader_test.dart
@@ -5,7 +5,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:sentry_flutter/src/web/script_loader/script_dom_api.dart';
 import 'package:sentry_flutter/src/web/script_loader/sentry_script_loader.dart';
 import 'package:sentry_flutter/src/web/sentry_js_bundle.dart';
-import 'package:web/web.dart';
 
 import '../mocks.dart';
 import 'utils.dart';
@@ -113,25 +112,23 @@ void main() {
 
     test('ignores terminal events after the script has loaded', () async {
       final loadFuture = loadScript('https://invalid', fixture.options);
-      final script = document.querySelector('script') as HTMLScriptElement;
 
-      script.dispatchEvent(Event('load'));
+      dispatchFirstScriptEvent('load');
 
-      expect(() => script.dispatchEvent(Event('error')), returnsNormally);
+      expect(() => dispatchFirstScriptEvent('error'), returnsNormally);
       await loadFuture;
     });
 
     test('ignores terminal events after the script has failed', () async {
       final loadFuture = loadScript('https://invalid', fixture.options);
-      final script = document.querySelector('script') as HTMLScriptElement;
       final errorExpectation = expectLater(
         loadFuture,
         throwsA('Failed to load https://invalid'),
       );
 
-      script.dispatchEvent(Event('error'));
+      dispatchFirstScriptEvent('error');
 
-      expect(() => script.dispatchEvent(Event('load')), returnsNormally);
+      expect(() => dispatchFirstScriptEvent('load'), returnsNormally);
       await errorExpectation;
     });
 

--- a/packages/flutter/test/web/sentry_script_loader_test.dart
+++ b/packages/flutter/test/web/sentry_script_loader_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:sentry_flutter/src/web/script_loader/script_dom_api.dart';
 import 'package:sentry_flutter/src/web/script_loader/sentry_script_loader.dart';
 import 'package:sentry_flutter/src/web/sentry_js_bundle.dart';
+import 'package:web/web.dart';
 
 import '../mocks.dart';
 import 'utils.dart';
@@ -108,6 +109,30 @@ void main() {
       final scriptElements = fetchAllScripts();
       expect(scriptElements.first.src,
           endsWith('$jsSdkVersion/bundle.tracing.min.js'));
+    });
+
+    test('ignores terminal events after the script has loaded', () async {
+      final loadFuture = loadScript('https://invalid', fixture.options);
+      final script = document.querySelector('script') as HTMLScriptElement;
+
+      script.dispatchEvent(Event('load'));
+
+      expect(() => script.dispatchEvent(Event('error')), returnsNormally);
+      await loadFuture;
+    });
+
+    test('ignores terminal events after the script has failed', () async {
+      final loadFuture = loadScript('https://invalid', fixture.options);
+      final script = document.querySelector('script') as HTMLScriptElement;
+      final errorExpectation = expectLater(
+        loadFuture,
+        throwsA('Failed to load https://invalid'),
+      );
+
+      script.dispatchEvent(Event('error'));
+
+      expect(() => script.dispatchEvent(Event('load')), returnsNormally);
+      await errorExpectation;
     });
 
     test('Closes and cleans up resources', () async {

--- a/packages/flutter/test/web/utils.dart
+++ b/packages/flutter/test/web/utils.dart
@@ -27,3 +27,8 @@ dynamic getJsOptions() {
 List<SentryScriptElement> fetchAllScripts() {
   return fetchScripts('script');
 }
+
+void dispatchFirstScriptEvent(String type) {
+  final script = document.querySelector('script') as HTMLScriptElement;
+  script.dispatchEvent(Event(type));
+}

--- a/packages/flutter/test/web/utils.dart
+++ b/packages/flutter/test/web/utils.dart
@@ -28,7 +28,7 @@ List<SentryScriptElement> fetchAllScripts() {
   return fetchScripts('script');
 }
 
-void dispatchFirstScriptEvent(String type) {
+void dispatchScriptEvent(String type) {
   final script = document.querySelector('script') as HTMLScriptElement;
   script.dispatchEvent(Event(type));
 }


### PR DESCRIPTION
## 📜 Description

The Flutter web script loader now settles its load future at most once and cancels both DOM event subscriptions afterward. Browser regression tests cover both load-then-error and error-then-load delivery.

## 💡 Motivation and Context

Browsers can deliver more than one terminal event for the same script element. The second event previously completed the same `Completer` again, surfacing `StateError: Bad state: Future already completed` as an SDK-originated fatal event. Keeping the subscriptions active after settlement also retained their callbacks and captured state for the lifetime of the script element.

Closes getsentry/sentry-dart#3906

## 💚 How did you test it?

Temporarily restored the original implementation and ran the browser suite. Both regression tests failed with `Bad state: Future already completed`; with the fix restored, all browser tests passed.

## :pencil: Checklist

- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [X] I updated the docs if needed
- [X] All tests passing
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](<https://develop.sentry.dev/>) spec
- [X] No breaking changes