### PR TITLE
docs(flutter): document add-to-app and replay when native init is off

### DIFF
--- a/packages/flutter/README.md
+++ b/packages/flutter/README.md
@@ -106,10 +106,34 @@ This includes all of Flutters internal access of `AssetBundle`s, like `Image.ass
 
 Please see the instructions [here](https://pub.dev/packages/sentry).
 
+##### Using with Flutter add-to-app
+
+If you [add Flutter to an existing Android or iOS app](https://docs.flutter.dev/add-to-app) that already starts a Sentry native SDK, keep that native init and tell the Flutter SDK not to start another one:
+
+```dart
+import 'package:flutter/widgets.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+Future<void> main() async {
+  await SentryFlutter.init(
+    (options) {
+      options.dsn = 'https://example@sentry.io/add-your-dsn-here';
+      options.autoInitializeNativeSdk = false;
+    },
+    appRunner: () => runApp(MyApp()),
+  );
+}
+```
+
+The native SDK has to be running before the Flutter engine starts, or events can be dropped. See the [native initialization guide](https://docs.sentry.io/platforms/dart/guides/flutter/native-init/).
+
+This flag only skips Flutter-driven native init. It does not turn the native layer off.
+
 ##### Known limitations
 
 - If you enable the `split-debug-info` feature, you must upload the Debug Symbols manually.
 - Layout related errors are only caught by [FlutterError.onError](https://api.flutter.dev/flutter/foundation/FlutterError/onError.html) in debug mode. In release mode, they are removed by the Flutter framework. See [Flutter build modes](https://flutter.dev/docs/testing/build-modes).
+- Session Replay does not work when `autoInitializeNativeSdk` is `false`. Replay is wired up while the Flutter SDK initializes the native SDKs, and that path is skipped if you init native yourself.
 
 ##### Uploading Debug Symbols and Source maps (Android, iOS/macOS and Web)
 

--- a/packages/flutter/lib/src/sentry_flutter_options.dart
+++ b/packages/flutter/lib/src/sentry_flutter_options.dart
@@ -26,10 +26,12 @@ class SentryFlutterOptions extends SentryOptions {
   }
 
   /// Initializes the Native SDKs on init.
-  /// Set this to `false` if you have an existing native SDK and don't want to re-initialize.
+  /// Set this to `false` if you have an existing native SDK and don't want to re-initialize,
+  /// for example in a Flutter [add-to-app](https://docs.flutter.dev/add-to-app) host.
   ///
   /// NOTE: Be careful and only use this if you know what you are doing.
   /// If you use this flag, make sure a native SDK is running before the Flutter Engine initializes or events might not be captured.
+  /// Flutter-driven native setup is skipped, including Session Replay, so replay will not work.
   /// Defaults to `true`.
   bool autoInitializeNativeSdk = true;
 


### PR DESCRIPTION
## Description

README now has an add-to-app snippet that sets `autoInitializeNativeSdk = false`. Known limitations mentions Session Replay does not work in that mode. The option dartdoc says the same.

## Motivation and Context

#2466 asked for add-to-app docs and the replay limitation when you init native yourself. buenaflor already confirmed replay setup is skipped on that path.

## How did you test it?

Read the native init path and the existing native-init guide. No runtime change.

## Checklist

- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [ ] All tests passing
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the develop docs spec
- [x] No breaking changes