### PR TITLE
fix(dart): Handle HTTP 413 in HttpTransport

### DIFF
--- a/packages/dart/lib/src/client_reports/discard_reason.dart
+++ b/packages/dart/lib/src/client_reports/discard_reason.dart
@@ -14,4 +14,5 @@ enum DiscardReason {
   rateLimitBackoff,
   internalSdkError,
   ignored,
+  sendError,
 }

--- a/packages/dart/lib/src/client_reports/discarded_event.dart
+++ b/packages/dart/lib/src/client_reports/discarded_event.dart
@@ -43,6 +43,8 @@ extension _OutcomeExtension on DiscardReason {
         return 'internal_sdk_error';
       case DiscardReason.ignored:
         return 'ignored';
+      case DiscardReason.sendError:
+        return 'send_error';
     }
   }
 }

--- a/packages/dart/lib/src/transport/http_transport.dart
+++ b/packages/dart/lib/src/transport/http_transport.dart
@@ -64,9 +64,14 @@ class HttpTransport implements Transport {
     if (response.statusCode == 200) {
       return _parseEventId(response);
     }
+    if (response.statusCode == 413) {
+      internalLogger
+          .error('Envelope discarded because it exceeded Sentry\'s maximum '
+              'envelope size limit (HTTP 413 Content Too Large)');
+    }
     if (response.statusCode >= 400 && response.statusCode != 429) {
       TransportUtils.recordLostEvents(
-          _options, envelope, DiscardReason.networkError);
+          _options, envelope, DiscardReason.sendError);
     }
     if (response.statusCode == 429) {
       internalLogger.warning('Rate limit reached, failed to send envelope');

--- a/packages/dart/test/transport/http_transport_test.dart
+++ b/packages/dart/test/transport/http_transport_test.dart
@@ -284,7 +284,7 @@ void main() {
       await sut.send(envelope);
 
       expect(fixture.clientReportRecorder.discardedEvents.first.reason,
-          DiscardReason.networkError);
+          DiscardReason.sendError);
       expect(fixture.clientReportRecorder.discardedEvents.first.category,
           DataCategory.error);
     });
@@ -309,12 +309,12 @@ void main() {
           .clientReportRecorder.discardedEvents
           .firstWhereOrNull((element) =>
               element.category == DataCategory.transaction &&
-              element.reason == DiscardReason.networkError);
+              element.reason == DiscardReason.sendError);
 
       final spanDiscardedEvent = fixture.clientReportRecorder.discardedEvents
           .firstWhereOrNull((element) =>
               element.category == DataCategory.span &&
-              element.reason == DiscardReason.networkError);
+              element.reason == DiscardReason.sendError);
 
       expect(transactionDiscardedEvent, isNotNull);
       expect(spanDiscardedEvent, isNotNull);
@@ -341,7 +341,7 @@ void main() {
       await sut.send(envelope);
 
       expect(fixture.clientReportRecorder.discardedEvents.first.reason,
-          DiscardReason.networkError);
+          DiscardReason.sendError);
       expect(fixture.clientReportRecorder.discardedEvents.first.category,
           DataCategory.feedback);
     });
@@ -378,9 +378,93 @@ void main() {
       await sut.send(envelope);
 
       expect(fixture.clientReportRecorder.discardedEvents.first.reason,
-          DiscardReason.networkError);
+          DiscardReason.sendError);
       expect(fixture.clientReportRecorder.discardedEvents.first.category,
           DataCategory.error);
+    });
+
+    test('does record lost event with send_error for 413', () async {
+      final httpMock = MockClient((http.Request request) async {
+        return http.Response('{}', 413);
+      });
+      final sut = fixture.getSut(httpMock, MockRateLimiter());
+
+      final sentryEvent = SentryEvent();
+      final envelope = SentryEnvelope.fromEvent(
+        sentryEvent,
+        fixture.options.sdk,
+        dsn: fixture.options.dsn,
+      );
+      await sut.send(envelope);
+
+      expect(fixture.clientReportRecorder.discardedEvents.first.reason,
+          DiscardReason.sendError);
+      expect(fixture.clientReportRecorder.discardedEvents.first.category,
+          DataCategory.error);
+    });
+  });
+
+  group('413 logging', () {
+    late Fixture fixture;
+    final logCalls = <_LogCall>[];
+
+    setUp(() {
+      fixture = Fixture();
+      logCalls.clear();
+      SentryInternalLogger.configure(
+        isEnabled: true,
+        minLevel: SentryLevel.error,
+        logOutput: ({
+          required String name,
+          required SentryLevel level,
+          required String message,
+          Object? error,
+          StackTrace? stackTrace,
+        }) {
+          logCalls.add(_LogCall(level, message));
+        },
+      );
+    });
+
+    tearDown(() {
+      SentryInternalLogger.configure(isEnabled: false);
+    });
+
+    test('logs error explaining the envelope was discarded for size', () async {
+      final httpMock = MockClient((http.Request request) async {
+        return http.Response('{}', 413);
+      });
+      final sut = fixture.getSut(httpMock, MockRateLimiter());
+
+      final sentryEvent = SentryEvent();
+      final envelope = SentryEnvelope.fromEvent(
+        sentryEvent,
+        fixture.options.sdk,
+        dsn: fixture.options.dsn,
+      );
+      await sut.send(envelope);
+
+      final sizeLimitLog =
+          logCalls.firstWhereOrNull((call) => call.message.contains('413'));
+      expect(sizeLimitLog, isNotNull);
+      expect(sizeLimitLog!.level, SentryLevel.error);
+    });
+
+    test('does not log size limit error for a plain 400', () async {
+      final httpMock = MockClient((http.Request request) async {
+        return http.Response('{}', 400);
+      });
+      final sut = fixture.getSut(httpMock, MockRateLimiter());
+
+      final sentryEvent = SentryEvent();
+      final envelope = SentryEnvelope.fromEvent(
+        sentryEvent,
+        fixture.options.sdk,
+        dsn: fixture.options.dsn,
+      );
+      await sut.send(envelope);
+
+      expect(logCalls.any((call) => call.message.contains('413')), isFalse);
     });
   });
 }
