### PR TITLE
feat(dart): Add sentry.trace_lifecycle span attribute

### DIFF
--- a/packages/dart/lib/src/constants.dart
+++ b/packages/dart/lib/src/constants.dart
@@ -131,6 +131,9 @@ abstract class SemanticAttributesConstants {
   /// The operation name of a span.
   static const sentryOp = 'sentry.op';
 
+  /// The chosen trace lifecycle mode of the SDK (`stream` or `static`).
+  static const sentryTraceLifecycle = 'sentry.trace_lifecycle';
+
   /// The prefix for feature flag evaluations recorded on spans.
   static const featureFlagEvaluationPrefix = 'flag.evaluation.';
 

--- a/packages/dart/lib/src/sentry_tracer.dart
+++ b/packages/dart/lib/src/sentry_tracer.dart
@@ -156,6 +156,16 @@ class SentryTracer extends ISentrySpan {
       final transaction = SentryTransaction(this);
       transaction.measurements.addAll(_measurements);
 
+      final trace = transaction.contexts.trace;
+      if (trace != null &&
+          _hub.options.traceLifecycle == SentryTraceLifecycle.static) {
+        trace.data = {
+          SemanticAttributesConstants.sentryTraceLifecycle:
+              SentryTraceLifecycle.static.name,
+          ...?trace.data,
+        };
+      }
+
       profileInfo = (status == null || status == SpanStatus.ok())
           ? await profiler?.finishFor(transaction)
           : null;
@@ -266,6 +276,13 @@ class SentryTracer extends ISentrySpan {
       startTimestamp: startTimestamp,
       finishedCallback: _finishedCallback,
     );
+
+    if (_hub.options.traceLifecycle == SentryTraceLifecycle.static) {
+      child.setData(
+        SemanticAttributesConstants.sentryTraceLifecycle,
+        SentryTraceLifecycle.static.name,
+      );
+    }
 
     _children.add(child);
 

--- a/packages/dart/lib/src/telemetry/span/span_capture_pipeline.dart
+++ b/packages/dart/lib/src/telemetry/span/span_capture_pipeline.dart
@@ -37,6 +37,8 @@ class SpanCapturePipeline {
 
           span.addAttributesIfAbsent(defaultAttributes(_options, scope: scope));
           span.addAttributesIfAbsent({
+            SemanticAttributesConstants.sentryTraceLifecycle:
+                SentryAttribute.string(_options.traceLifecycle.name),
             SemanticAttributesConstants.sentrySegmentName:
                 SentryAttribute.string(span.segmentSpan.name),
             SemanticAttributesConstants.sentryTransaction:

--- a/packages/dart/test/sentry_tracer_test.dart
+++ b/packages/dart/test/sentry_tracer_test.dart
@@ -123,6 +123,34 @@ void main() {
       expect(tr.transaction.extra?['test'], {'key': 'value'});
     });
 
+    test('sets sentry.trace_lifecycle to static on trace context', () async {
+      final sut = fixture.getSut();
+
+      await sut.finish();
+
+      final tr = fixture.hub.captureTransactionCalls.first;
+      expect(
+        tr.transaction.contexts.trace
+            ?.data?[SemanticAttributesConstants.sentryTraceLifecycle],
+        'static',
+      );
+    });
+
+    test('sets sentry.trace_lifecycle to static on child spans', () async {
+      final sut = fixture.getSut();
+      final child = sut.startChild('operation');
+      await child.finish();
+
+      await sut.finish();
+
+      final tr = fixture.hub.captureTransactionCalls.first;
+      expect(
+        tr.transaction.spans.first
+            .data[SemanticAttributesConstants.sentryTraceLifecycle],
+        'static',
+      );
+    });
+
     test('tracer starts child', () async {
       final sut = fixture.getSut();
 

--- a/packages/dart/test/telemetry/span/span_capture_pipeline_test.dart
+++ b/packages/dart/test/telemetry/span/span_capture_pipeline_test.dart
@@ -128,6 +128,17 @@ void main() {
             'release-from-lifecycle-callback');
       });
 
+      test('adds sentry.trace_lifecycle stream attribute', () async {
+        final span = fixture.createRecordingSpan();
+        await fixture.pipeline.captureSpan(span, scope: fixture.scope);
+
+        expect(
+          span.attributes[SemanticAttributesConstants.sentryTraceLifecycle]
+              ?.value,
+          'stream',
+        );
+      });
+
       test('preserves array attributes on captured spans', () async {
         final span = fixture.createRecordingSpan();
         span.setAttribute('tags', SentryAttribute.stringArray(['a', 'b']));


### PR DESCRIPTION
## :scroll: Description
Spans now carry `sentry.trace_lifecycle` so Sentry can tell whether a span was sent as a streamed span or inside a transaction.

- **Stream:** `SpanCapturePipeline` sets `"stream"` with `addAttributesIfAbsent`, so a value already on the span is kept.
- **Static:** `SentryTracer` sets `"static"` on the transaction's `contexts.trace.data` at finish (existing keys win) and on each child span at creation.

The key lives on `SemanticAttributesConstants.sentryTraceLifecycle`. Values match `SentryTraceLifecycle` (`stream` / `static`).

## :bulb: Motivation and Context
Without this attribute, the product cannot reliably distinguish streamed spans from transaction-sent spans, which also blocks measuring streaming adoption as it becomes the default.

Follows [sentry-conventions#442](https://github.com/getsentry/sentry-conventions/pull/442).

Closes #3788

## :green_heart: How did you test it?
Unit tests:

- `packages/dart/test/telemetry/span/span_capture_pipeline_test.dart` — streamed spans get `"stream"`
- `packages/dart/test/sentry_tracer_test.dart` — the transaction trace context and child spans get `"static"`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec
- [x] No breaking changes


## :crystal_ball: Next steps
