### PR TITLE
chore(flutter): Align Android plugin Kotlin and Gradle versions with the example app

### DIFF
--- a/packages/flutter/analysis_options.yaml
+++ b/packages/flutter/analysis_options.yaml
@@ -5,6 +5,13 @@ analyzer:
     - test/*.mocks.dart
     - microbenchmarks/**
     - lib/src/native/cocoa/binding.dart
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
   language:
     strict-casts: true
     strict-inference: true

--- a/packages/flutter/android/build.gradle
+++ b/packages/flutter/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.8.0'
+    ext.kotlin_version = '2.2.20'
     repositories {
         google()
         mavenCentral()

--- a/packages/flutter/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/flutter/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/packages/flutter/example/analysis_options.yaml
+++ b/packages/flutter/example/analysis_options.yaml
@@ -13,6 +13,14 @@ analyzer:
     deprecated_member_use_from_same_package: warning
     # ignore sentry/path on pubspec as we change it on deployment
     invalid_dependency: ignore
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 
 linter:
   rules:


### PR DESCRIPTION
## :scroll: Description

Build/tooling-only change in `packages/flutter`. No Dart or Kotlin source is touched and there is no public API change.

- `android/build.gradle` — `ext.kotlin_version` `1.8.0` → `2.2.20`
- `android/gradle/wrapper/gradle-wrapper.properties` — Gradle `7.5.1` → `7.6.6`
- `analysis_options.yaml` and `example/analysis_options.yaml` — add `exclude` entries for `build/**` and the platform folders (`android`, `ios`, `web`, `windows`, `macos`, `linux`)

## :bulb: Motivation and Context

**Kotlin version.**  The plugin module still declared KGP `1.8.0` in its own buildscript the kotlin version was failing to build for apps made with the new flutter 3.47.0 and also in addition  everything around it had already moved on: `example/android/settings.gradle` defaults `kotlinAndroidVersion` to `2.2.20`, and the compatibility matrix in `.github/workflows/kotlin-version-compatibility.yml` builds the example against KGP `2.2.20` and `2.3.0`. Aligning the plugin's buildscript to `2.2.20` means a standalone build of `packages/flutter/android` uses the same toolchain CI already exercises through the example app, instead of pulling a second, much older `kotlin-gradle-plugin` onto the classpath.

**Gradle version.** KGP 2.2.x requires Gradle 7.6.3 or newer, so the wrapper at `7.5.1` cannot run the bumped Kotlin plugin — the two changes go together. I picked `7.6.6` (latest 7.6.x patch) rather than Gradle 8 to keep this the smallest bump that clears the requirement.

**Analyzer excludes.** After a local build, `flutter analyze` in `packages/flutter` and `packages/flutter/example` picks up generated Dart under `build/` and under the platform directories, producing diagnostics that have nothing to do with SDK sources. Excluding those paths makes local analysis output match what CI reports on a clean checkout, without changing which SDK code is analyzed.

## :green_heart: How did you test it?

Verified locally:

* `flutter analyze` is clean in `packages/flutter` and `packages/flutter/example`, including after a local build that populates `build/` — which is the noise the new excludes are there to remove.
* `flutter build apk` succeeds for `packages/flutter/example` with the aligned Kotlin plugin version.
* Consumed the SDK from this branch in my own Flutter application and it builds and runs against Android as expected.

No tests were added: the change carries no runtime behavior. The existing `Kotlin Version Compatibility` and `flutter` workflows both trigger on these paths and cover the toolchain change in CI as well.

## :pencil: Checklist

- [x] I reviewed submitted code
- [x] I added tests to verify changes — n/a, build configuration only
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed — no user-facing docs affected
- [ ] All tests passing
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec — no public API change
- [x] No breaking changes

## :crystal_ball: Next steps




