### PR TITLE
chore: Add melos commands for example app and e2e tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,21 @@ melos bootstrap
 
 This resolves all package dependencies and configures git hooks for pre-commit checks.
 
+### 4. Common commands
+
+Run these from the repo root. Use `melos run --list` to see all available scripts and their
+descriptions.
+
+| Command | What it does |
+|---------|--------------|
+| `melos run analyze:dart` | Run `dart analyze` on Dart-only packages |
+| `melos run analyze:flutter` | Run `flutter analyze` on Flutter packages |
+| `melos run format` | Apply formatting to all packages |
+| `melos run test:dart` | Run tests for Dart-only packages |
+| `melos run test:flutter` | Run tests for Flutter packages |
+| `melos run example:flutter -- <platform>` | Build & run the Flutter example (`ios`, `android`, `web`, `macos`, `windows`, or `linux`) |
+| `melos run e2e:dart` | Run the Dart e2e test against sentry.io (requires `SENTRY_AUTH_TOKEN_E2E`) |
+
 ## Project Structure
 
 ### Core SDKs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ descriptions.
 | `melos run format` | Apply formatting to all packages |
 | `melos run test:dart` | Run tests for Dart-only packages |
 | `melos run test:flutter` | Run tests for Flutter packages |
-| `melos run example:flutter -- <platform>` | Build & run the Flutter example (`ios`, `android`, `web`, `macos`, `windows`, or `linux`) |
+| `melos run example:flutter -- <platform>` | Build & run the Flutter example (`ios`, `android`, `web`, `macos`, or `linux`; not supported on Windows, since melos runs scripts through `cmd.exe` there) |
 | `melos run e2e:dart` | Run the Dart e2e test against sentry.io (requires `SENTRY_AUTH_TOKEN_E2E`) |
 
 ## Project Structure

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,6 @@ descriptions.
 | `melos run test:dart` | Run tests for Dart-only packages |
 | `melos run test:flutter` | Run tests for Flutter packages |
 | `melos run example:flutter -- <platform>` | Build & run the Flutter example (`ios`, `android`, `web`, `macos`, or `linux`; not supported on Windows, since melos runs scripts through `cmd.exe` there) |
-| `melos run e2e:dart` | Run the Dart e2e test against sentry.io (requires `SENTRY_AUTH_TOKEN_E2E`) |
 
 ## Project Structure
 

--- a/melos.yaml
+++ b/melos.yaml
@@ -58,7 +58,8 @@ scripts:
     run: cd packages/flutter/example && ./run.sh
     description: |
       Build & run the Flutter example in release mode with obfuscation and symbol upload.
-      Usage: melos run example:flutter -- <ios|android|web|macos|windows|linux>
+      Usage: melos run example:flutter -- <ios|android|web|macos|linux>
+      Not supported on Windows: melos runs scripts through cmd.exe there, which can't execute run.sh.
 
   e2e:dart:
     run: cd e2e_test && dart pub get && dart run --define=SENTRY_ENVIRONMENT=e2e

--- a/melos.yaml
+++ b/melos.yaml
@@ -54,6 +54,20 @@ scripts:
       flutter: true
       dirExists: test
 
+  example:flutter:
+    run: cd packages/flutter/example && ./run.sh
+    description: |
+      Build & run the Flutter example in release mode with obfuscation and symbol upload.
+      Usage: melos run example:flutter -- <ios|android|web|macos|windows|linux>
+
+  e2e:dart:
+    run: cd e2e_test && dart pub get && dart run --define=SENTRY_ENVIRONMENT=e2e
+    description: |
+      Run the Dart e2e test against sentry.io. Requires SENTRY_AUTH_TOKEN_E2E.
+      Keep in sync with .github/workflows/e2e_dart.yml.
+    env:
+      SENTRY_DIST: '1'
+
   # Lifecycle script, executed as part of `melos clean`.
   postclean: melos exec --flutter -- "flutter clean"
 

--- a/melos.yaml
+++ b/melos.yaml
@@ -61,14 +61,6 @@ scripts:
       Usage: melos run example:flutter -- <ios|android|web|macos|linux>
       Not supported on Windows: melos runs scripts through cmd.exe there, which can't execute run.sh.
 
-  e2e:dart:
-    run: cd e2e_test && dart pub get && dart run --define=SENTRY_ENVIRONMENT=e2e
-    description: |
-      Run the Dart e2e test against sentry.io. Requires SENTRY_AUTH_TOKEN_E2E.
-      Keep in sync with .github/workflows/e2e_dart.yml.
-    env:
-      SENTRY_DIST: '1'
-
   # Lifecycle script, executed as part of `melos clean`.
   postclean: melos exec --flutter -- "flutter clean"
 

--- a/packages/flutter/example/run.sh
+++ b/packages/flutter/example/run.sh
@@ -11,6 +11,11 @@ CURRENT_DATE=$(date +%Y-%m-%d_%H-%M-%S)
 
 export SENTRY_RELEASE="$CURRENT_DATE"@"$VERSION"
 
+if [ $# -lt 1 ]; then
+    echo -e "[\033[92mrun\033[0m] Pass the platform you'd like to run: android, ios, macos, windows, linux, web"
+    exit 1
+fi
+
 echo -e "[\033[92mrun\033[0m] $1"
 
 # using 'build' as the base dir because `flutter clean` will delete it, so we don't end up with leftover symbols from a previous build


### PR DESCRIPTION
## :scroll: Description

Adds two melos scripts:

- `melos run example:flutter -- <platform>` — builds and runs the Flutter example app (delegates to the existing `packages/flutter/example/run.sh`, so there's still one source of truth for the build logic).
- `melos run e2e:dart` — runs the Dart e2e suite against sentry.io (mirrors `.github/workflows/e2e_dart.yml`, requires `SENTRY_AUTH_TOKEN_E2E` locally).

Also documents the existing and new scripts in a "Common commands" table in `CONTRIBUTING.md`, and fixes a small bug in `run.sh` where calling it with no arguments crashed on an unbound variable (`set -u`) instead of printing the usage message.

## :bulb: Motivation and Context

Closes #3660

Building the example app and running the e2e suite both require remembering raw shell commands that live in a few different places (`run.sh`, CI workflow files). This wraps them behind `melos run`, which is discoverable via `melos run --list`.

I kept this scoped to the two examples the issue calls out rather than guessing at everything "and so on" might cover.

## :green_heart: How did you test it?

- `melos run example:flutter -- ""` to confirm the script forwards args correctly and the run.sh usage guard fires as expected.
- `melos run e2e:dart` to confirm it resolves dependencies and fails fast with a clear error when `SENTRY_AUTH_TOKEN_E2E` isn't set (same behavior as CI without the secret).
- `bash -n packages/flutter/example/run.sh` to sanity check the shell syntax.

## :pencil: Checklist

- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec
- [x] No breaking changes

## :crystal_ball: Next steps

If there's appetite for it, a follow-up could tighten `test:dart`/`test:flutter`/`analyze:*` to match the flags CI actually uses (randomized test ordering, web/wasm runs, `--fatal-infos`), since those currently drift from what CI checks.