### PR TITLE
feat(replay): Mask SensitiveContent by default

### DIFF
--- a/packages/flutter/lib/src/sentry_privacy_options.dart
+++ b/packages/flutter/lib/src/sentry_privacy_options.dart
@@ -83,6 +83,14 @@ class SentryPrivacyOptions {
       );
     }
 
+    rules.add(
+      const SentryMaskingCustomRule<SensitiveContent>(
+        callback: _maskSensitiveContent,
+        name: 'SensitiveContent',
+        description: 'Mask SensitiveContent widget.',
+      ),
+    );
+
     // In Debug mode, check if users explicitly mask (or unmask) widgets that
     // look like they should be masked, e.g. Videos, WebViews, etc.
     if (runtimeChecker.isDebugMode()) {
@@ -199,4 +207,21 @@ SentryMaskingDecision _maskImagesExceptAssets(Element element, Image widget) {
     }
   }
   return SentryMaskingDecision.mask;
+}
+
+SentryMaskingDecision _maskSensitiveContent(
+  Element element,
+  SensitiveContent widget,
+) {
+  switch (widget.sensitivity) {
+    case ContentSensitivity.sensitive:
+    case ContentSensitivity.autoSensitive:
+      return SentryMaskingDecision.mask;
+    case ContentSensitivity.notSensitive:
+      return SentryMaskingDecision.continueProcessing;
+    // ContentSensitivity also has a private `_unknown` for future native
+    // modes Flutter does not recognize yet. Mask those.
+    default:
+      return SentryMaskingDecision.mask;
+  }
 }

--- a/packages/flutter/test/screenshot/masking_config_test.dart
+++ b/packages/flutter/test/screenshot/masking_config_test.dart
@@ -52,18 +52,14 @@ void main() async {
         expect(sut.shouldMask(element, element.widget), value);
       });
 
-      testWidgets(
-        'will not mask widget of a different type',
-        (tester) async {
-          final rootElement = await pumpTestElement(tester);
-          final element = rootElement.findFirstOfType<Text>();
-          expect(
-            sut.shouldMask(element, element.widget),
-            SentryMaskingDecision.continueProcessing,
-          );
-        },
-        skip: value == SentryMaskingDecision.unmask,
-      );
+      testWidgets('will not mask widget of a different type', (tester) async {
+        final rootElement = await pumpTestElement(tester);
+        final element = rootElement.findFirstOfType<Text>();
+        expect(
+          sut.shouldMask(element, element.widget),
+          SentryMaskingDecision.continueProcessing,
+        );
+      }, skip: value == SentryMaskingDecision.unmask);
     });
   }
 

--- a/packages/flutter/test/screenshot/masking_config_test.dart
+++ b/packages/flutter/test/screenshot/masking_config_test.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: invalid_use_of_internal_member
 
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
@@ -15,6 +16,8 @@ void main() async {
     'SentryMaskingConstantRule<SentryMask>(mask)',
     'SentryMaskingConstantRule<SentryUnmask>(unmask)',
   ];
+  const sensitiveContentRule =
+      'SentryMaskingCustomRule<SensitiveContent>(Mask SensitiveContent widget.)';
 
   testWidgets('will not mask if there are no rules', (tester) async {
     final sut = SentryMaskingConfig([]);
@@ -49,14 +52,18 @@ void main() async {
         expect(sut.shouldMask(element, element.widget), value);
       });
 
-      testWidgets('will not mask widget of a different type', (tester) async {
-        final rootElement = await pumpTestElement(tester);
-        final element = rootElement.findFirstOfType<Text>();
-        expect(
-          sut.shouldMask(element, element.widget),
-          SentryMaskingDecision.continueProcessing,
-        );
-      }, skip: value == SentryMaskingDecision.unmask);
+      testWidgets(
+        'will not mask widget of a different type',
+        (tester) async {
+          final rootElement = await pumpTestElement(tester);
+          final element = rootElement.findFirstOfType<Text>();
+          expect(
+            sut.shouldMask(element, element.widget),
+            SentryMaskingDecision.continueProcessing,
+          );
+        },
+        skip: value == SentryMaskingDecision.unmask,
+      );
     });
   }
 
@@ -188,6 +195,7 @@ void main() async {
         'SentryMaskingConstantRule<Text>(mask)',
         'SentryMaskingConstantRule<EditableText>(mask)',
         'SentryMaskingConstantRule<RichText>(mask)',
+        sensitiveContentRule,
         'SentryMaskingCustomRule<Widget>(Debug-mode-only warning for potentially sensitive widgets.)',
       ]);
     });
