### PR TITLE
fix(flutter): Unbreak JNI binding generation

### DIFF
--- a/packages/flutter/scripts/generate-jni-bindings.sh
+++ b/packages/flutter/scripts/generate-jni-bindings.sh
@@ -16,6 +16,17 @@ cd "$(dirname "$0")/../"
 
 binding_path="lib/src/native/java/binding.dart"
 
+# jnigen 0.14.2 bundles kotlinx-metadata-jvm 0.9.0, which refuses Kotlin metadata
+# newer than 2.1.0, so the example's default KGP 2.2.20 aborts the summarizer. Only
+# the summarized API shape matters here and it is the same either way. Flutter 3.47
+# raised its KGP floor to 2.2.20, so waive that check too -- as a Gradle property
+# rather than `flutter build --android-skip-build-dependency-validation`, because
+# jnigen resolves the compile classpath through a Gradle run of its own that never
+# sees the flutter flag. Drop both once jni/jnigen can move past 0.14.2, see
+# https://github.com/getsentry/sentry-dart/issues/3373
+export KOTLIN_ANDROID_PLUGIN_VERSION="${KOTLIN_ANDROID_PLUGIN_VERSION:-2.1.21}"
+export ORG_GRADLE_PROJECT_skipDependencyChecks=true
+
 cd example
 flutter build apk
 cd -

--- a/packages/flutter/scripts/safe-regenerate-jni.sh
+++ b/packages/flutter/scripts/safe-regenerate-jni.sh
@@ -17,6 +17,12 @@ cd "$(dirname "$0")/../"
 
 binding_path="lib/src/native/java/binding.dart"
 
+# Keep in sync with generate-jni-bindings.sh: jnigen 0.14.2 cannot read Kotlin
+# metadata newer than 2.1.0, which the example's default KGP 2.2.20 emits, and
+# Flutter's own KGP floor has to be waived to build below it.
+export KOTLIN_ANDROID_PLUGIN_VERSION="${KOTLIN_ANDROID_PLUGIN_VERSION:-2.1.21}"
+export ORG_GRADLE_PROJECT_skipDependencyChecks=true
+
 # Use fvm if available, otherwise bare commands.
 if command -v fvm &> /dev/null; then
     FLUTTER="fvm flutter"


### PR DESCRIPTION
## :scroll: Description

Pins the Kotlin Gradle Plugin for JNI binding generation only, and waives Flutter's KGP floor for those builds.

## :bulb: Motivation and Context

The `android` job of `Update Dependencies` has failed on **every run since 2026-08-27**. It builds the example APK, then jnigen's summarizer aborts:

```
Exception in thread "main" java.lang.IllegalArgumentException: Provided Metadata instance
has version 2.2.0, while maximum supported version is 2.1.0.
To support newer versions, update the kotlinx-metadata-jvm library.
	at ...jnigen.apisummarizer.disasm.KotlinMetadataAnnotationVisitor.visitEnd
Fatal: Cannot generate summary: FormatException: Unexpected end of input
```

jnigen 0.14.2 bundles `org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.9.0`, which reads Kotlin metadata up to 2.1.0. #3962 raised the example app's KGP from 2.0.21 to 2.2.20 (Flutter 3.47.0 requires it), so `io.sentry.flutter.SentryFlutterPlugin` now compiles to metadata 2.2.0 and the summarizer refuses it. Nothing about any particular SDK bump is involved — the 8.54.0 attempt was simply the first run that needed jnigen after that change landed.

Consequence: **Android SDK bumps no longer land at all.** #4001 is blocked on this.

jnigen 0.17.0 fixes this upstream by moving to `org.jetbrains.kotlin:kotlin-metadata-jvm:2.2.0`, but we cannot take it while `jni` is pinned to 0.14.2 (#3373) — jnigen 0.16+ emits extension-type bindings that require a matching `package:jni`.

## Why a Gradle property rather than the flutter flag

Flutter 3.47 refuses to build below KGP 2.2.20 and suggests `flutter build --android-skip-build-dependency-validation`. That flag is not enough: jnigen resolves the release compile classpath through **its own** Gradle invocation, which never sees it, so generation still failed at `AndroidSdkTools.getGradleClasspaths`.

`skipDependencyChecks` is the underlying Gradle project property, present in both Flutter 3.27.3 (which `generate-jni-bindings.sh` pins) and 3.47. Exporting `ORG_GRADLE_PROJECT_skipDependencyChecks` covers every Gradle invocation in the script and stays scoped to that process, so the example app's normal builds keep validating their toolchain.

KGP 2.1.21 clears Flutter 3.27.3's KGP floor of 1.7.0 comfortably.

## :green_heart: How did you test it?

Ran `./scripts/generate-jni-bindings.sh` locally on this branch, at `main`'s Android SDK 8.53.0:

- Before: failed at the summarizer with the metadata error above.
- After: completes with exit 0, generates every class in `ffi-jni.yaml`, and reports `Formatted 1 file (0 changed)`.
- `binding.dart` and `android/proguard-rules.pro` come out **byte-identical** to what is committed, so building with the older Kotlin compiler does not change what jnigen emits.

## :pencil: Checklist

- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec
- [x] No breaking changes

## :crystal_ball: Next steps

Unblocks #4001, which needs a regenerated `binding.dart` — 8.54.0 adds `flush()`, `startBuffering()`, `onAppForegrounded(boolean)`, `onAppBackgrounded()` and `onAppSessionEnded()` to `ReplayIntegration` and changes `captureReplay` to return `SentryId`.

Remove both exports once `jni`/`jnigen` can move past 0.14.2 (#3373).

Made with [Cursor](https://cursor.com)