### PR TITLE
build(flutter): Migrate Android plugin to built-in Kotlin

### DIFF
--- a/packages/flutter/android/build.gradle
+++ b/packages/flutter/android/build.gradle
@@ -1,5 +1,4 @@
 buildscript {
-    ext.kotlin_version = '1.8.0'
     repositories {
         google()
         mavenCentral()
@@ -7,7 +6,6 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:7.4.2'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
@@ -19,7 +17,6 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 36
@@ -56,15 +53,17 @@ android {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
     }
 }
 
 dependencies {
     api 'io.sentry:sentry-android:8.51.0'
     debugImplementation 'io.sentry:sentry-spotlight:8.51.0'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     // Required -- JUnit 4 framework
     testImplementation "junit:junit:4.13.2"

--- a/packages/flutter/microbenchmarks/android/settings.gradle
+++ b/packages/flutter/microbenchmarks/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.1.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.8.22" apply false
+    id "org.jetbrains.kotlin.android" version "2.0.21" apply false
 }
 
 include ":app"


### PR DESCRIPTION
## :scroll: Description

Follows the Flutter [built-in Kotlin migration guide for plugin authors](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors).

`packages/flutter` is the only package in the monorepo with Android native code. Its `android/build.gradle` now:

- no longer applies `kotlin-android` itself,
- no longer carries its own KGP `1.8.0` `buildscript` classpath,
- replaces `kotlinOptions` with a top-level `kotlin { compilerOptions { jvmTarget = JvmTarget.JVM_1_8 } }`,
- drops the explicit `kotlin-stdlib-jdk8` dependency, which was pinned to the now-removed `kotlin_version` and is added automatically by KGP.

The JVM target stays at 1.8 to match `compileOptions` in the same module — AGP fails the build if the Java and Kotlin targets diverge within a module, so raising it is a separate decision.

No `pubspec.yaml` change was needed: `sentry_flutter` already requires Flutter `>=3.44.0` and Dart `>=3.12.0`, which is exactly the floor the guide asks for. That is why this takes the guide's simple path rather than the backwards-compatible variant with the `agpMajor < 9` check.

Drive-by: `packages/flutter/microbenchmarks/android/settings.gradle` pinned KGP `1.8.22`, below the 2.0.0 minimum that Flutter 3.44 hard-errors on, so it is bumped to `2.0.21`. Note that project also pins AGP `8.1.0` while Flutter 3.44 errors below AGP `8.6.0`, so its Android build stays broken until AGP is bumped too — pre-existing, and CI only runs Dart analysis there.

## :bulb: Motivation and Context

Flutter is moving Kotlin compilation into AGP. Flutter 3.44 already prints an error-level warning naming `sentry_flutter` as a plugin that applies KGP, and future Flutter versions will fail the build outright for apps depending on such plugins. Migrating now keeps the SDK usable as apps move to AGP 9 and `android.builtInKotlin=true`.

Closes https://github.com/getsentry/sentry-dart/issues/3738

## :green_heart: How did you test it?

Verified against the Flutter 3.44.0 SDK source that this leaves the plugin buildable rather than assuming the guide holds:

- `FlutterPluginUtils.libPluginRegexGroovy` still matches our `apply plugin: 'com.android.library'` line while the KGP regexes no longer match anything, so Flutter classifies the project as a library without KGP and calls `pluginManager.apply("kotlin-android")` on our behalf.
- That happens inside `addFlutterTasks`, which runs eagerly while the app project's `plugins` block is evaluated, so KGP is applied before the plugin project's build script is evaluated and the `kotlin { }` extension exists by the time we reach it.

No local Android build was run; CI is the first build signal. `kotlin-version-compatibility.yml` is the job to watch — it builds the example APK against KGP 2.0.21 and 2.3.0, and after this change those versions compile the plugin's Kotlin too, instead of the 1.8.0 it was previously pinned to. That is the main risk in this diff: our Kotlin sources get compiled under a 2.x language version for the first time.

## :pencil: Checklist
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [ ] All tests passing
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec
- [x] No breaking changes

## :crystal_ball: Next steps

The example app, `min_version_test`, and `microbenchmarks` are apps and still apply KGP, which the guide permits. Migrating them needs AGP 9 + Flutter 3.47 + `android.builtInKotlin=true`, and `min_version_test` cannot move at all while our floor is Flutter 3.44.

## Changelog Entry

Migrate the Android plugin to Flutter's built-in Kotlin. `sentry_flutter` no longer applies the Kotlin Gradle Plugin itself, which silences Flutter 3.44's warning about plugins applying KGP and unblocks apps moving to AGP 9.