### PR TITLE
chore(deps): Pin Flutter development dependencies

### DIFF
--- a/packages/flutter/example/pubspec.yaml
+++ b/packages/flutter/example/pubspec.yaml
@@ -40,6 +40,7 @@ dependency_overrides:
   isar_flutter_libs:
     git:
       url: https://github.com/Deepjyoti120/isar_flutter_libs.git
+      ref: e61ce33af7118153d31689189077facbcfef8490
 
 dev_dependencies:
   flutter_lints: ^2.0.0
@@ -49,7 +50,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   test: ^1.21.1
-  build_runner: any
+  build_runner: ^2.4.2
 
 flutter:
   uses-material-design: true

--- a/packages/flutter/example/pubspec_overrides.yaml
+++ b/packages/flutter/example/pubspec_overrides.yaml
@@ -19,4 +19,6 @@ dependency_overrides:
   sentry_sqflite:
     path: ../../sqflite
   isar_flutter_libs:
-    git: https://github.com/Deepjyoti120/isar_flutter_libs.git
+    git:
+      url: https://github.com/Deepjyoti120/isar_flutter_libs.git
+      ref: e61ce33af7118153d31689189077facbcfef8490

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -48,7 +48,7 @@ dev_dependencies:
       ref: 6aa2c2642f507eab3df83373189170797a9fa5e7
   jnigen: 0.14.2
 
-  platform: any
+  platform: ^3.1.6
 flutter:
   plugin:
     platforms:


### PR DESCRIPTION
Pins the Flutter example's isar_flutter_libs Git source to an immutable commit in both its manifest and local override. It also bounds the example's build_runner and package's platform development dependencies so their resolution no longer floats between installs.