### PR TITLE
feat: Link errors to the active streamed span

### DIFF
--- a/packages/dart/lib/src/http_client/failed_request_client.dart
+++ b/packages/dart/lib/src/http_client/failed_request_client.dart
@@ -5,6 +5,7 @@ import '../hub.dart';
 import '../hub_adapter.dart';
 import '../protocol.dart';
 import '../throwable_mechanism.dart';
+import '../tracing/instrumentation/instrumentation.dart';
 import '../type_check_hint.dart';
 import '../utils/tracing_utils.dart';
 import 'sentry_http_client.dart';
@@ -213,10 +214,15 @@ class FailedRequestClient extends BaseClient {
       hint.set(TypeCheckHint.httpResponse, response);
     }
 
+    // Links the error to the `http.client` span of this request, which the
+    // tracing client registered before delegating to us.
+    final span = RequestSpanRegistry.lookup(request);
+
     await _hub.captureEvent(
       event,
       stackTrace: stackTrace,
       hint: hint,
+      withScope: span == null ? null : (scope) => span.applyToScope(scope),
     );
   }
 

--- a/packages/dart/lib/src/http_client/tracing_client.dart
+++ b/packages/dart/lib/src/http_client/tracing_client.dart
@@ -48,6 +48,10 @@ class TracingClient extends BaseClient {
           )
         : null;
 
