### PR TITLE
fix(flutter): Support AGP 9's built-in Kotlin

### DIFF
--- a/packages/flutter/android/build.gradle
+++ b/packages/flutter/android/build.gradle
@@ -64,10 +64,20 @@ android {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
+}
+
+// compilerOptions needs KGP 2.0 / 1.9+. Flutter 3.24-era apps (and this
+// repo's min_version_test) still ship KGP 1.8.x, which only has kotlinOptions.
+def kotlinExt = project.extensions.findByName('kotlin')
+if (kotlinExt?.hasProperty('compilerOptions')) {
     kotlin {
         compilerOptions {
             jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
         }
+    }
+} else {
+    android.kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
 }
 

--- a/packages/flutter/android/build.gradle
+++ b/packages/flutter/android/build.gradle
@@ -19,7 +19,12 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+
+if (agpMajor < 9) {
+    apply plugin: 'kotlin-android'
+}
 
 android {
     compileSdkVersion 36
@@ -56,8 +61,10 @@ android {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8
+    kotlin {
+        compilerOptions {
+            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
+        }
     }
 }
 

--- a/packages/flutter/android/build.gradle
+++ b/packages/flutter/android/build.gradle
@@ -64,17 +64,9 @@ android {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
-    if (builtInKotlin) {
-        // JvmTarget.JVM_1_8 needs KGP 1.9.0+; only safe here because AGP 9's built-in Kotlin
-        // doesn't use this module's own (much older) pinned kotlin_version.
-        kotlin {
-            compilerOptions {
-                jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
-            }
-        }
-    } else {
-        kotlinOptions {
-            jvmTarget = '1.8'
+    kotlin {
+        compilerOptions {
+            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
         }
     }
 }

--- a/packages/flutter/android/build.gradle
+++ b/packages/flutter/android/build.gradle
@@ -21,8 +21,11 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+// android.builtInKotlin lets a project opt out of AGP 9's built-in Kotlin and fall back to the
+// standalone plugin, so it must be honored in addition to the AGP version.
+def builtInKotlin = agpMajor >= 9 && project.findProperty('android.builtInKotlin') != 'false'
 
-if (agpMajor < 9) {
+if (!builtInKotlin) {
     apply plugin: 'kotlin-android'
 }
 
@@ -61,9 +64,17 @@ android {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
-    kotlin {
-        compilerOptions {
-            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
+    if (builtInKotlin) {
+        // JvmTarget.JVM_1_8 needs KGP 1.9.0+; only safe here because AGP 9's built-in Kotlin
+        // doesn't use this module's own (much older) pinned kotlin_version.
+        kotlin {
+            compilerOptions {
+                jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
+            }
+        }
+    } else {
+        kotlinOptions {
+            jvmTarget = '1.8'
         }
     }
 }


### PR DESCRIPTION
AGP 9 makes the `org.jetbrains.kotlin.android` plugin redundant and rejects it outright at build time:

```
Failed to apply plugin 'org.jetbrains.kotlin.android'
The 'org.jetbrains.kotlin.android' plugin is no longer required for Kotlin support since AGP 9.0.
```

Guards the plugin application behind an AGP-major-version check and moves `jvmTarget` to the `compilerOptions` DSL, which works with both the standalone plugin (AGP < 9) and AGP 9's built-in Kotlin support ([reference](https://kotl.in/gradle/agp-built-in-kotlin)).

Tested against a Flutter 3.47 / AGP 9.3.0 app — builds cleanly with this change, fails without it.