### PR TITLE
ci: Replace curl-pipe-bash with action-setup-cli for Sentry CLI setup

### DIFF
--- a/.github/actions/size-analysis-setup/action.yml
+++ b/.github/actions/size-analysis-setup/action.yml
@@ -20,8 +20,7 @@ runs:
 
     - name: Install Sentry CLI
       if: env.SENTRY_AUTH_TOKEN != ''
-      shell: bash
-      run: curl -sL https://sentry.io/get-cli/ | sh
+      uses: getsentry/action-setup-cli@70d7e587b84c2e78cf4d37cd33d7b74fb3729c1b # v1
 
     - name: Determine build version
       shell: bash


### PR DESCRIPTION
## Summary
- The "Install Sentry CLI" step in `size-analysis-setup/action.yml` used `curl -sL https://sentry.io/get-cli/ | sh`, piping a remote install script directly into a shell.
- Replaced it with [`getsentry/action-setup-cli`](https://github.com/getsentry/action-setup-cli), which downloads the `sentry-cli` release asset for the runner's OS/arch and verifies its sha256 against the digest GitHub recorded for that asset via the Releases API, before adding it to `PATH`. Uses `gh` only, no `curl`.
- Preserved the existing `if: env.SENTRY_AUTH_TOKEN != ''` condition.

## Test plan
- [x] Validated `action.yml` parses correctly
- [ ] Verify size analysis jobs still install sentry-cli correctly on this PR

Fixes VULN-2252

🤖 Generated with [Claude Code](https://claude.com/claude-code)