### PR TITLE
ci(testflight): Cancel overlapping TestFlight jobs

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -40,9 +40,11 @@ jobs:
           APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
           APP_STORE_CONNECT_KEY: ${{ secrets.APP_STORE_CONNECT_KEY }}
-          # Unique per run and re-run. Used as CFBundleVersion so overlapping
-          # jobs (and retries) never collide on App Store Connect.
-          FASTLANE_BUNDLE_VERSION: ${{ github.run_number * 100 + github.run_attempt }}
+          # Passed through to Fastlane, which combines them into a unique
+          # CFBundleVersion. GitHub Actions expressions do not support
+          # arithmetic, so the math lives in the Fastfile.
+          FASTLANE_BUNDLE_VERSION: ${{ github.run_number }}
+          FASTLANE_RUN_ATTEMPT: ${{ github.run_attempt }}
           FASTLANE_KEYCHAIN_PASSWORD: ${{ secrets.FASTLANE_KEYCHAIN_PASSWORD }}
           MATCH_GIT_PRIVATE_KEY: ${{ secrets.MATCH_GIT_PRIVATE_KEY }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -9,9 +9,6 @@ on:
       - '.github/workflows/testflight.yml'
   workflow_dispatch:
 
-# Same shape as other workflows (workflow + branch), but fall back to github.ref
-# instead of run_id. On push, head_ref is empty and run_id is unique, so that
-# fallback would not cancel overlapping main uploads of the same TestFlight app.
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -9,12 +9,11 @@ on:
       - '.github/workflows/testflight.yml'
   workflow_dispatch:
 
-# One group for the whole workflow: every run uploads the same TestFlight app.
-# Do not use `head_ref || run_id` like the test workflows — on push, head_ref is
-# empty and run_id is unique, so main uploads would still overlap. Cancel the
-# stale run so TestFlight tracks the latest commit.
+# Same shape as other workflows (workflow + branch), but fall back to github.ref
+# instead of run_id. On push, head_ref is empty and run_id is unique, so that
+# fallback would not cancel overlapping main uploads of the same TestFlight app.
 concurrency:
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -9,6 +9,9 @@ on:
       - '.github/workflows/testflight.yml'
   workflow_dispatch:
 
+# Same shape as other workflows (workflow + branch), but fall back to github.ref
+# instead of run_id. On push, head_ref is empty and run_id is unique, so that
+# fallback would not cancel overlapping main uploads of the same TestFlight app.
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -11,11 +11,11 @@ on:
 
 # One group for the whole workflow: every run uploads the same TestFlight app.
 # Do not use `head_ref || run_id` like the test workflows — on push, head_ref is
-# empty and run_id is unique, so main uploads would still overlap. Keep the
-# in-flight Apple upload running instead of cancelling it.
+# empty and run_id is unique, so main uploads would still overlap. Cancel the
+# stale run so TestFlight tracks the latest commit.
 concurrency:
   group: ${{ github.workflow }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   upload_to_testflight:

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -47,11 +47,7 @@ jobs:
           APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
           APP_STORE_CONNECT_KEY: ${{ secrets.APP_STORE_CONNECT_KEY }}
-          # Passed through to Fastlane, which combines them into a unique
-          # CFBundleVersion. GitHub Actions expressions do not support
-          # arithmetic, so the math lives in the Fastfile.
           FASTLANE_BUNDLE_VERSION: ${{ github.run_number }}
-          FASTLANE_RUN_ATTEMPT: ${{ github.run_attempt }}
           FASTLANE_KEYCHAIN_PASSWORD: ${{ secrets.FASTLANE_KEYCHAIN_PASSWORD }}
           MATCH_GIT_PRIVATE_KEY: ${{ secrets.MATCH_GIT_PRIVATE_KEY }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -9,6 +9,14 @@ on:
       - '.github/workflows/testflight.yml'
   workflow_dispatch:
 
+# One group for the whole workflow: every run uploads the same TestFlight app.
+# Do not use `head_ref || run_id` like the test workflows — on push, head_ref is
+# empty and run_id is unique, so main uploads would still overlap. Keep the
+# in-flight Apple upload running instead of cancelling it.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   upload_to_testflight:
     name: Build and Upload to Testflight

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -40,7 +40,9 @@ jobs:
           APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
           APP_STORE_CONNECT_KEY: ${{ secrets.APP_STORE_CONNECT_KEY }}
-          FASTLANE_BUNDLE_VERSION: ${{ github.run_number }}
+          # Unique per run and re-run. Used as CFBundleVersion so overlapping
+          # jobs (and retries) never collide on App Store Connect.
+          FASTLANE_BUNDLE_VERSION: ${{ github.run_number * 100 + github.run_attempt }}
           FASTLANE_KEYCHAIN_PASSWORD: ${{ secrets.FASTLANE_KEYCHAIN_PASSWORD }}
           MATCH_GIT_PRIVATE_KEY: ${{ secrets.MATCH_GIT_PRIVATE_KEY }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}

--- a/packages/flutter/example/ios/fastlane/Fastfile
+++ b/packages/flutter/example/ios/fastlane/Fastfile
@@ -20,8 +20,17 @@ platform :ios do
       version_number: new_version,
       xcodeproj: "./Runner.xcodeproj"
     )
+
+    # latest_testflight_build_number + 1 races when two CI jobs overlap: both
+    # read the same latest, both upload N+1, and Apple rejects the second as a
+    # redundant binary. Prefer a unique CI-derived number (run_number * 100 +
+    # attempt) and only use TestFlight as a floor so we never go backwards.
+    ci_build = ENV.fetch("FASTLANE_BUNDLE_VERSION", "0").to_i
+    tf_build = latest_testflight_build_number
+    build_number = [ci_build, tf_build + 1].max
+    UI.message("Using build number #{build_number} (CI=#{ci_build}, TestFlight=#{tf_build})")
     increment_build_number(
-      build_number: latest_testflight_build_number + 1,
+      build_number: build_number,
       xcodeproj: "./Runner.xcodeproj"
     )
   end

--- a/packages/flutter/example/ios/fastlane/Fastfile
+++ b/packages/flutter/example/ios/fastlane/Fastfile
@@ -25,7 +25,11 @@ platform :ios do
     # read the same latest, both upload N+1, and Apple rejects the second as a
     # redundant binary. Prefer a unique CI-derived number (run_number * 100 +
     # attempt) and only use TestFlight as a floor so we never go backwards.
-    ci_build = ENV.fetch("FASTLANE_BUNDLE_VERSION", "0").to_i
+    # Arithmetic is done here because GitHub Actions expressions do not
+    # support * or +.
+    run_number = ENV.fetch("FASTLANE_BUNDLE_VERSION", "0").to_i
+    run_attempt = ENV.fetch("FASTLANE_RUN_ATTEMPT", "1").to_i
+    ci_build = run_number * 100 + run_attempt
     tf_build = latest_testflight_build_number
     build_number = [ci_build, tf_build + 1].max
     UI.message("Using build number #{build_number} (CI=#{ci_build}, TestFlight=#{tf_build})")

--- a/packages/flutter/example/ios/fastlane/Fastfile
+++ b/packages/flutter/example/ios/fastlane/Fastfile
@@ -20,21 +20,8 @@ platform :ios do
       version_number: new_version,
       xcodeproj: "./Runner.xcodeproj"
     )
-
-    # latest_testflight_build_number + 1 races when two CI jobs overlap: both
-    # read the same latest, both upload N+1, and Apple rejects the second as a
-    # redundant binary. Prefer a unique CI-derived number (run_number * 100 +
-    # attempt) and only use TestFlight as a floor so we never go backwards.
-    # Arithmetic is done here because GitHub Actions expressions do not
-    # support * or +.
-    run_number = ENV.fetch("FASTLANE_BUNDLE_VERSION", "0").to_i
-    run_attempt = ENV.fetch("FASTLANE_RUN_ATTEMPT", "1").to_i
-    ci_build = run_number * 100 + run_attempt
-    tf_build = latest_testflight_build_number
-    build_number = [ci_build, tf_build + 1].max
-    UI.message("Using build number #{build_number} (CI=#{ci_build}, TestFlight=#{tf_build})")
     increment_build_number(
-      build_number: build_number,
+      build_number: latest_testflight_build_number + 1,
       xcodeproj: "./Runner.xcodeproj"
     )
   end


### PR DESCRIPTION
## :scroll: Description

Overlapping TestFlight uploads on the same branch are cancelled instead of racing App Store Connect for the same build number.

The workflow now uses a concurrency group shaped like the other CI workflows (`workflow` + branch), but falls back to `github.ref` instead of `github.run_id`. On `push` to `main`, `head_ref` is empty and `run_id` is unique, so the usual fallback would not cancel anything. A newer `main` push now cancels the stale job. Fastlane still bumps with `latest_testflight_build_number + 1`.

## :bulb: Motivation and Context

The job fails intermittently with:

> Validation failed (409) Redundant Binary Upload. You've already uploaded a build with build number 'N'.

That happened when two `main` pushes overlapped: both read the same latest TestFlight number and both tried to upload `N+1`. Recent examples: [1115](https://github.com/getsentry/sentry-dart/actions/runs/32237730245), [1113](https://github.com/getsentry/sentry-dart/actions/runs/32142414962), [1111](https://github.com/getsentry/sentry-dart/actions/runs/32141380248).

This is the smaller fix. If 409s continue (for example Apple not indexing a just-uploaded build before the next run queries it), we can add unique CI build numbers later.

## :green_heart: How did you test it?

Diagnosed from the failed job logs (archive succeeded; `altool` 409 on upload). After merge, watch whether close `main` pushes still 409.

## :pencil: Checklist
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [ ] All tests passing
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec
- [x] No breaking changes

## :crystal_ball: Next steps
