### PR TITLE
feat(flutter): Extend standalone app start

### DIFF
--- a/packages/dart/lib/src/constants.dart
+++ b/packages/dart/lib/src/constants.dart
@@ -3,6 +3,7 @@ import 'package:meta/meta.dart';
 @internal
 class SentrySpanOperations {
   static const String appStart = 'app.start';
+  static const String appStartExtended = 'app.start.extended';
   static const String appStartPluginRegistration =
       'app.start.plugin_registration';
   static const String appStartSentrySetup = 'app.start.sentry_setup';

--- a/packages/flutter/example/lib/main.dart
+++ b/packages/flutter/example/lib/main.dart
@@ -14,18 +14,63 @@ import 'app_config.dart' as config;
 import 'home_screen.dart';
 import 'theme_provider.dart';
 
+Future<void>? _startupConfiguration;
+
 Future<void> main() async {
   await setupSentry(
-    () => runApp(
-      SentryWidget(
-        child: DefaultAssetBundle(
-          bundle: SentryAssetBundle(),
-          child: const MyApp(),
+    () async {
+      SentryFlutter.extendAppStart();
+      final startupConfiguration = _loadStartupConfiguration();
+      _startupConfiguration = startupConfiguration;
+      runApp(
+        SentryWidget(
+          child: DefaultAssetBundle(
+            bundle: SentryAssetBundle(),
+            child: const MyApp(),
+          ),
         ),
-      ),
-    ),
+      );
+      try {
+        await startupConfiguration;
+      } finally {
+        await SentryFlutter.finishExtendedAppStart();
+      }
+    },
     config.exampleDsn,
   );
+}
+
+Future<void> _loadStartupConfiguration() async {
+  final staticParent = SentryFlutter.getExtendedAppStartSpan();
+  if (staticParent != null) {
+    final child = staticParent.startChild(
+      'app.init',
+      description: 'Load startup configuration',
+    );
+    try {
+      await Future.delayed(const Duration(seconds: 1));
+    } finally {
+      await child.finish();
+    }
+    return;
+  }
+
+  final streamParent = SentryFlutter.getExtendedAppStartSpanV2();
+  if (streamParent != null) {
+    final child = Sentry.startInactiveSpan(
+      'Load startup configuration',
+      parentSpan: streamParent,
+      attributes: {
+        SemanticAttributesConstants.sentryOp:
+            SentryAttribute.string('app.init'),
+      },
+    );
+    try {
+      await Future.delayed(const Duration(seconds: 1));
+    } finally {
+      child.end();
+    }
+  }
 }
 
 Future<void> setupSentryWithCustomInit(
@@ -134,9 +179,10 @@ class _MyAppState extends State<MyApp> {
   void doWork() async {
     final rootDisplay = SentryFlutter.currentDisplay();
 
-    await Sentry.startSpan('Custom span that runs during app start', (_) async {
-      await Future.delayed(const Duration(seconds: 1));
-    });
+    final startupConfiguration = _startupConfiguration;
+    if (startupConfiguration != null) {
+      await startupConfiguration;
+    }
 
     rootDisplay?.reportFullyDisplayed();
   }

--- a/packages/flutter/example/lib/main.dart
+++ b/packages/flutter/example/lib/main.dart
@@ -14,14 +14,9 @@ import 'app_config.dart' as config;
 import 'home_screen.dart';
 import 'theme_provider.dart';
 
-Future<void>? _startupConfiguration;
-
 Future<void> main() async {
   await setupSentry(
     () async {
-      SentryFlutter.extendAppStart();
-      final startupConfiguration = _loadStartupConfiguration();
-      _startupConfiguration = startupConfiguration;
       runApp(
         SentryWidget(
           child: DefaultAssetBundle(
@@ -30,11 +25,6 @@ Future<void> main() async {
           ),
         ),
       );
-      try {
-        await startupConfiguration;
-      } finally {
-        await SentryFlutter.finishExtendedAppStart();
-      }
     },
     config.exampleDsn,
   );
@@ -177,11 +167,15 @@ class _MyAppState extends State<MyApp> {
   }
 
   void doWork() async {
+    // Extend before the first frame renders, so the App Start measures up to
+    // `finishExtendedAppStart` instead of the first frame.
+    SentryFlutter.extendAppStart();
     final rootDisplay = SentryFlutter.currentDisplay();
 
-    final startupConfiguration = _startupConfiguration;
-    if (startupConfiguration != null) {
-      await startupConfiguration;
+    try {
+      await _loadStartupConfiguration();
+    } finally {
+      await SentryFlutter.finishExtendedAppStart();
     }
 
     rootDisplay?.reportFullyDisplayed();

--- a/packages/flutter/lib/src/app_start/standalone/app_start_trace.dart
+++ b/packages/flutter/lib/src/app_start/standalone/app_start_trace.dart
@@ -13,21 +13,20 @@ const standaloneAppStartIdleTimeout = Duration(seconds: 3);
 const standaloneAppStartFinalTimeout = Duration(seconds: 30);
 
 @internal
-const standaloneExtendedAppStartName = 'Extended App Start';
+const standaloneAppStartExtensionName = 'Extended App Start';
 
 /// Prefix shared by every reason an extension is turned down, so the public
 /// entry point and both lifecycles read the same way in the logs.
 @internal
 const appStartExtensionRefusalPrefix = 'Not extending the app start';
 
-/// Records why an extension was turned down and refuses it.
+/// Records why an extension was turned down.
 ///
 /// The public entry point returns nothing, so a log is the only way a user
 /// finds out their extension never opened.
 @internal
-bool refuseAppStartExtension(String reason) {
+void logAppStartExtensionRefusal(String reason) {
   internalLogger.info('$appStartExtensionRefusalPrefix: $reason');
-  return false;
 }
 
 /// Prefix shared by every reason a finish is turned down, so the public entry
@@ -36,16 +35,15 @@ bool refuseAppStartExtension(String reason) {
 const appStartExtensionFinishRefusalPrefix =
     'Not finishing the extended app start';
 
-/// Records why a finish was turned down and refuses it.
+/// Records why a finish was turned down.
 ///
-/// The counterpart to [refuseAppStartExtension], and the more valuable of the
-/// two: a finish is refused precisely when the app start has already been
+/// The counterpart to [logAppStartExtensionRefusal], and the more valuable of
+/// the two: a finish is refused precisely when the app start has already been
 /// reported, so the user is looking at a duration they expected the extension
 /// to cover and nothing else would tell them why it does not.
 @internal
-Future<void> refuseAppStartExtensionFinish(String reason) {
+void logAppStartExtensionFinishRefusal(String reason) {
   internalLogger.info('$appStartExtensionFinishRefusalPrefix: $reason');
-  return Future<void>.value();
 }
 
 /// Where an app-start extension stands when the root is enriched.

--- a/packages/flutter/lib/src/app_start/standalone/app_start_trace.dart
+++ b/packages/flutter/lib/src/app_start/standalone/app_start_trace.dart
@@ -1,4 +1,5 @@
 import 'package:meta/meta.dart';
+import 'package:sentry/sentry.dart';
 
 @internal
 const standaloneAppStartRootName = 'App Start';
@@ -8,6 +9,35 @@ const standaloneAppStartIdleTimeout = Duration(seconds: 3);
 
 @internal
 const standaloneAppStartFinalTimeout = Duration(seconds: 30);
+
+@internal
+const standaloneExtendedAppStartName = 'Extended App Start';
+
+/// Where an app-start extension stands when the root is enriched.
+@internal
+typedef AppStartExtensionOutcome = ({bool completed, DateTime? endTimestamp});
+
+/// Returns the endpoint a standalone app start reports up to, or `null` when it
+/// has none.
+///
+/// An extension that has started but not completed leaves the app start still
+/// running, so there is nothing to report yet — both trace implementations must
+/// stay silent rather than report a window that ends mid-extension.
+@internal
+DateTime? resolveAppStartMeasurementEnd(
+  DateTime? appStartEndTimestamp,
+  AppStartExtensionOutcome extension,
+) {
+  if (appStartEndTimestamp == null || !extension.completed) {
+    return null;
+  }
+
+  final extensionEndTimestamp = extension.endTimestamp;
+  return extensionEndTimestamp != null &&
+          extensionEndTimestamp.isAfter(appStartEndTimestamp)
+      ? extensionEndTimestamp
+      : appStartEndTimestamp;
+}
 
 /// How far a standalone app-start trace has progressed.
 ///
@@ -45,6 +75,14 @@ enum AppStartTraceState {
 /// See `docs/standalone-app-start-spec.md` for the contract.
 @internal
 abstract interface class AppStartTrace {
+  bool tryExtend(DateTime startTimestamp);
+
+  ISentrySpan? get extendedSpan;
+
+  SentrySpanV2? get extendedSpanV2;
+
+  Future<void> finishExtended(DateTime endTimestamp);
+
   /// Ends the first-frame span and marks [endTimestamp] as the app-start end.
   ///
   /// The root is not ended here — it stays open for its idle timeout so late

--- a/packages/flutter/lib/src/app_start/standalone/app_start_trace.dart
+++ b/packages/flutter/lib/src/app_start/standalone/app_start_trace.dart
@@ -15,25 +15,15 @@ const standaloneAppStartFinalTimeout = Duration(seconds: 30);
 @internal
 const standaloneAppStartExtensionName = 'Extended App Start';
 
-/// Prefix shared by every reason an extension is turned down, so the public
-/// entry point and both lifecycles read the same way in the logs.
-@internal
-const appStartExtensionRefusalPrefix = 'Not extending the app start';
-
-/// Records why an extension was turned down.
+/// Records why an extension was turned down, so the public entry point and
+/// both lifecycles read the same way in the logs.
 ///
 /// The public entry point returns nothing, so a log is the only way a user
 /// finds out their extension never opened.
 @internal
 void logAppStartExtensionRefusal(String reason) {
-  internalLogger.info('$appStartExtensionRefusalPrefix: $reason');
+  internalLogger.info('Not extending the app start: $reason');
 }
-
-/// Prefix shared by every reason a finish is turned down, so the public entry
-/// point and both lifecycles read the same way in the logs.
-@internal
-const appStartExtensionFinishRefusalPrefix =
-    'Not finishing the extended app start';
 
 /// Records why a finish was turned down.
 ///
@@ -43,7 +33,7 @@ const appStartExtensionFinishRefusalPrefix =
 /// to cover and nothing else would tell them why it does not.
 @internal
 void logAppStartExtensionFinishRefusal(String reason) {
-  internalLogger.info('$appStartExtensionFinishRefusalPrefix: $reason');
+  internalLogger.info('Not finishing the extended app start: $reason');
 }
 
 /// How far a standalone app-start trace has progressed.
@@ -84,15 +74,23 @@ abstract interface class AppStartTrace {
   /// first frame until it is finished.
   ///
   /// Returns `false` when the extension was refused: one already exists, the
-  /// first frame has already rendered, or the trace is winding down.
+  /// first frame has already rendered, or the trace is winding down. Every
+  /// refusal is logged, which is why the public entry point can discard this.
   bool tryExtend(DateTime startTimestamp);
 
   /// The running extension span on the static lifecycle, or `null` on the
   /// streaming one and once the extension is no longer running.
+  ///
+  /// There is one getter per span protocol because a caller parenting its own
+  /// work under the extension needs the concrete type its lifecycle speaks.
+  /// Each implementation answers for its own protocol and `null` for the other,
+  /// so the pair follows `SentryFlutterOptions.traceLifecycle`.
   ISentrySpan? get extendedSpan;
 
   /// The running extension span on the streaming lifecycle, or `null` on the
   /// static one and once the extension is no longer running.
+  ///
+  /// See [extendedSpan] for why there is one getter per protocol.
   SentrySpanV2? get extendedSpanV2;
 
   /// Ends the extension span, releasing the app start to report.

--- a/packages/flutter/lib/src/app_start/standalone/app_start_trace.dart
+++ b/packages/flutter/lib/src/app_start/standalone/app_start_trace.dart
@@ -1,6 +1,8 @@
 import 'package:meta/meta.dart';
 import 'package:sentry/sentry.dart';
 
+import '../../utils/internal_logger.dart';
+
 @internal
 const standaloneAppStartRootName = 'App Start';
 
@@ -13,6 +15,21 @@ const standaloneAppStartFinalTimeout = Duration(seconds: 30);
 @internal
 const standaloneExtendedAppStartName = 'Extended App Start';
 
+/// Prefix shared by every reason an extension is turned down, so the public
+/// entry point and both lifecycles read the same way in the logs.
+@internal
+const appStartExtensionRefusalPrefix = 'Not extending the app start';
+
+/// Records why an extension was turned down and refuses it.
+///
+/// The public entry point returns nothing, so a log is the only way a user
+/// finds out their extension never opened.
+@internal
+bool refuseAppStartExtension(String reason) {
+  internalLogger.info('$appStartExtensionRefusalPrefix: $reason');
+  return false;
+}
+
 /// Where an app-start extension stands when the root is enriched.
 ///
 /// [isSettled] means the extension is no longer holding the app start open —
@@ -20,27 +37,10 @@ const standaloneExtendedAppStartName = 'Extended App Start';
 @internal
 typedef AppStartExtensionOutcome = ({bool isSettled, DateTime? endTimestamp});
 
-/// Returns the endpoint a standalone app start reports up to, or `null` when it
-/// has none.
-///
-/// An extension that has started but not settled leaves the app start still
-/// running, so there is nothing to report yet — both trace implementations must
-/// stay silent rather than report a window that ends mid-extension.
+/// The outcome of an app start that was never extended.
 @internal
-DateTime? resolveAppStartMeasurementEnd(
-  DateTime? appStartEndTimestamp,
-  AppStartExtensionOutcome extension,
-) {
-  if (appStartEndTimestamp == null || !extension.isSettled) {
-    return null;
-  }
-
-  final extensionEndTimestamp = extension.endTimestamp;
-  return extensionEndTimestamp != null &&
-          extensionEndTimestamp.isAfter(appStartEndTimestamp)
-      ? extensionEndTimestamp
-      : appStartEndTimestamp;
-}
+const AppStartExtensionOutcome noAppStartExtension =
+    (isSettled: true, endTimestamp: null);
 
 /// How far a standalone app-start trace has progressed.
 ///

--- a/packages/flutter/lib/src/app_start/standalone/app_start_trace.dart
+++ b/packages/flutter/lib/src/app_start/standalone/app_start_trace.dart
@@ -30,6 +30,24 @@ bool refuseAppStartExtension(String reason) {
   return false;
 }
 
+/// Prefix shared by every reason a finish is turned down, so the public entry
+/// point and both lifecycles read the same way in the logs.
+@internal
+const appStartExtensionFinishRefusalPrefix =
+    'Not finishing the extended app start';
+
+/// Records why a finish was turned down and refuses it.
+///
+/// The counterpart to [refuseAppStartExtension], and the more valuable of the
+/// two: a finish is refused precisely when the app start has already been
+/// reported, so the user is looking at a duration they expected the extension
+/// to cover and nothing else would tell them why it does not.
+@internal
+Future<void> refuseAppStartExtensionFinish(String reason) {
+  internalLogger.info('$appStartExtensionFinishRefusalPrefix: $reason');
+  return Future<void>.value();
+}
+
 /// Where an app-start extension stands when the root is enriched.
 ///
 /// [isSettled] means the extension is no longer holding the app start open —

--- a/packages/flutter/lib/src/app_start/standalone/app_start_trace.dart
+++ b/packages/flutter/lib/src/app_start/standalone/app_start_trace.dart
@@ -46,18 +46,6 @@ void logAppStartExtensionFinishRefusal(String reason) {
   internalLogger.info('$appStartExtensionFinishRefusalPrefix: $reason');
 }
 
-/// Where an app-start extension stands when the root is enriched.
-///
-/// [isSettled] means the extension is no longer holding the app start open —
-/// either it finished, or it was never started at all.
-@internal
-typedef AppStartExtensionOutcome = ({bool isSettled, DateTime? endTimestamp});
-
-/// The outcome of an app start that was never extended.
-@internal
-const AppStartExtensionOutcome noAppStartExtension =
-    (isSettled: true, endTimestamp: null);
-
 /// How far a standalone app-start trace has progressed.
 ///
 /// Shared by both trace implementations, which advance through it identically.

--- a/packages/flutter/lib/src/app_start/standalone/app_start_trace.dart
+++ b/packages/flutter/lib/src/app_start/standalone/app_start_trace.dart
@@ -14,13 +14,16 @@ const standaloneAppStartFinalTimeout = Duration(seconds: 30);
 const standaloneExtendedAppStartName = 'Extended App Start';
 
 /// Where an app-start extension stands when the root is enriched.
+///
+/// [isSettled] means the extension is no longer holding the app start open —
+/// either it finished, or it was never started at all.
 @internal
-typedef AppStartExtensionOutcome = ({bool completed, DateTime? endTimestamp});
+typedef AppStartExtensionOutcome = ({bool isSettled, DateTime? endTimestamp});
 
 /// Returns the endpoint a standalone app start reports up to, or `null` when it
 /// has none.
 ///
-/// An extension that has started but not completed leaves the app start still
+/// An extension that has started but not settled leaves the app start still
 /// running, so there is nothing to report yet — both trace implementations must
 /// stay silent rather than report a window that ends mid-extension.
 @internal
@@ -28,7 +31,7 @@ DateTime? resolveAppStartMeasurementEnd(
   DateTime? appStartEndTimestamp,
   AppStartExtensionOutcome extension,
 ) {
-  if (appStartEndTimestamp == null || !extension.completed) {
+  if (appStartEndTimestamp == null || !extension.isSettled) {
     return null;
   }
 
@@ -71,16 +74,27 @@ enum AppStartTraceState {
 /// hierarchy and status through its lifecycle's own payload. What gets
 /// reported is resolved once in `AppStartVitals`; the implementations differ
 /// only in how they write it.
-///
-/// See `docs/standalone-app-start-spec.md` for the contract.
 @internal
 abstract interface class AppStartTrace {
+  /// Opens the single extension span, keeping the app start open past the
+  /// first frame until it is finished.
+  ///
+  /// Returns `false` when the extension was refused: one already exists, the
+  /// first frame has already rendered, or the trace is winding down.
   bool tryExtend(DateTime startTimestamp);
 
+  /// The running extension span on the static lifecycle, or `null` on the
+  /// streaming one and once the extension is no longer running.
   ISentrySpan? get extendedSpan;
 
+  /// The running extension span on the streaming lifecycle, or `null` on the
+  /// static one and once the extension is no longer running.
   SentrySpanV2? get extendedSpanV2;
 
+  /// Ends the extension span, releasing the app start to report.
+  ///
+  /// Descendants started under the extension are left running; they keep the
+  /// root open on their own until they end or the root hits its deadline.
   Future<void> finishExtended(DateTime endTimestamp);
 
   /// Ends the first-frame span and marks [endTimestamp] as the app-start end.

--- a/packages/flutter/lib/src/app_start/standalone/app_start_vitals.dart
+++ b/packages/flutter/lib/src/app_start/standalone/app_start_vitals.dart
@@ -51,24 +51,21 @@ final class AppStartVitals {
     );
   }
 
-  /// The endpoint the app start is measured to, or `null` when the first frame
-  /// never arrived.
+  /// The later of the first frame and the extension, or `null` when the first
+  /// frame never arrived.
   ///
-  /// An extension that settled after the first frame moves the endpoint out to
-  /// it. One that contributes nothing — never started, still running, or
-  /// force-ended by the root's deadline — leaves the app start measured to the
-  /// first frame rather than withholding it, matching how sentry-java and
-  /// sentry-cocoa clamp a timed-out time-to-full-display back to
-  /// time-to-initial-display.
+  /// An extension contributing nothing — never started, still running, or
+  /// force-ended by the root's deadline — therefore leaves the app start
+  /// measured to the first frame rather than withholding it, matching how
+  /// sentry-java and sentry-cocoa clamp a timed-out time-to-full-display back
+  /// to time-to-initial-display.
   static DateTime? _resolveMeasurementEnd(
     DateTime? endTimestamp,
     DateTime? extensionEndTimestamp,
   ) {
-    if (endTimestamp == null) {
-      return null;
-    }
-    return extensionEndTimestamp != null &&
-            extensionEndTimestamp.isAfter(endTimestamp)
+    if (endTimestamp == null) return null;
+    if (extensionEndTimestamp == null) return endTimestamp;
+    return extensionEndTimestamp.isAfter(endTimestamp)
         ? extensionEndTimestamp
         : endTimestamp;
   }

--- a/packages/flutter/lib/src/app_start/standalone/app_start_vitals.dart
+++ b/packages/flutter/lib/src/app_start/standalone/app_start_vitals.dart
@@ -31,43 +31,58 @@ final class AppStartVitals {
 
   /// Resolves the reported signal for a root that is about to be captured.
   ///
-  /// [endTimestamp] is the first frame, or `null` when none arrived.
-  /// [extensionEndTimestamp] is what an app-start extension contributes, which
-  /// can move the measured endpoint past the first frame.
+  /// [firstFrameTimestamp] is when the first frame finished rasterizing, or
+  /// `null` when no frame arrived. [extensionEndTimestamp] is what an app-start
+  /// extension contributes, which can move the measured endpoint past the first
+  /// frame.
   factory AppStartVitals.resolve({
     required AppStartTiming timing,
     required String screen,
-    required DateTime? endTimestamp,
+    required DateTime? firstFrameTimestamp,
     required DateTime? extensionEndTimestamp,
   }) {
-    final measurementEnd =
-        _resolveMeasurementEnd(endTimestamp, extensionEndTimestamp);
     return AppStartVitals._(
       type: timing.type,
       screen: screen,
-      duration: measurementEnd == null
-          ? null
-          : timing.reportableDurationUntil(measurementEnd),
+      duration: _resolveDuration(
+        timing,
+        firstFrameTimestamp,
+        extensionEndTimestamp,
+      ),
     );
   }
 
-  /// The later of the first frame and the extension, or `null` when the first
-  /// frame never arrived.
+  /// The duration to the later of the first frame and the extension, or `null`
+  /// when the first frame never arrived.
   ///
   /// An extension contributing nothing — never started, still running, or
-  /// force-ended by the root's deadline — therefore leaves the app start
-  /// measured to the first frame rather than withholding it, matching how
-  /// sentry-java and sentry-cocoa clamp a timed-out time-to-full-display back
-  /// to time-to-initial-display.
-  static DateTime? _resolveMeasurementEnd(
-    DateTime? endTimestamp,
+  /// force-ended by the root's deadline — leaves the app start measured to the
+  /// first frame rather than withholding it, matching how sentry-java and
+  /// sentry-cocoa clamp a timed-out time-to-full-display back to
+  /// time-to-initial-display.
+  ///
+  /// An extension whose endpoint is implausible clamps back the same way. The
+  /// two windows are anchored differently — the extension runs on a budget
+  /// measured from trace creation, which a pre-warmed launch can enter up to
+  /// the plausibility ceiling after the process started — so an extension can
+  /// breach that ceiling while the first frame is still within it. Reporting
+  /// nothing there would make extending strictly worse than not extending.
+  static Duration? _resolveDuration(
+    AppStartTiming timing,
+    DateTime? firstFrameTimestamp,
     DateTime? extensionEndTimestamp,
   ) {
-    if (endTimestamp == null) return null;
-    if (extensionEndTimestamp == null) return endTimestamp;
-    return extensionEndTimestamp.isAfter(endTimestamp)
-        ? extensionEndTimestamp
-        : endTimestamp;
+    if (firstFrameTimestamp == null) return null;
+
+    final firstFrameDuration =
+        timing.reportableDurationUntil(firstFrameTimestamp);
+    if (extensionEndTimestamp == null ||
+        !extensionEndTimestamp.isAfter(firstFrameTimestamp)) {
+      return firstFrameDuration;
+    }
+
+    return timing.reportableDurationUntil(extensionEndTimestamp) ??
+        firstFrameDuration;
   }
 
   /// Cold or warm.

--- a/packages/flutter/lib/src/app_start/standalone/app_start_vitals.dart
+++ b/packages/flutter/lib/src/app_start/standalone/app_start_vitals.dart
@@ -4,7 +4,6 @@ import 'package:meta/meta.dart';
 
 import '../../../sentry_flutter.dart';
 import '../app_start_timing.dart';
-import 'app_start_trace.dart';
 
 /// What a standalone app-start root reports, resolved once for both trace
 /// lifecycles.
@@ -33,42 +32,44 @@ final class AppStartVitals {
   /// Resolves the reported signal for a root that is about to be captured.
   ///
   /// [endTimestamp] is the first frame, or `null` when none arrived.
-  /// [extension] is where an app-start extension stands, which can move the
-  /// measured endpoint past the first frame or withhold it entirely.
-  /// [deadlineExceeded] marks a root torn down by its hard deadline.
+  /// [extensionEndTimestamp] is what an app-start extension contributes, which
+  /// can move the measured endpoint past the first frame.
   factory AppStartVitals.resolve({
     required AppStartTiming timing,
     required String screen,
     required DateTime? endTimestamp,
-    required AppStartExtensionOutcome extension,
-    required bool deadlineExceeded,
+    required DateTime? extensionEndTimestamp,
   }) {
-    final measurementEnd = _resolveMeasurementEnd(endTimestamp, extension);
+    final measurementEnd =
+        _resolveMeasurementEnd(endTimestamp, extensionEndTimestamp);
     return AppStartVitals._(
       type: timing.type,
       screen: screen,
-      duration: measurementEnd == null || deadlineExceeded
+      duration: measurementEnd == null
           ? null
           : timing.reportableDurationUntil(measurementEnd),
     );
   }
 
-  /// The endpoint the app start is measured to, or `null` when it has none.
+  /// The endpoint the app start is measured to, or `null` when the first frame
+  /// never arrived.
   ///
-  /// An extension that has started but not settled leaves the app start still
-  /// running, so there is nothing to report yet — better to withhold the
-  /// duration than to report a window that ends mid-extension.
+  /// An extension that settled after the first frame moves the endpoint out to
+  /// it. One that contributes nothing — never started, still running, or
+  /// force-ended by the root's deadline — leaves the app start measured to the
+  /// first frame rather than withholding it, matching how sentry-java and
+  /// sentry-cocoa clamp a timed-out time-to-full-display back to
+  /// time-to-initial-display.
   static DateTime? _resolveMeasurementEnd(
     DateTime? endTimestamp,
-    AppStartExtensionOutcome extension,
+    DateTime? extensionEndTimestamp,
   ) {
-    if (endTimestamp == null || !extension.isSettled) {
+    if (endTimestamp == null) {
       return null;
     }
-
-    final extensionEnd = extension.endTimestamp;
-    return extensionEnd != null && extensionEnd.isAfter(endTimestamp)
-        ? extensionEnd
+    return extensionEndTimestamp != null &&
+            extensionEndTimestamp.isAfter(endTimestamp)
+        ? extensionEndTimestamp
         : endTimestamp;
   }
 
@@ -86,10 +87,9 @@ final class AppStartVitals {
   /// Time from process start to the first frame, or to the end of an extension
   /// that outlasted it.
   ///
-  /// `null` when the app start has no measurable duration: no first frame
-  /// arrived, an extension is still running so the window has no end yet, or
-  /// the root hit its hard deadline and the window is truncated. Type and
-  /// screen are still reported in those cases.
+  /// `null` when no first frame arrived and the app start therefore has no
+  /// measurable window at all. Type and screen are still reported in that
+  /// case.
   final Duration? duration;
 
   /// The cold/warm measurement for the static payload, or `null` when there is

--- a/packages/flutter/lib/src/app_start/standalone/app_start_vitals.dart
+++ b/packages/flutter/lib/src/app_start/standalone/app_start_vitals.dart
@@ -4,6 +4,7 @@ import 'package:meta/meta.dart';
 
 import '../../../sentry_flutter.dart';
 import '../app_start_timing.dart';
+import 'app_start_trace.dart';
 
 /// What a standalone app-start root reports, resolved once for both trace
 /// lifecycles.
@@ -32,20 +33,44 @@ final class AppStartVitals {
   /// Resolves the reported signal for a root that is about to be captured.
   ///
   /// [endTimestamp] is the first frame, or `null` when none arrived.
+  /// [extension] is where an app-start extension stands, which can move the
+  /// measured endpoint past the first frame or withhold it entirely.
   /// [deadlineExceeded] marks a root torn down by its hard deadline.
   factory AppStartVitals.resolve({
     required AppStartTiming timing,
     required String screen,
     required DateTime? endTimestamp,
+    required AppStartExtensionOutcome extension,
     required bool deadlineExceeded,
-  }) =>
-      AppStartVitals._(
-        type: timing.type,
-        screen: screen,
-        duration: endTimestamp == null || deadlineExceeded
-            ? null
-            : timing.reportableDurationUntil(endTimestamp),
-      );
+  }) {
+    final measurementEnd = _resolveMeasurementEnd(endTimestamp, extension);
+    return AppStartVitals._(
+      type: timing.type,
+      screen: screen,
+      duration: measurementEnd == null || deadlineExceeded
+          ? null
+          : timing.reportableDurationUntil(measurementEnd),
+    );
+  }
+
+  /// The endpoint the app start is measured to, or `null` when it has none.
+  ///
+  /// An extension that has started but not settled leaves the app start still
+  /// running, so there is nothing to report yet — better to withhold the
+  /// duration than to report a window that ends mid-extension.
+  static DateTime? _resolveMeasurementEnd(
+    DateTime? endTimestamp,
+    AppStartExtensionOutcome extension,
+  ) {
+    if (endTimestamp == null || !extension.isSettled) {
+      return null;
+    }
+
+    final extensionEnd = extension.endTimestamp;
+    return extensionEnd != null && extensionEnd.isAfter(endTimestamp)
+        ? extensionEnd
+        : endTimestamp;
+  }
 
   /// Cold or warm.
   ///
@@ -58,11 +83,13 @@ final class AppStartVitals {
   /// The route observed at the first frame, or the `root /` fallback.
   final String screen;
 
-  /// Time from process start to the first frame.
+  /// Time from process start to the first frame, or to the end of an extension
+  /// that outlasted it.
   ///
   /// `null` when the app start has no measurable duration: no first frame
-  /// arrived, or the root hit its hard deadline and the window is truncated.
-  /// Type and screen are still reported in that case.
+  /// arrived, an extension is still running so the window has no end yet, or
+  /// the root hit its hard deadline and the window is truncated. Type and
+  /// screen are still reported in those cases.
   final Duration? duration;
 
   /// The cold/warm measurement for the static payload, or `null` when there is

--- a/packages/flutter/lib/src/app_start/standalone/standalone_app_start_handler.dart
+++ b/packages/flutter/lib/src/app_start/standalone/standalone_app_start_handler.dart
@@ -22,7 +22,6 @@ class StandaloneAppStartHandler {
   final FrameCallbackHandler _frameCallbackHandler;
   final SentryNativeBinding _native;
 
-  AppStartTrace? _trace;
   String? _startScreenName;
   TimingsCallback? _timingsCallback;
   SentryFlutterOptions? _options;
@@ -89,7 +88,6 @@ class StandaloneAppStartHandler {
       );
     } else {
       final trace = _createAppStartTrace(options, timing);
-      _trace = trace;
       if (trace == null) {
         internalLogger.info(
           'Skipping standalone app start: trace was not created',
@@ -161,7 +159,7 @@ class StandaloneAppStartHandler {
         // the user may navigate away before the app-start span finishes.
         _startScreenName ??= SentryNavigatorObserver.currentRouteName;
 
-        _trace?.recordFirstFrame(endTimestamp);
+        options.standaloneAppStartTrace?.recordFirstFrame(endTimestamp);
 
         // Keep display tracking last because TTFD may wait for its timeout.
         await _displayTracking?.record(endTimestamp);
@@ -184,11 +182,13 @@ class StandaloneAppStartHandler {
   Future<void> close() async {
     _closed = true;
     _removeTimingsCallback();
-    await _trace?.close();
+    // Read before closing: a trace that reports while closing unpublishes
+    // itself, and this teardown still has to await the one it started with.
+    final trace = _options?.standaloneAppStartTrace;
+    await trace?.close();
     _unpublishTrace();
     _displayTracking?.cancel();
     _displayTracking = null;
-    _trace = null;
     _startScreenName = null;
   }
 

--- a/packages/flutter/lib/src/app_start/standalone/standalone_app_start_handler.dart
+++ b/packages/flutter/lib/src/app_start/standalone/standalone_app_start_handler.dart
@@ -28,6 +28,10 @@ class StandaloneAppStartHandler {
 
   /// Set by [_prepareTimeToDisplay]; `null` until then.
   AppStartDisplayTracking? _displayTracking;
+
+  /// The options [_trace] was published on, so [close] clears the same ones.
+  SentryFlutterOptions? _publishedOptions;
+
   bool _started = false;
   bool _closed = false;
 
@@ -85,11 +89,15 @@ class StandaloneAppStartHandler {
         'Skipping standalone app start: native timing unavailable or invalid',
       );
     } else {
-      _trace = _createAppStartTrace(options, timing);
-      if (_trace == null) {
+      final trace = _createAppStartTrace(options, timing);
+      _trace = trace;
+      if (trace == null) {
         internalLogger.info(
           'Skipping standalone app start: trace was not created',
         );
+      } else {
+        options.standaloneAppStartTrace = trace;
+        _publishedOptions = options;
       }
     }
 
@@ -171,7 +179,14 @@ class StandaloneAppStartHandler {
   Future<void> close() async {
     _closed = true;
     _removeTimingsCallback();
-    await _trace?.close();
+    final trace = _trace;
+    await trace?.close();
+    final publishedOptions = _publishedOptions;
+    if (trace != null &&
+        identical(publishedOptions?.standaloneAppStartTrace, trace)) {
+      publishedOptions?.standaloneAppStartTrace = null;
+    }
+    _publishedOptions = null;
     _displayTracking?.cancel();
     _displayTracking = null;
     _trace = null;

--- a/packages/flutter/lib/src/app_start/standalone/standalone_app_start_handler.dart
+++ b/packages/flutter/lib/src/app_start/standalone/standalone_app_start_handler.dart
@@ -25,12 +25,10 @@ class StandaloneAppStartHandler {
   AppStartTrace? _trace;
   String? _startScreenName;
   TimingsCallback? _timingsCallback;
+  SentryFlutterOptions? _options;
 
   /// Set by [_prepareTimeToDisplay]; `null` until then.
   AppStartDisplayTracking? _displayTracking;
-
-  /// The options [_trace] was published on, so [close] clears the same ones.
-  SentryFlutterOptions? _publishedOptions;
 
   bool _started = false;
   bool _closed = false;
@@ -49,6 +47,7 @@ class StandaloneAppStartHandler {
       return;
     }
     _started = true;
+    _options = options;
 
     AppStartTiming? timing;
     try {
@@ -97,7 +96,6 @@ class StandaloneAppStartHandler {
         );
       } else {
         options.standaloneAppStartTrace = trace;
-        _publishedOptions = options;
       }
     }
 
@@ -132,17 +130,7 @@ class StandaloneAppStartHandler {
   /// Stops exposing the trace once it can no longer be extended, so a reported
   /// app start does not stay reachable — and retained — for the process
   /// lifetime.
-  ///
-  /// A trace published by someone else is left alone.
-  void _unpublishTrace() {
-    final publishedOptions = _publishedOptions;
-    final trace = _trace;
-    if (trace != null &&
-        identical(publishedOptions?.standaloneAppStartTrace, trace)) {
-      publishedOptions?.standaloneAppStartTrace = null;
-    }
-    _publishedOptions = null;
-  }
+  void _unpublishTrace() => _options?.standaloneAppStartTrace = null;
 
   String _resolveStartScreenName() => resolveRouteDisplayName(_startScreenName);
 

--- a/packages/flutter/lib/src/app_start/standalone/standalone_app_start_handler.dart
+++ b/packages/flutter/lib/src/app_start/standalone/standalone_app_start_handler.dart
@@ -118,13 +118,30 @@ class StandaloneAppStartHandler {
           hub: _hub,
           timing: timing,
           startScreenNameProvider: _resolveStartScreenName,
+          onCompleted: _unpublishTrace,
         ),
       SentryTraceLifecycle.stream => StreamingAppStartTrace.tryCreate(
           hub: _hub,
           timing: timing,
           startScreenNameProvider: _resolveStartScreenName,
+          onCompleted: _unpublishTrace,
         ),
     };
+  }
+
+  /// Stops exposing the trace once it can no longer be extended, so a reported
+  /// app start does not stay reachable — and retained — for the process
+  /// lifetime.
+  ///
+  /// A trace published by someone else is left alone.
+  void _unpublishTrace() {
+    final publishedOptions = _publishedOptions;
+    final trace = _trace;
+    if (trace != null &&
+        identical(publishedOptions?.standaloneAppStartTrace, trace)) {
+      publishedOptions?.standaloneAppStartTrace = null;
+    }
+    _publishedOptions = null;
   }
 
   String _resolveStartScreenName() => resolveRouteDisplayName(_startScreenName);
@@ -179,14 +196,8 @@ class StandaloneAppStartHandler {
   Future<void> close() async {
     _closed = true;
     _removeTimingsCallback();
-    final trace = _trace;
-    await trace?.close();
-    final publishedOptions = _publishedOptions;
-    if (trace != null &&
-        identical(publishedOptions?.standaloneAppStartTrace, trace)) {
-      publishedOptions?.standaloneAppStartTrace = null;
-    }
-    _publishedOptions = null;
+    await _trace?.close();
+    _unpublishTrace();
     _displayTracking?.cancel();
     _displayTracking = null;
     _trace = null;

--- a/packages/flutter/lib/src/app_start/standalone/static_app_start_trace.dart
+++ b/packages/flutter/lib/src/app_start/standalone/static_app_start_trace.dart
@@ -26,8 +26,11 @@ final class StaticAppStartTrace implements AppStartTrace {
   DateTime? _endTimestamp;
   AppStartTraceState _state = AppStartTraceState.open;
 
-  // The final deadline drains descendants asynchronously. Block extension
-  // mutations while that sweep is in progress.
+  // One way flag — never cleared — once the final deadline starts draining
+  // descendants asynchronously. It blocks extension mutations across that
+  // sweep, after which the terminal state normally takes over; when the drain
+  // fails before reaching it, this stays the only thing refusing to extend a
+  // root that is already past its deadline.
   bool _finalizing = false;
 
   bool get _isFinalizingOrTerminal => _finalizing || _state.isTerminal;
@@ -202,7 +205,7 @@ final class StaticAppStartTrace implements AppStartTrace {
       final vitals = AppStartVitals.resolve(
         timing: _timing,
         screen: _startScreenNameProvider(),
-        endTimestamp: _endTimestamp,
+        firstFrameTimestamp: _endTimestamp,
         extensionEndTimestamp: _extensionLifecycle.measurementEnd,
       );
 

--- a/packages/flutter/lib/src/app_start/standalone/static_app_start_trace.dart
+++ b/packages/flutter/lib/src/app_start/standalone/static_app_start_trace.dart
@@ -20,11 +20,19 @@ final class StaticAppStartTrace implements AppStartTrace {
   final DateTime _finalDeadlineTimestamp;
   final String Function() _startScreenNameProvider;
 
+  final _StaticAppStartExtensionLifecycle _extensionLifecycle;
   Timer? _finalTimeoutTimer;
   DateTime? _endTimestamp;
   AppStartTraceState _state = AppStartTraceState.open;
 
+  // The final deadline drains descendants asynchronously. Block extension
+  // mutations while that sweep is in progress.
+  bool _finalizing = false;
+
+  bool get _isFinalizingOrTerminal => _finalizing || _state.isTerminal;
+
   StaticAppStartTrace._({
+    required Hub hub,
     required AppStartTiming timing,
     required SentryTracer root,
     required ISentrySpan firstFrameRenderSpan,
@@ -34,7 +42,11 @@ final class StaticAppStartTrace implements AppStartTrace {
         _root = root,
         _firstFrameRenderSpan = firstFrameRenderSpan,
         _finalDeadlineTimestamp = finalDeadlineTimestamp,
-        _startScreenNameProvider = startScreenNameProvider;
+        _startScreenNameProvider = startScreenNameProvider,
+        _extensionLifecycle = _StaticAppStartExtensionLifecycle(
+          hub: hub,
+          root: root,
+        );
 
   /// Opens the standalone root and its breakdown children.
   ///
@@ -85,6 +97,7 @@ final class StaticAppStartTrace implements AppStartTrace {
       }
 
       trace = StaticAppStartTrace._(
+        hub: hub,
         timing: timing,
         root: root,
         firstFrameRenderSpan: firstFrameRenderSpan,
@@ -124,6 +137,30 @@ final class StaticAppStartTrace implements AppStartTrace {
   }
 
   @override
+  bool tryExtend(DateTime startTimestamp) {
+    if (_isFinalizingOrTerminal || _firstFrameRenderSpan.endTimestamp != null) {
+      return false;
+    }
+
+    return _extensionLifecycle.tryStart(startTimestamp);
+  }
+
+  @override
+  ISentrySpan? get extendedSpan => _extensionLifecycle.activeSpan;
+
+  @override
+  SentrySpanV2? get extendedSpanV2 => null;
+
+  @override
+  Future<void> finishExtended(DateTime endTimestamp) {
+    if (_isFinalizingOrTerminal) {
+      return Future<void>.value();
+    }
+
+    return _extensionLifecycle.finish(endTimestamp);
+  }
+
+  @override
   void recordFirstFrame(DateTime endTimestamp) {
     if (_state.isTerminal || _endTimestamp != null) return;
     // Set before finishing the child: finishing the last outstanding child can
@@ -140,6 +177,7 @@ final class StaticAppStartTrace implements AppStartTrace {
     if (_state.isTerminal) return;
     _state = AppStartTraceState.closed;
     _clearFinalTimeout();
+    await _extensionLifecycle.close();
     await _flushTrace(_root);
   }
 
@@ -150,7 +188,10 @@ final class StaticAppStartTrace implements AppStartTrace {
       final vitals = AppStartVitals.resolve(
         timing: _timing,
         screen: _startScreenNameProvider(),
-        endTimestamp: _endTimestamp,
+        endTimestamp: resolveAppStartMeasurementEnd(
+          _endTimestamp,
+          _extensionLifecycle.completionSnapshot,
+        ),
         deadlineExceeded: _root.status == SpanStatus.deadlineExceeded(),
       );
 
@@ -197,18 +238,23 @@ final class StaticAppStartTrace implements AppStartTrace {
 
   /// Force-ends the trace once the hard deadline passes.
   ///
-  /// Runs at most once — the final-timeout [Timer] is one-shot — so no
-  /// re-entry guard is needed beyond the terminal check. The state stays
+  /// Runs at most once — the final-timeout [Timer] is one-shot — so the
+  /// terminal check is enough to keep it out; [_finalizing] is what keeps
+  /// extensions out while the drain below awaits. The state stays
   /// [AppStartTraceState.open] throughout, which lets a first frame arriving
   /// between the awaits below still run [recordFirstFrame]. That is harmless:
   /// the root is already `deadlineExceeded`, so the vitals omit the duration
   /// either way.
   Future<void> _finishAtDeadline() async {
-    if (_state.isTerminal) return;
+    if (_isFinalizingOrTerminal) return;
+    _finalizing = true;
     _clearFinalTimeout();
 
     final status = SpanStatus.deadlineExceeded();
     _root.status = status;
+
+    await _extensionLifecycle.waitForPendingFinish();
+    if (_state.isTerminal) return;
 
     // The tracer stores parents before descendants. Reverse the list so finish
     // callbacks observe a drained subtree before its parent ends.
@@ -257,5 +303,129 @@ final class StaticAppStartTrace implements AppStartTrace {
         stackTrace: stackTrace,
       );
     }
+  }
+}
+
+final class _StaticAppStartExtensionLifecycle {
+  final Hub _hub;
+  final SentryTracer _root;
+
+  late final SdkLifecycleCallback<OnSpanFinish> _spanFinishCallback;
+  SentrySpan? _span;
+  Future<void>? _finishFuture;
+  DateTime? _endTimestamp;
+  bool _closed = false;
+
+  _StaticAppStartExtensionLifecycle({
+    required Hub hub,
+    required SentryTracer root,
+  })  : _hub = hub,
+        _root = root {
+    _spanFinishCallback = _handleSpanFinish;
+  }
+
+  bool tryStart(DateTime startTimestamp) {
+    if (_closed || _span != null) return false;
+
+    final span = _root.startChild(
+      SentrySpanOperations.appStartExtended,
+      description: standaloneExtendedAppStartName,
+      startTimestamp: startTimestamp.toUtc(),
+    );
+    if (span is! SentrySpan) return false;
+
+    span.origin = SentryTraceOrigins.autoAppStart;
+    _span = span;
+    _hub.options.lifecycleRegistry.registerCallback<OnSpanFinish>(
+      _spanFinishCallback,
+    );
+    return true;
+  }
+
+  ISentrySpan? get activeSpan {
+    final span = _span;
+    return span == null || span.finished ? null : span;
+  }
+
+  AppStartExtensionOutcome get completionSnapshot {
+    final span = _span;
+    return (
+      completed: span == null || (span.finished && _endTimestamp != null),
+      endTimestamp: _endTimestamp,
+    );
+  }
+
+  Future<void> finish(DateTime endTimestamp) {
+    if (_closed || _span == null) return Future<void>.value();
+    return _finishFuture ??= _finishSpan(endTimestamp.toUtc());
+  }
+
+  Future<void> waitForPendingFinish() async {
+    final finishFuture = _finishFuture;
+    if (finishFuture != null) await finishFuture;
+  }
+
+  Future<void> close() async {
+    if (_closed) return;
+    _closed = true;
+
+    final finishFuture = _finishFuture;
+    if (finishFuture != null) {
+      await finishFuture;
+      return;
+    }
+
+    final span = _span;
+    if (span != null && _endTimestamp == null) {
+      await _finishSpan(span.endTimestamp);
+    }
+  }
+
+  // Handle callers finishing the span directly instead of using
+  // finishExtendedAppStart().
+  void _handleSpanFinish(OnSpanFinish event) {
+    final span = _span;
+    if (span == null || !identical(event.span, span) || _endTimestamp != null) {
+      return;
+    }
+
+    final endTimestamp = span.endTimestamp;
+    if (endTimestamp == null) return;
+
+    _endTimestamp = endTimestamp;
+    if (_root.status != SpanStatus.deadlineExceeded()) {
+      span.status = SpanStatus.ok();
+    }
+    _removeSpanFinishCallback();
+  }
+
+  Future<void> _finishSpan(DateTime? endTimestamp) async {
+    if (_endTimestamp != null) return;
+    final span = _span;
+    try {
+      final timestamp =
+          (span?.endTimestamp ?? endTimestamp ?? _hub.options.clock()).toUtc();
+      _endTimestamp = timestamp;
+      if (span == null) return;
+
+      span.status = SpanStatus.ok();
+      if (!span.finished) {
+        await span.finish(endTimestamp: timestamp);
+      }
+    } catch (error, stackTrace) {
+      internalLogger.error(
+        'Failed to finish static extended app start',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    } finally {
+      _removeSpanFinishCallback();
+    }
+  }
+
+  void _removeSpanFinishCallback() {
+    _hub.options.lifecycleRegistry.removeCallback<OnSpanFinish>(
+      _spanFinishCallback,
+    );
   }
 }

--- a/packages/flutter/lib/src/app_start/standalone/static_app_start_trace.dart
+++ b/packages/flutter/lib/src/app_start/standalone/static_app_start_trace.dart
@@ -19,6 +19,7 @@ final class StaticAppStartTrace implements AppStartTrace {
   final ISentrySpan _firstFrameRenderSpan;
   final DateTime _finalDeadlineTimestamp;
   final String Function() _startScreenNameProvider;
+  final void Function()? _onCompleted;
 
   final _StaticAppStartExtensionLifecycle _extensionLifecycle;
   Timer? _finalTimeoutTimer;
@@ -38,11 +39,13 @@ final class StaticAppStartTrace implements AppStartTrace {
     required ISentrySpan firstFrameRenderSpan,
     required DateTime finalDeadlineTimestamp,
     required String Function() startScreenNameProvider,
+    required void Function()? onCompleted,
   })  : _timing = timing,
         _root = root,
         _firstFrameRenderSpan = firstFrameRenderSpan,
         _finalDeadlineTimestamp = finalDeadlineTimestamp,
         _startScreenNameProvider = startScreenNameProvider,
+        _onCompleted = onCompleted,
         _extensionLifecycle = _StaticAppStartExtensionLifecycle(
           hub: hub,
           root: root,
@@ -54,10 +57,14 @@ final class StaticAppStartTrace implements AppStartTrace {
   /// root, an unsampled first-frame span, or a failure while building the
   /// children. Anything already created is flushed, so no span outlives a
   /// failed creation.
+  ///
+  /// [onCompleted] fires once the root has reported and the trace can no
+  /// longer be extended, so the owner can stop holding on to it.
   static StaticAppStartTrace? tryCreate({
     required Hub hub,
     required AppStartTiming timing,
     required String Function() startScreenNameProvider,
+    void Function()? onCompleted,
   }) {
     // onFinish captures `trace` below before it is assigned. The tracer cannot
     // finish before it has a child, and the first child is created after the
@@ -104,6 +111,7 @@ final class StaticAppStartTrace implements AppStartTrace {
         finalDeadlineTimestamp:
             createdAt.add(standaloneAppStartFinalTimeout).toUtc(),
         startScreenNameProvider: startScreenNameProvider,
+        onCompleted: onCompleted,
       );
 
       for (final phase in timing.phases) {
@@ -220,6 +228,7 @@ final class StaticAppStartTrace implements AppStartTrace {
     } finally {
       _state = AppStartTraceState.completed;
     }
+    _onCompleted?.call();
   }
 
   void _scheduleFinalTimeout() {
@@ -347,10 +356,14 @@ final class _StaticAppStartExtensionLifecycle {
     return span == null || span.finished ? null : span;
   }
 
+  /// [_endTimestamp] alone is not enough here: [_finishSpan] latches it before
+  /// awaiting `finish()`, so the span is briefly mid-finish while the root
+  /// could be enriched. The streaming lifecycle ends spans synchronously and
+  /// has no such window.
   AppStartExtensionOutcome get completionSnapshot {
     final span = _span;
     return (
-      completed: span == null || (span.finished && _endTimestamp != null),
+      isSettled: span == null || (span.finished && _endTimestamp != null),
       endTimestamp: _endTimestamp,
     );
   }
@@ -393,10 +406,18 @@ final class _StaticAppStartExtensionLifecycle {
     if (endTimestamp == null) return;
 
     _endTimestamp = endTimestamp;
-    if (_root.status != SpanStatus.deadlineExceeded()) {
-      span.status = SpanStatus.ok();
-    }
+    span.status = _resolvedStatus;
     _removeSpanFinishCallback();
+  }
+
+  /// A finished extension normalizes to success, except once the root has hit
+  /// its final deadline — then it carries the deadline outcome instead, which
+  /// is what the deadline drain would have stamped on it.
+  SpanStatus get _resolvedStatus {
+    final deadlineExceeded = SpanStatus.deadlineExceeded();
+    return _root.status == deadlineExceeded
+        ? deadlineExceeded
+        : SpanStatus.ok();
   }
 
   Future<void> _finishSpan(DateTime? endTimestamp) async {
@@ -408,7 +429,7 @@ final class _StaticAppStartExtensionLifecycle {
       _endTimestamp = timestamp;
       if (span == null) return;
 
-      span.status = SpanStatus.ok();
+      span.status = _resolvedStatus;
       if (!span.finished) {
         await span.finish(endTimestamp: timestamp);
       }

--- a/packages/flutter/lib/src/app_start/standalone/static_app_start_trace.dart
+++ b/packages/flutter/lib/src/app_start/standalone/static_app_start_trace.dart
@@ -254,9 +254,9 @@ final class StaticAppStartTrace implements AppStartTrace {
   /// terminal check is enough to keep it out; [_finalizing] is what keeps
   /// extensions out while the drain below awaits. The state stays
   /// [AppStartTraceState.open] throughout, which lets a first frame arriving
-  /// between the awaits below still run [recordFirstFrame]. That is harmless:
-  /// the root is already `deadlineExceeded`, so the vitals omit the duration
-  /// either way.
+  /// between the awaits below still run [recordFirstFrame] — and it should:
+  /// that frame is the endpoint the app start reports, since a root past its
+  /// deadline still measures to the first frame.
   Future<void> _finishAtDeadline() async {
     if (_isFinalizingOrTerminal) return;
     _finalizing = true;
@@ -336,7 +336,7 @@ final class _StaticAppStartExtensionLifecycle {
   SentrySpan? _span;
   Future<void>? _finishFuture;
   DateTime? _endTimestamp;
-  bool _deadlineStamped = false;
+  bool _settledAfterDeadline = false;
   bool _closed = false;
 
   _StaticAppStartExtensionLifecycle({
@@ -380,11 +380,12 @@ final class _StaticAppStartExtensionLifecycle {
     return span == null || span.finished ? null : span;
   }
 
-  /// What the extension contributes to the app-start measurement.
+  /// The endpoint the extension contributes to the app-start measurement.
   ///
-  /// `null` once the deadline drain stamped the extension, since that endpoint
-  /// is the deadline rather than anything the extension actually reached.
-  DateTime? get measurementEnd => _deadlineStamped ? null : _endTimestamp;
+  /// `null` when it contributes none: it never started, it is still running,
+  /// or it only settled once the root was already past its deadline — that
+  /// endpoint is the deadline rather than anything the extension reached.
+  DateTime? get measurementEnd => _settledAfterDeadline ? null : _endTimestamp;
 
   Future<void> finish(DateTime endTimestamp) {
     if (_closed) {
@@ -395,7 +396,7 @@ final class _StaticAppStartExtensionLifecycle {
       logAppStartExtensionFinishRefusal('it was never extended');
       return Future<void>.value();
     }
-    return _finishFuture ??= _finishSpan(endTimestamp.toUtc());
+    return _finishFuture ??= _finishSpan(endTimestamp: endTimestamp.toUtc());
   }
 
   Future<void> waitForPendingFinish() async {
@@ -413,9 +414,8 @@ final class _StaticAppStartExtensionLifecycle {
       return;
     }
 
-    final span = _span;
-    if (span != null && _endTimestamp == null) {
-      await _finishSpan(span.endTimestamp);
+    if (_span != null && _endTimestamp == null) {
+      await _finishSpan();
     }
   }
 
@@ -431,7 +431,7 @@ final class _StaticAppStartExtensionLifecycle {
     if (endTimestamp == null) return;
 
     final status = _resolvedStatus;
-    _deadlineStamped = status == SpanStatus.deadlineExceeded();
+    _settledAfterDeadline = status == SpanStatus.deadlineExceeded();
     _endTimestamp = endTimestamp;
     span.status = status;
     _removeSpanFinishCallback();
@@ -447,16 +447,21 @@ final class _StaticAppStartExtensionLifecycle {
         : SpanStatus.ok();
   }
 
-  Future<void> _finishSpan(DateTime? endTimestamp) async {
+  /// Settles the extension, ending the span unless the caller already did.
+  ///
+  /// A span the caller ended keeps its own endpoint; [endTimestamp] applies to
+  /// one that is still running, and falls back to now when omitted.
+  Future<void> _finishSpan({DateTime? endTimestamp}) async {
     if (_endTimestamp != null) return;
     final span = _span;
+    if (span == null) return;
+
     try {
       final timestamp =
-          (span?.endTimestamp ?? endTimestamp ?? _hub.options.clock()).toUtc();
+          (span.endTimestamp ?? endTimestamp ?? _hub.options.clock()).toUtc();
       final status = _resolvedStatus;
-      _deadlineStamped = status == SpanStatus.deadlineExceeded();
+      _settledAfterDeadline = status == SpanStatus.deadlineExceeded();
       _endTimestamp = timestamp;
-      if (span == null) return;
 
       span.status = status;
       if (!span.finished) {

--- a/packages/flutter/lib/src/app_start/standalone/static_app_start_trace.dart
+++ b/packages/flutter/lib/src/app_start/standalone/static_app_start_trace.dart
@@ -336,7 +336,7 @@ final class _StaticAppStartExtensionLifecycle {
   SentrySpan? _span;
   Future<void>? _finishFuture;
   DateTime? _endTimestamp;
-  bool _settledAfterDeadline = false;
+  bool _forceEnded = false;
   bool _closed = false;
 
   _StaticAppStartExtensionLifecycle({
@@ -382,10 +382,10 @@ final class _StaticAppStartExtensionLifecycle {
 
   /// The endpoint the extension contributes to the app-start measurement.
   ///
-  /// `null` when it contributes none: it never started, it is still running,
-  /// or it only settled once the root was already past its deadline — that
-  /// endpoint is the deadline rather than anything the extension reached.
-  DateTime? get measurementEnd => _settledAfterDeadline ? null : _endTimestamp;
+  /// `null` when it contributes none: it never started, it is still running, or
+  /// it was force-ended — by the root's deadline or by SDK close — which ends
+  /// the span at the teardown rather than at anything the extension reached.
+  DateTime? get measurementEnd => _forceEnded ? null : _endTimestamp;
 
   Future<void> finish(DateTime endTimestamp) {
     if (_closed) {
@@ -431,7 +431,7 @@ final class _StaticAppStartExtensionLifecycle {
     if (endTimestamp == null) return;
 
     final status = _resolvedStatus;
-    _settledAfterDeadline = status == SpanStatus.deadlineExceeded();
+    _forceEnded = status == SpanStatus.deadlineExceeded();
     _endTimestamp = endTimestamp;
     span.status = status;
     _removeSpanFinishCallback();
@@ -460,7 +460,9 @@ final class _StaticAppStartExtensionLifecycle {
       final timestamp =
           (span.endTimestamp ?? endTimestamp ?? _hub.options.clock()).toUtc();
       final status = _resolvedStatus;
-      _settledAfterDeadline = status == SpanStatus.deadlineExceeded();
+      // Only [close] gets here already closed, and the extension it ends never
+      // reached this endpoint on its own.
+      _forceEnded = _closed || status == SpanStatus.deadlineExceeded();
       _endTimestamp = timestamp;
 
       span.status = status;

--- a/packages/flutter/lib/src/app_start/standalone/static_app_start_trace.dart
+++ b/packages/flutter/lib/src/app_start/standalone/static_app_start_trace.dart
@@ -292,9 +292,11 @@ final class StaticAppStartTrace implements AppStartTrace {
   /// Finishes every open child and then the root.
   ///
   /// Reads the children off the tracer, which owns them — no-op spans are
-  /// never added to it, so there is nothing to filter out here.
+  /// never added to it, so there is nothing to filter out here. Reversed for
+  /// the same reason as the deadline drain: descendants end before the parents
+  /// the tracer stored ahead of them.
   static Future<void> _flushTrace(SentryTracer root) async {
-    for (final child in root.children.toList()) {
+    for (final child in root.children.reversed.toList()) {
       if (!child.finished) {
         await _finishSpan(child);
       }

--- a/packages/flutter/lib/src/app_start/standalone/static_app_start_trace.dart
+++ b/packages/flutter/lib/src/app_start/standalone/static_app_start_trace.dart
@@ -203,8 +203,7 @@ final class StaticAppStartTrace implements AppStartTrace {
         timing: _timing,
         screen: _startScreenNameProvider(),
         endTimestamp: _endTimestamp,
-        extension: _extensionLifecycle.outcome,
-        deadlineExceeded: _root.status == SpanStatus.deadlineExceeded(),
+        extensionEndTimestamp: _extensionLifecycle.measurementEnd,
       );
 
       final type = vitals.type.name;
@@ -337,6 +336,7 @@ final class _StaticAppStartExtensionLifecycle {
   SentrySpan? _span;
   Future<void>? _finishFuture;
   DateTime? _endTimestamp;
+  bool _deadlineStamped = false;
   bool _closed = false;
 
   _StaticAppStartExtensionLifecycle({
@@ -380,18 +380,11 @@ final class _StaticAppStartExtensionLifecycle {
     return span == null || span.finished ? null : span;
   }
 
-  /// [_endTimestamp] alone is not enough here: [_finishSpan] latches it before
-  /// awaiting `finish()`, so the span is briefly mid-finish while the root
-  /// could be enriched. The streaming lifecycle ends spans synchronously and
-  /// has no such window.
-  AppStartExtensionOutcome get outcome {
-    final span = _span;
-    if (span == null) return noAppStartExtension;
-    return (
-      isSettled: span.finished && _endTimestamp != null,
-      endTimestamp: _endTimestamp,
-    );
-  }
+  /// What the extension contributes to the app-start measurement.
+  ///
+  /// `null` once the deadline drain stamped the extension, since that endpoint
+  /// is the deadline rather than anything the extension actually reached.
+  DateTime? get measurementEnd => _deadlineStamped ? null : _endTimestamp;
 
   Future<void> finish(DateTime endTimestamp) {
     if (_closed) {
@@ -437,8 +430,10 @@ final class _StaticAppStartExtensionLifecycle {
     final endTimestamp = span.endTimestamp;
     if (endTimestamp == null) return;
 
+    final status = _resolvedStatus;
+    _deadlineStamped = status == SpanStatus.deadlineExceeded();
     _endTimestamp = endTimestamp;
-    span.status = _resolvedStatus;
+    span.status = status;
     _removeSpanFinishCallback();
   }
 
@@ -458,10 +453,12 @@ final class _StaticAppStartExtensionLifecycle {
     try {
       final timestamp =
           (span?.endTimestamp ?? endTimestamp ?? _hub.options.clock()).toUtc();
+      final status = _resolvedStatus;
+      _deadlineStamped = status == SpanStatus.deadlineExceeded();
       _endTimestamp = timestamp;
       if (span == null) return;
 
-      span.status = _resolvedStatus;
+      span.status = status;
       if (!span.finished) {
         await span.finish(endTimestamp: timestamp);
       }

--- a/packages/flutter/lib/src/app_start/standalone/static_app_start_trace.dart
+++ b/packages/flutter/lib/src/app_start/standalone/static_app_start_trace.dart
@@ -146,8 +146,11 @@ final class StaticAppStartTrace implements AppStartTrace {
 
   @override
   bool tryExtend(DateTime startTimestamp) {
-    if (_isFinalizingOrTerminal || _firstFrameRenderSpan.endTimestamp != null) {
-      return false;
+    if (_isFinalizingOrTerminal) {
+      return refuseAppStartExtension('the app start already ended');
+    }
+    if (_firstFrameRenderSpan.endTimestamp != null) {
+      return refuseAppStartExtension('the first frame already rendered');
     }
 
     return _extensionLifecycle.tryStart(startTimestamp);
@@ -196,10 +199,8 @@ final class StaticAppStartTrace implements AppStartTrace {
       final vitals = AppStartVitals.resolve(
         timing: _timing,
         screen: _startScreenNameProvider(),
-        endTimestamp: resolveAppStartMeasurementEnd(
-          _endTimestamp,
-          _extensionLifecycle.completionSnapshot,
-        ),
+        endTimestamp: _endTimestamp,
+        extension: _extensionLifecycle.completionSnapshot,
         deadlineExceeded: _root.status == SpanStatus.deadlineExceeded(),
       );
 
@@ -334,14 +335,21 @@ final class _StaticAppStartExtensionLifecycle {
   }
 
   bool tryStart(DateTime startTimestamp) {
-    if (_closed || _span != null) return false;
+    if (_closed) {
+      return refuseAppStartExtension('the app start already ended');
+    }
+    if (_span != null) {
+      return refuseAppStartExtension('it is already extended');
+    }
 
     final span = _root.startChild(
       SentrySpanOperations.appStartExtended,
       description: standaloneExtendedAppStartName,
       startTimestamp: startTimestamp.toUtc(),
     );
-    if (span is! SentrySpan) return false;
+    if (span is! SentrySpan) {
+      return refuseAppStartExtension('the extension span was not recorded');
+    }
 
     span.origin = SentryTraceOrigins.autoAppStart;
     _span = span;
@@ -362,8 +370,9 @@ final class _StaticAppStartExtensionLifecycle {
   /// has no such window.
   AppStartExtensionOutcome get completionSnapshot {
     final span = _span;
+    if (span == null) return noAppStartExtension;
     return (
-      isSettled: span == null || (span.finished && _endTimestamp != null),
+      isSettled: span.finished && _endTimestamp != null,
       endTimestamp: _endTimestamp,
     );
   }

--- a/packages/flutter/lib/src/app_start/standalone/static_app_start_trace.dart
+++ b/packages/flutter/lib/src/app_start/standalone/static_app_start_trace.dart
@@ -165,7 +165,7 @@ final class StaticAppStartTrace implements AppStartTrace {
   @override
   Future<void> finishExtended(DateTime endTimestamp) {
     if (_isFinalizingOrTerminal) {
-      return Future<void>.value();
+      return refuseAppStartExtensionFinish('the app start already ended');
     }
 
     return _extensionLifecycle.finish(endTimestamp);
@@ -316,6 +316,14 @@ final class StaticAppStartTrace implements AppStartTrace {
   }
 }
 
+/// Owns the single extension span for the static lifecycle.
+///
+/// Deliberately not shared with its streaming counterpart, which mirrors this
+/// class step for step: the two operate on different span protocols, one ends
+/// spans asynchronously and the other synchronously, and each expresses status
+/// its own way. Unifying them would mean a type parameter plus an adapter per
+/// protocol to bridge those three differences, for one implementation each —
+/// the same reason the two trace classes above them stay separate.
 final class _StaticAppStartExtensionLifecycle {
   final Hub _hub;
   final SentryTracer _root;
@@ -378,7 +386,12 @@ final class _StaticAppStartExtensionLifecycle {
   }
 
   Future<void> finish(DateTime endTimestamp) {
-    if (_closed || _span == null) return Future<void>.value();
+    if (_closed) {
+      return refuseAppStartExtensionFinish('the app start already ended');
+    }
+    if (_span == null) {
+      return refuseAppStartExtensionFinish('it was never extended');
+    }
     return _finishFuture ??= _finishSpan(endTimestamp.toUtc());
   }
 

--- a/packages/flutter/lib/src/app_start/standalone/static_app_start_trace.dart
+++ b/packages/flutter/lib/src/app_start/standalone/static_app_start_trace.dart
@@ -147,10 +147,12 @@ final class StaticAppStartTrace implements AppStartTrace {
   @override
   bool tryExtend(DateTime startTimestamp) {
     if (_isFinalizingOrTerminal) {
-      return refuseAppStartExtension('the app start already ended');
+      logAppStartExtensionRefusal('the app start already ended');
+      return false;
     }
     if (_firstFrameRenderSpan.endTimestamp != null) {
-      return refuseAppStartExtension('the first frame already rendered');
+      logAppStartExtensionRefusal('the first frame already rendered');
+      return false;
     }
 
     return _extensionLifecycle.tryStart(startTimestamp);
@@ -165,7 +167,8 @@ final class StaticAppStartTrace implements AppStartTrace {
   @override
   Future<void> finishExtended(DateTime endTimestamp) {
     if (_isFinalizingOrTerminal) {
-      return refuseAppStartExtensionFinish('the app start already ended');
+      logAppStartExtensionFinishRefusal('the app start already ended');
+      return Future<void>.value();
     }
 
     return _extensionLifecycle.finish(endTimestamp);
@@ -200,7 +203,7 @@ final class StaticAppStartTrace implements AppStartTrace {
         timing: _timing,
         screen: _startScreenNameProvider(),
         endTimestamp: _endTimestamp,
-        extension: _extensionLifecycle.completionSnapshot,
+        extension: _extensionLifecycle.outcome,
         deadlineExceeded: _root.status == SpanStatus.deadlineExceeded(),
       );
 
@@ -344,19 +347,22 @@ final class _StaticAppStartExtensionLifecycle {
 
   bool tryStart(DateTime startTimestamp) {
     if (_closed) {
-      return refuseAppStartExtension('the app start already ended');
+      logAppStartExtensionRefusal('the app start already ended');
+      return false;
     }
     if (_span != null) {
-      return refuseAppStartExtension('it is already extended');
+      logAppStartExtensionRefusal('it is already extended');
+      return false;
     }
 
     final span = _root.startChild(
       SentrySpanOperations.appStartExtended,
-      description: standaloneExtendedAppStartName,
+      description: standaloneAppStartExtensionName,
       startTimestamp: startTimestamp.toUtc(),
     );
     if (span is! SentrySpan) {
-      return refuseAppStartExtension('the extension span was not recorded');
+      logAppStartExtensionRefusal('the extension span was not recorded');
+      return false;
     }
 
     span.origin = SentryTraceOrigins.autoAppStart;
@@ -376,7 +382,7 @@ final class _StaticAppStartExtensionLifecycle {
   /// awaiting `finish()`, so the span is briefly mid-finish while the root
   /// could be enriched. The streaming lifecycle ends spans synchronously and
   /// has no such window.
-  AppStartExtensionOutcome get completionSnapshot {
+  AppStartExtensionOutcome get outcome {
     final span = _span;
     if (span == null) return noAppStartExtension;
     return (
@@ -387,10 +393,12 @@ final class _StaticAppStartExtensionLifecycle {
 
   Future<void> finish(DateTime endTimestamp) {
     if (_closed) {
-      return refuseAppStartExtensionFinish('the app start already ended');
+      logAppStartExtensionFinishRefusal('the app start already ended');
+      return Future<void>.value();
     }
     if (_span == null) {
-      return refuseAppStartExtensionFinish('it was never extended');
+      logAppStartExtensionFinishRefusal('it was never extended');
+      return Future<void>.value();
     }
     return _finishFuture ??= _finishSpan(endTimestamp.toUtc());
   }

--- a/packages/flutter/lib/src/app_start/standalone/streaming_app_start_trace.dart
+++ b/packages/flutter/lib/src/app_start/standalone/streaming_app_start_trace.dart
@@ -269,7 +269,7 @@ final class _StreamingAppStartExtensionLifecycle {
   RecordingSentrySpanV2? _span;
   Future<void>? _finishFuture;
   DateTime? _endTimestamp;
-  bool _settledAfterDeadline = false;
+  bool _forceEnded = false;
   bool _closed = false;
 
   _StreamingAppStartExtensionLifecycle({
@@ -320,10 +320,10 @@ final class _StreamingAppStartExtensionLifecycle {
 
   /// The endpoint the extension contributes to the app-start measurement.
   ///
-  /// `null` when it contributes none: it never started, it is still running,
-  /// or it only settled once the root was already past its deadline — that
-  /// endpoint is the deadline rather than anything the extension reached.
-  DateTime? get measurementEnd => _settledAfterDeadline ? null : _endTimestamp;
+  /// `null` when it contributes none: it never started, it is still running, or
+  /// it was force-ended — by the root's deadline or by SDK close — which ends
+  /// the span at the teardown rather than at anything the extension reached.
+  DateTime? get measurementEnd => _forceEnded ? null : _endTimestamp;
 
   Future<void> finish(DateTime endTimestamp) {
     if (_closed) {
@@ -369,7 +369,7 @@ final class _StreamingAppStartExtensionLifecycle {
         SemanticAttributesConstants.sentryStatusMessage,
         SentryAttribute.string(SentrySpanStatusMessages.deadlineExceeded),
       );
-      _settledAfterDeadline = true;
+      _forceEnded = true;
     } else {
       span.status = SentrySpanStatusV2.ok;
     }
@@ -395,6 +395,9 @@ final class _StreamingAppStartExtensionLifecycle {
     try {
       final timestamp =
           (span.endTimestamp ?? endTimestamp ?? _hub.options.clock()).toUtc();
+      // Only [close] gets here already closed, and the extension it ends never
+      // reached this endpoint on its own.
+      _forceEnded = _closed;
       _endTimestamp = timestamp;
 
       span.status = SentrySpanStatusV2.ok;

--- a/packages/flutter/lib/src/app_start/standalone/streaming_app_start_trace.dart
+++ b/packages/flutter/lib/src/app_start/standalone/streaming_app_start_trace.dart
@@ -203,7 +203,7 @@ final class StreamingAppStartTrace implements AppStartTrace {
       final vitals = AppStartVitals.resolve(
         timing: _timing,
         screen: _startScreenNameProvider(),
-        endTimestamp: _endTimestamp,
+        firstFrameTimestamp: _endTimestamp,
         extensionEndTimestamp: _extensionLifecycle.measurementEnd,
       );
 

--- a/packages/flutter/lib/src/app_start/standalone/streaming_app_start_trace.dart
+++ b/packages/flutter/lib/src/app_start/standalone/streaming_app_start_trace.dart
@@ -204,8 +204,7 @@ final class StreamingAppStartTrace implements AppStartTrace {
         timing: _timing,
         screen: _startScreenNameProvider(),
         endTimestamp: _endTimestamp,
-        extension: _extensionLifecycle.outcome,
-        deadlineExceeded: _root.deadlineExceeded,
+        extensionEndTimestamp: _extensionLifecycle.measurementEnd,
       );
 
       _root.setAttribute(
@@ -267,6 +266,7 @@ final class _StreamingAppStartExtensionLifecycle {
   RecordingSentrySpanV2? _span;
   Future<void>? _finishFuture;
   DateTime? _endTimestamp;
+  bool _deadlineStamped = false;
   bool _closed = false;
 
   _StreamingAppStartExtensionLifecycle({
@@ -315,9 +315,12 @@ final class _StreamingAppStartExtensionLifecycle {
     return span == null || span.isEnded ? null : span;
   }
 
-  AppStartExtensionOutcome get outcome => _span == null
-      ? noAppStartExtension
-      : (isSettled: _endTimestamp != null, endTimestamp: _endTimestamp);
+  /// What the extension contributes to the app-start measurement.
+  ///
+  /// `null` once the root force-ended the extension at its deadline, since
+  /// that endpoint is the deadline rather than anything the extension actually
+  /// reached.
+  DateTime? get measurementEnd => _deadlineStamped ? null : _endTimestamp;
 
   Future<void> finish(DateTime endTimestamp) {
     if (_closed) {
@@ -364,6 +367,7 @@ final class _StreamingAppStartExtensionLifecycle {
         SemanticAttributesConstants.sentryStatusMessage,
         SentryAttribute.string(SentrySpanStatusMessages.deadlineExceeded),
       );
+      _deadlineStamped = true;
     } else {
       span.status = SentrySpanStatusV2.ok;
     }

--- a/packages/flutter/lib/src/app_start/standalone/streaming_app_start_trace.dart
+++ b/packages/flutter/lib/src/app_start/standalone/streaming_app_start_trace.dart
@@ -255,8 +255,11 @@ final class StreamingAppStartTrace implements AppStartTrace {
 
 /// Owns the single extension span for the streaming lifecycle.
 ///
-/// Mirrors `_StaticAppStartExtensionLifecycle` step for step; see the note
-/// there for why the two are not shared.
+/// Mirrors `_StaticAppStartExtensionLifecycle` member for member; see the note
+/// there for why the two are not shared. It diverges in two places, both
+/// because the idle root here force-ends its descendants synchronously: there
+/// is no `waitForPendingFinish`, since no finish can be in flight when the
+/// deadline lands, and [_finishSpan] never has to stamp a deadline status.
 final class _StreamingAppStartExtensionLifecycle {
   final Hub _hub;
   final IdleRecordingSentrySpanV2 _root;
@@ -266,7 +269,7 @@ final class _StreamingAppStartExtensionLifecycle {
   RecordingSentrySpanV2? _span;
   Future<void>? _finishFuture;
   DateTime? _endTimestamp;
-  bool _deadlineStamped = false;
+  bool _settledAfterDeadline = false;
   bool _closed = false;
 
   _StreamingAppStartExtensionLifecycle({
@@ -315,12 +318,12 @@ final class _StreamingAppStartExtensionLifecycle {
     return span == null || span.isEnded ? null : span;
   }
 
-  /// What the extension contributes to the app-start measurement.
+  /// The endpoint the extension contributes to the app-start measurement.
   ///
-  /// `null` once the root force-ended the extension at its deadline, since
-  /// that endpoint is the deadline rather than anything the extension actually
-  /// reached.
-  DateTime? get measurementEnd => _deadlineStamped ? null : _endTimestamp;
+  /// `null` when it contributes none: it never started, it is still running,
+  /// or it only settled once the root was already past its deadline — that
+  /// endpoint is the deadline rather than anything the extension reached.
+  DateTime? get measurementEnd => _settledAfterDeadline ? null : _endTimestamp;
 
   Future<void> finish(DateTime endTimestamp) {
     if (_closed) {
@@ -331,7 +334,7 @@ final class _StreamingAppStartExtensionLifecycle {
       logAppStartExtensionFinishRefusal('it was never extended');
       return Future<void>.value();
     }
-    return _finishFuture ??= _finishSpan(endTimestamp.toUtc());
+    return _finishFuture ??= _finishSpan(endTimestamp: endTimestamp.toUtc());
   }
 
   Future<void> close() async {
@@ -344,9 +347,8 @@ final class _StreamingAppStartExtensionLifecycle {
       return;
     }
 
-    final span = _span;
-    if (span != null && _endTimestamp == null) {
-      await _finishSpan(span.endTimestamp);
+    if (_span != null && _endTimestamp == null) {
+      await _finishSpan();
     }
   }
 
@@ -367,7 +369,7 @@ final class _StreamingAppStartExtensionLifecycle {
         SemanticAttributesConstants.sentryStatusMessage,
         SentryAttribute.string(SentrySpanStatusMessages.deadlineExceeded),
       );
-      _deadlineStamped = true;
+      _settledAfterDeadline = true;
     } else {
       span.status = SentrySpanStatusV2.ok;
     }
@@ -376,18 +378,24 @@ final class _StreamingAppStartExtensionLifecycle {
     _removeSpanEndCallback();
   }
 
+  /// Settles the extension, ending the span unless the caller already did.
+  ///
+  /// A span the caller ended keeps its own endpoint; [endTimestamp] applies to
+  /// one that is still running, and falls back to now when omitted.
+  ///
   /// Unlike the static lifecycle, this always settles on success: the root
   /// force-ends the extension synchronously when it hits its deadline, and
   /// [_handleSpanEnd] latches [_endTimestamp] with the deadline outcome before
   /// anything here can run, so a deadline never reaches this path.
-  Future<void> _finishSpan(DateTime? endTimestamp) async {
+  Future<void> _finishSpan({DateTime? endTimestamp}) async {
     if (_endTimestamp != null) return;
     final span = _span;
+    if (span == null) return;
+
     try {
       final timestamp =
-          (span?.endTimestamp ?? endTimestamp ?? _hub.options.clock()).toUtc();
+          (span.endTimestamp ?? endTimestamp ?? _hub.options.clock()).toUtc();
       _endTimestamp = timestamp;
-      if (span == null) return;
 
       span.status = SentrySpanStatusV2.ok;
       if (!span.isEnded) {

--- a/packages/flutter/lib/src/app_start/standalone/streaming_app_start_trace.dart
+++ b/packages/flutter/lib/src/app_start/standalone/streaming_app_start_trace.dart
@@ -15,6 +15,7 @@ final class StreamingAppStartTrace implements AppStartTrace {
   final IdleRecordingSentrySpanV2 _root;
   final RecordingSentrySpanV2 _firstFrameRenderSpan;
   final String Function() _startScreenNameProvider;
+  final void Function()? _onCompleted;
 
   final _StreamingAppStartExtensionLifecycle _extensionLifecycle;
   DateTime? _endTimestamp;
@@ -26,14 +27,17 @@ final class StreamingAppStartTrace implements AppStartTrace {
     required IdleRecordingSentrySpanV2 root,
     required RecordingSentrySpanV2 firstFrameRenderSpan,
     required String Function() startScreenNameProvider,
+    required void Function()? onCompleted,
   })  : _hub = hub,
         _timing = timing,
         _root = root,
         _firstFrameRenderSpan = firstFrameRenderSpan,
         _startScreenNameProvider = startScreenNameProvider,
+        _onCompleted = onCompleted,
         _extensionLifecycle = _StreamingAppStartExtensionLifecycle(
           hub: hub,
           root: root,
+          timing: timing,
         );
 
   /// Opens the standalone root and its breakdown children.
@@ -42,10 +46,14 @@ final class StreamingAppStartTrace implements AppStartTrace {
   /// first-frame span the SDK did not record, or a failure while building the
   /// children. Anything already created is flushed, so no span outlives a
   /// failed creation.
+  ///
+  /// [onCompleted] fires once the root has reported and the trace can no
+  /// longer be extended, so the owner can stop holding on to it.
   static StreamingAppStartTrace? tryCreate({
     required Hub hub,
     required AppStartTiming timing,
     required String Function() startScreenNameProvider,
+    void Function()? onCompleted,
   }) {
     // Held outside the try so a partially built trace can still be flushed.
     IdleRecordingSentrySpanV2? root;
@@ -90,6 +98,7 @@ final class StreamingAppStartTrace implements AppStartTrace {
         root: root,
         firstFrameRenderSpan: firstFrameRenderSpan,
         startScreenNameProvider: startScreenNameProvider,
+        onCompleted: onCompleted,
       );
       for (final phase in timing.phases) {
         final child = hub.startInactiveSpan(
@@ -223,6 +232,7 @@ final class StreamingAppStartTrace implements AppStartTrace {
         _processSpan,
       );
     }
+    _onCompleted?.call();
   }
 
   @override
@@ -240,6 +250,7 @@ final class StreamingAppStartTrace implements AppStartTrace {
 final class _StreamingAppStartExtensionLifecycle {
   final Hub _hub;
   final IdleRecordingSentrySpanV2 _root;
+  final AppStartTiming _timing;
 
   late final SdkLifecycleCallback<OnSpanEndV2> _spanEndCallback;
   RecordingSentrySpanV2? _span;
@@ -250,8 +261,10 @@ final class _StreamingAppStartExtensionLifecycle {
   _StreamingAppStartExtensionLifecycle({
     required Hub hub,
     required IdleRecordingSentrySpanV2 root,
+    required AppStartTiming timing,
   })  : _hub = hub,
-        _root = root {
+        _root = root,
+        _timing = timing {
     _spanEndCallback = _handleSpanEnd;
   }
 
@@ -262,14 +275,10 @@ final class _StreamingAppStartExtensionLifecycle {
       standaloneExtendedAppStartName,
       parentSpan: _root,
       startTimestamp: startTimestamp.toUtc(),
-      attributes: {
-        SemanticAttributesConstants.sentryOp: SentryAttribute.string(
-          SentrySpanOperations.appStartExtended,
-        ),
-        SemanticAttributesConstants.sentryOrigin: SentryAttribute.string(
-          SentryTraceOrigins.autoAppStart,
-        ),
-      },
+      attributes: StreamingAppStartTrace._childAttributes(
+        _timing,
+        SentrySpanOperations.appStartExtended,
+      ),
     );
     if (span is! RecordingSentrySpanV2) return false;
 
@@ -286,7 +295,7 @@ final class _StreamingAppStartExtensionLifecycle {
   }
 
   AppStartExtensionOutcome get completionSnapshot => (
-        completed: _span == null || _endTimestamp != null,
+        isSettled: _span == null || _endTimestamp != null,
         endTimestamp: _endTimestamp,
       );
 
@@ -336,6 +345,10 @@ final class _StreamingAppStartExtensionLifecycle {
     _removeSpanEndCallback();
   }
 
+  /// Unlike the static lifecycle, this always settles on success: the root
+  /// force-ends the extension synchronously when it hits its deadline, and
+  /// [_handleSpanEnd] latches [_endTimestamp] with the deadline outcome before
+  /// anything here can run, so a deadline never reaches this path.
   Future<void> _finishSpan(DateTime? endTimestamp) async {
     if (_endTimestamp != null) return;
     final span = _span;

--- a/packages/flutter/lib/src/app_start/standalone/streaming_app_start_trace.dart
+++ b/packages/flutter/lib/src/app_start/standalone/streaming_app_start_trace.dart
@@ -160,10 +160,12 @@ final class StreamingAppStartTrace implements AppStartTrace {
     // the idle root here, which force-ends its descendants synchronously, so
     // there is no window where the trace is winding down but not yet terminal.
     if (_state.isTerminal) {
-      return refuseAppStartExtension('the app start already ended');
+      logAppStartExtensionRefusal('the app start already ended');
+      return false;
     }
     if (_firstFrameRenderSpan.isEnded) {
-      return refuseAppStartExtension('the first frame already rendered');
+      logAppStartExtensionRefusal('the first frame already rendered');
+      return false;
     }
 
     return _extensionLifecycle.tryStart(startTimestamp);
@@ -178,7 +180,8 @@ final class StreamingAppStartTrace implements AppStartTrace {
   @override
   Future<void> finishExtended(DateTime endTimestamp) {
     if (_state.isTerminal) {
-      return refuseAppStartExtensionFinish('the app start already ended');
+      logAppStartExtensionFinishRefusal('the app start already ended');
+      return Future<void>.value();
     }
 
     return _extensionLifecycle.finish(endTimestamp);
@@ -201,7 +204,7 @@ final class StreamingAppStartTrace implements AppStartTrace {
         timing: _timing,
         screen: _startScreenNameProvider(),
         endTimestamp: _endTimestamp,
-        extension: _extensionLifecycle.completionSnapshot,
+        extension: _extensionLifecycle.outcome,
         deadlineExceeded: _root.deadlineExceeded,
       );
 
@@ -278,14 +281,16 @@ final class _StreamingAppStartExtensionLifecycle {
 
   bool tryStart(DateTime startTimestamp) {
     if (_closed) {
-      return refuseAppStartExtension('the app start already ended');
+      logAppStartExtensionRefusal('the app start already ended');
+      return false;
     }
     if (_span != null) {
-      return refuseAppStartExtension('it is already extended');
+      logAppStartExtensionRefusal('it is already extended');
+      return false;
     }
 
     final span = _hub.startInactiveSpan(
-      standaloneExtendedAppStartName,
+      standaloneAppStartExtensionName,
       parentSpan: _root,
       startTimestamp: startTimestamp.toUtc(),
       attributes: StreamingAppStartTrace._childAttributes(
@@ -294,7 +299,8 @@ final class _StreamingAppStartExtensionLifecycle {
       ),
     );
     if (span is! RecordingSentrySpanV2) {
-      return refuseAppStartExtension('the extension span was not recorded');
+      logAppStartExtensionRefusal('the extension span was not recorded');
+      return false;
     }
 
     _span = span;
@@ -309,16 +315,18 @@ final class _StreamingAppStartExtensionLifecycle {
     return span == null || span.isEnded ? null : span;
   }
 
-  AppStartExtensionOutcome get completionSnapshot => _span == null
+  AppStartExtensionOutcome get outcome => _span == null
       ? noAppStartExtension
       : (isSettled: _endTimestamp != null, endTimestamp: _endTimestamp);
 
   Future<void> finish(DateTime endTimestamp) {
     if (_closed) {
-      return refuseAppStartExtensionFinish('the app start already ended');
+      logAppStartExtensionFinishRefusal('the app start already ended');
+      return Future<void>.value();
     }
     if (_span == null) {
-      return refuseAppStartExtensionFinish('it was never extended');
+      logAppStartExtensionFinishRefusal('it was never extended');
+      return Future<void>.value();
     }
     return _finishFuture ??= _finishSpan(endTimestamp.toUtc());
   }

--- a/packages/flutter/lib/src/app_start/standalone/streaming_app_start_trace.dart
+++ b/packages/flutter/lib/src/app_start/standalone/streaming_app_start_trace.dart
@@ -156,8 +156,11 @@ final class StreamingAppStartTrace implements AppStartTrace {
 
   @override
   bool tryExtend(DateTime startTimestamp) {
-    if (_state.isTerminal || _firstFrameRenderSpan.isEnded) {
-      return false;
+    if (_state.isTerminal) {
+      return refuseAppStartExtension('the app start already ended');
+    }
+    if (_firstFrameRenderSpan.isEnded) {
+      return refuseAppStartExtension('the first frame already rendered');
     }
 
     return _extensionLifecycle.tryStart(startTimestamp);
@@ -194,10 +197,8 @@ final class StreamingAppStartTrace implements AppStartTrace {
       final vitals = AppStartVitals.resolve(
         timing: _timing,
         screen: _startScreenNameProvider(),
-        endTimestamp: resolveAppStartMeasurementEnd(
-          _endTimestamp,
-          _extensionLifecycle.completionSnapshot,
-        ),
+        endTimestamp: _endTimestamp,
+        extension: _extensionLifecycle.completionSnapshot,
         deadlineExceeded: _root.deadlineExceeded,
       );
 
@@ -269,7 +270,12 @@ final class _StreamingAppStartExtensionLifecycle {
   }
 
   bool tryStart(DateTime startTimestamp) {
-    if (_closed || _span != null) return false;
+    if (_closed) {
+      return refuseAppStartExtension('the app start already ended');
+    }
+    if (_span != null) {
+      return refuseAppStartExtension('it is already extended');
+    }
 
     final span = _hub.startInactiveSpan(
       standaloneExtendedAppStartName,
@@ -280,7 +286,9 @@ final class _StreamingAppStartExtensionLifecycle {
         SentrySpanOperations.appStartExtended,
       ),
     );
-    if (span is! RecordingSentrySpanV2) return false;
+    if (span is! RecordingSentrySpanV2) {
+      return refuseAppStartExtension('the extension span was not recorded');
+    }
 
     _span = span;
     _hub.options.lifecycleRegistry.registerCallback<OnSpanEndV2>(
@@ -294,10 +302,9 @@ final class _StreamingAppStartExtensionLifecycle {
     return span == null || span.isEnded ? null : span;
   }
 
-  AppStartExtensionOutcome get completionSnapshot => (
-        isSettled: _span == null || _endTimestamp != null,
-        endTimestamp: _endTimestamp,
-      );
+  AppStartExtensionOutcome get completionSnapshot => _span == null
+      ? noAppStartExtension
+      : (isSettled: _endTimestamp != null, endTimestamp: _endTimestamp);
 
   Future<void> finish(DateTime endTimestamp) {
     if (_closed || _span == null) return Future<void>.value();

--- a/packages/flutter/lib/src/app_start/standalone/streaming_app_start_trace.dart
+++ b/packages/flutter/lib/src/app_start/standalone/streaming_app_start_trace.dart
@@ -16,6 +16,7 @@ final class StreamingAppStartTrace implements AppStartTrace {
   final RecordingSentrySpanV2 _firstFrameRenderSpan;
   final String Function() _startScreenNameProvider;
 
+  final _StreamingAppStartExtensionLifecycle _extensionLifecycle;
   DateTime? _endTimestamp;
   AppStartTraceState _state = AppStartTraceState.open;
 
@@ -29,7 +30,11 @@ final class StreamingAppStartTrace implements AppStartTrace {
         _timing = timing,
         _root = root,
         _firstFrameRenderSpan = firstFrameRenderSpan,
-        _startScreenNameProvider = startScreenNameProvider;
+        _startScreenNameProvider = startScreenNameProvider,
+        _extensionLifecycle = _StreamingAppStartExtensionLifecycle(
+          hub: hub,
+          root: root,
+        );
 
   /// Opens the standalone root and its breakdown children.
   ///
@@ -141,6 +146,30 @@ final class StreamingAppStartTrace implements AppStartTrace {
   }
 
   @override
+  bool tryExtend(DateTime startTimestamp) {
+    if (_state.isTerminal || _firstFrameRenderSpan.isEnded) {
+      return false;
+    }
+
+    return _extensionLifecycle.tryStart(startTimestamp);
+  }
+
+  @override
+  ISentrySpan? get extendedSpan => null;
+
+  @override
+  SentrySpanV2? get extendedSpanV2 => _extensionLifecycle.activeSpan;
+
+  @override
+  Future<void> finishExtended(DateTime endTimestamp) {
+    if (_state.isTerminal) {
+      return Future<void>.value();
+    }
+
+    return _extensionLifecycle.finish(endTimestamp);
+  }
+
+  @override
   void recordFirstFrame(DateTime endTimestamp) {
     if (_state.isTerminal || _endTimestamp != null) return;
     _endTimestamp = endTimestamp.toUtc();
@@ -156,7 +185,10 @@ final class StreamingAppStartTrace implements AppStartTrace {
       final vitals = AppStartVitals.resolve(
         timing: _timing,
         screen: _startScreenNameProvider(),
-        endTimestamp: _endTimestamp,
+        endTimestamp: resolveAppStartMeasurementEnd(
+          _endTimestamp,
+          _extensionLifecycle.completionSnapshot,
+        ),
         deadlineExceeded: _root.deadlineExceeded,
       );
 
@@ -197,6 +229,140 @@ final class StreamingAppStartTrace implements AppStartTrace {
   Future<void> close() async {
     if (_state.isTerminal) return;
     _state = AppStartTraceState.closed;
-    _root.end();
+    try {
+      await _extensionLifecycle.close();
+    } finally {
+      _root.end();
+    }
+  }
+}
+
+final class _StreamingAppStartExtensionLifecycle {
+  final Hub _hub;
+  final IdleRecordingSentrySpanV2 _root;
+
+  late final SdkLifecycleCallback<OnSpanEndV2> _spanEndCallback;
+  RecordingSentrySpanV2? _span;
+  Future<void>? _finishFuture;
+  DateTime? _endTimestamp;
+  bool _closed = false;
+
+  _StreamingAppStartExtensionLifecycle({
+    required Hub hub,
+    required IdleRecordingSentrySpanV2 root,
+  })  : _hub = hub,
+        _root = root {
+    _spanEndCallback = _handleSpanEnd;
+  }
+
+  bool tryStart(DateTime startTimestamp) {
+    if (_closed || _span != null) return false;
+
+    final span = _hub.startInactiveSpan(
+      standaloneExtendedAppStartName,
+      parentSpan: _root,
+      startTimestamp: startTimestamp.toUtc(),
+      attributes: {
+        SemanticAttributesConstants.sentryOp: SentryAttribute.string(
+          SentrySpanOperations.appStartExtended,
+        ),
+        SemanticAttributesConstants.sentryOrigin: SentryAttribute.string(
+          SentryTraceOrigins.autoAppStart,
+        ),
+      },
+    );
+    if (span is! RecordingSentrySpanV2) return false;
+
+    _span = span;
+    _hub.options.lifecycleRegistry.registerCallback<OnSpanEndV2>(
+      _spanEndCallback,
+    );
+    return true;
+  }
+
+  SentrySpanV2? get activeSpan {
+    final span = _span;
+    return span == null || span.isEnded ? null : span;
+  }
+
+  AppStartExtensionOutcome get completionSnapshot => (
+        completed: _span == null || _endTimestamp != null,
+        endTimestamp: _endTimestamp,
+      );
+
+  Future<void> finish(DateTime endTimestamp) {
+    if (_closed || _span == null) return Future<void>.value();
+    return _finishFuture ??= _finishSpan(endTimestamp.toUtc());
+  }
+
+  Future<void> close() async {
+    if (_closed) return;
+    _closed = true;
+
+    final finishFuture = _finishFuture;
+    if (finishFuture != null) {
+      await finishFuture;
+      return;
+    }
+
+    final span = _span;
+    if (span != null && _endTimestamp == null) {
+      await _finishSpan(span.endTimestamp);
+    }
+  }
+
+  // Handle callers ending the span directly instead of using
+  // finishExtendedAppStart().
+  void _handleSpanEnd(OnSpanEndV2 event) {
+    final span = _span;
+    if (span == null || !identical(event.span, span) || _endTimestamp != null) {
+      return;
+    }
+
+    final endTimestamp = span.endTimestamp;
+    if (endTimestamp == null) return;
+
+    if (_root.deadlineExceeded) {
+      span.status = SentrySpanStatusV2.error;
+      span.setAttribute(
+        SemanticAttributesConstants.sentryStatusMessage,
+        SentryAttribute.string(SentrySpanStatusMessages.deadlineExceeded),
+      );
+    } else {
+      span.status = SentrySpanStatusV2.ok;
+    }
+
+    _endTimestamp = endTimestamp;
+    _removeSpanEndCallback();
+  }
+
+  Future<void> _finishSpan(DateTime? endTimestamp) async {
+    if (_endTimestamp != null) return;
+    final span = _span;
+    try {
+      final timestamp =
+          (span?.endTimestamp ?? endTimestamp ?? _hub.options.clock()).toUtc();
+      _endTimestamp = timestamp;
+      if (span == null) return;
+
+      span.status = SentrySpanStatusV2.ok;
+      if (!span.isEnded) {
+        span.end(endTimestamp: timestamp);
+      }
+    } catch (error, stackTrace) {
+      internalLogger.error(
+        'Failed to finish streaming extended app start',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    } finally {
+      _removeSpanEndCallback();
+    }
+  }
+
+  void _removeSpanEndCallback() {
+    _hub.options.lifecycleRegistry.removeCallback<OnSpanEndV2>(
+      _spanEndCallback,
+    );
   }
 }

--- a/packages/flutter/lib/src/app_start/standalone/streaming_app_start_trace.dart
+++ b/packages/flutter/lib/src/app_start/standalone/streaming_app_start_trace.dart
@@ -156,6 +156,9 @@ final class StreamingAppStartTrace implements AppStartTrace {
 
   @override
   bool tryExtend(DateTime startTimestamp) {
+    // No `_finalizing` guard like the static trace's. The deadline is owned by
+    // the idle root here, which force-ends its descendants synchronously, so
+    // there is no window where the trace is winding down but not yet terminal.
     if (_state.isTerminal) {
       return refuseAppStartExtension('the app start already ended');
     }
@@ -175,7 +178,7 @@ final class StreamingAppStartTrace implements AppStartTrace {
   @override
   Future<void> finishExtended(DateTime endTimestamp) {
     if (_state.isTerminal) {
-      return Future<void>.value();
+      return refuseAppStartExtensionFinish('the app start already ended');
     }
 
     return _extensionLifecycle.finish(endTimestamp);
@@ -248,6 +251,10 @@ final class StreamingAppStartTrace implements AppStartTrace {
   }
 }
 
+/// Owns the single extension span for the streaming lifecycle.
+///
+/// Mirrors `_StaticAppStartExtensionLifecycle` step for step; see the note
+/// there for why the two are not shared.
 final class _StreamingAppStartExtensionLifecycle {
   final Hub _hub;
   final IdleRecordingSentrySpanV2 _root;
@@ -307,7 +314,12 @@ final class _StreamingAppStartExtensionLifecycle {
       : (isSettled: _endTimestamp != null, endTimestamp: _endTimestamp);
 
   Future<void> finish(DateTime endTimestamp) {
-    if (_closed || _span == null) return Future<void>.value();
+    if (_closed) {
+      return refuseAppStartExtensionFinish('the app start already ended');
+    }
+    if (_span == null) {
+      return refuseAppStartExtensionFinish('it was never extended');
+    }
     return _finishFuture ??= _finishSpan(endTimestamp.toUtc());
   }
 

--- a/packages/flutter/lib/src/sentry_flutter.dart
+++ b/packages/flutter/lib/src/sentry_flutter.dart
@@ -351,6 +351,93 @@ mixin SentryFlutter {
     return SentryDisplay(spanId, hub: hub);
   }
 
+  /// Extends the active standalone App Start trace, if one exists.
+  ///
+  /// Call this in [init]'s `appRunner` before `runApp`, then pair it with
+  /// [finishExtendedAppStart] in a `try` / `finally` block:
+  ///
+  /// ```dart
+  /// await SentryFlutter.init(
+  ///   (options) {
+  ///     options
+  ///       ..dsn = 'YOUR_DSN'
+  ///       ..tracesSampleRate = 1.0
+  ///       ..enableStandaloneAppStartTracing = true;
+  ///   },
+  ///   appRunner: () async {
+  ///     SentryFlutter.extendAppStart();
+  ///     runApp(const MyApp());
+  ///
+  ///     try {
+  ///       await completeStartupWork();
+  ///     } finally {
+  ///       await SentryFlutter.finishExtendedAppStart();
+  ///     }
+  ///   },
+  /// );
+  /// ```
+  @experimental
+  static void extendAppStart() {
+    final options = Sentry.currentHub.options;
+    if (options is SentryFlutterOptions) {
+      options.standaloneAppStartTrace?.tryExtend(options.clock());
+    }
+  }
+
+  /// Returns the active static-lifecycle extended App Start span.
+  ///
+  /// The returned span may be finished directly with [ISentrySpan.finish].
+  /// This completes the extension like [finishExtendedAppStart]; calling both
+  /// is unnecessary.
+  ///
+  /// Use this getter when [SentryFlutterOptions.traceLifecycle] is
+  /// [SentryTraceLifecycle.static]. It returns `null` when standalone App Start
+  /// is inactive, already finished, unavailable, or using the streaming
+  /// lifecycle instead.
+  @experimental
+  static ISentrySpan? getExtendedAppStartSpan() {
+    final options = Sentry.currentHub.options;
+    return options is SentryFlutterOptions
+        ? options.standaloneAppStartTrace?.extendedSpan
+        : null;
+  }
+
+  /// Returns the active streaming-lifecycle extended App Start span.
+  ///
+  /// The returned span may be ended directly with [SentrySpanV2.end].
+  /// This completes the extension like [finishExtendedAppStart]; calling both
+  /// is unnecessary.
+  ///
+  /// Use this getter when [SentryFlutterOptions.traceLifecycle] is
+  /// [SentryTraceLifecycle.stream]. It returns `null` when standalone App Start
+  /// is inactive, already finished, unavailable, or using the static lifecycle
+  /// instead.
+  @experimental
+  static SentrySpanV2? getExtendedAppStartSpanV2() {
+    final options = Sentry.currentHub.options;
+    return options is SentryFlutterOptions
+        ? options.standaloneAppStartTrace?.extendedSpanV2
+        : null;
+  }
+
+  /// Finishes the active standalone App Start extension, if one exists.
+  ///
+  /// Alternatively, finish or end the span returned by the lifecycle-specific
+  /// extended App Start getter.
+  ///
+  /// Open descendants remain active while the standalone App Start root keeps
+  /// its existing first-frame, idle, and deadline lifecycle.
+  @experimental
+  static Future<void> finishExtendedAppStart() async {
+    final options = Sentry.currentHub.options;
+    if (options is SentryFlutterOptions) {
+      final trace = options.standaloneAppStartTrace;
+      if (trace != null) {
+        await trace.finishExtended(options.clock());
+      }
+    }
+  }
+
   /// Pauses the app hang tracking.
   /// Only for iOS and macOS.
   static Future<void> pauseAppHangTracking() async {

--- a/packages/flutter/lib/src/sentry_flutter.dart
+++ b/packages/flutter/lib/src/sentry_flutter.dart
@@ -17,6 +17,7 @@ import 'event_processor/widget_event_processor.dart';
 import 'file_system_transport.dart';
 import 'flutter_exception_type_identifier.dart';
 import 'frame_callback_handler.dart';
+import 'app_start/standalone/app_start_trace.dart';
 import 'app_start/standalone/standalone_app_start_integration.dart';
 import 'app_start/standalone/standalone_app_start_handler.dart';
 import 'app_start/ui_load_attached/generic_app_start_integration.dart';
@@ -353,8 +354,22 @@ mixin SentryFlutter {
 
   /// Extends the active standalone App Start trace, if one exists.
   ///
-  /// Call this in [init]'s `appRunner` before `runApp`, then pair it with
-  /// [finishExtendedAppStart] in a `try` / `finally` block:
+  /// The App Start then measures up to [finishExtendedAppStart] instead of the
+  /// first frame, so startup work that runs past the first frame is part of the
+  /// reported duration.
+  ///
+  /// **Always finish what you extend.** Until the extension finishes, the App
+  /// Start is still in progress: it stays open past its idle timeout, and is
+  /// reported without a duration if it hits its 30 second deadline first. Pair
+  /// this with [finishExtendedAppStart] in a `try` / `finally` so an early
+  /// return or a throw cannot strand it.
+  ///
+  /// Requires [SentryFlutterOptions.enableStandaloneAppStartTracing] on iOS or
+  /// Android. Does nothing on other platforms, once the first frame has
+  /// rendered, or when the App Start is already extended — each of those is
+  /// logged rather than reported back to the caller.
+  ///
+  /// Call this in [init]'s `appRunner` before `runApp`:
   ///
   /// ```dart
   /// await SentryFlutter.init(
@@ -383,7 +398,15 @@ mixin SentryFlutter {
       return;
     }
     try {
-      options.standaloneAppStartTrace?.tryExtend(options.clock());
+      final trace = options.standaloneAppStartTrace;
+      if (trace == null) {
+        internalLogger.info(
+          '$appStartExtensionRefusalPrefix: '
+          'standalone app-start tracing is not active',
+        );
+        return;
+      }
+      trace.tryExtend(options.clock());
     } catch (error, stackTrace) {
       internalLogger.error(
         'Failed to extend app start',
@@ -451,11 +474,14 @@ mixin SentryFlutter {
 
   /// Finishes the active standalone App Start extension, if one exists.
   ///
+  /// This is what releases the App Start opened by [extendAppStart] to report.
   /// Alternatively, finish or end the span returned by the lifecycle-specific
-  /// extended App Start getter.
+  /// extended App Start getter — either one completes the extension, so there
+  /// is no need to do both.
   ///
-  /// Open descendants remain active while the standalone App Start root keeps
-  /// its existing first-frame, idle, and deadline lifecycle.
+  /// Spans you started under the extension are left running. They hold the App
+  /// Start open on their own until they finish or it hits its deadline, so
+  /// finish them too if they should not delay it.
   @experimental
   static Future<void> finishExtendedAppStart() async {
     final options = Sentry.currentHub.options;

--- a/packages/flutter/lib/src/sentry_flutter.dart
+++ b/packages/flutter/lib/src/sentry_flutter.dart
@@ -482,6 +482,11 @@ mixin SentryFlutter {
   /// Spans you started under the extension are left running. They hold the App
   /// Start open on their own until they finish or it hits its deadline, so
   /// finish them too if they should not delay it.
+  ///
+  /// Does nothing when there is no extension left to finish — it was never
+  /// started, or the App Start has already been reported because it hit its
+  /// deadline first. As with [extendAppStart], each of those is logged rather
+  /// than reported back to the caller.
   @experimental
   static Future<void> finishExtendedAppStart() async {
     final options = Sentry.currentHub.options;
@@ -489,7 +494,15 @@ mixin SentryFlutter {
       return;
     }
     try {
-      await options.standaloneAppStartTrace?.finishExtended(options.clock());
+      final trace = options.standaloneAppStartTrace;
+      if (trace == null) {
+        internalLogger.info(
+          '$appStartExtensionFinishRefusalPrefix: '
+          'there is no app start left to finish',
+        );
+        return;
+      }
+      await trace.finishExtended(options.clock());
     } catch (error, stackTrace) {
       internalLogger.error(
         'Failed to finish the extended app start',

--- a/packages/flutter/lib/src/sentry_flutter.dart
+++ b/packages/flutter/lib/src/sentry_flutter.dart
@@ -401,12 +401,13 @@ mixin SentryFlutter {
     try {
       final trace = options.standaloneAppStartTrace;
       if (trace == null) {
-        internalLogger.info(
-          '$appStartExtensionRefusalPrefix: '
+        logAppStartExtensionRefusal(
           'standalone app-start tracing is not active',
         );
         return;
       }
+      // The refusal is logged by the trace; this entry point reports nothing
+      // back to the caller.
       trace.tryExtend(options.clock());
     } catch (error, stackTrace) {
       internalLogger.error(
@@ -497,8 +498,7 @@ mixin SentryFlutter {
     try {
       final trace = options.standaloneAppStartTrace;
       if (trace == null) {
-        internalLogger.info(
-          '$appStartExtensionFinishRefusalPrefix: '
+        logAppStartExtensionFinishRefusal(
           'there is no app start left to finish',
         );
         return;

--- a/packages/flutter/lib/src/sentry_flutter.dart
+++ b/packages/flutter/lib/src/sentry_flutter.dart
@@ -359,10 +359,11 @@ mixin SentryFlutter {
   /// reported duration.
   ///
   /// **Always finish what you extend.** Until the extension finishes, the App
-  /// Start is still in progress: it stays open past its idle timeout, and is
-  /// reported without a duration if it hits its 30 second deadline first. Pair
-  /// this with [finishExtendedAppStart] in a `try` / `finally` so an early
-  /// return or a throw cannot strand it.
+  /// Start is still in progress: it stays open past its idle timeout, and if
+  /// it hits its 30 second deadline first the extension is dropped from the
+  /// reported duration, which falls back to the first frame. Pair this with
+  /// [finishExtendedAppStart] in a `try` / `finally` so an early return or a
+  /// throw cannot strand it.
   ///
   /// Requires [SentryFlutterOptions.enableStandaloneAppStartTracing] on iOS or
   /// Android. Does nothing on other platforms, once the first frame has

--- a/packages/flutter/lib/src/sentry_flutter.dart
+++ b/packages/flutter/lib/src/sentry_flutter.dart
@@ -379,8 +379,17 @@ mixin SentryFlutter {
   @experimental
   static void extendAppStart() {
     final options = Sentry.currentHub.options;
-    if (options is SentryFlutterOptions) {
+    if (options is! SentryFlutterOptions) {
+      return;
+    }
+    try {
       options.standaloneAppStartTrace?.tryExtend(options.clock());
+    } catch (error, stackTrace) {
+      internalLogger.error(
+        'Failed to extend app start',
+        error: error,
+        stackTrace: stackTrace,
+      );
     }
   }
 
@@ -397,9 +406,19 @@ mixin SentryFlutter {
   @experimental
   static ISentrySpan? getExtendedAppStartSpan() {
     final options = Sentry.currentHub.options;
-    return options is SentryFlutterOptions
-        ? options.standaloneAppStartTrace?.extendedSpan
-        : null;
+    if (options is! SentryFlutterOptions) {
+      return null;
+    }
+    try {
+      return options.standaloneAppStartTrace?.extendedSpan;
+    } catch (error, stackTrace) {
+      internalLogger.error(
+        'Failed to read the extended app-start span',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      return null;
+    }
   }
 
   /// Returns the active streaming-lifecycle extended App Start span.
@@ -415,9 +434,19 @@ mixin SentryFlutter {
   @experimental
   static SentrySpanV2? getExtendedAppStartSpanV2() {
     final options = Sentry.currentHub.options;
-    return options is SentryFlutterOptions
-        ? options.standaloneAppStartTrace?.extendedSpanV2
-        : null;
+    if (options is! SentryFlutterOptions) {
+      return null;
+    }
+    try {
+      return options.standaloneAppStartTrace?.extendedSpanV2;
+    } catch (error, stackTrace) {
+      internalLogger.error(
+        'Failed to read the extended app-start span',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      return null;
+    }
   }
 
   /// Finishes the active standalone App Start extension, if one exists.
@@ -430,11 +459,17 @@ mixin SentryFlutter {
   @experimental
   static Future<void> finishExtendedAppStart() async {
     final options = Sentry.currentHub.options;
-    if (options is SentryFlutterOptions) {
-      final trace = options.standaloneAppStartTrace;
-      if (trace != null) {
-        await trace.finishExtended(options.clock());
-      }
+    if (options is! SentryFlutterOptions) {
+      return;
+    }
+    try {
+      await options.standaloneAppStartTrace?.finishExtended(options.clock());
+    } catch (error, stackTrace) {
+      internalLogger.error(
+        'Failed to finish the extended app start',
+        error: error,
+        stackTrace: stackTrace,
+      );
     }
   }
 

--- a/packages/flutter/lib/src/sentry_flutter_options.dart
+++ b/packages/flutter/lib/src/sentry_flutter_options.dart
@@ -5,6 +5,7 @@ import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart' as meta;
 import 'package:sentry/sentry.dart';
 
+import 'app_start/standalone/app_start_trace.dart';
 import 'binding_wrapper.dart';
 import 'event_processor/screenshot_event_processor.dart';
 import 'navigation/time_to_display_tracker.dart';
@@ -198,6 +199,9 @@ class SentryFlutterOptions extends SentryOptions {
   @meta.internal
   bool get usesStandaloneAppStart =>
       enableStandaloneAppStartTracing && (platform.isIOS || platform.isAndroid);
+
+  @meta.internal
+  AppStartTrace? standaloneAppStartTrace;
 
   /// Automatically attaches a screenshot when capturing an error or exception.
   ///

--- a/packages/flutter/test/app_start/standalone/app_start_vitals_test.dart
+++ b/packages/flutter/test/app_start/standalone/app_start_vitals_test.dart
@@ -14,7 +14,7 @@ void main() {
   group('$AppStartVitals', () {
     test('reports the duration from process start to the first frame', () {
       final vitals = fixture.resolve(
-        endTimestamp:
+        firstFrameTimestamp:
             fixture.processStart.add(const Duration(milliseconds: 750)),
       );
 
@@ -25,7 +25,8 @@ void main() {
       final vitals = fixture.resolve(
         type: AppStartType.warm,
         screen: 'MyHomePage',
-        endTimestamp: fixture.processStart.add(const Duration(seconds: 1)),
+        firstFrameTimestamp:
+            fixture.processStart.add(const Duration(seconds: 1)),
       );
 
       expect(vitals.type, AppStartType.warm);
@@ -33,14 +34,14 @@ void main() {
     });
 
     test('returns null duration when no first frame arrived', () {
-      final vitals = fixture.resolve(endTimestamp: null);
+      final vitals = fixture.resolve(firstFrameTimestamp: null);
 
       expect(vitals.duration, isNull);
     });
 
     test('measures to an extension that outlasted the first frame', () {
       final vitals = fixture.resolve(
-        endTimestamp:
+        firstFrameTimestamp:
             fixture.processStart.add(const Duration(milliseconds: 750)),
         extensionEndTimestamp:
             fixture.processStart.add(const Duration(milliseconds: 1200)),
@@ -51,7 +52,7 @@ void main() {
 
     test('keeps the first frame when the extension ended before it', () {
       final vitals = fixture.resolve(
-        endTimestamp:
+        firstFrameTimestamp:
             fixture.processStart.add(const Duration(milliseconds: 750)),
         extensionEndTimestamp:
             fixture.processStart.add(const Duration(milliseconds: 400)),
@@ -63,7 +64,7 @@ void main() {
     test('keeps the first frame when the extension contributed no endpoint',
         () {
       final vitals = fixture.resolve(
-        endTimestamp:
+        firstFrameTimestamp:
             fixture.processStart.add(const Duration(milliseconds: 750)),
         extensionEndTimestamp: null,
       );
@@ -75,7 +76,7 @@ void main() {
       final vitals = fixture.resolve(
         type: AppStartType.warm,
         screen: 'MyHomePage',
-        endTimestamp: null,
+        firstFrameTimestamp: null,
       );
 
       expect(vitals.type, AppStartType.warm);
@@ -85,7 +86,31 @@ void main() {
     test('returns null duration when the window exceeds the plausible ceiling',
         () {
       final vitals = fixture.resolve(
-        endTimestamp: fixture.processStart.add(const Duration(seconds: 61)),
+        firstFrameTimestamp:
+            fixture.processStart.add(const Duration(seconds: 61)),
+      );
+
+      expect(vitals.duration, isNull);
+    });
+
+    test('keeps the first frame when the extension exceeds the ceiling', () {
+      final vitals = fixture.resolve(
+        firstFrameTimestamp:
+            fixture.processStart.add(const Duration(seconds: 41)),
+        extensionEndTimestamp:
+            fixture.processStart.add(const Duration(seconds: 65)),
+      );
+
+      expect(vitals.duration, const Duration(seconds: 41));
+    });
+
+    test('returns null duration when the first frame also exceeds the ceiling',
+        () {
+      final vitals = fixture.resolve(
+        firstFrameTimestamp:
+            fixture.processStart.add(const Duration(seconds: 61)),
+        extensionEndTimestamp:
+            fixture.processStart.add(const Duration(seconds: 65)),
       );
 
       expect(vitals.duration, isNull);
@@ -94,7 +119,8 @@ void main() {
     test('returns null duration when the first frame precedes process start',
         () {
       final vitals = fixture.resolve(
-        endTimestamp: fixture.processStart.subtract(const Duration(seconds: 1)),
+        firstFrameTimestamp:
+            fixture.processStart.subtract(const Duration(seconds: 1)),
       );
 
       expect(vitals.duration, isNull);
@@ -103,7 +129,8 @@ void main() {
     group('measurement', () {
       test('is a cold app start on a cold launch', () {
         final vitals = fixture.resolve(
-          endTimestamp: fixture.processStart.add(const Duration(seconds: 1)),
+          firstFrameTimestamp:
+              fixture.processStart.add(const Duration(seconds: 1)),
         );
 
         expect(vitals.measurement?.name, 'app_start_cold');
@@ -113,14 +140,15 @@ void main() {
       test('is a warm app start on a warm launch', () {
         final vitals = fixture.resolve(
           type: AppStartType.warm,
-          endTimestamp: fixture.processStart.add(const Duration(seconds: 1)),
+          firstFrameTimestamp:
+              fixture.processStart.add(const Duration(seconds: 1)),
         );
 
         expect(vitals.measurement?.name, 'app_start_warm');
       });
 
       test('returns null when the duration is absent', () {
-        final vitals = fixture.resolve(endTimestamp: null);
+        final vitals = fixture.resolve(firstFrameTimestamp: null);
 
         expect(vitals.measurement, isNull);
       });
@@ -129,7 +157,8 @@ void main() {
     group('durationAttributeKey', () {
       test('is the cold key on a cold launch', () {
         final vitals = fixture.resolve(
-          endTimestamp: fixture.processStart.add(const Duration(seconds: 1)),
+          firstFrameTimestamp:
+              fixture.processStart.add(const Duration(seconds: 1)),
         );
 
         expect(vitals.durationAttributeKey, 'app.vitals.start.cold.value');
@@ -138,7 +167,8 @@ void main() {
       test('is the warm key on a warm launch', () {
         final vitals = fixture.resolve(
           type: AppStartType.warm,
-          endTimestamp: fixture.processStart.add(const Duration(seconds: 1)),
+          firstFrameTimestamp:
+              fixture.processStart.add(const Duration(seconds: 1)),
         );
 
         expect(vitals.durationAttributeKey, 'app.vitals.start.warm.value');
@@ -164,13 +194,13 @@ class Fixture {
   AppStartVitals resolve({
     AppStartType type = AppStartType.cold,
     String screen = 'root /',
-    required DateTime? endTimestamp,
+    required DateTime? firstFrameTimestamp,
     DateTime? extensionEndTimestamp,
   }) =>
       AppStartVitals.resolve(
         timing: timing(type: type),
         screen: screen,
-        endTimestamp: endTimestamp,
+        firstFrameTimestamp: firstFrameTimestamp,
         extensionEndTimestamp: extensionEndTimestamp,
       );
 }

--- a/packages/flutter/test/app_start/standalone/app_start_vitals_test.dart
+++ b/packages/flutter/test/app_start/standalone/app_start_vitals_test.dart
@@ -2,6 +2,7 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sentry_flutter/src/app_start/app_start_timing.dart';
+import 'package:sentry_flutter/src/app_start/standalone/app_start_trace.dart';
 import 'package:sentry_flutter/src/app_start/standalone/app_start_vitals.dart';
 
 void main() {
@@ -34,6 +35,44 @@ void main() {
 
     test('returns null duration when no first frame arrived', () {
       final vitals = fixture.resolve(endTimestamp: null);
+
+      expect(vitals.duration, isNull);
+    });
+
+    test('measures to an extension that outlasted the first frame', () {
+      final vitals = fixture.resolve(
+        endTimestamp:
+            fixture.processStart.add(const Duration(milliseconds: 750)),
+        extension: (
+          isSettled: true,
+          endTimestamp:
+              fixture.processStart.add(const Duration(milliseconds: 1200)),
+        ),
+      );
+
+      expect(vitals.duration, const Duration(milliseconds: 1200));
+    });
+
+    test('keeps the first frame when the extension ended before it', () {
+      final vitals = fixture.resolve(
+        endTimestamp:
+            fixture.processStart.add(const Duration(milliseconds: 750)),
+        extension: (
+          isSettled: true,
+          endTimestamp:
+              fixture.processStart.add(const Duration(milliseconds: 400)),
+        ),
+      );
+
+      expect(vitals.duration, const Duration(milliseconds: 750));
+    });
+
+    test('returns null duration while an extension is unsettled', () {
+      final vitals = fixture.resolve(
+        endTimestamp:
+            fixture.processStart.add(const Duration(milliseconds: 750)),
+        extension: (isSettled: false, endTimestamp: null),
+      );
 
       expect(vitals.duration, isNull);
     });
@@ -141,12 +180,14 @@ class Fixture {
     AppStartType type = AppStartType.cold,
     String screen = 'root /',
     required DateTime? endTimestamp,
+    AppStartExtensionOutcome extension = noAppStartExtension,
     bool deadlineExceeded = false,
   }) =>
       AppStartVitals.resolve(
         timing: timing(type: type),
         screen: screen,
         endTimestamp: endTimestamp,
+        extension: extension,
         deadlineExceeded: deadlineExceeded,
       );
 }

--- a/packages/flutter/test/app_start/standalone/app_start_vitals_test.dart
+++ b/packages/flutter/test/app_start/standalone/app_start_vitals_test.dart
@@ -2,7 +2,6 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sentry_flutter/src/app_start/app_start_timing.dart';
-import 'package:sentry_flutter/src/app_start/standalone/app_start_trace.dart';
 import 'package:sentry_flutter/src/app_start/standalone/app_start_vitals.dart';
 
 void main() {
@@ -43,11 +42,8 @@ void main() {
       final vitals = fixture.resolve(
         endTimestamp:
             fixture.processStart.add(const Duration(milliseconds: 750)),
-        extension: (
-          isSettled: true,
-          endTimestamp:
-              fixture.processStart.add(const Duration(milliseconds: 1200)),
-        ),
+        extensionEndTimestamp:
+            fixture.processStart.add(const Duration(milliseconds: 1200)),
       );
 
       expect(vitals.duration, const Duration(milliseconds: 1200));
@@ -57,33 +53,22 @@ void main() {
       final vitals = fixture.resolve(
         endTimestamp:
             fixture.processStart.add(const Duration(milliseconds: 750)),
-        extension: (
-          isSettled: true,
-          endTimestamp:
-              fixture.processStart.add(const Duration(milliseconds: 400)),
-        ),
+        extensionEndTimestamp:
+            fixture.processStart.add(const Duration(milliseconds: 400)),
       );
 
       expect(vitals.duration, const Duration(milliseconds: 750));
     });
 
-    test('returns null duration while an extension is unsettled', () {
+    test('keeps the first frame when the extension contributed no endpoint',
+        () {
       final vitals = fixture.resolve(
         endTimestamp:
             fixture.processStart.add(const Duration(milliseconds: 750)),
-        extension: (isSettled: false, endTimestamp: null),
+        extensionEndTimestamp: null,
       );
 
-      expect(vitals.duration, isNull);
-    });
-
-    test('returns null duration when the root hit its deadline', () {
-      final vitals = fixture.resolve(
-        endTimestamp: fixture.processStart.add(const Duration(seconds: 1)),
-        deadlineExceeded: true,
-      );
-
-      expect(vitals.duration, isNull);
+      expect(vitals.duration, const Duration(milliseconds: 750));
     });
 
     test('still reports type and screen when the duration is absent', () {
@@ -180,14 +165,12 @@ class Fixture {
     AppStartType type = AppStartType.cold,
     String screen = 'root /',
     required DateTime? endTimestamp,
-    AppStartExtensionOutcome extension = noAppStartExtension,
-    bool deadlineExceeded = false,
+    DateTime? extensionEndTimestamp,
   }) =>
       AppStartVitals.resolve(
         timing: timing(type: type),
         screen: screen,
         endTimestamp: endTimestamp,
-        extension: extension,
-        deadlineExceeded: deadlineExceeded,
+        extensionEndTimestamp: extensionEndTimestamp,
       );
 }

--- a/packages/flutter/test/app_start/standalone/standalone_app_start_handler_test.dart
+++ b/packages/flutter/test/app_start/standalone/standalone_app_start_handler_test.dart
@@ -319,7 +319,9 @@ void main() {
       );
     });
 
-    test('clears the published standalone trace once it completes', () async {
+    test(
+        'clears the published standalone trace once the static lifecycle completes',
+        () async {
       await fixture.startLifecycle();
       final root = fixture.appStartRoots.single.tracer;
 
@@ -328,6 +330,23 @@ void main() {
       fixture.frameHandler.timingsCallback!([fixture.frameTiming]);
       await pumpEventQueue(times: 10);
       await root.finish(endTimestamp: fixture.snapshot);
+
+      expect(fixture.options.standaloneAppStartTrace, isNull);
+    });
+
+    test(
+        'clears the published standalone trace once the stream lifecycle completes',
+        () async {
+      fixture.useStreamingLifecycle();
+      await fixture.startLifecycle();
+      final root = fixture.streamAppStartRoots.single;
+
+      expect(fixture.options.standaloneAppStartTrace, isNotNull);
+
+      fixture.frameHandler.timingsCallback!([fixture.frameTiming]);
+      await pumpEventQueue(times: 10);
+      root.end(endTimestamp: fixture.snapshot);
+      await pumpEventQueue(times: 10);
 
       expect(fixture.options.standaloneAppStartTrace, isNull);
     });

--- a/packages/flutter/test/app_start/standalone/standalone_app_start_handler_test.dart
+++ b/packages/flutter/test/app_start/standalone/standalone_app_start_handler_test.dart
@@ -319,6 +319,19 @@ void main() {
       );
     });
 
+    test('clears the published standalone trace once it completes', () async {
+      await fixture.startLifecycle();
+      final root = fixture.appStartRoots.single.tracer;
+
+      expect(fixture.options.standaloneAppStartTrace, isNotNull);
+
+      fixture.frameHandler.timingsCallback!([fixture.frameTiming]);
+      await pumpEventQueue(times: 10);
+      await root.finish(endTimestamp: fixture.snapshot);
+
+      expect(fixture.options.standaloneAppStartTrace, isNull);
+    });
+
     test('close removes the first-frame callback', () async {
       await fixture.startLifecycle();
 

--- a/packages/flutter/test/app_start/standalone/standalone_app_start_handler_test.dart
+++ b/packages/flutter/test/app_start/standalone/standalone_app_start_handler_test.dart
@@ -13,7 +13,6 @@ import 'package:sentry_flutter/src/native/native_app_start.dart';
 import 'package:sentry_flutter/src/navigation/time_to_display_tracker.dart';
 import 'package:sentry_flutter/src/navigation/time_to_display_tracker_v2.dart';
 
-import '../../app_start_trace_test_support.dart';
 import '../../fake_frame_callback_handler.dart';
 import '../../mocks.dart';
 import '../../mocks.mocks.dart';
@@ -300,23 +299,6 @@ void main() {
       await fixture.getSut().close();
 
       expect(fixture.options.standaloneAppStartTrace, isNull);
-    });
-
-    test('close preserves a replacement standalone trace', () async {
-      await fixture.startLifecycle();
-      final publishedTrace = fixture.options.standaloneAppStartTrace;
-      final replacementTrace = TestAppStartTrace();
-
-      expect(publishedTrace, isNotNull);
-
-      fixture.options.standaloneAppStartTrace = replacementTrace;
-
-      await fixture.getSut().close();
-
-      expect(
-        fixture.options.standaloneAppStartTrace,
-        same(replacementTrace),
-      );
     });
 
     test(

--- a/packages/flutter/test/app_start/standalone/standalone_app_start_handler_test.dart
+++ b/packages/flutter/test/app_start/standalone/standalone_app_start_handler_test.dart
@@ -13,6 +13,7 @@ import 'package:sentry_flutter/src/native/native_app_start.dart';
 import 'package:sentry_flutter/src/navigation/time_to_display_tracker.dart';
 import 'package:sentry_flutter/src/navigation/time_to_display_tracker_v2.dart';
 
+import '../../app_start_trace_test_support.dart';
 import '../../fake_frame_callback_handler.dart';
 import '../../mocks.dart';
 import '../../mocks.mocks.dart';
@@ -80,6 +81,47 @@ void main() {
       expect(
         fixture.rootSpans.map((span) => span.context.traceId).toSet(),
         hasLength(1),
+      );
+    });
+
+    test(
+        'produces equivalent static and streaming outputs for nested extension completion',
+        () async {
+      final staticFixture = Fixture();
+      final streamingFixture = Fixture()..useStreamingLifecycle();
+      addTearDown(() async {
+        await staticFixture.getSut().close();
+        await streamingFixture.getSut().close();
+      });
+
+      final staticSnapshot = await staticFixture.runExtendedScenario();
+      final streamingSnapshot = await streamingFixture.runExtendedScenario();
+
+      expect(staticSnapshot.rootCount, 1);
+      expect(streamingSnapshot.rootCount, 1);
+      expect(staticSnapshot.extensionChildCount, 1);
+      expect(streamingSnapshot.extensionChildCount, 1);
+      expect(staticSnapshot.extensionStart, streamingSnapshot.extensionStart);
+      expect(staticSnapshot.extensionEnd, streamingSnapshot.extensionEnd);
+      expect(staticSnapshot.childEnd, streamingSnapshot.childEnd);
+      expect(
+        staticSnapshot.grandchildEnd,
+        streamingSnapshot.grandchildEnd,
+      );
+      expect(staticSnapshot.extensionSuccessful, isTrue);
+      expect(streamingSnapshot.extensionSuccessful, isTrue);
+      expect(staticSnapshot.childOpenAfterExtension, isTrue);
+      expect(staticSnapshot.grandchildOpenAfterExtension, isTrue);
+      expect(streamingSnapshot.childOpenAfterExtension, isTrue);
+      expect(streamingSnapshot.grandchildOpenAfterExtension, isTrue);
+      expect(staticSnapshot.childSuccessful, isTrue);
+      expect(staticSnapshot.grandchildSuccessful, isTrue);
+      expect(streamingSnapshot.childSuccessful, isTrue);
+      expect(streamingSnapshot.grandchildSuccessful, isTrue);
+      expect(staticSnapshot.measurementMilliseconds, 600.0);
+      expect(
+        streamingSnapshot.measurementMilliseconds,
+        staticSnapshot.measurementMilliseconds,
       );
     });
 
@@ -243,6 +285,40 @@ void main() {
       expect(root.tracer.finished, isTrue);
     });
 
+    test('publishes the active standalone trace after start', () async {
+      await fixture.startLifecycle();
+
+      expect(fixture.options.standaloneAppStartTrace, isNotNull);
+    });
+
+    test('close clears the published standalone trace', () async {
+      await fixture.startLifecycle();
+      final publishedTrace = fixture.options.standaloneAppStartTrace;
+
+      expect(publishedTrace, isNotNull);
+
+      await fixture.getSut().close();
+
+      expect(fixture.options.standaloneAppStartTrace, isNull);
+    });
+
+    test('close preserves a replacement standalone trace', () async {
+      await fixture.startLifecycle();
+      final publishedTrace = fixture.options.standaloneAppStartTrace;
+      final replacementTrace = TestAppStartTrace();
+
+      expect(publishedTrace, isNotNull);
+
+      fixture.options.standaloneAppStartTrace = replacementTrace;
+
+      await fixture.getSut().close();
+
+      expect(
+        fixture.options.standaloneAppStartTrace,
+        same(replacementTrace),
+      );
+    });
+
     test('close removes the first-frame callback', () async {
       await fixture.startLifecycle();
 
@@ -359,8 +435,17 @@ class Fixture {
   final native = MockSentryNativeBinding();
   final transport = _FakeTransport();
   final rootSpans = <SentrySpan>[];
+  final streamRootSpans = <IdleRecordingSentrySpanV2>[];
+  final streamChildSpans = <RecordingSentrySpanV2>[];
   List<SentrySpan> get appStartRoots =>
       rootSpans.where((span) => span.context.operation == 'app.start').toList();
+  List<IdleRecordingSentrySpanV2> get streamAppStartRoots => streamRootSpans
+      .where(
+        (span) =>
+            span.attributes[SemanticAttributesConstants.sentryOp]?.value ==
+            SentrySpanOperations.appStart,
+      )
+      .toList();
   final processStart = DateTime.fromMillisecondsSinceEpoch(0, isUtc: true);
   final setup = DateTime.fromMillisecondsSinceEpoch(200, isUtc: true);
   final snapshot = DateTime.fromMillisecondsSinceEpoch(300, isUtc: true);
@@ -397,6 +482,14 @@ class Fixture {
         rootSpans.add(event.span as SentrySpan);
       }
     });
+    options.lifecycleRegistry.registerCallback<OnSpanStartV2>((event) {
+      final span = event.span;
+      if (span is IdleRecordingSentrySpanV2) {
+        streamRootSpans.add(span);
+      } else if (span is RecordingSentrySpanV2 && span.parentSpan != null) {
+        streamChildSpans.add(span);
+      }
+    });
     options.timeToDisplayTracker = TimeToDisplayTracker(
       hub: hub,
       options: options,
@@ -421,6 +514,122 @@ class Fixture {
       );
 
   Future<void> startLifecycle() => getSut().start(options);
+
+  Future<_ExtendedScenarioSnapshot> runExtendedScenario() async {
+    final extensionStart = processStart.add(const Duration(milliseconds: 250));
+    final childStart = extensionStart.add(const Duration(milliseconds: 25));
+    final grandchildStart =
+        extensionStart.add(const Duration(milliseconds: 50));
+    final extensionEnd = processStart.add(const Duration(milliseconds: 600));
+    final grandchildEnd = processStart.add(const Duration(milliseconds: 700));
+    final childEnd = processStart.add(const Duration(milliseconds: 800));
+    final rootEnd = processStart.add(const Duration(milliseconds: 900));
+
+    await startLifecycle();
+    await pumpEventQueue(times: 10);
+
+    final trace = options.standaloneAppStartTrace!;
+    expect(trace.tryExtend(extensionStart), isTrue);
+
+    switch (options.traceLifecycle) {
+      case SentryTraceLifecycle.static:
+        final extension = trace.extendedSpan as SentrySpan;
+        final child = extension.startChild(
+          'extended child',
+          startTimestamp: childStart,
+        ) as SentrySpan;
+        final grandchild = child.startChild(
+          'extended grandchild',
+          startTimestamp: grandchildStart,
+        ) as SentrySpan;
+
+        frameHandler.timingsCallback!([frameTiming]);
+        await pumpEventQueue(times: 10);
+        await trace.finishExtended(extensionEnd);
+        final childOpenAfterExtension = !child.finished;
+        final grandchildOpenAfterExtension = !grandchild.finished;
+        await grandchild.finish(
+          status: SpanStatus.ok(),
+          endTimestamp: grandchildEnd,
+        );
+        await child.finish(status: SpanStatus.ok(), endTimestamp: childEnd);
+        await pumpEventQueue(times: 10);
+        await appStartRoots.single.tracer.finish(endTimestamp: rootEnd);
+        await pumpEventQueue(times: 10);
+
+        return _ExtendedScenarioSnapshot(
+          rootCount: appStartRoots.length,
+          extensionChildCount: appStartRoots.single.tracer.children
+              .where(
+                (span) =>
+                    span.context.operation ==
+                    SentrySpanOperations.appStartExtended,
+              )
+              .length,
+          extensionStart: extension.startTimestamp,
+          extensionEnd: extension.endTimestamp!,
+          childEnd: child.endTimestamp!,
+          grandchildEnd: grandchild.endTimestamp!,
+          extensionSuccessful: extension.status == SpanStatus.ok(),
+          childOpenAfterExtension: childOpenAfterExtension,
+          grandchildOpenAfterExtension: grandchildOpenAfterExtension,
+          childSuccessful: child.status == SpanStatus.ok(),
+          grandchildSuccessful: grandchild.status == SpanStatus.ok(),
+          measurementMilliseconds: appStartRoots
+              .single.tracer.measurements['app_start_cold']!.value
+              .toDouble(),
+        );
+      case SentryTraceLifecycle.stream:
+        final extension = trace.extendedSpanV2 as RecordingSentrySpanV2;
+        final child = hub.startInactiveSpan(
+          'extended child',
+          parentSpan: extension,
+          startTimestamp: childStart,
+        ) as RecordingSentrySpanV2;
+        final grandchild = hub.startInactiveSpan(
+          'extended grandchild',
+          parentSpan: child,
+          startTimestamp: grandchildStart,
+        ) as RecordingSentrySpanV2;
+
+        frameHandler.timingsCallback!([frameTiming]);
+        await pumpEventQueue(times: 10);
+        await trace.finishExtended(extensionEnd);
+        final childOpenAfterExtension = !child.isEnded;
+        final grandchildOpenAfterExtension = !grandchild.isEnded;
+        grandchild.end(endTimestamp: grandchildEnd);
+        child.end(endTimestamp: childEnd);
+        await pumpEventQueue(times: 10);
+        streamAppStartRoots.single.end(endTimestamp: rootEnd);
+        await pumpEventQueue(times: 10);
+
+        return _ExtendedScenarioSnapshot(
+          rootCount: streamAppStartRoots.length,
+          extensionChildCount: streamChildSpans
+              .where(
+                (span) =>
+                    identical(span.parentSpan, streamAppStartRoots.single) &&
+                    span.attributes[SemanticAttributesConstants.sentryOp]
+                            ?.value ==
+                        SentrySpanOperations.appStartExtended,
+              )
+              .length,
+          extensionStart: extension.startTimestamp,
+          extensionEnd: extension.endTimestamp!,
+          childEnd: child.endTimestamp!,
+          grandchildEnd: grandchild.endTimestamp!,
+          extensionSuccessful: extension.status == SentrySpanStatusV2.ok,
+          childOpenAfterExtension: childOpenAfterExtension,
+          grandchildOpenAfterExtension: grandchildOpenAfterExtension,
+          childSuccessful: child.status == SentrySpanStatusV2.ok,
+          grandchildSuccessful: grandchild.status == SentrySpanStatusV2.ok,
+          measurementMilliseconds: streamAppStartRoots
+              .single
+              .attributes[SemanticAttributesConstants.appVitalsStartValue]!
+              .value as double,
+        );
+    }
+  }
 
   SpanId seedLegacyStaticDisplayTracking() {
     final transactionId = SentryTransactionContext(
@@ -467,6 +676,36 @@ class Fixture {
       null,
     );
   }
+}
+
+final class _ExtendedScenarioSnapshot {
+  final int rootCount;
+  final int extensionChildCount;
+  final DateTime extensionStart;
+  final DateTime extensionEnd;
+  final DateTime childEnd;
+  final DateTime grandchildEnd;
+  final bool extensionSuccessful;
+  final bool childOpenAfterExtension;
+  final bool grandchildOpenAfterExtension;
+  final bool childSuccessful;
+  final bool grandchildSuccessful;
+  final double measurementMilliseconds;
+
+  const _ExtendedScenarioSnapshot({
+    required this.rootCount,
+    required this.extensionChildCount,
+    required this.extensionStart,
+    required this.extensionEnd,
+    required this.childEnd,
+    required this.grandchildEnd,
+    required this.extensionSuccessful,
+    required this.childOpenAfterExtension,
+    required this.grandchildOpenAfterExtension,
+    required this.childSuccessful,
+    required this.grandchildSuccessful,
+    required this.measurementMilliseconds,
+  });
 }
 
 class _FakeTransport implements Transport {

--- a/packages/flutter/test/app_start/standalone/static_app_start_trace_test.dart
+++ b/packages/flutter/test/app_start/standalone/static_app_start_trace_test.dart
@@ -760,7 +760,7 @@ void main() {
       )).called(1);
     });
 
-    testWidgets('suppresses measurement for an unfinished extension deadline',
+    testWidgets('omits measurement without a first frame at the deadline',
         (tester) async {
       final sut = fixture.getSut()!;
       final root = fixture.root!.tracer;
@@ -779,6 +779,49 @@ void main() {
       expect(root.measurements['app_start_cold'], isNull);
       expect(root.data['app_start_type'], 'cold');
       expect(root.data['app.vitals.start.screen'], 'root /');
+    });
+
+    testWidgets('measures to the first frame when the extension never finished',
+        (tester) async {
+      final sut = fixture.getSut()!;
+      final root = fixture.root!.tracer;
+      expect(
+        sut.tryExtend(
+          fixture.processStart.add(const Duration(milliseconds: 400)),
+        ),
+        isTrue,
+      );
+
+      sut.recordFirstFrame(fixture.naturalEnd);
+      await tester.pump(Duration(seconds: 30));
+      await tester.pump();
+
+      expect(root.status, SpanStatus.deadlineExceeded());
+      expect(root.measurements['app_start_cold']?.value, 350);
+    });
+
+    testWidgets('keeps the extension endpoint when a descendant deadlines',
+        (tester) async {
+      final sut = fixture.getSut()!;
+      final root = fixture.root!.tracer;
+      expect(
+        sut.tryExtend(
+          fixture.processStart.add(const Duration(milliseconds: 400)),
+        ),
+        isTrue,
+      );
+      final extension = sut.extendedSpan as SentrySpan;
+      extension.startChild('extended child');
+
+      sut.recordFirstFrame(fixture.naturalEnd);
+      await sut.finishExtended(
+        fixture.processStart.add(const Duration(milliseconds: 600)),
+      );
+      await tester.pump(Duration(seconds: 30));
+      await tester.pump();
+
+      expect(root.status, SpanStatus.deadlineExceeded());
+      expect(root.measurements['app_start_cold']?.value, 600);
     });
 
     testWidgets('marks an unfinished extension subtree deadline exceeded',

--- a/packages/flutter/test/app_start/standalone/static_app_start_trace_test.dart
+++ b/packages/flutter/test/app_start/standalone/static_app_start_trace_test.dart
@@ -505,6 +505,26 @@ void main() {
       expect(root.finished, isTrue);
     });
 
+    test('when closing measures the app start to the first frame', () async {
+      final sut = fixture.getSut()!;
+      final root = fixture.root!.tracer;
+      expect(
+        sut.tryExtend(
+          fixture.processStart.add(const Duration(milliseconds: 400)),
+        ),
+        isTrue,
+      );
+
+      sut.recordFirstFrame(fixture.naturalEnd);
+      // Closing force-ends the extension long after the first frame, and that
+      // endpoint must not become the app start's.
+      fixture.clock = fixture.processStart.add(const Duration(seconds: 5));
+      await sut.close();
+      await pumpEventQueue(times: 10);
+
+      expect(root.measurements['app_start_cold']?.value, 350);
+    });
+
     test('when closing flushes root-owned children', () async {
       final sut = fixture.getSut()!;
       final root = fixture.root!.tracer;
@@ -960,13 +980,16 @@ class Fixture {
   late final createdAt = processStart.add(Duration(milliseconds: 300));
   SentrySpan? root;
 
+  /// What `options.clock` reads, so a test can move time on after creation.
+  late DateTime clock = createdAt;
+
   final transport = _FakeTransport();
 
   late final options = defaultTestOptions()
     ..transport = transport
     ..tracesSampleRate = 1.0
     ..traceLifecycle = SentryTraceLifecycle.static
-    ..clock = () => createdAt;
+    ..clock = () => clock;
   late final hub = Hub(options);
   late final pluginRegistration = processStart.add(Duration(milliseconds: 100));
   late final sentrySetup = processStart.add(Duration(milliseconds: 200));
@@ -1006,11 +1029,14 @@ class Fixture {
       final span = event.span;
       if (span is SentrySpan && span.isRootSpan) root ??= span;
     });
-    return StaticAppStartTrace.tryCreate(
+    final trace = StaticAppStartTrace.tryCreate(
       hub: hub,
       timing: timing ?? this.timing,
       startScreenNameProvider: () => 'root /',
     );
+    // Otherwise the 30s final-timeout timer outlives the test.
+    addTearDown(() => trace?.close());
+    return trace;
   }
 }
 

--- a/packages/flutter/test/app_start/standalone/static_app_start_trace_test.dart
+++ b/packages/flutter/test/app_start/standalone/static_app_start_trace_test.dart
@@ -58,7 +58,7 @@ void main() {
       final extension = sut.extendedSpan as SentrySpan;
       expect(
           extension.context.operation, SentrySpanOperations.appStartExtended);
-      expect(extension.context.description, standaloneExtendedAppStartName);
+      expect(extension.context.description, standaloneAppStartExtensionName);
       expect(extension.origin, SentryTraceOrigins.autoAppStart);
       expect(extension.status, isNull);
       expect(extension.startTimestamp, extensionStart);

--- a/packages/flutter/test/app_start/standalone/static_app_start_trace_test.dart
+++ b/packages/flutter/test/app_start/standalone/static_app_start_trace_test.dart
@@ -1,9 +1,12 @@
 // ignore_for_file: invalid_use_of_internal_member
 
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:sentry_flutter/src/app_start/app_start_timing.dart';
+import 'package:sentry_flutter/src/app_start/standalone/app_start_trace.dart';
 import 'package:sentry_flutter/src/app_start/standalone/static_app_start_trace.dart';
 
 import '../../mocks.dart';
@@ -42,6 +45,350 @@ void main() {
         root.children.map((span) => span.context.parentSpanId),
         everyElement(root.context.spanId),
       );
+    });
+
+    test('creates one extended app-start span before first frame', () {
+      final sut = fixture.getSut()!;
+      final extensionStart = fixture.processStart.add(
+        const Duration(milliseconds: 400),
+      );
+
+      expect(sut.tryExtend(extensionStart), isTrue);
+
+      final extension = sut.extendedSpan as SentrySpan;
+      expect(
+          extension.context.operation, SentrySpanOperations.appStartExtended);
+      expect(extension.context.description, standaloneExtendedAppStartName);
+      expect(extension.origin, SentryTraceOrigins.autoAppStart);
+      expect(extension.status, isNull);
+      expect(extension.startTimestamp, extensionStart);
+      expect(sut.extendedSpanV2, isNull);
+      expect(sut.tryExtend(extensionStart), isFalse);
+    });
+
+    test('rejects extension after the first frame', () {
+      final sut = fixture.getSut()!;
+      sut.recordFirstFrame(fixture.naturalEnd);
+
+      expect(
+        sut.tryExtend(fixture.processStart.add(const Duration(seconds: 1))),
+        isFalse,
+      );
+      expect(sut.extendedSpan, isNull);
+    });
+
+    test('leaves open extension descendants running', () async {
+      final sut = fixture.getSut()!;
+      final extensionStart = fixture.processStart.add(
+        const Duration(milliseconds: 400),
+      );
+      expect(sut.tryExtend(extensionStart), isTrue);
+
+      final extension = sut.extendedSpan as SentrySpan;
+      final child = extension.startChild(
+        'extended child',
+        startTimestamp: extensionStart.add(const Duration(milliseconds: 1)),
+      ) as SentrySpan;
+      final grandchild = child.startChild(
+        'extended grandchild',
+        startTimestamp: extensionStart.add(const Duration(milliseconds: 2)),
+      ) as SentrySpan;
+      final extensionEnd = extensionStart.add(const Duration(seconds: 1));
+
+      await sut.finishExtended(extensionEnd);
+
+      expect(grandchild.finished, isFalse);
+      expect(child.finished, isFalse);
+      expect(extension.status, SpanStatus.ok());
+      expect(grandchild.endTimestamp, isNull);
+      expect(child.endTimestamp, isNull);
+      expect(extension.endTimestamp, extensionEnd);
+    });
+
+    test('direct extension finish leaves open descendants running', () async {
+      final sut = fixture.getSut()!;
+      final extensionStart = fixture.processStart.add(
+        const Duration(milliseconds: 400),
+      );
+      expect(sut.tryExtend(extensionStart), isTrue);
+
+      final extension = sut.extendedSpan as SentrySpan;
+      final child = extension.startChild(
+        'extended child',
+        startTimestamp: extensionStart.add(const Duration(milliseconds: 1)),
+      ) as SentrySpan;
+      final extensionEnd = extensionStart.add(const Duration(seconds: 1));
+
+      await extension.finish(endTimestamp: extensionEnd);
+
+      expect(child.finished, isFalse);
+      expect(child.endTimestamp, isNull);
+      expect(extension.status, SpanStatus.ok());
+      expect(extension.endTimestamp, extensionEnd);
+    });
+
+    testWidgets('finishes direct extension descendants at the final deadline',
+        (tester) async {
+      final sut = fixture.getSut()!;
+      final extensionStart = fixture.processStart.add(
+        const Duration(milliseconds: 400),
+      );
+      expect(sut.tryExtend(extensionStart), isTrue);
+      final extension = sut.extendedSpan as SentrySpan;
+      final child = extension.startChild('extended child') as SentrySpan;
+
+      sut.recordFirstFrame(fixture.naturalEnd);
+      await extension.finish(
+        endTimestamp: extensionStart.add(const Duration(seconds: 1)),
+      );
+      expect(child.finished, isFalse);
+
+      await tester.pump(const Duration(seconds: 30));
+      await tester.pump();
+
+      expect(child.finished, isTrue);
+      expect(child.status, SpanStatus.deadlineExceeded());
+      expect(fixture.root!.tracer.status, SpanStatus.deadlineExceeded());
+    });
+
+    test('direct extension finish normalizes its status to successful',
+        () async {
+      final sut = fixture.getSut()!;
+      final extensionStart = fixture.processStart.add(
+        const Duration(milliseconds: 400),
+      );
+      expect(sut.tryExtend(extensionStart), isTrue);
+      final extension = sut.extendedSpan as SentrySpan;
+
+      await extension.finish(
+        status: SpanStatus.internalError(),
+        endTimestamp: extensionStart.add(const Duration(seconds: 1)),
+      );
+
+      expect(extension.status, SpanStatus.ok());
+    });
+
+    test('swallows extension finish callback failures', () async {
+      final sut = fixture.getSut()!;
+      final extensionStart = fixture.processStart.add(
+        const Duration(milliseconds: 400),
+      );
+      expect(sut.tryExtend(extensionStart), isTrue);
+      final extension = sut.extendedSpan as SentrySpan;
+      fixture.options.lifecycleRegistry.registerCallback<OnSpanFinish>((event) {
+        if (identical(event.span, extension)) {
+          throw StateError('extension finish failed');
+        }
+      });
+
+      await expectLater(
+        sut.finishExtended(extensionStart.add(const Duration(seconds: 1))),
+        completes,
+      );
+
+      expect(extension.finished, isTrue);
+    });
+
+    test('returns null after the extension finishes', () async {
+      final sut = fixture.getSut()!;
+      final extensionStart = fixture.processStart.add(
+        const Duration(milliseconds: 400),
+      );
+      expect(sut.tryExtend(extensionStart), isTrue);
+
+      final extensionEnd = extensionStart.add(const Duration(seconds: 1));
+
+      await sut.finishExtended(extensionEnd);
+
+      expect(sut.extendedSpan, isNull);
+    });
+
+    test('preserves finished extension descendants', () async {
+      final sut = fixture.getSut()!;
+      final extensionStart = fixture.processStart.add(
+        const Duration(milliseconds: 400),
+      );
+      expect(sut.tryExtend(extensionStart), isTrue);
+
+      final extension = sut.extendedSpan as SentrySpan;
+      final child = extension.startChild(
+        'extended child',
+        startTimestamp: extensionStart.add(const Duration(milliseconds: 1)),
+      ) as SentrySpan;
+      final childEnd = extensionStart.add(const Duration(milliseconds: 500));
+      await child.finish(
+        status: SpanStatus.internalError(),
+        endTimestamp: childEnd,
+      );
+      final extensionEnd = extensionStart.add(const Duration(seconds: 1));
+
+      await sut.finishExtended(extensionEnd);
+
+      expect(child.status, SpanStatus.internalError());
+      expect(child.endTimestamp, childEnd);
+    });
+
+    test('does not finish the root when the extension finishes', () async {
+      final sut = fixture.getSut()!;
+      final extensionStart = fixture.processStart.add(
+        const Duration(milliseconds: 400),
+      );
+      expect(sut.tryExtend(extensionStart), isTrue);
+
+      await sut.finishExtended(extensionStart.add(const Duration(seconds: 1)));
+
+      expect(fixture.root!.tracer.finished, isFalse);
+    });
+
+    test('reuses the first asynchronous extension completion', () async {
+      final sut = fixture.getSut()!;
+      final extensionStart = fixture.processStart.add(
+        const Duration(milliseconds: 400),
+      );
+      expect(sut.tryExtend(extensionStart), isTrue);
+      final extension = sut.extendedSpan as SentrySpan;
+
+      final first = sut.finishExtended(
+        extensionStart.add(const Duration(seconds: 1)),
+      );
+      final second = sut.finishExtended(
+        extensionStart.add(const Duration(seconds: 2)),
+      );
+
+      expect(second, same(first));
+      await first;
+      expect(
+        extension.endTimestamp,
+        extensionStart.add(const Duration(seconds: 1)),
+      );
+    });
+
+    testWidgets('finishes open extension descendants at the final deadline',
+        (tester) async {
+      final sut = fixture.getSut()!;
+      final extensionStart = fixture.processStart.add(
+        const Duration(milliseconds: 400),
+      );
+      expect(sut.tryExtend(extensionStart), isTrue);
+      final extension = sut.extendedSpan as SentrySpan;
+      final child = extension.startChild('extended child') as SentrySpan;
+
+      sut.recordFirstFrame(fixture.naturalEnd);
+      await sut.finishExtended(extensionStart.add(const Duration(seconds: 1)));
+      expect(child.finished, isFalse);
+
+      await tester.pump(const Duration(seconds: 30));
+      await tester.pump();
+
+      expect(child.finished, isTrue);
+      expect(child.status, SpanStatus.deadlineExceeded());
+      expect(fixture.root!.tracer.status, SpanStatus.deadlineExceeded());
+    });
+
+    test('measures the extension endpoint after the first frame', () async {
+      final sut = fixture.getSut()!;
+      final extensionStart = fixture.processStart.add(
+        const Duration(milliseconds: 400),
+      );
+      final extensionEnd = fixture.processStart.add(
+        const Duration(milliseconds: 600),
+      );
+      expect(sut.tryExtend(extensionStart), isTrue);
+
+      sut.recordFirstFrame(fixture.naturalEnd);
+      await sut.finishExtended(extensionEnd);
+      await fixture.root!.tracer.finish(
+        endTimestamp: fixture.rootFinish,
+      );
+      await pumpEventQueue(times: 10);
+
+      expect(fixture.root!.tracer.measurements['app_start_cold']?.value, 600);
+    });
+
+    test('keeps the natural endpoint when the extension ends first', () async {
+      final sut = fixture.getSut()!;
+      final extensionStart = fixture.processStart.add(
+        const Duration(milliseconds: 200),
+      );
+      final extensionEnd = fixture.processStart.add(
+        const Duration(milliseconds: 250),
+      );
+      expect(sut.tryExtend(extensionStart), isTrue);
+
+      await sut.finishExtended(extensionEnd);
+      sut.recordFirstFrame(fixture.naturalEnd);
+      await fixture.root!.tracer.finish(endTimestamp: fixture.rootFinish);
+      await pumpEventQueue(times: 10);
+
+      expect(fixture.root!.tracer.measurements['app_start_cold']?.value, 350);
+    });
+
+    test('measures the direct extension endpoint when finish is also requested',
+        () async {
+      final sut = fixture.getSut()!;
+      final extensionStart = fixture.processStart.add(
+        const Duration(milliseconds: 400),
+      );
+      SentrySpan? extension;
+      final onSpanFinishBlocker = Completer<void>();
+      fixture.options.lifecycleRegistry.registerCallback<OnSpanFinish>(
+        (event) async {
+          if (identical(event.span, extension)) {
+            await onSpanFinishBlocker.future;
+          }
+        },
+      );
+      expect(sut.tryExtend(extensionStart), isTrue);
+
+      extension = sut.extendedSpan as SentrySpan;
+      final directEnd = extensionStart.add(const Duration(seconds: 1));
+      final laterEnd = extensionStart.add(const Duration(seconds: 2));
+      final directFinish = extension.finish(endTimestamp: directEnd);
+
+      await sut.finishExtended(laterEnd);
+      onSpanFinishBlocker.complete();
+      await directFinish;
+      sut.recordFirstFrame(fixture.naturalEnd);
+      await fixture.root!.tracer.finish(endTimestamp: fixture.rootFinish);
+      await pumpEventQueue(times: 10);
+
+      expect(
+        fixture.root!.tracer.measurements['app_start_cold']?.value,
+        1400.0,
+      );
+    });
+
+    test('ignores later unrelated root children for measurement', () async {
+      final sut = fixture.getSut()!;
+      final extensionStart = fixture.processStart.add(
+        const Duration(milliseconds: 400),
+      );
+      final extensionEnd = fixture.processStart.add(
+        const Duration(milliseconds: 600),
+      );
+      expect(sut.tryExtend(extensionStart), isTrue);
+
+      sut.recordFirstFrame(fixture.naturalEnd);
+      await sut.finishExtended(extensionEnd);
+      final unrelated = fixture.root!.tracer.startChild(
+        'unrelated child',
+        startTimestamp: fixture.processStart.add(
+          const Duration(milliseconds: 700),
+        ),
+      );
+      await unrelated.finish(
+        endTimestamp: fixture.processStart.add(
+          const Duration(milliseconds: 900),
+        ),
+      );
+      await fixture.root!.tracer.finish(
+        endTimestamp: fixture.processStart.add(
+          const Duration(milliseconds: 1000),
+        ),
+      );
+      await pumpEventQueue(times: 10);
+
+      expect(fixture.root!.tracer.measurements['app_start_cold']?.value, 600);
     });
 
     test('uses the first frame render operation for its span', () {
@@ -143,6 +490,23 @@ void main() {
       expect(root.data['app.vitals.start.screen'], 'root /');
     });
 
+    test('when closing finishes an open extension before the root', () async {
+      final sut = fixture.getSut()!;
+      expect(
+        sut.tryExtend(
+          fixture.processStart.add(const Duration(milliseconds: 400)),
+        ),
+        isTrue,
+      );
+      final extension = sut.extendedSpan as SentrySpan;
+      final root = fixture.root!.tracer;
+
+      await sut.close();
+
+      expect(extension.finished, isTrue);
+      expect(root.finished, isTrue);
+    });
+
     test('when closing flushes root-owned children', () async {
       final sut = fixture.getSut()!;
       final root = fixture.root!.tracer;
@@ -209,6 +573,36 @@ void main() {
       expect(root.measurements['app_start_cold'], isNull);
     });
 
+    testWidgets('handles children added by deadline finish callbacks',
+        (tester) async {
+      final sut = fixture.getSut()!;
+      final root = fixture.root!.tracer;
+      final extensionStart = fixture.processStart.add(
+        const Duration(milliseconds: 400),
+      );
+      expect(sut.tryExtend(extensionStart), isTrue);
+      final extension = sut.extendedSpan as SentrySpan;
+      final child = extension.startChild('extended child') as SentrySpan;
+      final grandchild = child.startChild('extended grandchild') as SentrySpan;
+      fixture.options.lifecycleRegistry.registerCallback<OnSpanFinish>(
+        (event) async {
+          if (identical(event.span, grandchild)) {
+            final lateChild = extension.startChild('late child');
+            await lateChild.finish(
+              status: SpanStatus.deadlineExceeded(),
+              endTimestamp: fixture.createdAt.add(const Duration(seconds: 30)),
+            );
+          }
+        },
+      );
+
+      await tester.pump(const Duration(seconds: 30));
+      await tester.pump();
+
+      expect(root.finished, isTrue);
+      expect(root.status, SpanStatus.deadlineExceeded());
+    });
+
     testWidgets('finishes root-owned children at the final deadline',
         (tester) async {
       fixture.getSut();
@@ -227,6 +621,68 @@ void main() {
       expect(root.finished, isTrue);
     });
 
+    testWidgets('rejects extension during deadline finalization',
+        (tester) async {
+      final sut = fixture.getSut()!;
+      var extensionAccepted = false;
+      fixture.options.lifecycleRegistry.registerCallback<OnSpanFinish>((event) {
+        if (event.span.context.operation ==
+            SentrySpanOperations.appStartFirstFrameRender) {
+          extensionAccepted = sut.tryExtend(fixture.createdAt);
+        }
+      });
+
+      await tester.pump(const Duration(seconds: 30));
+      await tester.pump();
+
+      expect(extensionAccepted, isFalse);
+      expect(fixture.root!.tracer.finished, isTrue);
+    });
+
+    testWidgets('ignores extension finish during deadline finalization',
+        (tester) async {
+      final sut = fixture.getSut()!;
+      final extensionStart = fixture.processStart.add(
+        const Duration(milliseconds: 400),
+      );
+      fixture.options.lifecycleRegistry.registerCallback<OnSpanFinish>(
+        (event) async {
+          if (event.span.context.operation ==
+              SentrySpanOperations.appStartExtended) {
+            await sut.finishExtended(
+              extensionStart.add(const Duration(seconds: 1)),
+            );
+          }
+        },
+      );
+      expect(sut.tryExtend(extensionStart), isTrue);
+      final extension = sut.extendedSpan as SentrySpan;
+
+      await tester.pump(const Duration(seconds: 30));
+      await tester.pump();
+
+      expect(extension.status, SpanStatus.deadlineExceeded());
+    });
+
+    testWidgets('when closing preserves extension deadline status',
+        (tester) async {
+      final sut = fixture.getSut()!;
+      expect(sut.tryExtend(fixture.createdAt), isTrue);
+      final extension = sut.extendedSpan as SentrySpan;
+      Future<void>? closeFuture;
+      fixture.options.lifecycleRegistry.registerCallback<OnSpanFinish>((event) {
+        if (identical(event.span, extension)) {
+          closeFuture = sut.close();
+        }
+      });
+
+      await tester.pump(const Duration(seconds: 30));
+      await tester.pump();
+      await closeFuture;
+
+      expect(extension.status, SpanStatus.deadlineExceeded());
+    });
+
     testWidgets('finishes the root once at the final deadline', (tester) async {
       final mockFixture = MockCreationFixture();
       final deadline = mockFixture.createdAt.add(Duration(seconds: 30));
@@ -243,6 +699,65 @@ void main() {
         status: SpanStatus.deadlineExceeded(),
         endTimestamp: deadline,
       )).called(1);
+    });
+
+    testWidgets('suppresses measurement for an unfinished extension deadline',
+        (tester) async {
+      final sut = fixture.getSut()!;
+      final root = fixture.root!.tracer;
+      expect(
+        sut.tryExtend(
+          fixture.processStart.add(const Duration(milliseconds: 400)),
+        ),
+        isTrue,
+      );
+
+      await tester.pump(Duration(seconds: 30));
+      await tester.pump();
+
+      expect(root.finished, isTrue);
+      expect(root.status, SpanStatus.deadlineExceeded());
+      expect(root.measurements['app_start_cold'], isNull);
+      expect(root.data['app_start_type'], 'cold');
+      expect(root.data['app.vitals.start.screen'], 'root /');
+    });
+
+    testWidgets('marks an unfinished extension subtree deadline exceeded',
+        (tester) async {
+      final sut = fixture.getSut()!;
+      final extensionStart = fixture.processStart.add(
+        const Duration(milliseconds: 400),
+      );
+      expect(sut.tryExtend(extensionStart), isTrue);
+      final extension = sut.extendedSpan as SentrySpan;
+      final child = extension.startChild('extended child') as SentrySpan;
+      final grandchild = child.startChild('extended grandchild') as SentrySpan;
+      final finishOrder = <SpanId>[];
+      fixture.options.lifecycleRegistry.registerCallback<OnSpanFinish>((event) {
+        final span = event.span;
+        if (span is SentrySpan &&
+            (identical(span, extension) ||
+                identical(span, child) ||
+                identical(span, grandchild) ||
+                identical(span, fixture.root))) {
+          finishOrder.add(span.context.spanId);
+        }
+      });
+      final deadline = fixture.createdAt.add(const Duration(seconds: 30));
+
+      await tester.pump(const Duration(seconds: 30));
+      await tester.pump();
+
+      for (final span in [extension, child, grandchild]) {
+        expect(span.status, SpanStatus.deadlineExceeded());
+        expect(span.endTimestamp, deadline);
+      }
+      expect(finishOrder, [
+        grandchild.context.spanId,
+        child.context.spanId,
+        extension.context.spanId,
+        fixture.root!.context.spanId,
+      ]);
     });
 
     testWidgets('when closing cancels the final deadline', (tester) async {

--- a/packages/flutter/test/app_start/standalone/static_app_start_trace_test.dart
+++ b/packages/flutter/test/app_start/standalone/static_app_start_trace_test.dart
@@ -516,6 +516,42 @@ void main() {
       expect(root.finished, isTrue);
     });
 
+    test('when closing drains an extension subtree from the bottom up',
+        () async {
+      final sut = fixture.getSut()!;
+      expect(
+        sut.tryExtend(
+          fixture.processStart.add(const Duration(milliseconds: 400)),
+        ),
+        isTrue,
+      );
+      final extension = sut.extendedSpan as SentrySpan;
+      final child = extension.startChild('extended child') as SentrySpan;
+      final grandchild = child.startChild('extended grandchild') as SentrySpan;
+      final finishOrder = <SpanId>[];
+      fixture.options.lifecycleRegistry.registerCallback<OnSpanFinish>((event) {
+        final span = event.span;
+        if (span is SentrySpan &&
+            (identical(span, extension) ||
+                identical(span, child) ||
+                identical(span, grandchild) ||
+                identical(span, fixture.root))) {
+          finishOrder.add(span.context.spanId);
+        }
+      });
+
+      await sut.close();
+
+      // The extension goes first — closing settles it before the root is
+      // flushed — and the rest of the subtree then drains child-last.
+      expect(finishOrder, [
+        extension.context.spanId,
+        grandchild.context.spanId,
+        child.context.spanId,
+        fixture.root!.context.spanId,
+      ]);
+    });
+
     testWidgets('waits for idle timeout after natural end', (tester) async {
       final sut = fixture.getSut()!;
       final root = fixture.root!.tracer;

--- a/packages/flutter/test/app_start/standalone/static_app_start_trace_test.dart
+++ b/packages/flutter/test/app_start/standalone/static_app_start_trace_test.dart
@@ -6,7 +6,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:sentry_flutter/src/app_start/app_start_timing.dart';
-import 'package:sentry_flutter/src/app_start/standalone/app_start_trace.dart';
 import 'package:sentry_flutter/src/app_start/standalone/static_app_start_trace.dart';
 
 import '../../mocks.dart';
@@ -56,10 +55,9 @@ void main() {
       expect(sut.tryExtend(extensionStart), isTrue);
 
       final extension = sut.extendedSpan as SentrySpan;
-      expect(
-          extension.context.operation, SentrySpanOperations.appStartExtended);
-      expect(extension.context.description, standaloneAppStartExtensionName);
-      expect(extension.origin, SentryTraceOrigins.autoAppStart);
+      expect(extension.context.operation, 'app.start.extended');
+      expect(extension.context.description, 'Extended App Start');
+      expect(extension.origin, 'auto.app.start');
       expect(extension.status, isNull);
       expect(extension.startTimestamp, extensionStart);
       expect(sut.extendedSpanV2, isNull);

--- a/packages/flutter/test/app_start/standalone/static_app_start_trace_test.dart
+++ b/packages/flutter/test/app_start/standalone/static_app_start_trace_test.dart
@@ -683,6 +683,31 @@ void main() {
       expect(extension.status, SpanStatus.deadlineExceeded());
     });
 
+    testWidgets('when closing before the extension drains keeps the deadline',
+        (tester) async {
+      final sut = fixture.getSut()!;
+      expect(sut.tryExtend(fixture.createdAt), isTrue);
+      final extension = sut.extendedSpan as SentrySpan;
+      // The drain walks descendants first, so closing from the child's finish
+      // callback reaches the extension while it is still open.
+      final child = extension.startChild('extended child') as SentrySpan;
+      Future<void>? closeFuture;
+      fixture.options.lifecycleRegistry.registerCallback<OnSpanFinish>((event) {
+        if (identical(event.span, child)) {
+          closeFuture = sut.close();
+        }
+      });
+
+      await tester.pump(const Duration(seconds: 30));
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+      await tester.pump();
+      await closeFuture;
+
+      expect(extension.status, SpanStatus.deadlineExceeded());
+      expect(fixture.root!.tracer.status, SpanStatus.deadlineExceeded());
+    });
+
     testWidgets('finishes the root once at the final deadline', (tester) async {
       final mockFixture = MockCreationFixture();
       final deadline = mockFixture.createdAt.add(Duration(seconds: 30));

--- a/packages/flutter/test/app_start/standalone/streaming_app_start_trace_test.dart
+++ b/packages/flutter/test/app_start/standalone/streaming_app_start_trace_test.dart
@@ -99,7 +99,7 @@ void main() {
       );
     });
 
-    testWidgets('omits duration for an unfinished extension at deadline',
+    testWidgets('omits duration without a first frame at deadline',
         (tester) async {
       final sut = fixture.getSut()!;
       expect(
@@ -125,6 +125,49 @@ void main() {
             .attributes[SemanticAttributesConstants.sentryStatusMessage]?.value,
         'deadline_exceeded',
       );
+    });
+
+    testWidgets('measures to the first frame when the extension never ended',
+        (tester) async {
+      final sut = fixture.getSut()!;
+      expect(
+        sut.tryExtend(
+          fixture.processStart.add(const Duration(milliseconds: 400)),
+        ),
+        isTrue,
+      );
+
+      sut.recordFirstFrame(fixture.naturalEnd);
+      await tester.pump(const Duration(seconds: 30));
+      await tester.pump();
+
+      final root = fixture.root!;
+      expect(root.status, SentrySpanStatusV2.error);
+      expect(root.attributes['app.vitals.start.value']?.value, 350.0);
+    });
+
+    testWidgets('keeps the extension endpoint when a descendant deadlines',
+        (tester) async {
+      final sut = fixture.getSut()!;
+      expect(
+        sut.tryExtend(
+          fixture.processStart.add(const Duration(milliseconds: 400)),
+        ),
+        isTrue,
+      );
+      final extension = sut.extendedSpanV2 as RecordingSentrySpanV2;
+      fixture.hub.startInactiveSpan('extended child', parentSpan: extension);
+
+      sut.recordFirstFrame(fixture.naturalEnd);
+      await sut.finishExtended(
+        fixture.processStart.add(const Duration(milliseconds: 600)),
+      );
+      await tester.pump(const Duration(seconds: 30));
+      await tester.pump();
+
+      final root = fixture.root!;
+      expect(root.status, SentrySpanStatusV2.error);
+      expect(root.attributes['app.vitals.start.value']?.value, 600.0);
     });
 
     testWidgets('close preserves extension deadline status', (tester) async {

--- a/packages/flutter/test/app_start/standalone/streaming_app_start_trace_test.dart
+++ b/packages/flutter/test/app_start/standalone/streaming_app_start_trace_test.dart
@@ -591,6 +591,26 @@ void main() {
       expect(root.attributes['app.vitals.start.screen']?.value, 'root /');
     });
 
+    test('close measures the app start to the first frame', () async {
+      final sut = fixture.getSut()!;
+      final root = fixture.root!;
+      expect(
+        sut.tryExtend(
+          fixture.processStart.add(const Duration(milliseconds: 400)),
+        ),
+        isTrue,
+      );
+
+      sut.recordFirstFrame(fixture.naturalEnd);
+      // Closing force-ends the extension long after the first frame, and that
+      // endpoint must not become the app start's.
+      fixture.clock = fixture.processStart.add(const Duration(seconds: 5));
+      await sut.close();
+      await pumpEventQueue(times: 10);
+
+      expect(root.attributes['app.vitals.start.value']?.value, 350.0);
+    });
+
     test('close completes when extension finalization fails', () async {
       final sut = fixture.getSut()!;
       final root = fixture.root!;
@@ -618,11 +638,14 @@ class Fixture {
   final children = <SentrySpanV2>[];
   final processor = MockTelemetryProcessor();
 
+  /// What `options.clock` reads, so a test can move time on after creation.
+  late DateTime clock = processStart.add(Duration(milliseconds: 300));
+
   late final options = defaultTestOptions()
     ..tracesSampleRate = 1.0
     ..traceLifecycle = SentryTraceLifecycle.stream
     ..telemetryProcessor = processor
-    ..clock = () => processStart.add(Duration(milliseconds: 300));
+    ..clock = () => clock;
   late final hub = Hub(options);
   late final pluginRegistration = processStart.add(Duration(milliseconds: 100));
   late final sentrySetup = processStart.add(Duration(milliseconds: 200));
@@ -659,11 +682,14 @@ class Fixture {
   }
 
   StreamingAppStartTrace? getSut() {
-    return StreamingAppStartTrace.tryCreate(
+    final trace = StreamingAppStartTrace.tryCreate(
       hub: hub,
       timing: timing,
       startScreenNameProvider: () => 'root /',
     );
+    // Otherwise the root's idle and deadline timers outlive the test.
+    addTearDown(() => trace?.close());
+    return trace;
   }
 }
 

--- a/packages/flutter/test/app_start/standalone/streaming_app_start_trace_test.dart
+++ b/packages/flutter/test/app_start/standalone/streaming_app_start_trace_test.dart
@@ -140,6 +140,7 @@ void main() {
 
       await tester.pump(const Duration(seconds: 30));
       await tester.pump();
+      expect(closeFuture, isNotNull);
       await closeFuture;
 
       expect(extension.status, SentrySpanStatusV2.error);

--- a/packages/flutter/test/app_start/standalone/streaming_app_start_trace_test.dart
+++ b/packages/flutter/test/app_start/standalone/streaming_app_start_trace_test.dart
@@ -1,5 +1,7 @@
 // ignore_for_file: invalid_use_of_internal_member, experimental_member_use
 
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:sentry_flutter/src/app_start/app_start_timing.dart';
@@ -33,6 +35,121 @@ void main() {
       expect(root.attributes['sentry.segment.name']?.value, 'App Start');
     });
 
+    test('measures the later extension endpoint instead of the root endpoint',
+        () async {
+      final sut = fixture.getSut()!;
+      final extensionStart = fixture.processStart.add(
+        const Duration(milliseconds: 400),
+      );
+      final extensionEnd = fixture.processStart.add(
+        const Duration(milliseconds: 600),
+      );
+      expect(sut.tryExtend(extensionStart), isTrue);
+
+      sut.recordFirstFrame(fixture.naturalEnd);
+      await sut.finishExtended(extensionEnd);
+      fixture.root!.end(
+        endTimestamp: fixture.processStart.add(const Duration(seconds: 1)),
+      );
+      await pumpEventQueue(times: 10);
+
+      expect(
+        fixture.root!.attributes['app.vitals.start.value']?.value,
+        600.0,
+      );
+      expect(
+        fixture.root!.attributes['app.vitals.start.cold.value']?.value,
+        600.0,
+      );
+    });
+
+    test('keeps the natural endpoint above an early extension endpoint',
+        () async {
+      final sut = fixture.getSut()!;
+      final extensionStart = fixture.processStart.add(
+        const Duration(milliseconds: 200),
+      );
+      final extensionEnd = fixture.processStart.add(
+        const Duration(milliseconds: 250),
+      );
+      expect(sut.tryExtend(extensionStart), isTrue);
+
+      await sut.finishExtended(extensionEnd);
+      sut.recordFirstFrame(fixture.naturalEnd);
+      final unrelated = fixture.hub.startInactiveSpan(
+        'unrelated child',
+        parentSpan: fixture.root,
+        startTimestamp: fixture.processStart.add(
+          const Duration(milliseconds: 700),
+        ),
+      ) as RecordingSentrySpanV2;
+      unrelated.end(
+        endTimestamp: fixture.processStart.add(
+          const Duration(milliseconds: 900),
+        ),
+      );
+      fixture.root!.end(
+        endTimestamp: fixture.processStart.add(const Duration(seconds: 1)),
+      );
+      await pumpEventQueue(times: 10);
+
+      expect(
+        fixture.root!.attributes['app.vitals.start.value']?.value,
+        350.0,
+      );
+    });
+
+    testWidgets('omits duration for an unfinished extension at deadline',
+        (tester) async {
+      final sut = fixture.getSut()!;
+      expect(
+        sut.tryExtend(
+          fixture.processStart.add(const Duration(milliseconds: 400)),
+        ),
+        isTrue,
+      );
+      final extension = sut.extendedSpanV2 as RecordingSentrySpanV2;
+
+      await tester.pump(const Duration(seconds: 30));
+      await tester.pump();
+
+      final root = fixture.root!;
+      expect(root.isEnded, isTrue);
+      expect(root.status, SentrySpanStatusV2.error);
+      expect(root.attributes['app.vitals.start.value'], isNull);
+      expect(root.attributes['app.vitals.start.type']?.value, 'cold');
+      expect(root.attributes['app.vitals.start.screen']?.value, 'root /');
+      expect(extension.status, SentrySpanStatusV2.error);
+      expect(
+        extension
+            .attributes[SemanticAttributesConstants.sentryStatusMessage]?.value,
+        'deadline_exceeded',
+      );
+    });
+
+    testWidgets('close preserves extension deadline status', (tester) async {
+      final sut = fixture.getSut()!;
+      expect(sut.tryExtend(fixture.processStart), isTrue);
+      final extension = sut.extendedSpanV2 as RecordingSentrySpanV2;
+      Future<void>? closeFuture;
+      fixture.options.lifecycleRegistry.registerCallback<OnSpanEndV2>((event) {
+        if (identical(event.span, extension)) {
+          closeFuture = sut.close();
+        }
+      });
+
+      await tester.pump(const Duration(seconds: 30));
+      await tester.pump();
+      await closeFuture;
+
+      expect(extension.status, SentrySpanStatusV2.error);
+      expect(
+        extension
+            .attributes[SemanticAttributesConstants.sentryStatusMessage]?.value,
+        'deadline_exceeded',
+      );
+    });
+
     test('creates direct standalone breakdown children', () {
       fixture.getSut();
 
@@ -41,6 +158,271 @@ void main() {
         fixture.children.map((span) => span.parentSpan),
         everyElement(same(fixture.root)),
       );
+    });
+
+    test('creates one extended app-start span before first frame', () {
+      final sut = fixture.getSut()!;
+      final extensionStart = fixture.processStart.add(
+        const Duration(milliseconds: 400),
+      );
+
+      expect(sut.tryExtend(extensionStart), isTrue);
+
+      final extension = sut.extendedSpanV2 as RecordingSentrySpanV2;
+      expect(extension.parentSpan, same(fixture.root));
+      expect(
+        extension.attributes[SemanticAttributesConstants.sentryOp]?.value,
+        'app.start.extended',
+      );
+      expect(
+        extension.attributes[SemanticAttributesConstants.sentryOrigin]?.value,
+        'auto.app.start',
+      );
+      expect(sut.extendedSpan, isNull);
+    });
+
+    test('leaves open extension descendants running', () async {
+      final sut = fixture.getSut()!;
+      final extensionStart = fixture.processStart.add(
+        const Duration(milliseconds: 400),
+      );
+      expect(sut.tryExtend(extensionStart), isTrue);
+
+      final extension = sut.extendedSpanV2 as RecordingSentrySpanV2;
+      final child = fixture.hub.startInactiveSpan(
+        'extended child',
+        parentSpan: extension,
+        startTimestamp: extensionStart.add(const Duration(milliseconds: 1)),
+      ) as RecordingSentrySpanV2;
+      final grandchild = fixture.hub.startInactiveSpan(
+        'extended grandchild',
+        parentSpan: child,
+        startTimestamp: extensionStart.add(const Duration(milliseconds: 2)),
+      ) as RecordingSentrySpanV2;
+      final extensionEnd = extensionStart.add(const Duration(seconds: 1));
+
+      await sut.finishExtended(extensionEnd);
+      await pumpEventQueue(times: 10);
+
+      expect(grandchild.isEnded, isFalse);
+      expect(child.isEnded, isFalse);
+      expect(extension.status, SentrySpanStatusV2.ok);
+      expect(extension.endTimestamp, extensionEnd);
+    });
+
+    testWidgets('finishes open extension descendants at the final deadline',
+        (tester) async {
+      final sut = fixture.getSut()!;
+      final extensionStart = fixture.processStart.add(
+        const Duration(milliseconds: 400),
+      );
+      expect(sut.tryExtend(extensionStart), isTrue);
+      final extension = sut.extendedSpanV2 as RecordingSentrySpanV2;
+      final child = fixture.hub.startInactiveSpan(
+        'extended child',
+        parentSpan: extension,
+      ) as RecordingSentrySpanV2;
+
+      sut.recordFirstFrame(fixture.naturalEnd);
+      await sut.finishExtended(extensionStart.add(const Duration(seconds: 1)));
+      expect(child.isEnded, isFalse);
+
+      await tester.pump(const Duration(seconds: 30));
+      await tester.pump();
+
+      expect(child.isEnded, isTrue);
+      expect(child.status, SentrySpanStatusV2.error);
+      expect(
+        child
+            .attributes[SemanticAttributesConstants.sentryStatusMessage]?.value,
+        'deadline_exceeded',
+      );
+      expect(fixture.root!.status, SentrySpanStatusV2.error);
+    });
+
+    test('direct extension end leaves open descendants running', () async {
+      final sut = fixture.getSut()!;
+      final extensionStart = fixture.processStart.add(
+        const Duration(milliseconds: 400),
+      );
+      expect(sut.tryExtend(extensionStart), isTrue);
+
+      final extension = sut.extendedSpanV2 as RecordingSentrySpanV2;
+      final child = fixture.hub.startInactiveSpan(
+        'extended child',
+        parentSpan: extension,
+      ) as RecordingSentrySpanV2;
+      final extensionEnd = extensionStart.add(const Duration(seconds: 1));
+
+      extension.end(endTimestamp: extensionEnd);
+      await pumpEventQueue(times: 10);
+
+      expect(child.isEnded, isFalse);
+      expect(child.endTimestamp, isNull);
+      expect(extension.status, SentrySpanStatusV2.ok);
+      expect(extension.endTimestamp, extensionEnd);
+    });
+
+    testWidgets('finishes direct extension descendants at the final deadline',
+        (tester) async {
+      final sut = fixture.getSut()!;
+      final extensionStart = fixture.processStart.add(
+        const Duration(milliseconds: 400),
+      );
+      expect(sut.tryExtend(extensionStart), isTrue);
+      final extension = sut.extendedSpanV2 as RecordingSentrySpanV2;
+      final child = fixture.hub.startInactiveSpan(
+        'extended child',
+        parentSpan: extension,
+      ) as RecordingSentrySpanV2;
+
+      sut.recordFirstFrame(fixture.naturalEnd);
+      extension.end(
+        endTimestamp: extensionStart.add(const Duration(seconds: 1)),
+      );
+      expect(child.isEnded, isFalse);
+
+      await tester.pump(const Duration(seconds: 30));
+      await tester.pump();
+
+      expect(child.isEnded, isTrue);
+      expect(child.status, SentrySpanStatusV2.error);
+      expect(
+        child
+            .attributes[SemanticAttributesConstants.sentryStatusMessage]?.value,
+        'deadline_exceeded',
+      );
+      expect(fixture.root!.status, SentrySpanStatusV2.error);
+    });
+
+    test('direct extension end normalizes its status to successful', () async {
+      final sut = fixture.getSut()!;
+      final extensionStart = fixture.processStart.add(
+        const Duration(milliseconds: 400),
+      );
+      expect(sut.tryExtend(extensionStart), isTrue);
+      final extension = sut.extendedSpanV2 as RecordingSentrySpanV2;
+      extension.status = SentrySpanStatusV2.error;
+      fixture.hub.startInactiveSpan(
+        'extended child',
+        parentSpan: extension,
+      );
+      SentrySpanStatusV2? processedStatus;
+      fixture.options.lifecycleRegistry.registerCallback<OnProcessSpan>(
+        (event) {
+          if (identical(event.span, extension)) {
+            processedStatus = event.span.status;
+          }
+        },
+      );
+
+      extension.end(
+        endTimestamp: extensionStart.add(const Duration(seconds: 1)),
+      );
+      await pumpEventQueue(times: 10);
+
+      expect(extension.status, SentrySpanStatusV2.ok);
+      expect(processedStatus, SentrySpanStatusV2.ok);
+    });
+
+    test('returns null after the extension ends', () async {
+      final sut = fixture.getSut()!;
+      final extensionStart = fixture.processStart.add(
+        const Duration(milliseconds: 400),
+      );
+      expect(sut.tryExtend(extensionStart), isTrue);
+
+      final extensionEnd = extensionStart.add(const Duration(seconds: 1));
+
+      await sut.finishExtended(extensionEnd);
+
+      expect(sut.extendedSpanV2, isNull);
+    });
+
+    test('uses the direct extension endpoint when finish is also requested',
+        () async {
+      final sut = fixture.getSut()!;
+      final extensionStart = fixture.processStart.add(
+        const Duration(milliseconds: 400),
+      );
+      expect(sut.tryExtend(extensionStart), isTrue);
+
+      final extension = sut.extendedSpanV2 as RecordingSentrySpanV2;
+      final child = fixture.hub.startInactiveSpan(
+        'extended child',
+        parentSpan: extension,
+      ) as RecordingSentrySpanV2;
+      final directEnd = extensionStart.add(const Duration(seconds: 1));
+      final laterEnd = extensionStart.add(const Duration(seconds: 2));
+      extension.end(endTimestamp: directEnd);
+
+      await sut.finishExtended(laterEnd);
+      await pumpEventQueue(times: 10);
+
+      expect(child.isEnded, isFalse);
+      expect(extension.endTimestamp, directEnd);
+    });
+
+    test('measures the direct extension endpoint when finish is also requested',
+        () async {
+      final sut = fixture.getSut()!;
+      final extensionStart = fixture.processStart.add(
+        const Duration(milliseconds: 400),
+      );
+      RecordingSentrySpanV2? extension;
+      final onSpanEndBlocker = Completer<void>();
+      fixture.options.lifecycleRegistry.registerCallback<OnSpanEndV2>(
+        (event) async {
+          if (identical(event.span, extension)) {
+            await onSpanEndBlocker.future;
+          }
+        },
+      );
+      expect(sut.tryExtend(extensionStart), isTrue);
+
+      extension = sut.extendedSpanV2 as RecordingSentrySpanV2;
+      final directEnd = extensionStart.add(const Duration(seconds: 1));
+      final laterEnd = extensionStart.add(const Duration(seconds: 2));
+      extension.end(endTimestamp: directEnd);
+
+      await sut.finishExtended(laterEnd);
+      onSpanEndBlocker.complete();
+      sut.recordFirstFrame(fixture.naturalEnd);
+      fixture.root!.end(endTimestamp: fixture.rootFinish);
+      await pumpEventQueue(times: 10);
+
+      expect(
+        fixture.root!.attributes['app.vitals.start.value']?.value,
+        1400.0,
+      );
+    });
+
+    test('preserves ended extension descendants and leaves root open',
+        () async {
+      final sut = fixture.getSut()!;
+      final extensionStart = fixture.processStart.add(
+        const Duration(milliseconds: 400),
+      );
+      expect(sut.tryExtend(extensionStart), isTrue);
+
+      final extension = sut.extendedSpanV2 as RecordingSentrySpanV2;
+      final child = fixture.hub.startInactiveSpan(
+        'extended child',
+        parentSpan: extension,
+      ) as RecordingSentrySpanV2;
+      final childEnd = extensionStart.add(const Duration(milliseconds: 500));
+      child.status = SentrySpanStatusV2.error;
+      child.end(endTimestamp: childEnd);
+      await pumpEventQueue(times: 10);
+
+      final extensionEnd = extensionStart.add(const Duration(seconds: 1));
+      await sut.finishExtended(extensionEnd);
+      await pumpEventQueue(times: 10);
+
+      expect(child.status, SentrySpanStatusV2.error);
+      expect(child.endTimestamp, childEnd);
+      expect(extension.endTimestamp, extensionEnd);
+      expect(fixture.root!.isEnded, isFalse);
     });
 
     test('uses the first frame render operation for its span', () {
@@ -163,6 +545,23 @@ void main() {
       expect(root.isEnded, isTrue);
       expect(root.attributes['app.vitals.start.type']?.value, 'cold');
       expect(root.attributes['app.vitals.start.screen']?.value, 'root /');
+    });
+
+    test('close completes when extension finalization fails', () async {
+      final sut = fixture.getSut()!;
+      final root = fixture.root!;
+      expect(
+        sut.tryExtend(
+          fixture.processStart.add(const Duration(milliseconds: 400)),
+        ),
+        isTrue,
+      );
+      fixture.options.clock = () => throw StateError('clock failed');
+
+      await sut.close();
+      await pumpEventQueue(times: 10);
+
+      expect(root.isEnded, isTrue);
     });
   });
 }

--- a/packages/flutter/test/app_start_trace_test_support.dart
+++ b/packages/flutter/test/app_start_trace_test_support.dart
@@ -1,0 +1,37 @@
+// ignore_for_file: invalid_use_of_internal_member
+
+import 'package:sentry_flutter/sentry_flutter.dart';
+import 'package:sentry_flutter/src/app_start/standalone/app_start_trace.dart';
+
+final class TestAppStartTrace implements AppStartTrace {
+  TestAppStartTrace({
+    this.extendedSpan,
+    this.extendedSpanV2,
+  });
+
+  DateTime? extensionStart;
+  DateTime? extensionEnd;
+
+  @override
+  final ISentrySpan? extendedSpan;
+
+  @override
+  final SentrySpanV2? extendedSpanV2;
+
+  @override
+  bool tryExtend(DateTime startTimestamp) {
+    extensionStart = startTimestamp;
+    return true;
+  }
+
+  @override
+  Future<void> finishExtended(DateTime endTimestamp) async {
+    extensionEnd = endTimestamp;
+  }
+
+  @override
+  void recordFirstFrame(DateTime endTimestamp) {}
+
+  @override
+  Future<void> close() async {}
+}

--- a/packages/flutter/test/app_start_trace_test_support.dart
+++ b/packages/flutter/test/app_start_trace_test_support.dart
@@ -7,7 +7,12 @@ final class TestAppStartTrace implements AppStartTrace {
   TestAppStartTrace({
     this.extendedSpan,
     this.extendedSpanV2,
+    this.refuseExtension = false,
   });
+
+  /// Stands in for a trace that turns the extension down — already extended,
+  /// past its first frame, or winding down.
+  final bool refuseExtension;
 
   DateTime? extensionStart;
   DateTime? extensionEnd;
@@ -20,6 +25,7 @@ final class TestAppStartTrace implements AppStartTrace {
 
   @override
   bool tryExtend(DateTime startTimestamp) {
+    if (refuseExtension) return false;
     extensionStart = startTimestamp;
     return true;
   }

--- a/packages/flutter/test/sentry_flutter_test.dart
+++ b/packages/flutter/test/sentry_flutter_test.dart
@@ -22,6 +22,7 @@ import 'package:sentry_flutter/src/version.dart';
 import 'package:sentry_flutter/src/view_hierarchy/view_hierarchy_integration.dart';
 import 'package:sentry_flutter/src/web/javascript_transport.dart';
 
+import 'app_start_trace_test_support.dart';
 import 'mocks.dart';
 import 'mocks.mocks.dart';
 import 'sentry_flutter_util.dart';
@@ -708,6 +709,105 @@ void main() {
     await expectLater(SentryFlutter.pauseAppHangTracking(), completes);
   });
 
+  group('extended app start', () {
+    late _ExtendedAppStartFixture fixture;
+
+    setUp(() async {
+      loadTestPackage();
+      await Sentry.close();
+
+      fixture = _ExtendedAppStartFixture();
+      await fixture.init();
+    });
+
+    tearDown(() async {
+      await Sentry.close();
+    });
+
+    test('extendAppStart forwards one SDK clock timestamp', () {
+      SentryFlutter.extendAppStart();
+
+      expect(fixture.trace.extensionStart, fixture.now);
+    });
+
+    test('getters return their lifecycle-specific spans', () {
+      expect(
+        SentryFlutter.getExtendedAppStartSpan(),
+        same(fixture.trace.extendedSpan),
+      );
+      expect(
+        SentryFlutter.getExtendedAppStartSpanV2(),
+        same(fixture.trace.extendedSpanV2),
+      );
+    });
+
+    test('wrong-lifecycle getters return null', () async {
+      final staticTrace = TestAppStartTrace(
+        extendedSpan: MockSentrySpan(),
+      );
+      fixture.options.standaloneAppStartTrace = staticTrace;
+
+      expect(
+        SentryFlutter.getExtendedAppStartSpan(),
+        same(staticTrace.extendedSpan),
+      );
+      expect(SentryFlutter.getExtendedAppStartSpanV2(), isNull);
+
+      await Sentry.close();
+
+      final streamOptions = defaultTestOptions(checker: MockRuntimeChecker());
+      final streamHub = Hub(streamOptions);
+      final streamTrace = TestAppStartTrace(
+        extendedSpanV2: streamHub.startInactiveSpan('Extended App Start'),
+      );
+      streamOptions.standaloneAppStartTrace = streamTrace;
+      await Sentry.init((_) {}, options: streamOptions);
+
+      expect(SentryFlutter.getExtendedAppStartSpan(), isNull);
+      expect(
+        SentryFlutter.getExtendedAppStartSpanV2(),
+        same(streamTrace.extendedSpanV2),
+      );
+    });
+
+    test('finishExtendedAppStart forwards one SDK clock timestamp', () async {
+      await SentryFlutter.finishExtendedAppStart();
+
+      expect(fixture.trace.extensionEnd, fixture.now);
+    });
+
+    test(
+        'APIs stay inactive after close and when standalone app start is disabled',
+        () async {
+      await Sentry.close();
+
+      SentryFlutter.extendAppStart();
+      expect(SentryFlutter.getExtendedAppStartSpan(), isNull);
+      expect(SentryFlutter.getExtendedAppStartSpanV2(), isNull);
+      await SentryFlutter.finishExtendedAppStart();
+
+      final disabledOptions = defaultTestOptions(checker: MockRuntimeChecker())
+        ..enableStandaloneAppStartTracing = false;
+      await Sentry.init((_) {}, options: disabledOptions);
+
+      SentryFlutter.extendAppStart();
+      expect(SentryFlutter.getExtendedAppStartSpan(), isNull);
+      expect(SentryFlutter.getExtendedAppStartSpanV2(), isNull);
+      await SentryFlutter.finishExtendedAppStart();
+    });
+
+    test('APIs are safe without an active trace', () async {
+      fixture.options.standaloneAppStartTrace = null;
+
+      SentryFlutter.extendAppStart();
+
+      expect(SentryFlutter.getExtendedAppStartSpan(), isNull);
+      expect(SentryFlutter.getExtendedAppStartSpanV2(), isNull);
+
+      await SentryFlutter.finishExtendedAppStart();
+    });
+  });
+
   group('exception identifiers', () {
     setUp(() async {
       loadTestPackage();
@@ -764,6 +864,19 @@ MockSentryNativeBinding mockNativeBinding() {
 }
 
 void appRunner() {}
+
+final class _ExtendedAppStartFixture {
+  final now = DateTime.utc(2024, 1, 1, 12);
+  final trace = TestAppStartTrace();
+  late final SentryFlutterOptions options = defaultTestOptions(
+    checker: MockRuntimeChecker(),
+  )..clock = () => now;
+
+  Future<void> init() async {
+    options.standaloneAppStartTrace = trace;
+    await Sentry.init((_) {}, options: options);
+  }
+}
 
 void loadTestPackage() {
   PackageInfo.setMockInitialValues(

--- a/packages/flutter/test/sentry_flutter_test.dart
+++ b/packages/flutter/test/sentry_flutter_test.dart
@@ -730,6 +730,23 @@ void main() {
       expect(fixture.trace.extensionStart, fixture.now);
     });
 
+    test('extendAppStart stays quiet when the trace refuses the extension',
+        () async {
+      await Sentry.close();
+
+      final refusingOptions = defaultTestOptions(checker: MockRuntimeChecker());
+      final refusingTrace = TestAppStartTrace(refuseExtension: true);
+      refusingOptions.standaloneAppStartTrace = refusingTrace;
+      await Sentry.init((_) {}, options: refusingOptions);
+
+      SentryFlutter.extendAppStart();
+
+      expect(refusingTrace.extensionStart, isNull);
+      expect(SentryFlutter.getExtendedAppStartSpan(), isNull);
+      expect(SentryFlutter.getExtendedAppStartSpanV2(), isNull);
+      await expectLater(SentryFlutter.finishExtendedAppStart(), completes);
+    });
+
     test('getters return their lifecycle-specific spans', () {
       expect(
         SentryFlutter.getExtendedAppStartSpan(),


### PR DESCRIPTION
## 📜 Description

Experimental `SentryFlutter` API for extending the standalone App Start past the first frame, so startup work that finishes later is part of the reported duration.

```dart
appRunner: () async {
  SentryFlutter.extendAppStart();
  runApp(const MyApp());

  try {
    await completeStartupWork();
  } finally {
    await SentryFlutter.finishExtendedAppStart();
  }
},
```

`extendAppStart()` opens one `app.start.extended` child of the `App Start` root and holds the root open. `finishExtendedAppStart()` closes it and releases the app start to report, measuring to the extension end when it outlasts the first frame. While an extension is still open the duration is withheld, rather than reporting a window that ends mid-extension.

To nest work under the extension, take the span itself: `getExtendedAppStartSpan()` for the V1 `ISentrySpan` on the static lifecycle, `getExtendedAppStartSpanV2()` for the V2 `SentrySpanV2` on the streaming one — two getters because the protocols don't merge into anything worth exposing publicly. Each returns `null` on the other lifecycle and once the extension has ended. Finishing the span completes the extension on its own.

Requires `enableStandaloneAppStartTracing` on iOS or Android. All entry points are guarded at the boundary so an SDK bug can't throw into `appRunner`, and refusals are logged rather than returned. Operation and method names are verbatim from sentry-java and sentry-cocoa.

> < />!NOTE< />  <br>Stacked on getsentry/sentry-dart#3896 — that is the base branch and should be read first.

## 💡 Motivation and Context

Standalone App Start measures process start to first frame, so work finishing after it — remote config, auth restore, flag hydration — falls outside the window and understates startup. This lets the app say where startup really ends.

Closes getsentry/sentry-dart#3767

## 💚 How did you test it?

Unit coverage on both lifecycles: hierarchy and status, nested descendants, the deadline interaction, finishing the span directly instead of via the API, refused extensions and refused finishes, vitals endpoint resolution, and unpublish-on-complete. The example app is wired up end to end.

## :pencil: Checklist

- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [X] All tests passing
- [X] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](<https://develop.sentry.dev/>) spec
- [X] No breaking changes

## 🔮 Next steps

* Attach E2E trace links for both lifecycles, matching getsentry/sentry-dart#3896
* Merge getsentry/sentry-dart#3896 first — this targets that branch
* docs-site follow-up: add the Flutter section alongside the existing Java / Cocoa / React Native ones

Made with [Cursor](<https://cursor.com>)