@@ -200,6 +208,7 @@ void main() async {
       expect(rulesAsStrings(sut), [
         ...alwaysEnabledRules,
         'SentryMaskingConstantRule<Image>(mask)',
+        sensitiveContentRule,
         'SentryMaskingCustomRule<Widget>(Debug-mode-only warning for potentially sensitive widgets.)',
       ]);
     });
@@ -212,6 +221,7 @@ void main() async {
       expect(rulesAsStrings(sut), [
         ...alwaysEnabledRules,
         'SentryMaskingCustomRule<Image>(Mask all images except asset images.)',
+        sensitiveContentRule,
         'SentryMaskingCustomRule<Widget>(Debug-mode-only warning for potentially sensitive widgets.)',
       ]);
     });
@@ -226,6 +236,7 @@ void main() async {
         'SentryMaskingConstantRule<Text>(mask)',
         'SentryMaskingConstantRule<EditableText>(mask)',
         'SentryMaskingConstantRule<RichText>(mask)',
+        sensitiveContentRule,
         'SentryMaskingCustomRule<Widget>(Debug-mode-only warning for potentially sensitive widgets.)',
       ]);
     });
@@ -237,8 +248,50 @@ void main() async {
         ..maskAssetImages = false;
       expect(rulesAsStrings(sut), [
         ...alwaysEnabledRules,
+        sensitiveContentRule,
         'SentryMaskingCustomRule<Widget>(Debug-mode-only warning for potentially sensitive widgets.)',
       ]);
+    });
+
+    group('when masking SensitiveContent', () {
+      Future<SentryMaskingDecision> decisionFor(
+        WidgetTester tester,
+        ContentSensitivity sensitivity,
+      ) async {
+        final sut = SentryPrivacyOptions()
+          ..maskAllText = false
+          ..maskAllImages = false;
+        final config = sut.buildMaskingConfig(RuntimeChecker());
+        final rootElement = await pumpTestElement(
+          tester,
+          children: [
+            SensitiveContent(sensitivity: sensitivity, child: const SizedBox()),
+          ],
+        );
+        final element = rootElement.findFirstOfType<SensitiveContent>();
+        return config.shouldMask(element, element.widget);
+      }
+
+      testWidgets('with sensitive masks the widget', (tester) async {
+        expect(
+          await decisionFor(tester, ContentSensitivity.sensitive),
+          SentryMaskingDecision.mask,
+        );
+      });
+
+      testWidgets('with autoSensitive masks the widget', (tester) async {
+        expect(
+          await decisionFor(tester, ContentSensitivity.autoSensitive),
+          SentryMaskingDecision.mask,
+        );
+      });
+
+      testWidgets('with notSensitive does not mask the widget', (tester) async {
+        expect(
+          await decisionFor(tester, ContentSensitivity.notSensitive),
+          SentryMaskingDecision.continueProcessing,
+        );
+      });
     });
 
     group('user rules', () {
@@ -248,6 +301,7 @@ void main() async {
         'SentryMaskingConstantRule<Text>(mask)',
         'SentryMaskingConstantRule<EditableText>(mask)',
         'SentryMaskingConstantRule<RichText>(mask)',
+        sensitiveContentRule,
         'SentryMaskingCustomRule<Widget>(Debug-mode-only warning for potentially sensitive widgets.)',
       ];
       test('mask() takes precedence', () {


### PR DESCRIPTION
## Summary

Mask Flutter's `SensitiveContent` widget in session replay / screenshot capture by default, respecting `ContentSensitivity`.

* `sensitive` and `autoSensitive` → mask the widget and its children
* `notSensitive` → continue processing so text/image rules can still apply to children

v10 already requires Flutter `>=3.44`, so this uses a typed `SentryMaskingCustomRule<SensitiveContent>` instead of the version-gate + dynamic `.sensitivity` probe from getsentry/sentry-dart#2989.

## Motivation

Users can already call `options.privacy.mask<SensitiveContent>()`. Privacy-sensitive widgets should be masked out of the box.

Closes getsentry/sentry-dart#2987

## Test plan

- [X] `fvm flutter test test/screenshot/masking_config_test.dart` (24 passed, 1 skipped)
- [X] `fvm flutter analyze` on the changed files
- [X] Confirm a `SensitiveContent(sensitivity: ContentSensitivity.sensitive)` widget is redacted in a replay capture
- [X] Confirm `ContentSensitivity.notSensitive` is not redacted by this rule

Made with [Cursor](<https://cursor.com>)