### PR TITLE
chore(deps): Update Android SDK to v8.54.0

### DIFF
--- a/packages/flutter/android/build.gradle
+++ b/packages/flutter/android/build.gradle
@@ -82,8 +82,8 @@ if (kotlinExt?.hasProperty('compilerOptions')) {
 }
 
 dependencies {
-    api 'io.sentry:sentry-android:8.53.0'
-    debugImplementation 'io.sentry:sentry-spotlight:8.53.0'
+    api 'io.sentry:sentry-android:8.54.0'
+    debugImplementation 'io.sentry:sentry-spotlight:8.54.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     // Required -- JUnit 4 framework

--- a/packages/flutter/example/integration_test/replay_test.dart
+++ b/packages/flutter/example/integration_test/replay_test.dart
@@ -63,6 +63,19 @@ void main() {
     testWidgets('captureReplay sets native replay ID', (tester) async {
       if (!(Platform.isAndroid || Platform.isIOS)) return;
       await setupSentryAndApp(tester);
+
+      // Since sentry-java 8.54.0 init posts the replay start to the main looper
+      // instead of running it inline, so capturing right away can land before
+      // recording began. Wait for the id the replayStarted callback publishes.
+      if (Platform.isAndroid) {
+        final deadline = DateTime.now().add(const Duration(seconds: 10));
+        while (DateTime.now().isBefore(deadline)) {
+          final started = SentryFlutter.native?.replayId;
+          if (started != null && started != const SentryId.empty()) break;
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+        }
+      }
+
       final id = await SentryFlutter.native?.captureReplay();
       expect(id, isA<SentryId>());
       expect(SentryFlutter.native?.replayId, isNotNull);

--- a/packages/flutter/example/integration_test/replay_test.dart
+++ b/packages/flutter/example/integration_test/replay_test.dart
@@ -8,9 +8,33 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:sentry_flutter_example/main.dart';
+import 'package:sentry_flutter/src/native/java/binding.dart' as native;
 import 'package:sentry_flutter/src/native/java/sentry_native_java.dart';
 import 'package:sentry_flutter/src/replay/replay_config.dart';
 import 'package:sentry_flutter/src/replay/scheduled_recorder_config.dart';
+
+/// Since sentry-java 8.54.0 the replay lifecycle transitions are posted to the
+/// Android main looper, so the state settles a turn after the call returns.
+Future<void> _waitUntilRecording(
+  native.ReplayIntegration replay,
+  bool expected,
+) async {
+  final deadline = DateTime.now().add(const Duration(seconds: 10));
+  while (replay.isRecording() != expected) {
+    if (!DateTime.now().isBefore(deadline)) {
+      fail('Replay stayed at isRecording=${!expected} for 10s');
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+  }
+}
+
+/// Returns the native replay integration, registering its release.
+native.ReplayIntegration _replayIntegration() {
+  final replay = native.SentryFlutterPlugin.privateSentryGetReplayIntegration();
+  expect(replay, isNotNull);
+  addTearDown(replay!.release);
+  return replay;
+}
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -64,16 +88,10 @@ void main() {
       if (!(Platform.isAndroid || Platform.isIOS)) return;
       await setupSentryAndApp(tester);
 
-      // Since sentry-java 8.54.0 init posts the replay start to the main looper
-      // instead of running it inline, so capturing right away can land before
-      // recording began. Wait for the id the replayStarted callback publishes.
+      // init posts the replay start rather than running it inline, so
+      // capturing right away would land before recording began.
       if (Platform.isAndroid) {
-        final deadline = DateTime.now().add(const Duration(seconds: 10));
-        while (DateTime.now().isBefore(deadline)) {
-          final started = SentryFlutter.native?.replayId;
-          if (started != null && started != const SentryId.empty()) break;
-          await Future<void>.delayed(const Duration(milliseconds: 50));
-        }
+        await _waitUntilRecording(_replayIntegration(), true);
       }
 
       final id = await SentryFlutter.native?.captureReplay();
@@ -81,6 +99,26 @@ void main() {
       expect(SentryFlutter.native?.replayId, isNotNull);
       expect(SentryFlutter.native?.replayId, isNot(const SentryId.empty()));
     });
+
+    testWidgets('captureReplay only returns an ID while recording',
+        (tester) async {
+      await setupSentryAndApp(tester);
+      final replay = _replayIntegration();
+
+      // Let the start posted by init land first. Stopping out of INITIAL is not
+      // an allowed transition, so it would no-op and then start underneath us.
+      await _waitUntilRecording(replay, true);
+
+      replay.stop();
+      await _waitUntilRecording(replay, false);
+      expect(
+          await SentryFlutter.native?.captureReplay(), const SentryId.empty());
+
+      replay.start();
+      await _waitUntilRecording(replay, true);
+      expect(await SentryFlutter.native?.captureReplay(),
+          isNot(const SentryId.empty()));
+    }, skip: !Platform.isAndroid);
 
     // We would like to add a test that ensures a native-initiated replay stop
     // clears the replay ID from the scope. Currently we can't add that test

--- a/packages/flutter/lib/src/native/java/binding.dart
+++ b/packages/flutter/lib/src/native/java/binding.dart
@@ -3452,6 +3452,101 @@ class ReplayIntegration extends jni$_.JObject {
     _start(reference.pointer, _id_start as jni$_.JMethodIDPtr).check();
   }
 
+  static final _id_startBuffering = _class.instanceMethodId(
+    r'startBuffering',
+    r'()V',
+  );
+
+  static final _startBuffering = jni$_.ProtectedJniExtensions.lookup<
+          jni$_.NativeFunction<
+              jni$_.JThrowablePtr Function(
+                jni$_.Pointer<jni$_.Void>,
+                jni$_.JMethodIDPtr,
+              )>>('globalEnv_CallVoidMethod')
+      .asFunction<
+          jni$_.JThrowablePtr Function(
+            jni$_.Pointer<jni$_.Void>,
+            jni$_.JMethodIDPtr,
+          )>();
+
+  /// from: `public void startBuffering()`
+  void startBuffering() {
+    _startBuffering(reference.pointer, _id_startBuffering as jni$_.JMethodIDPtr)
+        .check();
+  }
+
+  static final _id_onAppForegrounded = _class.instanceMethodId(
+    r'onAppForegrounded',
+    r'(Z)V',
+  );
+
+  static final _onAppForegrounded = jni$_.ProtectedJniExtensions.lookup<
+          jni$_.NativeFunction<
+              jni$_.JThrowablePtr Function(
+                  jni$_.Pointer<jni$_.Void>,
+                  jni$_.JMethodIDPtr,
+                  jni$_.VarArgs<(jni$_.Int32,)>)>>('globalEnv_CallVoidMethod')
+      .asFunction<
+          jni$_.JThrowablePtr Function(
+              jni$_.Pointer<jni$_.Void>, jni$_.JMethodIDPtr, int)>();
+
+  /// from: `public void onAppForegrounded(boolean z)`
+  void onAppForegrounded(
+    bool z,
+  ) {
+    _onAppForegrounded(reference.pointer,
+            _id_onAppForegrounded as jni$_.JMethodIDPtr, z ? 1 : 0)
+        .check();
+  }
+
+  static final _id_onAppBackgrounded = _class.instanceMethodId(
+    r'onAppBackgrounded',
+    r'()V',
+  );
+
+  static final _onAppBackgrounded = jni$_.ProtectedJniExtensions.lookup<
+          jni$_.NativeFunction<
+              jni$_.JThrowablePtr Function(
+                jni$_.Pointer<jni$_.Void>,
+                jni$_.JMethodIDPtr,
+              )>>('globalEnv_CallVoidMethod')
+      .asFunction<
+          jni$_.JThrowablePtr Function(
+            jni$_.Pointer<jni$_.Void>,
+            jni$_.JMethodIDPtr,
+          )>();
+
+  /// from: `public void onAppBackgrounded()`
+  void onAppBackgrounded() {
+    _onAppBackgrounded(
+            reference.pointer, _id_onAppBackgrounded as jni$_.JMethodIDPtr)
+        .check();
+  }
+
+  static final _id_onAppSessionEnded = _class.instanceMethodId(
+    r'onAppSessionEnded',
+    r'()V',
+  );
+
+  static final _onAppSessionEnded = jni$_.ProtectedJniExtensions.lookup<
+          jni$_.NativeFunction<
+              jni$_.JThrowablePtr Function(
+                jni$_.Pointer<jni$_.Void>,
+                jni$_.JMethodIDPtr,
+              )>>('globalEnv_CallVoidMethod')
+      .asFunction<
+          jni$_.JThrowablePtr Function(
+            jni$_.Pointer<jni$_.Void>,
+            jni$_.JMethodIDPtr,
+          )>();
+
+  /// from: `public void onAppSessionEnded()`
+  void onAppSessionEnded() {
+    _onAppSessionEnded(
+            reference.pointer, _id_onAppSessionEnded as jni$_.JMethodIDPtr)
+        .check();
+  }
+
   static final _id_resume = _class.instanceMethodId(
     r'resume',
     r'()V',
@@ -3476,28 +3571,29 @@ class ReplayIntegration extends jni$_.JObject {
 
   static final _id_captureReplay = _class.instanceMethodId(
     r'captureReplay',
-    r'(Ljava/lang/Boolean;)V',
+    r'(Ljava/lang/Boolean;)Lio/sentry/protocol/SentryId;',
   );
 
   static final _captureReplay = jni$_.ProtectedJniExtensions.lookup<
               jni$_.NativeFunction<
-                  jni$_.JThrowablePtr Function(
+                  jni$_.JniResult Function(
                       jni$_.Pointer<jni$_.Void>,
                       jni$_.JMethodIDPtr,
                       jni$_.VarArgs<(jni$_.Pointer<jni$_.Void>,)>)>>(
-          'globalEnv_CallVoidMethod')
+          'globalEnv_CallObjectMethod')
       .asFunction<
-          jni$_.JThrowablePtr Function(jni$_.Pointer<jni$_.Void>,
+          jni$_.JniResult Function(jni$_.Pointer<jni$_.Void>,
               jni$_.JMethodIDPtr, jni$_.Pointer<jni$_.Void>)>();
 
-  /// from: `public void captureReplay(java.lang.Boolean boolean)`
-  void captureReplay(
+  /// from: `public io.sentry.protocol.SentryId captureReplay(java.lang.Boolean boolean)`
+  /// The returned object must be released after use, by calling the [release] method.
+  SentryId captureReplay(
     jni$_.JBoolean? boolean,
   ) {
     final _$boolean = boolean?.reference ?? jni$_.jNullReference;
-    _captureReplay(reference.pointer, _id_captureReplay as jni$_.JMethodIDPtr,
-            _$boolean.pointer)
-        .check();
+    return _captureReplay(reference.pointer,
+            _id_captureReplay as jni$_.JMethodIDPtr, _$boolean.pointer)
+        .object<SentryId>(const $SentryId$Type());
   }
 
   static final _id_getReplayId = _class.instanceMethodId(
@@ -3523,6 +3619,28 @@ class ReplayIntegration extends jni$_.JObject {
     return _getReplayId(
             reference.pointer, _id_getReplayId as jni$_.JMethodIDPtr)
         .object<SentryId>(const $SentryId$Type());
+  }
+
+  static final _id_flush = _class.instanceMethodId(
+    r'flush',
+    r'()V',
+  );
+
+  static final _flush = jni$_.ProtectedJniExtensions.lookup<
+          jni$_.NativeFunction<
+              jni$_.JThrowablePtr Function(
+                jni$_.Pointer<jni$_.Void>,
+                jni$_.JMethodIDPtr,
+              )>>('globalEnv_CallVoidMethod')
+      .asFunction<
+          jni$_.JThrowablePtr Function(
+            jni$_.Pointer<jni$_.Void>,
+            jni$_.JMethodIDPtr,
+          )>();
+
+  /// from: `public void flush()`
+  void flush() {
+    _flush(reference.pointer, _id_flush as jni$_.JMethodIDPtr).check();
   }
 
   static final _id_setBreadcrumbConverter = _class.instanceMethodId(

--- a/packages/flutter/lib/src/native/java/sentry_native_java.dart
+++ b/packages/flutter/lib/src/native/java/sentry_native_java.dart
@@ -179,10 +179,10 @@ class SentryNativeJava extends SentryNativeChannel {
       return using((arena) {
         _nativeReplay ??=
             native.SentryFlutterPlugin.privateSentryGetReplayIntegration();
-        // The passed parameter is `isTerminating`
-        _nativeReplay?.captureReplay(false.toJBoolean()..releasedBy(arena));
-
-        final nativeReplayId = _nativeReplay?.getReplayId();
+        // The passed parameter is `isTerminating`. The returned id is empty when
+        // nothing was captured, e.g. when onErrorSampleRate didn't sample.
+        final nativeReplayId =
+            _nativeReplay?.captureReplay(false.toJBoolean()..releasedBy(arena));
         nativeReplayId?.releasedBy(arena);
 
         JString? jString;


### PR DESCRIPTION
## :scroll: Description

Updates the Sentry Android SDK from 8.53.0 to 8.54.0 and regenerates `binding.dart`.

- [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8540)
- [diff](https://github.com/getsentry/sentry-java/compare/8.53.0...8.54.0)

## :bulb: Motivation and Context

The `android` job of `Update Dependencies` has failed on **every run since 2026-08-27**, so the nightly updater could not produce this PR. It builds the example APK, then jnigen's summarizer aborts:

```
Exception in thread "main" java.lang.IllegalArgumentException: Provided Metadata instance
has version 2.2.0, while maximum supported version is 2.1.0.
To support newer versions, update the kotlinx-metadata-jvm library.
	at ...jnigen.apisummarizer.disasm.KotlinMetadataAnnotationVisitor.visitEnd
```

jnigen 0.14.2 bundles `org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.9.0`, which reads Kotlin metadata up to 2.1.0. #3962 raised the example app's KGP from 2.0.21 to 2.2.20 (Flutter 3.47.0 requires it), so `io.sentry.flutter.SentryFlutterPlugin` now compiles to metadata 2.2.0 and the summarizer refuses it. No particular SDK bump is implicated — 8.54.0 was simply the first update that needed jnigen after that landed.

The `binding.dart` here was generated locally with a workaround. **The generation script itself is still broken and is not fixed in this PR**, so the nightly updater will keep failing until that is addressed separately.

## :recycle: Public API changes in 8.54.0

8.54.0 reworks the replay lifecycle in `ReplayController`/`IReplayApi`, and `io.sentry.android.replay.ReplayIntegration` is listed in `ffi-jni.yaml`, so `binding.dart` genuinely changes:

- New: `flush()`, `startBuffering()`, `onAppForegrounded(boolean)`, `onAppBackgrounded()`, `onAppSessionEnded()`
- `captureReplay(Boolean)` now returns `io.sentry.protocol.SentryId` instead of `void`
- `isManualPause$sentry_android_replay_release()` returns `boolean` rather than `AtomicBoolean`, plus a new `setManualPause$sentry_android_replay_release(boolean)`
- `getLifecycleLock$sentry_android_replay_release()` removed

`SentryNativeJava.captureReplay` now takes that return value instead of following up with a separate `getReplayId()`. It is the id of the replay actually captured and empty when nothing was, so an event no longer picks up a live replay id when the capture was skipped — for instance when `onErrorSampleRate` did not sample it.

## :green_heart: How did you test it?

- Regenerated at **8.53.0** first as a control: reproduces the committed `binding.dart` and `android/proguard-rules.pro` **byte-for-byte**, confirming the workaround used to run jnigen does not itself change what is emitted.
- Regenerated at **8.54.0** to produce the `binding.dart` in this PR (+127/−9), containing exactly the signatures listed above.
- `flutter analyze` clean, and `flutter test test/native/` passes (27 tests).

## :pencil: Checklist

- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec
- [x] No breaking changes

## :warning: Replay now starts asynchronously

Worth knowing for review: 8.53.0 started the replay inline while `SentryAndroid.init` held the lifecycle lock, so a replay id existed the moment `init` returned. 8.54.0 has `init` call `onAppForegrounded(true)`, which posts the start to the main looper via `mainLooperHandler.post`, so `lifecycleState` stays `INITIAL` until that runnable drains.

Practical effect: an error captured in the very first moments after `init` may not be linked to a replay, because `captureReplay` returns `EMPTY_ID` while not recording. This is upstream behaviour, not something introduced here, and it is why `captureReplay sets native replay ID` had to await the `replayStarted` callback — `getReplayId()` reads the same state and would have been empty too.
