### PR TITLE
feat(flutter): Unhandled Flutter errors do not mark sessions as crashed but unhandled instead

### DIFF
--- a/packages/flutter/darwin/sentry_flutter/Sources/sentry_flutter/SentryFlutterPlugin.swift
+++ b/packages/flutter/darwin/sentry_flutter/Sources/sentry_flutter/SentryFlutterPlugin.swift
@@ -421,9 +421,7 @@ public class SentryFlutterPlugin: NSObject, FlutterPlugin {
     }
 
     private func captureEnvelope(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-        guard let arguments = call.arguments as? [Any],
-              !arguments.isEmpty,
-              let data = (arguments.first as? FlutterStandardTypedData)?.data else {
+        guard let data = (call.arguments as? FlutterStandardTypedData)?.data else {
             print("Envelope is null or empty!")
             result(FlutterError(code: "2", message: "Envelope is null or empty", details: nil))
             return
@@ -433,7 +431,7 @@ public class SentryFlutterPlugin: NSObject, FlutterPlugin {
             result(FlutterError(code: "3", message: "Cannot parse the envelope data", details: nil))
             return
         }
-        SentrySDK.internal.envelope.capture(envelope)
+        SentrySDK.internal.envelope.captureNonTerminating(envelope)
         result("")
         return
     }

--- a/packages/flutter/lib/src/file_system_transport.dart
+++ b/packages/flutter/lib/src/file_system_transport.dart
@@ -17,10 +17,7 @@ class FileSystemTransport implements Transport {
     final envelopeData = bytesBuilder.takeBytes();
 
     try {
-      await _native.captureEnvelope(
-        envelopeData,
-        envelope.containsUnhandledException,
-      );
+      await _native.captureEnvelope(envelopeData);
     } catch (exception, stackTrace) {
       internalLogger.error(
         'Failed to save envelope',

--- a/packages/flutter/lib/src/native/c/sentry_native.dart
+++ b/packages/flutter/lib/src/native/c/sentry_native.dart
@@ -120,10 +120,7 @@ class SentryNative with SentryNativeSafeInvoker implements SentryNativeBinding {
   bool get supportsCaptureEnvelope => false;
 
   @override
-  FutureOr<void> captureEnvelope(
-    Uint8List envelopeData,
-    bool containsUnhandledException,
-  ) {
+  FutureOr<void> captureEnvelope(Uint8List envelopeData) {
     throw UnsupportedError('$SentryNative.captureEnvelope() is not supported');
   }
 

--- a/packages/flutter/lib/src/native/java/android_core_worker.dart
+++ b/packages/flutter/lib/src/native/java/android_core_worker.dart
@@ -71,10 +71,7 @@ class AndroidCoreWorker {
     _worker = null;
   }
 
-  void captureEnvelope(
-    Uint8List envelopeData,
-    bool containsUnhandledException,
-  ) {
+  void captureEnvelope(Uint8List envelopeData) {
     if (_isClosed) return;
 
     final client = _worker;
@@ -84,29 +81,17 @@ class AndroidCoreWorker {
       );
       _captureEnvelope(
         envelopeData,
-        containsUnhandledException,
         automatedTestMode: _config.automatedTestMode,
       );
       return;
     }
 
-    _captureEnvelopeFromWorker(
-      client,
-      envelopeData,
-      containsUnhandledException,
-    );
+    _captureEnvelopeFromWorker(client, envelopeData);
   }
 
-  void _captureEnvelopeFromWorker(
-    Worker client,
-    Uint8List envelopeData,
-    bool containsUnhandledException,
-  ) {
+  void _captureEnvelopeFromWorker(Worker client, Uint8List envelopeData) {
     client.send(
-      _CaptureEnvelopeRequest(
-        TransferableTypedData.fromList([envelopeData]),
-        containsUnhandledException,
-      ),
+      _CaptureEnvelopeRequest(TransferableTypedData.fromList([envelopeData])),
     );
   }
 
@@ -363,11 +348,7 @@ class _AndroidCoreWorkerHandler extends WorkerHandler {
     switch (msg) {
       case _CaptureEnvelopeRequest request:
         final data = request.envelopeData.materialize().asUint8List();
-        _captureEnvelope(
-          data,
-          request.containsUnhandledException,
-          automatedTestMode: _config.automatedTestMode,
-        );
+        _captureEnvelope(data, automatedTestMode: _config.automatedTestMode);
       case _AddBreadcrumbRequest request:
         _addBreadcrumb(
           request.breadcrumb,
@@ -456,12 +437,8 @@ class _AndroidCoreWorkerHandler extends WorkerHandler {
 
 class _CaptureEnvelopeRequest {
   final TransferableTypedData envelopeData;
-  final bool containsUnhandledException;
 
-  const _CaptureEnvelopeRequest(
-    this.envelopeData,
-    this.containsUnhandledException,
-  );
+  const _CaptureEnvelopeRequest(this.envelopeData);
 }
 
 class _LoadDebugImagesRequest {
@@ -504,18 +481,14 @@ class _RemoveContextsRequest {
 }
 
 void _captureEnvelope(
-  Uint8List envelopeData,
-  bool containsUnhandledException, {
+  Uint8List envelopeData, {
   bool automatedTestMode = false,
 }) {
   JObject? id;
   JByteArray? byteArray;
   try {
     byteArray = toJByteArray(envelopeData);
-    id = native.InternalSentrySdk.captureEnvelope(
-      byteArray,
-      containsUnhandledException,
-    );
+    id = native.InternalSentrySdk.captureEnvelopeNonTerminating(byteArray);
 
     if (id == null) {
       internalLogger.error(

--- a/packages/flutter/lib/src/native/java/sentry_native_java.dart
+++ b/packages/flutter/lib/src/native/java/sentry_native_java.dart
@@ -54,11 +54,8 @@ class SentryNativeJava extends SentryNativeChannel {
   }
 
   @override
-  FutureOr<void> captureEnvelope(
-    Uint8List envelopeData,
-    bool containsUnhandledException,
-  ) {
-    _coreWorker?.captureEnvelope(envelopeData, containsUnhandledException);
+  FutureOr<void> captureEnvelope(Uint8List envelopeData) {
+    _coreWorker?.captureEnvelope(envelopeData);
   }
 
   @override

--- a/packages/flutter/lib/src/native/sentry_native_binding.dart
+++ b/packages/flutter/lib/src/native/sentry_native_binding.dart
@@ -18,10 +18,7 @@ abstract class SentryNativeBinding {
 
   bool get supportsCaptureEnvelope;
 
-  FutureOr<void> captureEnvelope(
-    Uint8List envelopeData,
-    bool containsUnhandledException,
-  );
+  FutureOr<void> captureEnvelope(Uint8List envelopeData);
 
   FutureOr<void> captureStructuredEnvelope(SentryEnvelope envelope);
 

--- a/packages/flutter/lib/src/native/sentry_native_channel.dart
+++ b/packages/flutter/lib/src/native/sentry_native_channel.dart
@@ -120,10 +120,7 @@ class SentryNativeChannel
   bool get supportsCaptureEnvelope => true;
 
   @override
-  FutureOr<void> captureEnvelope(
-    Uint8List envelopeData,
-    bool containsUnhandledException,
-  ) {
+  FutureOr<void> captureEnvelope(Uint8List envelopeData) {
     if (options.platform.isAndroid) {
       assert(
         false,
@@ -131,10 +128,7 @@ class SentryNativeChannel
       );
       return null;
     }
-    return channel.invokeMethod('captureEnvelope', [
-      envelopeData,
-      containsUnhandledException,
-    ]);
+    return channel.invokeMethod('captureEnvelope', envelopeData);
   }
 
   @override

--- a/packages/flutter/lib/src/web/sentry_web.dart
+++ b/packages/flutter/lib/src/web/sentry_web.dart
@@ -65,10 +65,7 @@ class SentryWeb with SentryNativeSafeInvoker implements SentryNativeBinding {
   }
 
   @override
-  FutureOr<void> captureEnvelope(
-    Uint8List envelopeData,
-    bool containsUnhandledException,
-  ) {
+  FutureOr<void> captureEnvelope(Uint8List envelopeData) {
     _logNotSupported('capture raw envelope data');
   }
 

--- a/packages/flutter/test/file_system_transport_test.dart
+++ b/packages/flutter/test/file_system_transport_test.dart
@@ -43,7 +43,7 @@ void main() {
 
   test('$FileSystemTransport returns emptyId if channel throws', () async {
     fixture.options.automatedTestMode = false;
-    when(fixture.binding.captureEnvelope(any, false)).thenThrow(Exception());
+    when(fixture.binding.captureEnvelope(any)).thenThrow(Exception());
 
     final transport = fixture.getSut();
     final event = SentryEvent();
@@ -62,63 +62,57 @@ void main() {
     expect(SentryId.empty(), sentryId);
   });
 
-  test(
-    'sets unhandled exception flag in captureEnvelope to true for unhandled exception',
-    () async {
-      final transport = fixture.getSut();
+  test('forwards an envelope containing an unhandled exception', () async {
+    final transport = fixture.getSut();
 
-      final unhandledException = SentryException(
-        mechanism: Mechanism(type: 'UnhandledException', handled: false),
-        threadId: 99,
-        type: 'Exception',
-        value: 'Unhandled exception',
-      );
-      final event = SentryEvent(exceptions: [unhandledException]);
-      final sdkVersion = SdkVersion(
-        name: 'fixture-sdkName',
-        version: 'fixture-sdkVersion',
-      );
-      final envelope = SentryEnvelope.fromEvent(
-        event,
-        sdkVersion,
-        dsn: fixture.options.dsn,
-      );
+    final unhandledException = SentryException(
+      mechanism: Mechanism(type: 'UnhandledException', handled: false),
+      threadId: 99,
+      type: 'Exception',
+      value: 'Unhandled exception',
+    );
+    final event = SentryEvent(exceptions: [unhandledException]);
+    final sdkVersion = SdkVersion(
+      name: 'fixture-sdkName',
+      version: 'fixture-sdkVersion',
+    );
+    final envelope = SentryEnvelope.fromEvent(
+      event,
+      sdkVersion,
+      dsn: fixture.options.dsn,
+    );
 
-      await transport.send(envelope);
+    await transport.send(envelope);
 
-      verify(fixture.binding.captureEnvelope(captureAny, true)).captured.single
-          as Uint8List;
-    },
-  );
+    verify(fixture.binding.captureEnvelope(captureAny)).captured.single
+        as Uint8List;
+  });
 
-  test(
-    'sets unhandled exception flag in captureEnvelope to false for handled exception',
-    () async {
-      final transport = fixture.getSut();
+  test('forwards an envelope containing a handled exception', () async {
+    final transport = fixture.getSut();
 
-      final unhandledException = SentryException(
-        mechanism: Mechanism(type: 'UnhandledException', handled: true),
-        threadId: 99,
-        type: 'Exception',
-        value: 'Unhandled exception',
-      );
-      final event = SentryEvent(exceptions: [unhandledException]);
-      final sdkVersion = SdkVersion(
-        name: 'fixture-sdkName',
-        version: 'fixture-sdkVersion',
-      );
-      final envelope = SentryEnvelope.fromEvent(
-        event,
-        sdkVersion,
-        dsn: fixture.options.dsn,
-      );
+    final unhandledException = SentryException(
+      mechanism: Mechanism(type: 'UnhandledException', handled: true),
+      threadId: 99,
+      type: 'Exception',
+      value: 'Unhandled exception',
+    );
+    final event = SentryEvent(exceptions: [unhandledException]);
+    final sdkVersion = SdkVersion(
+      name: 'fixture-sdkName',
+      version: 'fixture-sdkVersion',
+    );
+    final envelope = SentryEnvelope.fromEvent(
+      event,
+      sdkVersion,
+      dsn: fixture.options.dsn,
+    );
 
-      await transport.send(envelope);
+    await transport.send(envelope);
 
-      verify(fixture.binding.captureEnvelope(captureAny, false)).captured.single
-          as Uint8List;
-    },
-  );
+    verify(fixture.binding.captureEnvelope(captureAny)).captured.single
+        as Uint8List;
+  });
 
   test('$FileSystemTransport asserts the event', () async {
     final transport = fixture.getSut();
@@ -138,9 +132,7 @@ void main() {
     await transport.send(envelope);
 
     final envelopeData =
-        verify(
-              fixture.binding.captureEnvelope(captureAny, false),
-            ).captured.single
+        verify(fixture.binding.captureEnvelope(captureAny)).captured.single
             as Uint8List;
     final envelopeString = utf8.decode(envelopeData);
     final lines = envelopeString.split('\n');
@@ -174,7 +166,7 @@ class Fixture {
   final binding = MockSentryNativeBinding();
 
   Fixture() {
-    when(binding.captureEnvelope(any, any)).thenReturn(null);
+    when(binding.captureEnvelope(any)).thenReturn(null);
   }
 
   FileSystemTransport getSut() {

--- a/packages/flutter/test/mocks.mocks.dart
+++ b/packages/flutter/test/mocks.mocks.dart
@@ -4,14 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i12;
-import 'dart:developer' as _i21;
+import 'dart:developer' as _i22;
 import 'dart:typed_data' as _i17;
 import 'dart:ui' as _i6;
 
 import 'package:flutter/foundation.dart' as _i8;
 import 'package:flutter/gestures.dart' as _i7;
 import 'package:flutter/rendering.dart' as _i10;
-import 'package:flutter/scheduler.dart' as _i20;
+import 'package:flutter/scheduler.dart' as _i21;
 import 'package:flutter/services.dart' as _i4;
 import 'package:flutter/src/widgets/_window.dart' as _i11;
 import 'package:flutter/src/widgets/binding.dart' as _i5;
@@ -21,18 +21,18 @@ import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i15;
 import 'package:sentry/src/sentry_tracer.dart' as _i3;
 import 'package:sentry_flutter/sentry_flutter.dart' as _i2;
-import 'package:sentry_flutter/src/binding_wrapper.dart' as _i26;
+import 'package:sentry_flutter/src/binding_wrapper.dart' as _i20;
 import 'package:sentry_flutter/src/frames_tracking/sentry_delayed_frames_tracker.dart'
     as _i19;
 import 'package:sentry_flutter/src/native/sentry_native_binding.dart' as _i16;
 import 'package:sentry_flutter/src/navigation/time_to_display_tracker.dart'
-    as _i23;
-import 'package:sentry_flutter/src/navigation/time_to_full_display_tracker.dart'
-    as _i25;
-import 'package:sentry_flutter/src/navigation/time_to_initial_display_tracker.dart'
     as _i24;
+import 'package:sentry_flutter/src/navigation/time_to_full_display_tracker.dart'
+    as _i26;
+import 'package:sentry_flutter/src/navigation/time_to_initial_display_tracker.dart'
+    as _i25;
 import 'package:sentry_flutter/src/replay/replay_config.dart' as _i18;
-import 'package:sentry_flutter/src/web/sentry_js_binding.dart' as _i22;
+import 'package:sentry_flutter/src/web/sentry_js_binding.dart' as _i23;
 
 import 'mocks.dart' as _i14;
 
@@ -1327,16 +1327,8 @@ class MockSentryNativeBinding extends _i1.Mock
           as _i12.FutureOr<void>);
 
   @override
-  _i12.FutureOr<void> captureEnvelope(
-    _i17.Uint8List? envelopeData,
-    bool? containsUnhandledException,
-  ) =>
-      (super.noSuchMethod(
-            Invocation.method(#captureEnvelope, [
-              envelopeData,
-              containsUnhandledException,
-            ]),
-          )
+  _i12.FutureOr<void> captureEnvelope(_i17.Uint8List? envelopeData) =>
+      (super.noSuchMethod(Invocation.method(#captureEnvelope, [envelopeData]))
           as _i12.FutureOr<void>);
 
   @override
@@ -1498,7 +1490,7 @@ class MockSentryDelayedFramesTracker extends _i1.Mock
 /// A class which mocks [BindingWrapper].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockBindingWrapper extends _i1.Mock implements _i26.BindingWrapper {
+class MockBindingWrapper extends _i1.Mock implements _i20.BindingWrapper {
   MockBindingWrapper() {
     _i1.throwOnMissingStub(this);
   }
@@ -1627,16 +1619,16 @@ class MockWidgetsFlutterBinding extends _i1.Mock
   );
 
   @override
-  _i20.SchedulingStrategy get schedulingStrategy =>
+  _i21.SchedulingStrategy get schedulingStrategy =>
       (super.noSuchMethod(
             Invocation.getter(#schedulingStrategy),
             returnValue:
                 ({
                   required int priority,
-                  required _i20.SchedulerBinding scheduler,
+                  required _i21.SchedulerBinding scheduler,
                 }) => false,
           )
-          as _i20.SchedulingStrategy);
+          as _i21.SchedulingStrategy);
 
   @override
   int get transientCallbackCount =>
@@ -1663,12 +1655,12 @@ class MockWidgetsFlutterBinding extends _i1.Mock
           as bool);
 
   @override
-  _i20.SchedulerPhase get schedulerPhase =>
+  _i21.SchedulerPhase get schedulerPhase =>
       (super.noSuchMethod(
             Invocation.getter(#schedulerPhase),
-            returnValue: _i20.SchedulerPhase.idle,
+            returnValue: _i21.SchedulerPhase.idle,
           )
-          as _i20.SchedulerPhase);
+          as _i21.SchedulerPhase);
 
   @override
   bool get framesEnabled =>
@@ -1698,7 +1690,7 @@ class MockWidgetsFlutterBinding extends _i1.Mock
           as Duration);
 
   @override
-  set schedulingStrategy(_i20.SchedulingStrategy? value) => super.noSuchMethod(
+  set schedulingStrategy(_i21.SchedulingStrategy? value) => super.noSuchMethod(
     Invocation.setter(#schedulingStrategy, value),
     returnValueForMissingStub: null,
   );
@@ -2235,10 +2227,10 @@ class MockWidgetsFlutterBinding extends _i1.Mock
 
   @override
   _i12.Future<T> scheduleTask<T>(
-    _i20.TaskCallback<T>? task,
-    _i20.Priority? priority, {
+    _i21.TaskCallback<T>? task,
+    _i21.Priority? priority, {
     String? debugLabel,
-    _i21.Flow? flow,
+    _i22.Flow? flow,
   }) =>
       (super.noSuchMethod(
             Invocation.method(
@@ -2279,7 +2271,7 @@ class MockWidgetsFlutterBinding extends _i1.Mock
 
   @override
   int scheduleFrameCallback(
-    _i20.FrameCallback? callback, {
+    _i21.FrameCallback? callback, {
     bool? rescheduling = false,
     bool? scheduleNewFrame = true,
   }) =>
@@ -2329,7 +2321,7 @@ class MockWidgetsFlutterBinding extends _i1.Mock
           as bool);
 
   @override
-  void addPersistentFrameCallback(_i20.FrameCallback? callback) =>
+  void addPersistentFrameCallback(_i21.FrameCallback? callback) =>
       super.noSuchMethod(
         Invocation.method(#addPersistentFrameCallback, [callback]),
         returnValueForMissingStub: null,
@@ -2337,7 +2329,7 @@ class MockWidgetsFlutterBinding extends _i1.Mock
 
   @override
   void addPostFrameCallback(
-    _i20.FrameCallback? callback, {
+    _i21.FrameCallback? callback, {
     String? debugLabel = 'callback',
   }) => super.noSuchMethod(
     Invocation.method(
@@ -2391,11 +2383,11 @@ class MockWidgetsFlutterBinding extends _i1.Mock
   );
 
   @override
-  _i20.PerformanceModeRequestHandle? requestPerformanceMode(
+  _i21.PerformanceModeRequestHandle? requestPerformanceMode(
     _i6.DartPerformanceMode? mode,
   ) =>
       (super.noSuchMethod(Invocation.method(#requestPerformanceMode, [mode]))
-          as _i20.PerformanceModeRequestHandle?);
+          as _i21.PerformanceModeRequestHandle?);
 
   @override
   void handleDrawFrame() => super.noSuchMethod(
@@ -2601,6 +2593,16 @@ class MockWidgetsFlutterBinding extends _i1.Mock
     Invocation.method(#removeSemanticsActionListener, [listener]),
     returnValueForMissingStub: null,
   );
+
+  @override
+  _i6.Rect? getRectOfSemanticsNodeInViewCoordinates(int? viewId, int? nodeId) =>
+      (super.noSuchMethod(
+            Invocation.method(#getRectOfSemanticsNodeInViewCoordinates, [
+              viewId,
+              nodeId,
+            ]),
+          )
+          as _i6.Rect?);
 
   @override
   _i13.SemanticsHandle ensureSemantics() =>
@@ -2846,7 +2848,7 @@ class MockWidgetsFlutterBinding extends _i1.Mock
 /// A class which mocks [SentryJsBinding].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockSentryJsBinding extends _i1.Mock implements _i22.SentryJsBinding {
+class MockSentryJsBinding extends _i1.Mock implements _i23.SentryJsBinding {
   MockSentryJsBinding() {
     _i1.throwOnMissingStub(this);
   }
@@ -2892,7 +2894,7 @@ class MockSentryJsBinding extends _i1.Mock implements _i22.SentryJsBinding {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockTimeToDisplayTracker extends _i1.Mock
-    implements _i23.TimeToDisplayTracker {
+    implements _i24.TimeToDisplayTracker {
   MockTimeToDisplayTracker() {
     _i1.throwOnMissingStub(this);
   }
@@ -3000,7 +3002,7 @@ class MockTimeToDisplayTracker extends _i1.Mock
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockTimeToInitialDisplayTracker extends _i1.Mock
-    implements _i24.TimeToInitialDisplayTracker {
+    implements _i25.TimeToInitialDisplayTracker {
   MockTimeToInitialDisplayTracker() {
     _i1.throwOnMissingStub(this);
   }
@@ -3030,7 +3032,7 @@ class MockTimeToInitialDisplayTracker extends _i1.Mock
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockTimeToFullDisplayTracker extends _i1.Mock
-    implements _i25.TimeToFullDisplayTracker {
+    implements _i26.TimeToFullDisplayTracker {
   MockTimeToFullDisplayTracker() {
     _i1.throwOnMissingStub(this);
   }

--- a/packages/flutter/test/native/android_core_worker_test_real.dart
+++ b/packages/flutter/test/native/android_core_worker_test_real.dart
@@ -32,7 +32,7 @@ void main() {
       );
 
       final worker = AndroidCoreWorker(options);
-      worker.captureEnvelope(Uint8List.fromList([1, 2, 3]), false);
+      worker.captureEnvelope(Uint8List.fromList([1, 2, 3]));
 
       expect(
         logs.any(
@@ -168,10 +168,9 @@ void main() {
       await worker.start();
 
       final payload = Uint8List.fromList([4, 5, 6]);
-      worker.captureEnvelope(payload, true);
+      worker.captureEnvelope(payload);
 
       final msg = await inboxes.last.first as dynamic;
-      expect(msg.containsUnhandledException, true);
       final transferable = msg.envelopeData as TransferableTypedData;
       final data = transferable.materialize().asUint8List();
       expect(data, [4, 5, 6]);
@@ -204,7 +203,7 @@ void main() {
       worker.close();
     });
 
-    test('sends envelope capture requests sequentially with flags', () async {
+    test('sends envelope capture requests sequentially', () async {
       final options = SentryFlutterOptions();
       options.debug = true;
       options.diagnosticLevel = SentryLevel.debug;
@@ -221,16 +220,13 @@ void main() {
       final worker = AndroidCoreWorker(options, spawn: fakeSpawn);
       await worker.start();
 
-      worker.captureEnvelope(Uint8List.fromList([10]), true);
-      worker.captureEnvelope(Uint8List.fromList([11]), false);
+      worker.captureEnvelope(Uint8List.fromList([10]));
+      worker.captureEnvelope(Uint8List.fromList([11]));
 
       final inbox = inboxes.last;
       final msgs = await inbox.take(2).toList();
       final msg1 = msgs[0] as dynamic;
       final msg2 = msgs[1] as dynamic;
-
-      expect(msg1.containsUnhandledException, true);
-      expect(msg2.containsUnhandledException, false);
 
       final t1 = msg1.envelopeData as TransferableTypedData;
       final t2 = msg2.envelopeData as TransferableTypedData;

--- a/packages/flutter/test/native/sentry_native_java_test_real.dart
+++ b/packages/flutter/test/native/sentry_native_java_test_real.dart
@@ -110,10 +110,7 @@ class _FakeCoreWorker implements AndroidCoreWorker {
   }
 
   @override
-  void captureEnvelope(
-    Uint8List envelopeData,
-    bool containsUnhandledException,
-  ) {
+  void captureEnvelope(Uint8List envelopeData) {
     // No-op for testing
   }
 

--- a/packages/flutter/test/sentry_flutter_test.dart
+++ b/packages/flutter/test/sentry_flutter_test.dart
@@ -899,7 +899,7 @@ MockSentryNativeBinding mockNativeBinding() {
   when(result.supportsLoadContexts).thenReturn(true);
   when(result.supportsCaptureEnvelope).thenReturn(true);
   when(result.supportsReplay).thenReturn(false);
-  when(result.captureEnvelope(any, any)).thenReturn(null);
+  when(result.captureEnvelope(any)).thenReturn(null);
   when(result.init(any)).thenReturn(null);
   when(result.close()).thenReturn(null);
   return result;

--- a/packages/flutter/test/sentry_native/sentry_native_test_ffi.dart
+++ b/packages/flutter/test/sentry_native/sentry_native_test_ffi.dart
@@ -266,7 +266,7 @@ void main() {
 
       test('captureEnvelope', () async {
         final data = Uint8List.fromList([1, 2, 3]);
-        expect(() => sut.captureEnvelope(data, false), throwsUnsupportedError);
+        expect(() => sut.captureEnvelope(data), throwsUnsupportedError);
       });
 
       test('loadContexts', () async {

--- a/packages/flutter/test/sentry_native_channel_test.dart
+++ b/packages/flutter/test/sentry_native_channel_test.dart
@@ -301,7 +301,7 @@ void main() {
 
           final data = Uint8List.fromList([1, 2, 3]);
 
-          expect(() => sut.captureEnvelope(data, false), matcher);
+          expect(() => sut.captureEnvelope(data), matcher);
 
           verifyZeroInteractions(channel);
         } else {
@@ -310,11 +310,11 @@ void main() {
           late Uint8List captured;
           when(channel.invokeMethod('captureEnvelope', any)).thenAnswer(
             (invocation) async => {
-              captured = invocation.positionalArguments[1][0] as Uint8List,
+              captured = invocation.positionalArguments[1] as Uint8List,
             },
           );
 
-          await sut.captureEnvelope(data, false);
+          await sut.captureEnvelope(data);
 
           expect(captured, data);
         }

--- a/packages/flutter/test/web/sentry_web_test.dart
+++ b/packages/flutter/test/web/sentry_web_test.dart
@@ -227,7 +227,7 @@ void main() {
 
         test('methods execute without calling JS binding', () {
           sut.addBreadcrumb(Breadcrumb());
-          sut.captureEnvelope(Uint8List(0), false);
+          sut.captureEnvelope(Uint8List(0));
           sut.clearBreadcrumbs();
           sut.displayRefreshRate();
           sut.fetchNativeAppStart();


### PR DESCRIPTION
## :scroll: Description

Capture Dart and Flutter envelopes through the Android and Cocoa non-terminating envelope APIs.

Unhandled framework errors now keep the current native session running with the same session ID. The native SDK finalizes that session as `unhandled` when it ends gracefully, while a later real crash still takes precedence as `crashed`.

Stacked on [#4006](https://github.com/getsentry/sentry-dart/pull/4006), which provides Sentry Android 8.55.0, Sentry Cocoa 9.27.0, and the generated JNI API.

Fixes #3300

## :bulb: Motivation and Context

Flutter can continue running after an unhandled framework error. Treating that error as a terminating native crash ends the session and starts a replacement, skewing crash-free session metrics.

## :green_heart: How did you test it?

- Added transport, method-channel, and Android worker regression coverage
- Ran 99 focused transport/channel/worker tests
- Ran 28 additional affected Flutter/native tests
- Passed Flutter analysis with fatal warnings
- Verified Dart 3.13 formatting

The Android release APK build passed during final stack verification.

## :pencil: Checklist

- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All focused tests passing
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec
- [x] No breaking changes

## :crystal_ball: Next steps

Follow-up stacked PR: update native sessions for sampled-out unhandled errors (#3786).

Made with [Cursor](https://cursor.com)