### PR TITLE
ci: Remove secrets: inherit from changelog-preview workflow

### DIFF
--- a/.github/workflows/changelog-preview.yml
+++ b/.github/workflows/changelog-preview.yml
@@ -16,4 +16,3 @@ permissions:
 jobs:
   changelog-preview:
     uses: getsentry/craft/.github/workflows/changelog-preview.yml@cdb657d4bbc70cd497876ad158984b4d345a48ae # v2
-    secrets: inherit


### PR DESCRIPTION
## Summary
- `changelog-preview.yml` used `secrets: inherit` when calling the reusable `getsentry/craft/.github/workflows/changelog-preview.yml`, exposing every repository secret to the called workflow.
- The called workflow only declares `inputs` under `workflow_call` (no `secrets`) and only reads the auto-provisioned `${{ secrets.GITHUB_TOKEN }}`, which reusable workflows already receive without inheritance.
- Removed `secrets: inherit` entirely — no explicit secrets map is needed. Note: unlike most other repos with this exact pattern, this workflow is `active` on GitHub (not disabled), so it's fixed in place rather than deleted.

## Test plan
- [x] Confirmed the pinned `getsentry/craft/.github/workflows/changelog-preview.yml@cdb657d` declares no `workflow_call.secrets` and only uses `secrets.GITHUB_TOKEN`
- [x] Confirmed via GitHub API that this workflow's state is `active`
- [ ] Verify the Changelog Preview check still runs and posts correctly on this PR

Fixes VULN-2251

🤖 Generated with [Claude Code](https://claude.com/claude-code)