### PR TITLE
fix(dart): Fix inApp detection for web stacktraces

### DIFF
--- a/packages/dart/lib/src/sentry_stack_trace_factory.dart
+++ b/packages/dart/lib/src/sentry_stack_trace_factory.dart
@@ -61,6 +61,24 @@ class SentryStackTraceFactory {
     );
   }
 
+  // `package:stack_trace`'s V8 trace parser unconditionally treats the
+  // first line as an exception-message header and skips it. dart2wasm's
+  // `StackTrace.toString()` - unlike a real V8 JS error - never includes
+  // that header, so the parser silently drops the first (often only) real
+  // frame. Detect that shape and prepend a synthetic header line to absorb
+  // the skip instead.
+  static final _v8FrameLineStart = RegExp(r'^\s{0,4}at ');
+
+  String _ensureV8MessageHeader(String stackTrace) {
+    final firstNewline = stackTrace.indexOf('\n');
+    final firstLine =
+        firstNewline == -1 ? stackTrace : stackTrace.substring(0, firstNewline);
+    if (_v8FrameLineStart.hasMatch(firstLine)) {
+      return '\n$stackTrace';
+    }
+    return stackTrace;
+  }
+
   _StackInfo _parseStackTrace(dynamic stackTrace) {
     if (stackTrace is Chain) {
       return _StackInfo(stackTrace.traces);
@@ -87,8 +105,9 @@ class SentryStackTraceFactory {
       //     #01 abs 000000723d637527 _kDartIsolateSnapshotInstructions+0x1e5527
 
       final startOffset = _frameRegex.firstMatch(stackTrace)?.start ?? 0;
-      final chain = Chain.parse(
-          startOffset == 0 ? stackTrace : stackTrace.substring(startOffset));
+      final trimmed =
+          startOffset == 0 ? stackTrace : stackTrace.substring(startOffset);
+      final chain = Chain.parse(_ensureV8MessageHeader(trimmed));
       final info = _StackInfo(chain.traces);
       info.buildId = buildIdRegex.firstMatch(stackTrace)?.group(1);
       info.baseAddr = _baseAddrRegex.firstMatch(stackTrace)?.group(1);
@@ -100,9 +119,55 @@ class SentryStackTraceFactory {
     return _StackInfo([]);
   }
 
+  // DDC (`flutter run -d chrome`) serves every pub package's sources under
+  // this path prefix - there's no `package:` scheme on web, so this is the
+  // only signal available to recover the package name.
+  static final _webPackagePath = RegExp(r'(?:^|/)packages/([^/]+)/(.+)$');
+
+  // DDC also serves the Dart SDK sources it's compiled against under this
+  // path prefix.
+  static final _webSdkPath = RegExp(r'(?:^|/)dart-sdk/lib/(.+)$');
+
+  /// Rewrites a DDC-served web frame's URI back into the `package:`/`dart:`
+  /// shape [_isInApp] and [_absolutePathForCrashReport] already understand.
+  /// No-op for anything that isn't a recognized DDC path (in particular,
+  /// release/profile web builds, where app and dependency code share a
+  /// single bundle URL with no per-frame signal to recover).
+  Frame _normalizeWebFrame(Frame frame) {
+    final uri = frame.uri;
+    if (uri.scheme == 'package' || uri.scheme == 'dart') {
+      return frame;
+    }
+
+    final packageMatch = _webPackagePath.firstMatch(uri.path);
+    if (packageMatch != null) {
+      return Frame(
+        Uri.parse('package:${packageMatch.group(1)}/${packageMatch.group(2)}'),
+        frame.line,
+        frame.column,
+        frame.member,
+      );
+    }
+
+    final sdkMatch = _webSdkPath.firstMatch(uri.path);
+    if (sdkMatch != null) {
+      return Frame(
+        Uri.parse('dart:${sdkMatch.group(1)}'),
+        frame.line,
+        frame.column,
+        frame.member,
+      );
+    }
+
+    return frame;
+  }
+
   /// converts [Frame] to [SentryStackFrame]
   @visibleForTesting
-  SentryStackFrame? encodeStackTraceFrame(Frame frame) {
+  SentryStackFrame? encodeStackTraceFrame(Frame originalFrame) {
+    final frame = _options.platform.isWeb
+        ? _normalizeWebFrame(originalFrame)
+        : originalFrame;
     final member = frame.member;
 
     if (frame is UnparsedFrame && member != null) {
@@ -209,7 +274,33 @@ class SentryStackTraceFactory {
       return false;
     }
 
+    if (_options.platform.isWeb && _isKnownNonAppWebAsset(frame)) {
+      return false;
+    }
+
     return _options.considerInAppFramesByDefault;
+  }
+
+  // Bundled Flutter/engine web assets that never carry app code. In release
+  // and profile web builds, app code and every pub dependency are compiled
+  // into a single JS/wasm bundle with no per-frame signal to separate them -
+  // this denylist is the honest ceiling of what's classifiable client-side
+  // in that mode.
+  static const _nonAppWebAssets = {
+    'flutter.js',
+    'flutter_bootstrap.js',
+    'flutter_service_worker.js',
+    'canvaskit.js',
+    'skwasm.js',
+    'skwasm_st.js',
+    'skwasm_heavy.js',
+    'dart_sdk.js',
+  };
+
+  bool _isKnownNonAppWebAsset(Frame frame) {
+    final segments = frame.uri.pathSegments;
+    final fileName = segments.isEmpty ? '' : segments.last;
+    return _nonAppWebAssets.contains(fileName);
   }
 }
 

--- a/packages/dart/test/stack_trace_test.dart
+++ b/packages/dart/test/stack_trace_test.dart
@@ -68,6 +68,119 @@ void main() {
       expect(serializedFrame.inApp, false);
     });
 
+    group('on web with DDC-style packages/ path', () {
+      test('flutter package frame is not inApp', () {
+        final frame = Frame(
+          Uri.parse(
+              'http://localhost:8080/packages/flutter/src/widgets/framework.dart'),
+          1,
+          2,
+          'buzz',
+        );
+        final fixture = Fixture()..options.platform = MockPlatform(isWeb: true);
+        final serializedFrame = fixture.getSut().encodeStackTraceFrame(frame)!;
+
+        expect(serializedFrame.inApp, false);
+        expect(serializedFrame.package, 'flutter');
+      });
+
+      test('app package frame is inApp by default', () {
+        final frame = Frame(
+          Uri.parse('http://localhost:8080/packages/my_app/main.dart'),
+          1,
+          2,
+          'buzz',
+        );
+        final fixture = Fixture()..options.platform = MockPlatform(isWeb: true);
+        final serializedFrame = fixture.getSut().encodeStackTraceFrame(frame)!;
+
+        expect(serializedFrame.inApp, true);
+        expect(serializedFrame.package, 'my_app');
+      });
+
+      test('inAppExcludes applies to matched package name', () {
+        final frame = Frame(
+          Uri.parse('http://localhost:8080/packages/toolkit/baz.dart'),
+          1,
+          2,
+          'buzz',
+        );
+        final fixture = Fixture()..options.platform = MockPlatform(isWeb: true);
+        final serializedFrame = fixture
+            .getSut(inAppExcludes: ['toolkit']).encodeStackTraceFrame(frame)!;
+
+        expect(serializedFrame.inApp, false);
+      });
+
+      test('dart SDK path frame is not inApp', () {
+        final frame = Frame(
+          Uri.parse('http://localhost:8080/dart-sdk/lib/core/errors.dart'),
+          1,
+          2,
+          'buzz',
+        );
+        final fixture = Fixture()..options.platform = MockPlatform(isWeb: true);
+        final serializedFrame = fixture.getSut().encodeStackTraceFrame(frame)!;
+
+        expect(serializedFrame.inApp, false);
+      });
+
+      test('abs_path keeps the full package path instead of the basename', () {
+        final frame = Frame(
+          Uri.parse(
+              'http://localhost:8080/packages/flutter/src/widgets/framework.dart'),
+          1,
+          2,
+          'buzz',
+        );
+        final fixture = Fixture()..options.platform = MockPlatform(isWeb: true);
+        final serializedFrame = fixture.getSut().encodeStackTraceFrame(frame)!;
+
+        expect(serializedFrame.absPath,
+            '${eventOrigin}package:flutter/src/widgets/framework.dart');
+      });
+
+      test('module is populated when includeModuleInStackTrace is enabled', () {
+        final frame = Frame(
+          Uri.parse(
+              'http://localhost:8080/packages/my_app/features/login.dart'),
+          1,
+          2,
+          'buzz',
+        );
+        final fixture = Fixture()..options.platform = MockPlatform(isWeb: true);
+        final serializedFrame = fixture
+            .getSut(includeModuleInStackTrace: true)
+            .encodeStackTraceFrame(frame)!;
+
+        expect(serializedFrame.module, 'my_app/features');
+      });
+    });
+
+    group('on web release builds with no packages/ path signal', () {
+      test('known Flutter web bootstrap asset is not inApp', () {
+        final frame =
+            Frame(Uri.parse('https://example.com/flutter.js'), 1, 2, 'buzz');
+        final fixture = Fixture()..options.platform = MockPlatform(isWeb: true);
+        final serializedFrame = fixture.getSut().encodeStackTraceFrame(frame)!;
+
+        expect(serializedFrame.inApp, false);
+      });
+
+      test('single-bundle app frame falls back to considerInAppFramesByDefault',
+          () {
+        final frame =
+            Frame(Uri.parse('https://example.com/main.dart.js'), 1, 2, 'buzz');
+        final fixture = Fixture()..options.platform = MockPlatform(isWeb: true);
+        final serializedFrame = fixture.getSut().encodeStackTraceFrame(frame)!;
+
+        // Honest ceiling: app code and every dependency share this exact
+        // bundle URL in release/profile builds, so there's no way to tell
+        // them apart here - it must fall back to the configured default.
+        expect(serializedFrame.inApp, true);
+      });
+    });
+
     test('apply inAppIncludes with precedence', () {
       final frame = Frame(Uri.parse('package:toolkit/baz.dart'), 1, 2, 'buzz');
       final serializedFrame = Fixture().getSut(
@@ -300,6 +413,36 @@ isolate_instructions: 10fa27070, vm_instructions: 10fa21e20
           'platform': 'dart',
         }
       ]);
+    });
+
+    group('with a dart2wasm-style trace missing a message header', () {
+      // No leading newline: this mirrors the real StackTrace.toString()
+      // output on dart2wasm, which - unlike V8 JS errors - never prefixes
+      // the frames with an exception-message line.
+      final wasmTrace =
+          '    at wasm://wasm/00076276:wasm-function[123]:0xaded\n'
+          '    at InstantiatedApp.invokeMain (file:///main2.mjs:352:37)\n'
+          '    at file:///run_wasm2.mjs:6:12';
+
+      test('does not drop the first frame', () {
+        final frames = Fixture()
+            .getSut(considerInAppFramesByDefault: true)
+            .parse(wasmTrace)
+            .frames;
+
+        expect(frames, hasLength(3));
+      });
+    });
+
+    test('a normal V8 trace with a message header keeps its frame count', () {
+      final frames = Fixture()
+          .getSut(considerInAppFramesByDefault: true)
+          .parse('Error: boom\n'
+              '    at Object.deep (main.js:5202:17)\n'
+              '    at main (main.js:5217:9)')
+          .frames;
+
+      expect(frames, hasLength(2));
     });
 
     test('remove frames if only async gap is left', () {


### PR DESCRIPTION
## :scroll: Description

On Flutter Web, stack frames never carry `dart:`/`package:` URIs the way VM stack frames do — the browser reports plain `https://…` (or `dart-sdk/lib/...`, `packages/<pkg>/...`) URLs instead. `SentryStackTraceFactory._isInApp` only knew how to classify `dart:`/`package:` schemes, so it always fell through to `considerInAppFramesByDefault` (`true`) on web. In practice, that meant **every** frame on Flutter Web — your own code, the Flutter framework, and every pub dependency — was marked `in_app: true`.

This PR:

- Normalizes DDC (`flutter run -d chrome`) frame URIs served under `packages/<pkg>/...` and `dart-sdk/lib/...` back into `package:pkg/...` / `dart:...` shapes before classification runs. This makes the existing `dart:`/`package:flutter` checks work on web for the first time, and also makes `inAppIncludes`/`inAppExcludes` usable on web (previously silently a no-op, since they key off `Frame.package`, which requires a `package:` scheme). As a side effect, `abs_path` for these frames now keeps the full path instead of being truncated to just the file's basename, and `module` gets populated when `includeModuleInStackTrace` is on.
- Adds a small denylist for known Flutter/engine web bootstrap assets (`flutter.js`, `canvaskit.js`, `dart_sdk.js`, etc.) so those are never marked in-app either.
- Fixes a related, separate bug found while investigating: `package:stack_trace`'s V8 parser assumes the first line of a stack trace string is an exception message and unconditionally skips it. dart2wasm's `StackTrace.toString()` has no such header line, so the parser was silently dropping the first (and often only) real frame on `flutter build web --wasm`. Fixed by detecting that shape and prepending a synthetic header line before parsing.

**Known limitation, called out explicitly rather than silently punted:** in release/profile web builds (dart2js/dart2wasm), the entire app plus every pub dependency compile into a single bundle file, so every frame shares the exact same URL — there is no per-frame signal left for a client-side fix to separate app code from dependency code in that mode. The denylist above is the honest ceiling of what's achievable there. A more complete fix for release-mode `.pub-cache` frames (the example in the original issue) likely also needs a change to Sentry's server-side stack trace enhancer rules, since the existing `.pub-cache` rule is gated to `family:native` and never fires for web's `family:javascript` frames — tracked separately, out of scope for this SDK-side PR.

## :bulb: Motivation and Context

Fixes #3510. Flutter Web users had no working in-app/not-in-app grouping signal at all — every frame, including framework and third-party code, showed up as in-app, which pollutes Sentry's default grouping and suspect-frame selection for web issues.

## :green_heart: How did you test it?

Added test coverage in `packages/dart/test/stack_trace_test.dart`:
- DDC `packages/<pkg>/...` and `dart-sdk/lib/...` frame normalization, including that `inAppIncludes`/`inAppExcludes` now apply, `abs_path` keeps the full path, and `module` gets populated.
- The release-mode denylist, plus a pinned regression test confirming a shared-bundle app frame still correctly falls back to `considerInAppFramesByDefault` (documents the deliberate limitation rather than hiding it).
- The dart2wasm first-frame-loss fix, plus a control test confirming a normal V8 trace with a real message header is unaffected.

All 28 tests in `stack_trace_test.dart` pass, along with downstream consumers (`sentry_client_test.dart`, `sentry_exception_factory_test.dart`, `load_dart_debug_images_integration_test.dart`).

**Note:** a full `dart test` run in this environment surfaces ~39 pre-existing failures in unrelated files (`sentry_tracer_test.dart`, `sentry_transaction_test.dart`, etc.), all from the same root cause (`MockHub.configureScope` unimplemented in `packages/_sentry_testing`). Verified via `git stash` that these fail identically without this PR's changes — pre-existing environment issue, not a regression from this change.

## :pencil: Checklist
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing (see note above re: pre-existing unrelated failures)
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the develop docs spec
- [x] No breaking changes to the public API

## :crystal_ball: Next steps

- File a follow-up against `getsentry/sentry` to extend the `.pub-cache` / `packages/flutter/**` stack trace enhancer rules to `family:javascript` (currently `family:native`-only), which is what actually resolves the `.pub-cache` example from the original issue for release-mode web events.

## Changelog Entry

Fixes Flutter Web stack frames not being correctly marked as `in_app`/not-`in_app`. **Note for reviewers:** this is a behavior change for existing Flutter Web users — frames that were previously (incorrectly) always `in_app: true` will now often be correctly marked `in_app: false` in debug-mode-style traces, which can shift Sentry's default grouping/culprit-frame selection for already-triaged issues. Worth flagging in release notes rather than treating as a silent patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)