+    if (instrumentationSpan != null) {
+      RequestSpanRegistry.register(request, instrumentationSpan);
+    }
+
     // Regardless whether tracing is enabled or not, we always want to attach
     // Sentry trace headers (tracing without performance).
     if (containsTargetOrMatchesRegExp(

--- a/packages/dart/lib/src/hub.dart
+++ b/packages/dart/lib/src/hub.dart
@@ -101,6 +101,8 @@ class Hub {
         scope = s;
       }
 
+      scope = _linkActiveSpan(scope, item.scope);
+
       try {
         if (_options.isTracingEnabled()) {
           event = _assignTraceContext(event);
@@ -158,6 +160,8 @@ class Hub {
       } else {
         scope = s;
       }
+
+      scope = _linkActiveSpan(scope, item.scope);
 
       try {
         var event = SentryEvent(
@@ -354,6 +358,26 @@ class Hub {
         );
       }
     }
+  }
+
+  /// Attaches the currently active span to [scope] so that the captured event
+  /// is linked to it.
+  ///
+  /// Copies [scope] first when it is still [hubScope], because the active span
+  /// must not outlive the capture: nothing would unset it afterwards and every
+  /// later event would link to an already ended span.
+  ///
+  /// An active span already present on [scope] was set by a `withScope`
+  /// callback and is more specific than the ambient one, so it wins.
+  Scope _linkActiveSpan(Scope scope, Scope hubScope) {
+    final activeSpan = getActiveSpan();
+    if (activeSpan == null || scope.getActiveSpan() != null) {
+      return scope;
+    }
+    if (identical(scope, hubScope)) {
+      scope = scope.clone();
+    }
+    return scope..setActiveSpan(activeSpan);
   }
 
   FutureOr<Scope> _cloneAndRunWithScope(

--- a/packages/dart/lib/src/hub.dart
+++ b/packages/dart/lib/src/hub.dart
@@ -101,7 +101,7 @@ class Hub {
         scope = s;
       }
 
-      scope = _linkActiveSpan(scope, item.scope, event.throwable);
+      scope = _linkEventToSpan(scope, item.scope, event.throwable);
 
       try {
         if (_options.isTracingEnabled()) {
@@ -161,7 +161,7 @@ class Hub {
         scope = s;
       }
 
-      scope = _linkActiveSpan(scope, item.scope, throwable);
+      scope = _linkEventToSpan(scope, item.scope, throwable);
 
       try {
         var event = SentryEvent(
@@ -371,8 +371,12 @@ class Hub {
   /// [scope] was set by a `withScope` callback, so it wins outright. A span
   /// that [throwable] aborted beats the ambient one, which merely happened to
   /// be open at capture time.
-  Scope _linkActiveSpan(Scope scope, Scope hubScope, Object? throwable) {
-    if (scope.getActiveSpan() != null) {
+  ///
+  /// Static tracing has no span to link here — it links through
+  /// [_assignTraceContext] instead.
+  Scope _linkEventToSpan(Scope scope, Scope hubScope, Object? throwable) {
+    if (_options.traceLifecycle == SentryTraceLifecycle.static ||
+        scope.getActiveSpan() != null) {
       return scope;
     }
     final span = ThrowableSpanRegistry.lookup(throwable) ?? getActiveSpan();

--- a/packages/dart/lib/src/hub.dart
+++ b/packages/dart/lib/src/hub.dart
@@ -101,7 +101,7 @@ class Hub {
         scope = s;
       }
 
-      scope = _linkActiveSpan(scope, item.scope);
+      scope = _linkActiveSpan(scope, item.scope, event.throwable);
 
       try {
         if (_options.isTracingEnabled()) {
@@ -161,7 +161,7 @@ class Hub {
         scope = s;
       }
 
-      scope = _linkActiveSpan(scope, item.scope);
+      scope = _linkActiveSpan(scope, item.scope, throwable);
 
       try {
         var event = SentryEvent(
@@ -360,24 +360,29 @@ class Hub {
     }
   }
 
-  /// Attaches the currently active span to [scope] so that the captured event
-  /// is linked to it.
+  /// Attaches the span the captured event belongs to onto [scope] so that the
+  /// two are linked.
   ///
-  /// Copies [scope] first when it is still [hubScope], because the active span
-  /// must not outlive the capture: nothing would unset it afterwards and every
-  /// later event would link to an already ended span.
+  /// Copies [scope] first when it is still [hubScope], because the span must
+  /// not outlive the capture: nothing would unset it afterwards and every later
+  /// event would link to an already ended span.
   ///
-  /// An active span already present on [scope] was set by a `withScope`
-  /// callback and is more specific than the ambient one, so it wins.
-  Scope _linkActiveSpan(Scope scope, Scope hubScope) {
-    final activeSpan = getActiveSpan();
-    if (activeSpan == null || scope.getActiveSpan() != null) {
+  /// Preference goes to the most specific attribution. A span already on
+  /// [scope] was set by a `withScope` callback, so it wins outright. A span
+  /// that [throwable] aborted beats the ambient one, which merely happened to
+  /// be open at capture time.
+  Scope _linkActiveSpan(Scope scope, Scope hubScope, Object? throwable) {
+    if (scope.getActiveSpan() != null) {
+      return scope;
+    }
+    final span = ThrowableSpanRegistry.lookup(throwable) ?? getActiveSpan();
+    if (span == null) {
       return scope;
     }
     if (identical(scope, hubScope)) {
       scope = scope.clone();
     }
-    return scope..setActiveSpan(activeSpan);
+    return scope..setActiveSpan(span);
   }
 
   FutureOr<Scope> _cloneAndRunWithScope(

--- a/packages/dart/lib/src/scope.dart
+++ b/packages/dart/lib/src/scope.dart
@@ -392,11 +392,15 @@ class Scope {
     });
 
     final newSpan = span;
+    final newActiveSpan = _activeSpan;
     if (event.contexts.trace == null) {
       if (newSpan != null) {
         event.contexts.trace = newSpan.context.toTraceContext(
           sampled: newSpan.samplingDecision?.sampled,
         );
+      } else if (newActiveSpan != null) {
+        event.contexts.trace = newActiveSpan.toTraceContext();
+        event.transaction ??= newActiveSpan.segmentSpan.name;
       } else {
         event.contexts.trace =
             SentryTraceContext.fromPropagationContext(propagationContext);

--- a/packages/dart/lib/src/sentry_client.dart
+++ b/packages/dart/lib/src/sentry_client.dart
@@ -198,15 +198,18 @@ class SentryClient {
     }
 
     var traceContext = scope?.span?.traceContext();
-    if (traceContext == null) {
-      if (scope != null) {
-        scope.propagationContext.baggage ??= SentryBaggage({})
-          ..setValuesFromScope(scope, _options);
-        traceContext = SentryTraceContextHeader.fromBaggage(
-            scope.propagationContext.baggage!);
-      }
-    } else {
+    if (traceContext != null) {
       traceContext.replayId = scope?.replayId;
+    } else {
+      // Frozen and shared by every span of the segment, so it must not be
+      // mutated here. It already carries the replay id.
+      traceContext = scope?.getActiveSpan()?.resolveDsc();
+    }
+    if (traceContext == null && scope != null) {
+      scope.propagationContext.baggage ??= SentryBaggage({})
+        ..setValuesFromScope(scope, _options);
+      traceContext = SentryTraceContextHeader.fromBaggage(
+          scope.propagationContext.baggage!);
     }
 
     final envelope = SentryEnvelope.fromEvent(

--- a/packages/dart/lib/src/telemetry/span/recording_sentry_span_v2.dart
+++ b/packages/dart/lib/src/telemetry/span/recording_sentry_span_v2.dart
@@ -165,6 +165,24 @@ base class RecordingSentrySpanV2 implements SentrySpanV2 {
   /// All spans in the same segment share this DSC.
   SentryTraceContextHeader resolveDsc() => segmentSpan._getOrCreateDsc();
 
+  /// Converts this span into the `contexts.trace` of an event, which is what
+  /// links errors to this span.
+  @internal
+  SentryTraceContext toTraceContext() {
+    return SentryTraceContext(
+      traceId: _traceId,
+      spanId: _spanId,
+      parentSpanId: _parentSpan?.spanId,
+      operation:
+          _attributes[SemanticAttributesConstants.sentryOp]?.value as String? ??
+              'default',
+      description: _name,
+      origin: _attributes[SemanticAttributesConstants.sentryOrigin]?.value
+          as String?,
+      sampled: samplingDecision.sampled,
+    );
+  }
+
   @override
   bool get isEnded => _endTimestamp != null;
 

--- a/packages/dart/lib/src/tracing/instrumentation/instrumentation.dart
+++ b/packages/dart/lib/src/tracing/instrumentation/instrumentation.dart
@@ -5,3 +5,4 @@ export 'instrumentation_span.dart';
 export 'request_span_registry.dart';
 export 'span_factory.dart';
 export 'synchronous_span_marker.dart';
+export 'throwable_span_registry.dart';

--- a/packages/dart/lib/src/tracing/instrumentation/instrumentation.dart
+++ b/packages/dart/lib/src/tracing/instrumentation/instrumentation.dart
@@ -2,5 +2,6 @@
 library;
 
 export 'instrumentation_span.dart';
+export 'request_span_registry.dart';
 export 'span_factory.dart';
 export 'synchronous_span_marker.dart';

--- a/packages/dart/lib/src/tracing/instrumentation/instrumentation_span.dart
+++ b/packages/dart/lib/src/tracing/instrumentation/instrumentation_span.dart
@@ -138,7 +138,14 @@ class StreamingInstrumentationSpan implements InstrumentationSpan {
   dynamic get throwable => _throwable;
 
   @override
-  set throwable(dynamic throwable) => _throwable = throwable;
+  set throwable(dynamic throwable) {
+    _throwable = throwable;
+    // Lets whoever captures this error later link it back to this span, since
+    // integrations that rethrow are not the capture site.
+    if (_span case RecordingSentrySpanV2 recordingSpan) {
+      ThrowableSpanRegistry.register(throwable, recordingSpan);
+    }
+  }
 
   @override
   Future<void> finish({SpanStatus? status, DateTime? endTimestamp}) async {

--- a/packages/dart/lib/src/tracing/instrumentation/instrumentation_span.dart
+++ b/packages/dart/lib/src/tracing/instrumentation/instrumentation_span.dart
@@ -18,6 +18,9 @@ abstract class InstrumentationSpan {
   SentryTraceHeader toSentryTrace();
   SentryBaggageHeader? toBaggageHeader();
 
+  /// Links events captured with [scope] to this span.
+  void applyToScope(Scope scope);
+
   /// Returns true if this span is a recording span that records data.
   bool get isRecording;
 
@@ -71,6 +74,11 @@ class LegacyInstrumentationSpan implements InstrumentationSpan {
 
   @override
   SentryBaggageHeader? toBaggageHeader() => _span.toBaggageHeader();
+
+  /// No-op: with the static trace lifecycle errors are already linked to the
+  /// transaction bound to the scope.
+  @override
+  void applyToScope(Scope scope) {}
 
   @override
   bool get isRecording => _span is SentrySpan;
@@ -195,6 +203,13 @@ class StreamingInstrumentationSpan implements InstrumentationSpan {
       spanId: _span.spanId,
       sampled: null,
     );
+  }
+
+  @override
+  void applyToScope(Scope scope) {
+    if (_span case RecordingSentrySpanV2 recordingSpan) {
+      scope.setActiveSpan(recordingSpan);
+    }
   }
 
   SpanStatus _convertFromV2Status(SentrySpanStatusV2 status) {

--- a/packages/dart/lib/src/tracing/instrumentation/request_span_registry.dart
+++ b/packages/dart/lib/src/tracing/instrumentation/request_span_registry.dart
@@ -1,0 +1,30 @@
+import 'package:meta/meta.dart';
+
+import 'instrumentation_span.dart';
+
+/// Associates an HTTP request with the `http.client` span created for it, so
+/// that a failed request captured elsewhere can be linked to that span.
+///
+/// The two halves of an HTTP integration do not share per-request state: the
+/// span is created by the tracing client while the error is captured by the
+/// failed request client (`http`) or by an error interceptor running in another
+/// async context (Dio). Requests also run concurrently, so the association has
+/// to be keyed by the request itself.
+///
+/// Keys are held weakly: an entry is registered for every request but only read
+/// back for the ones that fail, and there is no hook that runs late enough to
+/// remove the others.
+@internal
+class RequestSpanRegistry {
+  RequestSpanRegistry._();
+
+  static final _spans = Expando<InstrumentationSpan>('sentry.request.span');
+
+  /// [request] must be an object `Expando` accepts as a key, which excludes
+  /// strings, numbers, booleans, records and `null`.
+  static void register(Object request, InstrumentationSpan span) {
+    _spans[request] = span;
+  }
+
+  static InstrumentationSpan? lookup(Object request) => _spans[request];
+}

--- a/packages/dart/lib/src/tracing/instrumentation/throwable_span_registry.dart
+++ b/packages/dart/lib/src/tracing/instrumentation/throwable_span_registry.dart
@@ -1,0 +1,53 @@
+import 'package:meta/meta.dart';
+
+import '../../../sentry.dart';
+
+/// Associates a throwable with the span that was aborted by it, so that an
+/// error captured elsewhere can be linked to that span.
+///
+/// Integrations that only mark their span and rethrow — the database ones, for
+/// example — are not the capture site. The error surfaces later through a
+/// global handler or through application code, by which time the span has
+/// ended and is reachable from nothing. The throwable is the only handle that
+/// travels that far, which makes it the key.
+///
+/// Keys are held weakly, and the innermost span wins: as a throwable unwinds
+/// through nested spans, each marks it, and the first one to do so is the most
+/// specific.
+@internal
+class ThrowableSpanRegistry {
+  ThrowableSpanRegistry._();
+
+  static final _spans = Expando<RecordingSentrySpanV2>('sentry.throwable.span');
+
+  static void register(Object? throwable, RecordingSentrySpanV2 span) {
+    final key = _keyOf(throwable);
+    if (key == null) {
+      return;
+    }
+    _spans[key] ??= span;
+  }
+
+  static RecordingSentrySpanV2? lookup(Object? throwable) {
+    final key = _keyOf(throwable);
+    return key == null ? null : _spans[key];
+  }
+
+  /// Returns the throwable to key on, or null when it cannot be tracked.
+  ///
+  /// A mechanism decorates the throwable after the span marked it, so it is
+  /// unwrapped. `Expando` rejects strings, numbers, booleans and records.
+  static Object? _keyOf(Object? throwable) {
+    if (throwable is ThrowableMechanism) {
+      throwable = throwable.throwable;
+    }
+    if (throwable == null ||
+        throwable is String ||
+        throwable is num ||
+        throwable is bool ||
+        throwable is Record) {
+      return null;
+    }
+    return throwable;
+  }
+}

--- a/packages/dart/test/http_client/sentry_http_client_test.dart
+++ b/packages/dart/test/http_client/sentry_http_client_test.dart
@@ -7,6 +7,7 @@ import 'package:mockito/mockito.dart';
 import 'package:sentry/sentry.dart';
 import 'package:sentry/src/http_client/failed_request_client.dart';
 import 'package:sentry/src/sentry_tracer.dart';
+import 'package:sentry/src/tracing/instrumentation/span_factory_integration.dart';
 import 'package:test/test.dart';
 
 import '../mocks/mock_transport.dart';
@@ -148,6 +149,69 @@ void main() {
       expect(tr.children.length, 1);
       expect(tr.children.first.context.operation, 'http.client');
     });
+
+    group('when streaming spans and a failed request is captured', () {
+      setUp(() => fixture.enableSpanStreaming());
+
+      test('links the error to the http.client span', () async {
+        final sut = fixture.getSut(
+          hub: fixture.realHub,
+          client: fixture.getClient(statusCode: 500),
+          badStatusCodes: [SentryStatusCode.range(500, 599)],
+          captureFailedRequests: true,
+        );
+
+        late SentrySpanV2 rootSpan;
+        await fixture.realHub.startSpan('root-span', (span) async {
+          rootSpan = span;
+          await sut.get(requestUri);
+        });
+
+        await fixture.processor.waitForProcessing();
+        final httpSpan = fixture.processor.findSpanByOperation('http.client')!;
+
+        final traceContext = fixture.transport.events.first.contexts.trace;
+        expect(traceContext?.spanId, httpSpan.spanId);
+        expect(traceContext?.parentSpanId, rootSpan.spanId);
+        expect(traceContext?.traceId, rootSpan.traceId);
+        expect(traceContext?.operation, 'http.client');
+      });
+
+      test('links the error to the http.client span when the client throws',
+          () async {
+        final sut = fixture.getSut(
+          hub: fixture.realHub,
+          client: createThrowingClient(),
+          captureFailedRequests: true,
+        );
+
+        await fixture.realHub.startSpan('root-span', (_) async {
+          await expectLater(
+              () => sut.get(requestUri), throwsA(isA<Exception>()));
+        });
+
+        await fixture.processor.waitForProcessing();
+        final httpSpan = fixture.processor.findSpanByOperation('http.client')!;
+
+        expect(fixture.transport.events.first.contexts.trace?.spanId,
+            httpSpan.spanId);
+      });
+
+      test('does not link the error when no span is active', () async {
+        final sut = fixture.getSut(
+          hub: fixture.realHub,
+          client: fixture.getClient(statusCode: 500),
+          badStatusCodes: [SentryStatusCode.range(500, 599)],
+          captureFailedRequests: true,
+        );
+
+        await sut.get(requestUri);
+
+        expect(fixture.processor.findSpanByOperation('http.client'), isNull);
+        expect(fixture.transport.events.first.contexts.trace?.parentSpanId,
+            isNull);
+      });
+    });
   });
 }
 
@@ -166,6 +230,7 @@ class Fixture {
   late MockHub mockHub;
   late Hub realHub;
   late MockTransport transport;
+  final processor = FakeTelemetryProcessor();
   final options = defaultTestOptions();
 
   Fixture() {
@@ -174,6 +239,15 @@ class Fixture {
     options.transport = transport;
     realHub = Hub(options);
     mockHub = MockHub();
+  }
+
+  void enableSpanStreaming() {
+    options.tracesSampleRate = 1.0;
+    options.recordHttpBreadcrumbs = false;
+    options.traceLifecycle = SentryTraceLifecycle.stream;
+    options.telemetryProcessor = processor;
+    options.addIntegration(InstrumentationSpanFactorySetupIntegration());
+    options.integrations.last.call(realHub, options);
   }
 
   SentryHttpClient getSut({

--- a/packages/dart/test/hub_span_test.dart
+++ b/packages/dart/test/hub_span_test.dart
@@ -1427,6 +1427,121 @@ void main() {
       });
     });
 
+    group('when capturing an error while a span is active', () {
+      test('links the event to the active span', () async {
+        final hub = fixture.getSut();
+
+        late SentrySpanV2 span;
+        await hub.startSpan('test-span', (s) async {
+          span = s;
+          await hub.captureEvent(SentryEvent());
+        });
+
+        expect(fixture.client.captureEventCalls.first.scope?.getActiveSpan(),
+            same(span));
+      });
+
+      test('links the exception to the active span', () async {
+        final hub = fixture.getSut();
+
+        late SentrySpanV2 span;
+        await hub.startSpan('test-span', (s) async {
+          span = s;
+          await hub.captureException(StateError('error'));
+        });
+
+        expect(fixture.client.captureEventCalls.first.scope?.getActiveSpan(),
+            same(span));
+      });
+
+      test('links the event to the innermost span', () async {
+        final hub = fixture.getSut();
+
+        late SentrySpanV2 childSpan;
+        await hub.startSpan('root-span', (_) async {
+          await hub.startSpan('child-span', (child) async {
+            childSpan = child;
+            await hub.captureEvent(SentryEvent());
+          });
+        });
+
+        expect(fixture.client.captureEventCalls.first.scope?.getActiveSpan(),
+            same(childSpan));
+      });
+
+      test('links the event to the idle span', () async {
+        final hub = fixture.getSut();
+        final idleSpan = hub.startIdleSpan('idle-span');
+
+        await hub.captureEvent(SentryEvent());
+
+        expect(fixture.client.captureEventCalls.first.scope?.getActiveSpan(),
+            same(idleSpan));
+      });
+
+      test('does not set the active span on the hub scope', () async {
+        final hub = fixture.getSut();
+
+        await hub.startSpan('test-span', (_) async {
+          await hub.captureEvent(SentryEvent());
+        });
+
+        expect(hub.scope.getActiveSpan(), isNull);
+      });
+
+      test('keeps the span set by withScope', () async {
+        final hub = fixture.getSut();
+        final explicitSpan =
+            hub.startInactiveSpan('explicit-span') as RecordingSentrySpanV2;
+
+        await hub.startSpan('test-span', (_) async {
+          await hub.captureEvent(
+            SentryEvent(),
+            withScope: (scope) => scope.setActiveSpan(explicitSpan),
+          );
+        });
+
+        expect(fixture.client.captureEventCalls.first.scope?.getActiveSpan(),
+            same(explicitSpan));
+      });
+
+      test('does not clone the scope when capturing a log', () async {
+        final hub = fixture.getSut();
+        fixture.options.enableLogs = true;
+
+        await hub.startSpan('test-span', (_) async {
+          await hub.captureLog(SentryLog(
+            timestamp: DateTime.now(),
+            traceId: SentryId.newId(),
+            level: SentryLogLevel.info,
+            body: 'log',
+            attributes: {},
+          ));
+        });
+
+        expect(fixture.client.captureLogCalls.first.scope, same(hub.scope));
+      });
+    });
+
+    group('when capturing an error while no span is active', () {
+      test('does not link the event to a span', () async {
+        final hub = fixture.getSut();
+
+        await hub.captureEvent(SentryEvent());
+
+        expect(fixture.client.captureEventCalls.first.scope?.getActiveSpan(),
+            isNull);
+      });
+
+      test('does not clone the scope', () async {
+        final hub = fixture.getSut();
+
+        await hub.captureEvent(SentryEvent());
+
+        expect(fixture.client.captureEventCalls.first.scope, same(hub.scope));
+      });
+    });
+
     group('when recording client reports for span discards', () {
       group('with ignoreSpans rule matching a segment', () {
         test('records ignored span outcome for the segment', () {

--- a/packages/dart/test/hub_span_test.dart
+++ b/packages/dart/test/hub_span_test.dart
@@ -1542,6 +1542,123 @@ void main() {
       });
     });
 
+    // Integrations that only mark the span and rethrow, such as the database
+    // ones, are not the capture site. The throwable is the only handle that
+    // travels from there to whoever reports the error later.
+    group('when capturing an error marked on a span that already ended', () {
+      test('links the exception to that span', () async {
+        final hub = fixture.getSut();
+        final span =
+            hub.startInactiveSpan('db.sql.execute') as RecordingSentrySpanV2;
+        final error = StateError('error');
+
+        StreamingInstrumentationSpan(span).throwable = error;
+        span.end();
+
+        await hub.captureException(error);
+
+        expect(fixture.client.captureEventCalls.first.scope?.getActiveSpan(),
+            same(span));
+      });
+
+      test('links the event to that span', () async {
+        final hub = fixture.getSut();
+        final span =
+            hub.startInactiveSpan('db.sql.execute') as RecordingSentrySpanV2;
+        final error = StateError('error');
+
+        StreamingInstrumentationSpan(span).throwable = error;
+        span.end();
+
+        await hub.captureEvent(SentryEvent(throwable: error));
+
+        expect(fixture.client.captureEventCalls.first.scope?.getActiveSpan(),
+            same(span));
+      });
+
+      test('links an exception wrapped in a mechanism', () async {
+        final hub = fixture.getSut();
+        final span =
+            hub.startInactiveSpan('db.sql.execute') as RecordingSentrySpanV2;
+        final error = StateError('error');
+
+        StreamingInstrumentationSpan(span).throwable = error;
+        span.end();
+
+        await hub.captureException(
+          ThrowableMechanism(Mechanism(type: 'test'), error),
+        );
+
+        expect(fixture.client.captureEventCalls.first.scope?.getActiveSpan(),
+            same(span));
+      });
+
+      test('prefers that span over the ambient active span', () async {
+        final hub = fixture.getSut();
+        final dbSpan =
+            hub.startInactiveSpan('db.sql.execute') as RecordingSentrySpanV2;
+        final error = StateError('error');
+
+        StreamingInstrumentationSpan(dbSpan).throwable = error;
+        dbSpan.end();
+
+        await hub.startSpan('test-span', (_) async {
+          await hub.captureException(error);
+        });
+
+        expect(fixture.client.captureEventCalls.first.scope?.getActiveSpan(),
+            same(dbSpan));
+      });
+
+      test('keeps the span set by withScope', () async {
+        final hub = fixture.getSut();
+        final dbSpan =
+            hub.startInactiveSpan('db.sql.execute') as RecordingSentrySpanV2;
+        final explicitSpan =
+            hub.startInactiveSpan('explicit-span') as RecordingSentrySpanV2;
+        final error = StateError('error');
+
+        StreamingInstrumentationSpan(dbSpan).throwable = error;
+        dbSpan.end();
+
+        await hub.captureException(
+          error,
+          withScope: (scope) => scope.setActiveSpan(explicitSpan),
+        );
+
+        expect(fixture.client.captureEventCalls.first.scope?.getActiveSpan(),
+            same(explicitSpan));
+      });
+
+      test('does not link an unrelated error', () async {
+        final hub = fixture.getSut();
+        final span =
+            hub.startInactiveSpan('db.sql.execute') as RecordingSentrySpanV2;
+
+        StreamingInstrumentationSpan(span).throwable = StateError('error');
+        span.end();
+
+        await hub.captureException(StateError('unrelated'));
+
+        expect(fixture.client.captureEventCalls.first.scope?.getActiveSpan(),
+            isNull);
+      });
+
+      test('ignores a throwable that cannot be tracked', () async {
+        final hub = fixture.getSut();
+        final span =
+            hub.startInactiveSpan('db.sql.execute') as RecordingSentrySpanV2;
+
+        StreamingInstrumentationSpan(span).throwable = 'error';
+        span.end();
+
+        await hub.captureException('error');
+
+        expect(fixture.client.captureEventCalls.first.scope?.getActiveSpan(),
+            isNull);
+      });
+    });
+
     group('when recording client reports for span discards', () {
       group('with ignoreSpans rule matching a segment', () {
         test('records ignored span outcome for the segment', () {

--- a/packages/dart/test/scope_test.dart
+++ b/packages/dart/test/scope_test.dart
@@ -630,6 +630,60 @@ void main() {
       expect(spanId1, isNot(spanId2));
     });
 
+    test('apply trace context to event with active span v2', () async {
+      final event = SentryEvent();
+      final rootSpan = fixture.createSpan(name: 'root-span');
+      final childSpan = fixture.createChildSpan(rootSpan, name: 'http.client');
+      childSpan.setAttribute(
+          SemanticAttributesConstants.sentryOp, SentryAttribute.string('op'));
+      final scope = fixture.getSut()..setActiveSpan(childSpan);
+
+      final updatedEvent = await scope.applyToEvent(event, Hint());
+
+      final traceContext = updatedEvent?.contexts.trace;
+      expect(traceContext?.traceId, rootSpan.traceId);
+      expect(traceContext?.spanId, childSpan.spanId);
+      expect(traceContext?.parentSpanId, rootSpan.spanId);
+      expect(traceContext?.operation, 'op');
+      expect(traceContext?.description, 'http.client');
+      expect(traceContext?.sampled, isTrue);
+    });
+
+    test('apply segment span name as transaction with active span v2',
+        () async {
+      final event = SentryEvent();
+      final rootSpan = fixture.createSpan(name: 'root-span');
+      final childSpan = fixture.createChildSpan(rootSpan);
+      final scope = fixture.getSut()..setActiveSpan(childSpan);
+
+      final updatedEvent = await scope.applyToEvent(event, Hint());
+
+      expect(updatedEvent?.transaction, 'root-span');
+    });
+
+    test('apply keeps scope transaction with active span v2', () async {
+      final event = SentryEvent();
+      final scope = fixture.getSut()
+        ..transaction = '/route/from/scope'
+        ..setActiveSpan(fixture.createSpan(name: 'root-span'));
+
+      final updatedEvent = await scope.applyToEvent(event, Hint());
+
+      expect(updatedEvent?.transaction, '/route/from/scope');
+    });
+
+    test('apply prefers legacy span over active span v2', () async {
+      final event = SentryEvent();
+      final scope = fixture.getSut()
+        ..span = fixture.sentryTracer
+        ..setActiveSpan(fixture.createSpan());
+
+      final updatedEvent = await scope.applyToEvent(event, Hint());
+
+      expect(updatedEvent?.contexts.trace?.spanId,
+          fixture.sentryTracer.context.spanId);
+    });
+
     test('should not apply the scope properties when event already has it ',
         () async {
       final eventUser = SentryUser(id: '123');
@@ -1002,6 +1056,20 @@ class Fixture {
       dscCreator: (_) =>
           SentryTraceContextHeader(SentryId.newId(), 'publicKey'),
       samplingDecision: SentryTracesSamplingDecision(true),
+    );
+  }
+
+  RecordingSentrySpanV2 createChildSpan(
+    RecordingSentrySpanV2 parent, {
+    String name = 'child-span',
+  }) {
+    return RecordingSentrySpanV2.child(
+      parent: parent,
+      name: name,
+      onSpanEnd: (_) async {},
+      clock: options.clock,
+      dscCreator: (_) =>
+          SentryTraceContextHeader(SentryId.newId(), 'publicKey'),
     );
   }
 

--- a/packages/dart/test/sentry_client_test.dart
+++ b/packages/dart/test/sentry_client_test.dart
@@ -730,6 +730,37 @@ void main() {
           scope.span!.traceContext()!.traceId, capturedTraceContext!.traceId);
     });
 
+    test(
+        'uses the segment dsc for trace header if an active span v2 is on scope',
+        () async {
+      final client = fixture.getSut();
+
+      final span = fixture.createRecordingSpanV2(name: 'root-span');
+      final scope = Scope(fixture.options)..setActiveSpan(span);
+
+      await client.captureEvent(SentryEvent(), scope: scope);
+
+      final capturedTraceContext =
+          fixture.transport.envelopes.first.header.traceContext;
+
+      expect(capturedTraceContext?.traceId, span.traceId);
+      expect(capturedTraceContext?.transaction, 'root-span');
+      expect(capturedTraceContext?.sampled, 'true');
+    });
+
+    test('does not mutate the frozen segment dsc with the replay id', () async {
+      final client = fixture.getSut();
+
+      final span = fixture.createRecordingSpanV2();
+      final scope = Scope(fixture.options)
+        ..setActiveSpan(span)
+        ..replayId = SentryId.fromId('1' * 32);
+
+      await client.captureEvent(SentryEvent(), scope: scope);
+
+      expect(span.resolveDsc().replayId, isNull);
+    });
+
     test('should contain a transaction in the envelope', () async {
       try {
         throw StateError('Error');
@@ -2564,6 +2595,18 @@ class Fixture {
 
   SentryLevel? loggedLevel;
   Object? loggedException;
+
+  RecordingSentrySpanV2 createRecordingSpanV2({String name = 'test-span'}) {
+    return RecordingSentrySpanV2.root(
+      name: name,
+      traceId: SentryId.newId(),
+      onSpanEnd: (_) async {},
+      clock: options.clock,
+      dscCreator: (span) =>
+          SentryTraceContextHeader.fromRecordingSpan(span, options, null),
+      samplingDecision: SentryTracesSamplingDecision(true),
+    );
+  }
 
   SentryClient getSut({
     bool sendDefaultPii = false,

--- a/packages/dio/lib/src/failed_request_interceptor.dart
+++ b/packages/dio/lib/src/failed_request_interceptor.dart
@@ -42,7 +42,16 @@ class FailedRequestInterceptor extends Interceptor {
 
       _hub.getSpan()?.throwable = err;
 
-      await _hub.captureException(throwableMechanism);
+      // Links the error to the `http.client` span of this request, which the
+      // tracing adapter registered. The span has already ended by now, but its
+      // ids are what the link is resolved by.
+      // ignore: invalid_use_of_internal_member
+      final span = RequestSpanRegistry.lookup(err.requestOptions);
+
+      await _hub.captureException(
+        throwableMechanism,
+        withScope: span == null ? null : (scope) => span.applyToScope(scope),
+      );
     }
     handler.next(err);
   }

--- a/packages/dio/lib/src/tracing_client_adapter.dart
+++ b/packages/dio/lib/src/tracing_client_adapter.dart
@@ -51,6 +51,10 @@ class TracingClientAdapter implements HttpClientAdapter {
           )
         : null;
 
+    if (instrumentationSpan != null) {
+      RequestSpanRegistry.register(options, instrumentationSpan);
+    }
+
     // Regardless whether tracing is enabled or not, we always want to attach
     // Sentry trace headers (tracing without performance).
     if (containsTargetOrMatchesRegExp(

--- a/packages/dio/test/spanv2_integration_test.dart
+++ b/packages/dio/test/spanv2_integration_test.dart
@@ -4,11 +4,13 @@ import 'package:_sentry_testing/_sentry_testing.dart';
 import 'package:dio/dio.dart';
 import 'package:sentry/sentry.dart';
 import 'package:sentry/src/tracing/instrumentation/span_factory_integration.dart';
+import 'package:sentry_dio/src/failed_request_interceptor.dart';
 import 'package:sentry_dio/src/tracing_client_adapter.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';
 import 'mocks/mock_http_client_adapter.dart';
+import 'mocks/mock_transport.dart';
 
 final requestUri = Uri.parse('https://example.com/api/users');
 
@@ -113,6 +115,55 @@ void main() {
       );
       expect(span.parentSpan, equals(transactionSpan));
     });
+
+    group('when a failed request is captured', () {
+      test('links the error to the http.client span', () async {
+        final dio = fixture.getDio(
+          // Responds instead of throwing, so the DioException is the one Dio
+          // itself creates for the bad status code.
+          mockAdapter: fixture.getRespondingMockAdapter(statusCode: 500),
+          captureFailedRequests: true,
+        );
+
+        late SentrySpanV2 transactionSpan;
+        await fixture.hub.startSpan(
+          'test-transaction',
+          (span) async {
+            transactionSpan = span;
+            try {
+              await dio.get<dynamic>('/api/users');
+            } catch (_) {}
+          },
+          parentSpan: null,
+        );
+
+        await fixture.processor.waitForProcessing();
+        final httpSpan = fixture.processor.findSpanByOperation('http.client')!;
+
+        final traceContext = fixture.transport.events.first.contexts.trace;
+        expect(traceContext?.spanId, httpSpan.spanId);
+        expect(traceContext?.parentSpanId, transactionSpan.spanId);
+        expect(traceContext?.traceId, transactionSpan.traceId);
+        expect(traceContext?.operation, 'http.client');
+      });
+
+      test('does not link the error when no span is active', () async {
+        final dio = fixture.getDio(
+          mockAdapter: fixture.getRespondingMockAdapter(statusCode: 500),
+          captureFailedRequests: true,
+        );
+
+        try {
+          await dio.get<dynamic>('/api/users');
+        } catch (_) {}
+
+        expect(fixture.processor.findSpanByOperation('http.client'), isNull);
+        expect(
+          fixture.transport.events.first.contexts.trace?.parentSpanId,
+          isNull,
+        );
+      });
+    });
   });
 }
 
@@ -120,23 +171,50 @@ class Fixture {
   late final Hub hub;
   late final SentryOptions options;
   late final FakeTelemetryProcessor processor;
+  final transport = MockTransport();
 
   Fixture() {
     processor = FakeTelemetryProcessor();
     options = defaultTestOptions()
       ..tracesSampleRate = 1.0
       ..traceLifecycle = SentryTraceLifecycle.stream
-      ..telemetryProcessor = processor;
+      ..telemetryProcessor = processor
+      ..transport = transport;
     hub = Hub(options);
 
     options.addIntegration(InstrumentationSpanFactorySetupIntegration());
     options.integrations.last.call(hub, options);
   }
 
-  Dio getDio({required MockHttpClientAdapter mockAdapter}) {
+  Dio getDio({
+    required MockHttpClientAdapter mockAdapter,
+    bool captureFailedRequests = false,
+  }) {
     final dio = Dio(BaseOptions(baseUrl: 'https://example.com'));
     dio.httpClientAdapter = TracingClientAdapter(client: mockAdapter, hub: hub);
+    if (captureFailedRequests) {
+      dio.interceptors.insert(
+        0,
+        FailedRequestInterceptor(
+          hub: hub,
+          failedRequestStatusCodes: [SentryStatusCode.range(500, 599)],
+          captureFailedRequests: true,
+        ),
+      );
+    }
     return dio;
+  }
+
+  MockHttpClientAdapter getRespondingMockAdapter({required int statusCode}) {
+    return MockHttpClientAdapter((_, __, ___) async {
+      return ResponseBody.fromString(
+        '{"error": "Internal Server Error"}',
+        statusCode,
+        headers: {
+          'content-type': ['application/json'],
+        },
+      );
+    });
   }
 
   MockHttpClientAdapter getMockAdapter({

--- a/packages/drift/test/spanv2_integration_test.dart
+++ b/packages/drift/test/spanv2_integration_test.dart
@@ -3,7 +3,7 @@
 library;
 
 import 'package:_sentry_testing/_sentry_testing.dart';
-import 'package:drift/drift.dart' hide isNotNull;
+import 'package:drift/drift.dart' hide isNotNull, isNull;
 import 'package:drift/native.dart';
 import 'package:sentry/sentry.dart';
 import 'package:sentry/src/tracing/instrumentation/span_factory_integration.dart';
@@ -173,6 +173,49 @@ void main() {
       );
       expect(span.parentSpan, equals(transactionSpan));
     });
+
+    // Drift never captures: it marks the span and rethrows, so the error is
+    // reported later by application code or a global handler.
+    group('when a failing query is reported after it escaped', () {
+      test('links the error to the db span', () async {
+        final db = fixture.db;
+
+        late SentrySpanV2 transactionSpan;
+        Object? escapedError;
+        await fixture.hub.startSpan(
+          'test-transaction',
+          (span) async {
+            transactionSpan = span;
+            try {
+              await db.customStatement('SELECT * FROM missing_table');
+            } catch (e) {
+              escapedError = e;
+            }
+          },
+          parentSpan: null,
+        );
+
+        await fixture.hub.captureException(escapedError);
+
+        await fixture.processor.waitForProcessing();
+        final dbSpan = fixture.processor.findSpanByOperation('db.sql.query')!;
+
+        final traceContext = fixture.capturedEvents.first.contexts.trace;
+        expect(traceContext?.spanId, dbSpan.spanId);
+        expect(traceContext?.parentSpanId, transactionSpan.spanId);
+        expect(traceContext?.traceId, transactionSpan.traceId);
+        expect(traceContext?.operation, 'db.sql.query');
+      });
+
+      test('does not link an error that no span marked', () async {
+        await fixture.hub.captureException(StateError('unrelated'));
+
+        expect(
+          fixture.capturedEvents.first.contexts.trace?.parentSpanId,
+          isNull,
+        );
+      });
+    });
   });
 }
 
@@ -181,6 +224,7 @@ class Fixture {
   late final SentryOptions options;
   late final FakeTelemetryProcessor processor;
   late AppDatabase db;
+  final capturedEvents = <SentryEvent>[];
 
   static const String dbName = 'test-db';
 
@@ -189,7 +233,13 @@ class Fixture {
     options = defaultTestOptions()
       ..tracesSampleRate = 1.0
       ..traceLifecycle = SentryTraceLifecycle.stream
-      ..telemetryProcessor = processor;
+      ..telemetryProcessor = processor
+      // Records the event after the scope was applied and drops it, so no
+      // transport is involved.
+      ..beforeSend = (event, hint) {
+        capturedEvents.add(event);
+        return null;
+      };
     hub = Hub(options);
 
     options.addIntegration(InstrumentationSpanFactorySetupIntegration());
@@ -207,6 +257,7 @@ class Fixture {
 
   Future<void> tearDown() async {
     processor.clear();
+    capturedEvents.clear();
 
     try {
       await db.close();

--- a/packages/flutter/example/lib/screens/performance_screen.dart
+++ b/packages/flutter/example/lib/screens/performance_screen.dart
@@ -182,6 +182,23 @@ class PerformanceScreen extends StatelessWidget {
                           'Demonstrates the new SpanV2 API with streaming trace lifecycle. Creates spans and sets attributes.',
                       buttonTitle: 'Emit SpanV2',
                     ),
+                  if (Sentry.currentHub.options.traceLifecycle ==
+                      SentryTraceLifecycle.stream) ...[
+                    TooltipButton(
+                      onPressed: () => makeFailingWebRequest(context),
+                      key: const Key('http_failing_request'),
+                      text:
+                          'Requests a 404 inside a span. The captured error should be linked to the http.client span in Sentry.',
+                      buttonTitle: 'Dart: Failing web request',
+                    ),
+                    TooltipButton(
+                      onPressed: () => makeFailingWebRequestWithDio(context),
+                      key: const Key('dio_failing_request'),
+                      text:
+                          'Requests a 404 through Dio inside a span. The captured error should be linked to the http.client span in Sentry.',
+                      buttonTitle: 'Dio: Failing web request',
+                    ),
+                  ],
                 ],
               ),
             ),
@@ -341,6 +358,72 @@ Future<void> makeWebRequest(BuildContext context) async {
     if (!context.mounted) return;
     await _showWebResponseDialog(context, response.statusCode, response.body);
   }
+}
+
+/// A URL that reliably answers 404, to demo linking an error to its
+/// `http.client` span.
+final _failingUrl = Uri.parse('${exampleUrl}0');
+
+final _failingStatusCodes = [SentryStatusCode(404)];
+
+Future<void> makeFailingWebRequest(BuildContext context) async {
+  final client = SentryHttpClient(
+    failedRequestStatusCodes: _failingStatusCodes,
+  );
+
+  late SentryId traceId;
+  int? statusCode;
+  await Sentry.startSpan('http-failing-request', (span) async {
+    traceId = span.traceId;
+    statusCode = (await client.get(_failingUrl)).statusCode;
+  });
+
+  if (!context.mounted) return;
+  await _showLinkedErrorDialog(context, traceId, statusCode);
+}
+
+Future<void> makeFailingWebRequestWithDio(BuildContext context) async {
+  final dio = Dio();
+  dio.addSentry(failedRequestStatusCodes: _failingStatusCodes);
+
+  late SentryId traceId;
+  int? statusCode;
+  await Sentry.startSpan('dio-failing-request', (span) async {
+    traceId = span.traceId;
+    try {
+      await dio.getUri<String>(_failingUrl);
+    } on DioException catch (exception) {
+      statusCode = exception.response?.statusCode;
+    }
+  });
+
+  if (!context.mounted) return;
+  await _showLinkedErrorDialog(context, traceId, statusCode);
+}
+
+Future<void> _showLinkedErrorDialog(
+  BuildContext context,
+  SentryId traceId,
+  int? statusCode,
+) async {
+  await showDialog<void>(
+    context: context,
+    builder: (context) {
+      return AlertDialog(
+        title: Text('Captured $statusCode'),
+        content: SelectableText(
+          'Search this trace in Sentry to see the error linked to the '
+          'http.client span:\n\n$traceId',
+        ),
+        actions: [
+          MaterialButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Close'),
+          ),
+        ],
+      );
+    },
+  );
 }
 
 Future<void> _showWebResponseDialog(

--- a/packages/flutter/test/frame_tracking/span_frame_metrics_collector_test.dart
+++ b/packages/flutter/test/frame_tracking/span_frame_metrics_collector_test.dart
@@ -511,6 +511,9 @@ class UnknownInstrumentationSpan implements InstrumentationSpan {
   SentryBaggageHeader? toBaggageHeader() => null;
 
   @override
+  void applyToScope(Scope scope) {}
+
+  @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is UnknownInstrumentationSpan && runtimeType == other.runtimeType;

--- a/packages/grpc/lib/src/sentry_grpc_interceptor.dart
+++ b/packages/grpc/lib/src/sentry_grpc_interceptor.dart
@@ -143,6 +143,7 @@ class SentryGrpcInterceptor extends ClientInterceptor {
               method.path,
               grpcError,
               stackTrace,
+              span,
             );
           }
         },
@@ -258,11 +259,13 @@ class SentryGrpcInterceptor extends ClientInterceptor {
     String methodPath,
     GrpcError? grpcError,
     StackTrace stackTrace,
+    InstrumentationSpan? span,
   ) =>
       _hub.captureException(
         error,
         stackTrace: stackTrace,
         withScope: (scope) {
+          span?.applyToScope(scope);
           scope.setContexts('gRPC', {
             'method': methodPath,
             if (grpcError != null) ...{

--- a/packages/grpc/test/sentry_grpc_interceptor_test.dart
+++ b/packages/grpc/test/sentry_grpc_interceptor_test.dart
@@ -650,6 +650,54 @@ void main() {
         expect(child.status, SentrySpanStatusV2.ok);
         expect(child.parentSpan, equals(transactionSpan));
       });
+
+      test('links the error to the grpc.client span', () async {
+        final client =
+            fixture.getSut(spanFirst: true, captureFailedRequests: true);
+        fixture.service.errorToThrow = GrpcError.internal('boom');
+
+        late SentrySpanV2 transactionSpan;
+        await fixture.spanFirstHub.startSpan(
+          'test-transaction',
+          (span) async {
+            transactionSpan = span;
+            try {
+              await client.testMethod('hello');
+            } catch (_) {}
+          },
+          parentSpan: null,
+        );
+
+        await fixture.spanFirstProcessor.waitForProcessing();
+        final grpcSpan =
+            fixture.spanFirstProcessor.findSpanByOperation('grpc.client')!;
+
+        final traceContext = fixture.capturedEvents.first.contexts.trace;
+        expect(traceContext?.spanId, grpcSpan.spanId);
+        expect(traceContext?.parentSpanId, transactionSpan.spanId);
+        expect(traceContext?.traceId, transactionSpan.traceId);
+        expect(traceContext?.operation, 'grpc.client');
+      });
+
+      test('does not link the error when no span is active', () async {
+        final client =
+            fixture.getSut(spanFirst: true, captureFailedRequests: true);
+        fixture.service.errorToThrow = GrpcError.internal('boom');
+
+        try {
+          await client.testMethod('hello');
+        } catch (_) {}
+        await pumpEventQueue();
+
+        expect(
+          fixture.spanFirstProcessor.findSpanByOperation('grpc.client'),
+          isNull,
+        );
+        expect(
+          fixture.capturedEvents.first.contexts.trace?.parentSpanId,
+          isNull,
+        );
+      });
     });
   });
 }
@@ -746,6 +794,7 @@ class Fixture {
 
   late Hub spanFirstHub;
   late FakeTelemetryProcessor spanFirstProcessor;
+  final capturedEvents = <SentryEvent>[];
 
   Future<void> setUp() async {
     service = _TestService();
@@ -773,7 +822,13 @@ class Fixture {
     final spanFirstOptions = defaultTestOptions()
       ..tracesSampleRate = 1.0
       ..traceLifecycle = SentryTraceLifecycle.stream
-      ..telemetryProcessor = spanFirstProcessor;
+      ..telemetryProcessor = spanFirstProcessor
+      // Records the event after the scope was applied and drops it, so no
+      // transport is involved.
+      ..beforeSend = (event, hint) {
+        capturedEvents.add(event);
+        return null;
+      };
     spanFirstHub = Hub(spanFirstOptions);
     spanFirstOptions.addIntegration(
       InstrumentationSpanFactorySetupIntegration(),
@@ -785,6 +840,7 @@ class Fixture {
     await _channel.shutdown();
     await _server.shutdown();
     spanFirstProcessor.clear();
+    capturedEvents.clear();
   }
 
   _TestClient getSut({

--- a/packages/link/lib/src/sentry_link.dart
+++ b/packages/link/lib/src/sentry_link.dart
@@ -75,7 +75,7 @@ class SentryLinkHandler {
         response: response,
       );
 
-      await hub.captureEvent(event);
+      await hub.captureEvent(event, withScope: _linkToSpan(request));
     }
 
     yield response;
@@ -109,9 +109,20 @@ class SentryLinkHandler {
         exception: exception,
       );
 
-      await hub.captureEvent(event);
+      await hub.captureEvent(event, withScope: _linkToSpan(request));
     }
     yield* Stream.error(exception);
+  }
+
+  /// Links the error to the span of this operation, which
+  /// [SentryTracingLink] registered further down the link chain.
+  ScopeCallback? _linkToSpan(Request request) {
+    // ignore: invalid_use_of_internal_member
+    final span = RequestSpanRegistry.lookup(request);
+    if (span == null) {
+      return null;
+    }
+    return (scope) => span.applyToScope(scope);
   }
 }
 

--- a/packages/link/lib/src/sentry_tracing_link.dart
+++ b/packages/link/lib/src/sentry_tracing_link.dart
@@ -54,6 +54,9 @@ class SentryTracingLink extends Link {
       sentryOperation,
       shouldStartTransaction,
     );
+    if (span != null) {
+      RequestSpanRegistry.register(request, span);
+    }
     return forward!(request).transform(StreamTransformer.fromHandlers(
       handleData: (data, sink) {
         final hasGraphQlError = data.errors?.isNotEmpty ?? false;

--- a/packages/link/test/spanv2_integration_test.dart
+++ b/packages/link/test/spanv2_integration_test.dart
@@ -8,6 +8,7 @@ import 'package:gql_exec/gql_exec.dart';
 import 'package:gql_link/gql_link.dart';
 import 'package:sentry/sentry.dart';
 import 'package:sentry/src/tracing/instrumentation/span_factory_integration.dart';
+import 'package:sentry_link/src/sentry_link.dart';
 import 'package:sentry_link/src/sentry_tracing_link.dart';
 import 'package:test/test.dart';
 
@@ -165,6 +166,49 @@ void main() {
       expect(span.attributes[SemanticAttributesConstants.sentryOrigin]?.value,
           equals('auto.graphql.sentry_link'));
     });
+
+    group('when a GraphQL error is captured', () {
+      test('links the error to the GraphQL span', () async {
+        late SentrySpanV2 transactionSpan;
+        await fixture.hub.startSpan(
+          'test-transaction',
+          (span) async {
+            transactionSpan = span;
+            await fixture
+                .createSentryGqlLink(shouldReturnError: true)
+                .request(fixture.getUserRequest())
+                .first;
+          },
+          parentSpan: null,
+        );
+
+        await fixture.processor.waitForProcessing();
+        final graphQlSpan =
+            fixture.processor.findSpanByOperation('http.graphql.query')!;
+
+        final traceContext = fixture.capturedEvents.first.contexts.trace;
+        expect(traceContext?.spanId, graphQlSpan.spanId);
+        expect(traceContext?.parentSpanId, transactionSpan.spanId);
+        expect(traceContext?.traceId, transactionSpan.traceId);
+        expect(traceContext?.operation, 'http.graphql.query');
+      });
+
+      test('does not link the error when no span is active', () async {
+        await fixture
+            .createSentryGqlLink(shouldReturnError: true)
+            .request(fixture.getUserRequest())
+            .first;
+
+        expect(
+          fixture.processor.findSpanByOperation('http.graphql.query'),
+          isNull,
+        );
+        expect(
+          fixture.capturedEvents.first.contexts.trace?.parentSpanId,
+          isNull,
+        );
+      });
+    });
   });
 }
 
@@ -172,6 +216,7 @@ class Fixture {
   late final Hub hub;
   late final SentryOptions options;
   late final FakeTelemetryProcessor processor;
+  final capturedEvents = <SentryEvent>[];
 
   Fixture() {
     processor = FakeTelemetryProcessor();
@@ -179,7 +224,13 @@ class Fixture {
       ..automatedTestMode = true
       ..tracesSampleRate = 1.0
       ..traceLifecycle = SentryTraceLifecycle.stream
-      ..telemetryProcessor = processor;
+      ..telemetryProcessor = processor
+      // Records the event after the scope was applied and drops it, so no
+      // transport is involved.
+      ..beforeSend = (event, hint) {
+        capturedEvents.add(event);
+        return null;
+      };
     hub = Hub(options);
 
     options.addIntegration(InstrumentationSpanFactorySetupIntegration());
@@ -202,8 +253,30 @@ class Fixture {
     return Link.from([sentryLink, mockLink]);
   }
 
+  /// Mirrors how [SentryGql.link] composes the error link above the tracing
+  /// link.
+  Link createSentryGqlLink({bool shouldReturnError = false}) {
+    return Link.from([
+      SentryLink.link(hub: hub),
+      SentryTracingLink(
+        shouldStartTransaction: false,
+        graphQlErrorsMarkTransactionAsFailed: true,
+        hub: hub,
+      ),
+      _MockLink(shouldReturnError: shouldReturnError),
+    ]);
+  }
+
+  Request getUserRequest() => Request(
+        operation: Operation(
+          document: parseString('query GetUser { user(id: "999") { name } }'),
+          operationName: 'GetUser',
+        ),
+      );
+
   Future<void> tearDown() async {
     processor.clear();
+    capturedEvents.clear();
     await hub.close();
   }
 }

--- a/packages/supabase/lib/src/sentry_supabase_error_client.dart
+++ b/packages/supabase/lib/src/sentry_supabase_error_client.dart
@@ -94,7 +94,17 @@ class SentrySupabaseErrorClient extends BaseClient {
         'body': supabaseRequest.body,
     };
 
-    return _hub.captureEvent(event, stackTrace: stackTrace, hint: hint);
+    // Links the error to the span of this request, which the tracing client
+    // registered before we saw the response.
+    // ignore: invalid_use_of_internal_member
+    final span = RequestSpanRegistry.lookup(request);
+
+    return _hub.captureEvent(
+      event,
+      stackTrace: stackTrace,
+      hint: hint,
+      withScope: span == null ? null : (scope) => span.applyToScope(scope),
+    );
   }
 }
 

--- a/packages/supabase/lib/src/sentry_supabase_tracing_client.dart
+++ b/packages/supabase/lib/src/sentry_supabase_tracing_client.dart
@@ -26,6 +26,9 @@ class SentrySupabaseTracingClient extends BaseClient {
     }
 
     final span = _createSpan(supabaseRequest);
+    if (span != null) {
+      RequestSpanRegistry.register(request, span);
+    }
 
     StreamedResponse? response;
 

--- a/packages/supabase/test/spanv2_integration_test.dart
+++ b/packages/supabase/test/spanv2_integration_test.dart
@@ -183,6 +183,49 @@ void main() {
       );
       expect(span.parentSpan, equals(transactionSpan));
     });
+
+    group('when a failed request is captured', () {
+      test('links the error to the db span', () async {
+        fixture.mockHttpClient.statusCode = 500;
+
+        late SentrySpanV2 transactionSpan;
+        await fixture.hub.startSpan(
+          'test-transaction',
+          (span) async {
+            transactionSpan = span;
+            try {
+              await fixture.client.from('users').select().eq('id', 1);
+            } catch (_) {}
+          },
+          parentSpan: null,
+        );
+
+        await fixture.processor.waitForProcessing();
+        await pumpEventQueue();
+        final dbSpan = fixture.processor.findSpanByOperation('db.select')!;
+
+        final traceContext = fixture.capturedEvents.first.contexts.trace;
+        expect(traceContext?.spanId, dbSpan.spanId);
+        expect(traceContext?.parentSpanId, transactionSpan.spanId);
+        expect(traceContext?.traceId, transactionSpan.traceId);
+        expect(traceContext?.operation, 'db.select');
+      });
+
+      test('does not link the error when no span is active', () async {
+        fixture.mockHttpClient.statusCode = 500;
+
+        try {
+          await fixture.client.from('users').select().eq('id', 1);
+        } catch (_) {}
+        await pumpEventQueue();
+
+        expect(fixture.processor.findSpanByOperation('db.select'), isNull);
+        expect(
+          fixture.capturedEvents.first.contexts.trace?.parentSpanId,
+          isNull,
+        );
+      });
+    });
   });
 }
 
@@ -192,6 +235,7 @@ class Fixture {
   late final FakeTelemetryProcessor processor;
   late final SupabaseClient client;
   late final MockHttpClient mockHttpClient;
+  final capturedEvents = <SentryEvent>[];
 
   Fixture() {
     processor = FakeTelemetryProcessor();
@@ -199,7 +243,13 @@ class Fixture {
       ..automatedTestMode = true
       ..tracesSampleRate = 1.0
       ..traceLifecycle = SentryTraceLifecycle.stream
-      ..telemetryProcessor = processor;
+      ..telemetryProcessor = processor
+      // Records the event after the scope was applied and drops it, so no
+      // transport is involved.
+      ..beforeSend = (event, hint) {
+        capturedEvents.add(event);
+        return null;
+      };
     hub = Hub(options);
 
     options.addIntegration(InstrumentationSpanFactorySetupIntegration());
@@ -218,16 +268,19 @@ class Fixture {
 
   Future<void> tearDown() async {
     processor.clear();
+    capturedEvents.clear();
     await hub.close();
   }
 }
 
 class MockHttpClient extends BaseClient {
+  int statusCode = 200;
+
   @override
   Future<StreamedResponse> send(BaseRequest request) async {
     return StreamedResponse(
       Stream.fromIterable([]),
-      200,
+      statusCode,
       headers: {'content-type': 'application/json'},
     );
   }


### PR DESCRIPTION
## :scroll: Description

Errors captured while a streamed span is active now carry that span's trace context, so Sentry can link them to a span instead of only placing them in the trace.

**Core** — `Scope.applyToEvent` stamps `contexts.trace` from the active span-v2 and takes the transaction name from its segment. `Hub` attaches the span an event belongs to onto a per-capture scope copy, in `captureEvent`/`captureException` only. The error envelope's DSC now comes from the segment's frozen header instead of incomplete scope baggage.

**Integrations that capture** — `http`, Dio, gRPC, Supabase and GraphQL (`sentry_link`) report failures themselves, so they hand their span to that capture and the error links to *its own* span rather than to the parent. gRPC does it directly; the others register the span per request because span creation and error capture sit in different layers.

**Integrations that rethrow** — the database ones mark the span and rethrow, so the error is reported later by application code or a global handler, when the span has ended and is reachable from nothing. The throwable is the only handle that travels that far, so it becomes the key: the streaming span registers itself against it, and the capture path resolves it back and stamps the event through the same scope path. This covers `drift`, `sqflite`, `hive`, `isar` and `file`, and restores under streaming what `Hub._throwableToSpan` already does for static tracing.

Where several links are possible the most specific wins: an explicit `withScope` span, then the span the throwable aborted, then the ambient active span.

No public API changes; `InstrumentationSpan.applyToScope`, `RequestSpanRegistry` and `ThrowableSpanRegistry` are all `@internal`.

## :bulb: Motivation and Context

Under `SentryTraceLifecycle.stream` there is no `scope.span`, so errors fell through to `SentryTraceContext.fromPropagationContext`, which mints a span id belonging to no span. Trace grouping worked, but the error-to-span link did not. This is the streaming equivalent of what the JS SDK does in `applySpanToEvent`.

`StreamingInstrumentationSpan.throwable` also wrote to a field nothing read, so every `span.throwable = e` in the database integrations was silently inert — the static-mode link had no streaming counterpart.

## :green_heart: How did you test it?

Unit tests per piece (hub seeding and precedence, scope apply, envelope DSC) plus end-to-end tests per integration: each asserts the error's trace context matches the instrumentation span's own id, and that nothing is linked when no span is involved. Asserting the exact span id matters — a weaker assertion would pass on the ambient-span fallback alone. The drift test drives a real failing query and reports the error after it escaped the span, which is the path that was broken.

Full suites pass: `sentry` (1724), `sentry_flutter` (1077), `sentry_sqflite` (113), `sentry_isar` (108), `sentry_supabase` (96), `sentry_hive` (94), `sentry_dio` (88), `sentry_grpc` (38), `sentry_drift` (36), `sentry_file` (29), `sentry_logging` (23), `sentry_link` (9).

Manually on an iOS simulator using two new demo buttons in the Flutter example. Both errors arrived in `sentry-flutter` with the span name as `transaction` — trace `2b5e767b74594702abf391f2bd5ba1b3`.

## :pencil: Checklist
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec
- [x] No breaking changes

## :crystal_ball: Next steps

- Throwables that `Expando` cannot key — strings, numbers, booleans, records — are skipped rather than wrapped. Static tracing wraps them, but at the cost of a set that grows without bound, so this is deliberate.
- Non-error envelopes (logs, metrics, outbound `baggage` headers) still carry an incomplete DSC. Fixable generally by freezing the root span's DSC into the propagation context.
- `captureMessage` and `captureFeedback` don't link to spans yet — additive follow-up if wanted.
- Dio's `FailedRequestInterceptor` only captures failures with a matching status code, so connection errors are never captured or linked there. Pre-existing behaviour, not changed here.

Made with [Cursor](https://cursor.com)