@@ -419,4 +503,11 @@ class Fixture {
       attributes: {},
     );
   }
+}
+
+class _LogCall {
+  final SentryLevel level;
+  final String message;
+
+  _LogCall(this.level, this.message);
 }

--- a/packages/dart/test/transport/http_transport_test.dart
+++ b/packages/dart/test/transport/http_transport_test.dart
@@ -444,8 +444,8 @@ void main() {
       );
       await sut.send(envelope);
 
-      final sizeLimitLog =
-          logCalls.firstWhereOrNull((call) => call.message.contains('413'));
+      final sizeLimitLog = logCalls.firstWhereOrNull(
+          (call) => call.message.contains('maximum envelope size limit'));
       expect(sizeLimitLog, isNotNull);
       expect(sizeLimitLog!.level, SentryLevel.error);
     });
@@ -464,7 +464,10 @@ void main() {
       );
       await sut.send(envelope);
 
-      expect(logCalls.any((call) => call.message.contains('413')), isFalse);
+      expect(
+          logCalls.any(
+              (call) => call.message.contains('maximum envelope size limit')),
+          isFalse);
     });
   });
 }


### PR DESCRIPTION
## :scroll: Description

`HttpTransport` (used by pure Dart apps and Flutter Desktop — Linux/Windows fall back to it since their native binding doesn't support `captureEnvelope`) now handles HTTP error responses per the [client-reports spec](https://develop.sentry.dev/sdk/telemetry/client-reports/#network-error-responses):

- Added `DiscardReason.sendError` (`"send_error"`).
- The `statusCode >= 400 && != 429` branch now records `DiscardReason.sendError` instead of `DiscardReason.networkError`. Per the spec, `network_error` is reserved for unretried connection-level failures (which the existing `catch` block already uses correctly); any HTTP error *response* — 413 included — should be `send_error`.
- A `413 Content Too Large` response additionally logs a distinct, actionable error explaining the envelope was discarded for exceeding Sentry's size limit, on top of the generic status/body log every non-200 response already gets.
- `429` handling is unchanged: still discarded, still no client report recorded (matches the spec's "MUST NOT record a client report" rule, since upstream already counts it).

## :bulb: Motivation and Context

Relay changed its response for oversized envelopes from HTTP 400 to HTTP 413 ([Relay #5474](https://github.com/getsentry/relay/pull/5474)) so SDKs can give users an actionable message instead of a silent drop. Investigating the fix surfaced that `HttpTransport` was already mislabeling **every** HTTP 4xx/5xx response (not just 413) with `networkError`, which contradicts the spec's discard-reason table — that reason is meant for real network/connection failures, not HTTP error responses.

Closes #3467 / [DART-296](https://linear.app/getsentry/issue/DART-296/sdk-handling-http-413-dartflutter).

Flutter's native `captureEnvelope` path (Android/iOS/macOS via sentry-android/sentry-cocoa) is unaffected by this change — those SDKs already own 413 compliance for mobile-originated sends independently of the Dart layer.

### SDK comparison

Before implementing, I checked how sentry-java, sentry-cocoa, sentry-javascript, and sentry-dotnet handle this, to align on the right shape rather than inventing our own:

| SDK | Generic 4xx/5xx (excl. 429) | 413 | 429 |
|---|---|---|---|
| **java** | discard, `send_error` | folded into the generic branch — no dedicated reason, just an extra log message | discard, no client report |
| **cocoa** | discard, `send_error` | folded into the generic branch — no dedicated reason, just an extra log message | discard, no client report |
| **dotnet** | discard, `send_error` | folded into the generic branch — no dedicated reason, just an extra log message | discard, no client report |
| **javascript** | discard, **no client report recorded** (dedicated 413 branch exists, but the generic 4xx/5xx path never calls `recordDroppedEvent` — an existing spec gap in that SDK) | discard, `send_error` (dedicated branch) | discard, no client report |
| **dart (this PR)** | discard, `send_error` (was `networkError` before this PR) | discard, `send_error` — folded into the generic branch, plus a distinct log message | discard, no client report (already correct) |

No SDK defines a dedicated "payload too large" discard reason — 413 always reuses `send_error`, matching the spec's design; the only differentiator across SDKs is whether/how a size-specific log message is added. This PR brings `sentry_dart` in line with the java/cocoa/dotnet shape. `sentry-javascript`'s generic-4xx gap is a separate, pre-existing issue in that repo, out of scope here.

## :green_heart: How did you test it?

- Added/updated tests in `packages/dart/test/transport/http_transport_test.dart`:
  - Existing 400/500/transaction+span/feedback discard-reason assertions updated from `networkError` to `sendError`.
  - New test asserting a 413 response records `send_error`.
  - New `413 logging` group asserting the size-limit error is logged for 413 and not logged for a plain 400.
- `dart analyze` and the full `packages/dart` test suite (1709 tests) pass.

## :pencil: Checklist

- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec
- [x] No breaking changes

## :crystal_ball: Next steps

None planned as part of this PR. Two related ideas came up during the SDK comparison but are intentionally out of scope: enriching the 413 log with envelope item types/byte size (cocoa-style), and an `onOversizedEvent`-style callback hook (java-style) — both would need their own spec if pursued.