### PR TITLE
fix(dart): Record client report outcome for dropped spans

### DIFF
--- a/packages/dart/lib/src/telemetry/processing/processor_integration.dart
+++ b/packages/dart/lib/src/telemetry/processing/processor_integration.dart
@@ -2,6 +2,7 @@ import 'package:meta/meta.dart';
 
 import '../../../sentry.dart';
 import '../../client_reports/discard_reason.dart';
+import '../../transport/data_category.dart';
 import '../../utils/internal_logger.dart';
 import 'in_memory_buffer.dart';
 import 'processor.dart';
@@ -67,6 +68,16 @@ class InMemoryTelemetryProcessorIntegration extends Integration<SentryOptions> {
       GroupedInMemoryTelemetryBuffer(
         encoder: (RecordingSentrySpanV2 item) =>
             utf8JsonEncoder.convert(item.toJson()),
+        onDrop: (item, {required cause, bytes}) {
+          switch (cause) {
+            case BufferDropCause.encodeFailed:
+              options.recorder.recordLostEvent(
+                  DiscardReason.internalSdkError, DataCategory.span);
+            case BufferDropCause.tooLarge:
+              options.recorder.recordLostEvent(
+                  DiscardReason.bufferOverflow, DataCategory.span);
+          }
+        },
         onFlush: (items) {
           final futures = items.values.map((itemData) {
             final span = itemData.$2;

--- a/packages/dart/test/telemetry/processing/processor_integration_test.dart
+++ b/packages/dart/test/telemetry/processing/processor_integration_test.dart
@@ -1,6 +1,7 @@
 import 'package:_sentry_testing/_sentry_testing.dart';
 import 'package:sentry/sentry.dart';
 import 'package:sentry/src/client_reports/discard_reason.dart';
+import 'package:sentry/src/transport/data_category.dart';
 import 'package:sentry/src/telemetry/processing/in_memory_buffer.dart';
 import 'package:sentry/src/telemetry/processing/processor.dart';
 import 'package:sentry/src/telemetry/processing/processor_integration.dart';
@@ -215,6 +216,29 @@ void main() {
 
         expect(fixture.transport.envelopes.first.header.traceContext?.replayId,
             SentryId.fromId('42'));
+      });
+
+      test('oversized span records buffer overflow client report', () async {
+        final options = fixture.options;
+        fixture.getSut().call(fixture.hub, options);
+
+        final processor =
+            options.telemetryProcessor as DefaultTelemetryProcessor;
+        final span = fixture.createSpan()
+          ..setAttribute(
+            'oversized',
+            SentryAttribute.string('x' * (1024 * 1024)),
+          );
+        span.end();
+        processor.addSpan(span);
+        await processor.flush();
+
+        expect(fixture.transport.envelopes, isEmpty);
+
+        final discardedEvent = fixture.recorder.discardedEvents.single;
+        expect(discardedEvent.reason, DiscardReason.bufferOverflow);
+        expect(discardedEvent.category, DataCategory.span);
+        expect(discardedEvent.quantity, 1);
       });
 
       test('adds span replay_id attribute to frozen envelope DSC', () async {


### PR DESCRIPTION
## :scroll: Description
Wires the `onDrop` callback of the span buffer (`GroupedInMemoryTelemetryBuffer` created in `InMemoryTelemetryProcessorIntegration._createSpanBuffer`) so that spans dropped by the buffer record a client report outcome, mirroring what #3745 already did for the log buffer.

- `buffer_overflow` when the encoded item exceeds the buffer limit
- `internal_sdk_error` when encoding fails

Both are recorded against the `span` data category via `recorder.recordLostEvent`. Spans have no `span_byte` category (unlike logs/metrics), so no byte-size outcome is recorded.

## :bulb: Motivation and Context
Previously, spans dropped by the buffer were silently lost without any discarded-event outcome, unlike logs and metrics which already had this wired up.

Fixes #3751

## :green_heart: How did you test it?
Unit tests. Added a red test (`oversized span records buffer overflow client report`) confirming the missing wiring before the fix, now passing.

I did not add an equivalent "unencodable span" integration test: `RecordingSentrySpanV2` is a `base class` with only a private constructor, so it can't be subclassed from test code to force `toJson()` to fail (unlike `SentryLog`/`SentryMetric`), and the encoder's JSON fallback stringifies otherwise-unencodable values rather than throwing. This matches the existing precedent in the same test file, where the log buffer only has an oversized-case test as well. The `encodeFailed` switch arm is implemented and structurally identical to the already-tested log/metric arms, and the underlying buffer-level `encodeFailed` → `onDrop` mechanism is generically covered in `buffer_test.dart`.

## :pencil: Checklist
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec
- [x] No breaking changes

## :crystal_ball: Next steps
None.