### PR TITLE
feat(flutter): Unsampled errors affect release health

### DIFF
--- a/packages/dart/lib/src/sdk_lifecycle_hooks.dart
+++ b/packages/dart/lib/src/sdk_lifecycle_hooks.dart
@@ -86,6 +86,15 @@ class OnBeforeSendEvent extends SdkLifecycleEvent {
   final Hint hint;
 }
 
+/// Dispatched when an event is dropped by the configured sample rate.
+@internal
+class OnEventSampledOut extends SdkLifecycleEvent {
+  OnEventSampledOut(this.event, this.hint);
+
+  final SentryEvent event;
+  final Hint hint;
+}
+
 /// Dispatched when a sampled span is started.
 @internal
 class OnSpanStart extends SdkLifecycleEvent {

--- a/packages/dart/lib/src/sentry_client.dart
+++ b/packages/dart/lib/src/sentry_client.dart
@@ -187,6 +187,9 @@ class SentryClient {
         () =>
             'Event ${sampledOutEvent.eventId} was dropped due to sampling decision.',
       );
+      await _options.lifecycleRegistry.dispatchCallback(
+        OnEventSampledOut(sampledOutEvent, hint),
+      );
       return _emptySentryId;
     }
 

--- a/packages/dart/test/sentry_client_test.dart
+++ b/packages/dart/test/sentry_client_test.dart
@@ -1176,6 +1176,20 @@ void main() {
       expect(fixture.transport.called(1), true);
     });
 
+    test('does not dispatch sampled out event when captured', () async {
+      var callbacks = 0;
+      fixture.options.lifecycleRegistry.registerCallback<OnEventSampledOut>((
+        event,
+      ) {
+        callbacks++;
+      });
+      final client = fixture.getSut(sampleRate: 1.0);
+
+      await client.captureEvent(fakeEvent);
+
+      expect(callbacks, 0);
+    });
+
     test('do not capture event, sample rate is 0% disabled', () async {
       final client = fixture.getSut(sampleRate: 0.0);
       await client.captureEvent(fakeEvent);
@@ -1213,6 +1227,81 @@ void main() {
 
       expect(beforeSendCalled, true);
       expect(fixture.transport.called(0), true);
+    });
+
+    test('dispatches the final event when sampling drops it', () async {
+      final finalEvent = SentryEvent(message: SentryMessage('final'));
+      final hint = Hint();
+      OnEventSampledOut? sampledOut;
+      fixture.options.lifecycleRegistry.registerCallback<OnEventSampledOut>((
+        event,
+      ) {
+        sampledOut = event;
+      });
+      final client = fixture.getSut(
+        sampleRate: 0.0,
+        beforeSend: (event, hint) => finalEvent,
+      );
+
+      await client.captureEvent(fakeEvent, hint: hint);
+
+      expect(sampledOut?.event, same(finalEvent));
+      expect(sampledOut?.hint, same(hint));
+    });
+
+    test(
+      'does not dispatch sampled out event when beforeSend drops it',
+      () async {
+        var callbacks = 0;
+        fixture.options.lifecycleRegistry.registerCallback<OnEventSampledOut>((
+          event,
+        ) {
+          callbacks++;
+        });
+        final client = fixture.getSut(
+          sampleRate: 0.0,
+          beforeSend: (event, hint) => null,
+        );
+
+        await client.captureEvent(fakeEvent);
+
+        expect(callbacks, 0);
+      },
+    );
+
+    test(
+      'does not dispatch sampled out event when a processor drops it',
+      () async {
+        var callbacks = 0;
+        fixture.options.lifecycleRegistry.registerCallback<OnEventSampledOut>((
+          event,
+        ) {
+          callbacks++;
+        });
+        final client = fixture.getSut(
+          sampleRate: 0.0,
+          eventProcessor: DropAllEventProcessor(),
+        );
+
+        await client.captureEvent(fakeEvent);
+
+        expect(callbacks, 0);
+      },
+    );
+
+    test('does not dispatch sampled out event when ignored', () async {
+      var callbacks = 0;
+      fixture.options.ignoreErrors = ['ignored'];
+      fixture.options.lifecycleRegistry.registerCallback<OnEventSampledOut>((
+        event,
+      ) {
+        callbacks++;
+      });
+      final client = fixture.getSut(sampleRate: 0.0);
+
+      await client.captureEvent(SentryEvent(message: SentryMessage('ignored')));
+
+      expect(callbacks, 0);
     });
   });
 

--- a/packages/flutter/darwin/sentry_flutter/Sources/sentry_flutter/SentryFlutterPlugin.swift
+++ b/packages/flutter/darwin/sentry_flutter/Sources/sentry_flutter/SentryFlutterPlugin.swift
@@ -83,6 +83,9 @@ public class SentryFlutterPlugin: NSObject, FlutterPlugin {
         case "captureEnvelope":
             captureEnvelope(call, result: result)
 
+        case "updateSessionForDroppedEventNonTerminating":
+            updateSessionForDroppedEventNonTerminating(call, result: result)
+
         case "fetchNativeAppStart":
             fetchNativeAppStart(result: result)
 
@@ -434,6 +437,15 @@ public class SentryFlutterPlugin: NSObject, FlutterPlugin {
         SentrySDK.internal.envelope.captureNonTerminating(envelope)
         result("")
         return
+    }
+
+    private func updateSessionForDroppedEventNonTerminating(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        guard let unhandled = call.arguments as? Bool else {
+            result(FlutterError(code: "4", message: "Unhandled flag is null", details: nil))
+            return
+        }
+        SentrySDK.internal.envelope.updateSessionForDroppedEventNonTerminating(unhandled: unhandled)
+        result("")
     }
 
     struct TimeSpan {

--- a/packages/flutter/darwin/sentry_flutter/Sources/sentry_flutter/SentryFlutterPlugin.swift
+++ b/packages/flutter/darwin/sentry_flutter/Sources/sentry_flutter/SentryFlutterPlugin.swift
@@ -439,7 +439,10 @@ public class SentryFlutterPlugin: NSObject, FlutterPlugin {
         return
     }
 
-    private func updateSessionForDroppedEventNonTerminating(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    private func updateSessionForDroppedEventNonTerminating(
+        _ call: FlutterMethodCall,
+        result: @escaping FlutterResult
+    ) {
         guard let unhandled = call.arguments as? Bool else {
             result(FlutterError(code: "4", message: "Unhandled flag is null", details: nil))
             return

--- a/packages/flutter/lib/src/integrations/native_session_integration.dart
+++ b/packages/flutter/lib/src/integrations/native_session_integration.dart
@@ -35,6 +35,7 @@ class NativeSessionIntegration implements Integration<SentryFlutterOptions> {
     _options?.lifecycleRegistry.removeCallback<OnEventSampledOut>(
       _updateSessionForSampledOutEvent,
     );
+    _options = null;
   }
 
   Future<void> _updateSessionForSampledOutEvent(

--- a/packages/flutter/lib/src/integrations/native_session_integration.dart
+++ b/packages/flutter/lib/src/integrations/native_session_integration.dart
@@ -1,0 +1,60 @@
+// ignore_for_file: invalid_use_of_internal_member
+
+import 'dart:async';
+
+import 'package:meta/meta.dart';
+
+import '../../sentry_flutter.dart';
+import '../native/sentry_native_binding.dart';
+import '../utils/internal_logger.dart';
+
+@internal
+class NativeSessionIntegration implements Integration<SentryFlutterOptions> {
+  static const integrationName = 'NativeSession';
+  final SentryNativeBinding _native;
+  SentryOptions? _options;
+
+  NativeSessionIntegration(this._native);
+
+  @override
+  void call(Hub hub, SentryFlutterOptions options) {
+    if (!options.enableAutoSessionTracking) {
+      internalLogger.info('$integrationName: disabled, skipping setup');
+      return;
+    }
+
+    _options = options;
+    options.lifecycleRegistry.registerCallback<OnEventSampledOut>(
+      _updateSessionForSampledOutEvent,
+    );
+    options.sdk.addIntegration(integrationName);
+  }
+
+  @override
+  void close() {
+    _options?.lifecycleRegistry.removeCallback<OnEventSampledOut>(
+      _updateSessionForSampledOutEvent,
+    );
+  }
+
+  Future<void> _updateSessionForSampledOutEvent(
+    OnEventSampledOut lifecycleEvent,
+  ) async {
+    final isUnhandled = lifecycleEvent.event.exceptions?.any(
+      (exception) => exception.mechanism?.handled == false,
+    );
+    if (isUnhandled != true) {
+      return;
+    }
+
+    try {
+      await _native.updateSessionForDroppedEventNonTerminating(true);
+    } catch (exception, stackTrace) {
+      internalLogger.warning(
+        '$integrationName: failed to update native session',
+        error: exception,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+}

--- a/packages/flutter/lib/src/native/c/sentry_native.dart
+++ b/packages/flutter/lib/src/native/c/sentry_native.dart
@@ -125,6 +125,13 @@ class SentryNative with SentryNativeSafeInvoker implements SentryNativeBinding {
   }
 
   @override
+  FutureOr<void> updateSessionForDroppedEventNonTerminating(bool unhandled) {
+    throw UnsupportedError(
+      '$SentryNative.updateSessionForDroppedEventNonTerminating() is not supported',
+    );
+  }
+
+  @override
   FutureOr<void> captureStructuredEnvelope(SentryEnvelope envelope) {
     throw UnsupportedError("Not supported on this platform");
   }

--- a/packages/flutter/lib/src/native/java/android_core_worker.dart
+++ b/packages/flutter/lib/src/native/java/android_core_worker.dart
@@ -95,6 +95,44 @@ class AndroidCoreWorker {
     );
   }
 
+  FutureOr<void> updateSessionForDroppedEventNonTerminating(bool unhandled) {
+    if (_isClosed) return null;
+
+    final client = _worker;
+    if (client == null) {
+      _updateSessionForDroppedEventNonTerminating(
+        unhandled,
+        automatedTestMode: _config.automatedTestMode,
+      );
+      return null;
+    }
+
+    return _updateSessionForDroppedEventNonTerminatingFromWorker(
+      client,
+      unhandled,
+    );
+  }
+
+  Future<void> _updateSessionForDroppedEventNonTerminatingFromWorker(
+    Worker client,
+    bool unhandled,
+  ) async {
+    try {
+      await client.request(
+        _UpdateSessionForDroppedEventNonTerminatingRequest(unhandled),
+      );
+    } catch (exception, stackTrace) {
+      internalLogger.error(
+        'Android core worker failed to update session for dropped event',
+        error: exception,
+        stackTrace: stackTrace,
+      );
+      if (_config.automatedTestMode) {
+        rethrow;
+      }
+    }
+  }
+
   FutureOr<List<DebugImage>?> loadDebugImages(SentryStackTrace stackTrace) {
     if (_isClosed) return null;
 
@@ -384,6 +422,12 @@ class _AndroidCoreWorkerHandler extends WorkerHandler {
         );
       case _LoadContextsRequest _:
         return _loadContexts(automatedTestMode: _config.automatedTestMode);
+      case _UpdateSessionForDroppedEventNonTerminatingRequest request:
+        _updateSessionForDroppedEventNonTerminating(
+          request.unhandled,
+          automatedTestMode: _config.automatedTestMode,
+        );
+        return null;
       case _AddBreadcrumbRequest request:
         _addBreadcrumb(
           request.breadcrumb,
@@ -439,6 +483,12 @@ class _CaptureEnvelopeRequest {
   final TransferableTypedData envelopeData;
 
   const _CaptureEnvelopeRequest(this.envelopeData);
+}
+
+class _UpdateSessionForDroppedEventNonTerminatingRequest {
+  final bool unhandled;
+
+  const _UpdateSessionForDroppedEventNonTerminatingRequest(this.unhandled);
 }
 
 class _LoadDebugImagesRequest {
@@ -507,6 +557,26 @@ void _captureEnvelope(
   } finally {
     byteArray?.release();
     id?.release();
+  }
+}
+
+void _updateSessionForDroppedEventNonTerminating(
+  bool unhandled, {
+  bool automatedTestMode = false,
+}) {
+  try {
+    native.InternalSentrySdk.updateSessionForDroppedEventNonTerminating(
+      unhandled,
+    );
+  } catch (exception, stackTrace) {
+    internalLogger.error(
+      'Failed to update session for dropped event',
+      error: exception,
+      stackTrace: stackTrace,
+    );
+    if (automatedTestMode) {
+      rethrow;
+    }
   }
 }
 

--- a/packages/flutter/lib/src/native/java/sentry_native_java.dart
+++ b/packages/flutter/lib/src/native/java/sentry_native_java.dart
@@ -59,6 +59,11 @@ class SentryNativeJava extends SentryNativeChannel {
   }
 
   @override
+  FutureOr<void> updateSessionForDroppedEventNonTerminating(bool unhandled) {
+    return _coreWorker?.updateSessionForDroppedEventNonTerminating(unhandled);
+  }
+
+  @override
   FutureOr<List<DebugImage>?> loadDebugImages(SentryStackTrace stackTrace) =>
       _coreWorker?.loadDebugImages(stackTrace);
 

--- a/packages/flutter/lib/src/native/sentry_native_binding.dart
+++ b/packages/flutter/lib/src/native/sentry_native_binding.dart
@@ -20,6 +20,8 @@ abstract class SentryNativeBinding {
 
   FutureOr<void> captureEnvelope(Uint8List envelopeData);
 
+  FutureOr<void> updateSessionForDroppedEventNonTerminating(bool unhandled);
+
   FutureOr<void> captureStructuredEnvelope(SentryEnvelope envelope);
 
   FutureOr<void> setUser(SentryUser? user);

--- a/packages/flutter/lib/src/native/sentry_native_channel.dart
+++ b/packages/flutter/lib/src/native/sentry_native_channel.dart
@@ -132,6 +132,21 @@ class SentryNativeChannel
   }
 
   @override
+  FutureOr<void> updateSessionForDroppedEventNonTerminating(bool unhandled) {
+    if (options.platform.isAndroid) {
+      assert(
+        false,
+        'updateSessionForDroppedEventNonTerminating should not be used through method channels on Android.',
+      );
+      return null;
+    }
+    return channel.invokeMethod(
+      'updateSessionForDroppedEventNonTerminating',
+      unhandled,
+    );
+  }
+
+  @override
   FutureOr<void> captureStructuredEnvelope(SentryEnvelope envelope) {
     throw UnsupportedError("Not supported on this platform");
   }

--- a/packages/flutter/lib/src/sentry_flutter.dart
+++ b/packages/flutter/lib/src/sentry_flutter.dart
@@ -25,6 +25,7 @@ import 'integrations/connectivity/connectivity_integration.dart';
 import 'integrations/flutter_framework_feature_flag_integration.dart';
 import 'integrations/frames_tracking_integration.dart';
 import 'integrations/integrations.dart';
+import 'integrations/native_session_integration.dart';
 import 'integrations/replay_telemetry_integration.dart';
 import 'integrations/screenshot_integration.dart';
 import 'integrations/native_trace_sync_integration.dart';
@@ -191,6 +192,9 @@ mixin SentryFlutter {
       // We also need to call this before the native sdk integrations so release is properly propagated.
       integrations.add(LoadReleaseIntegration());
       integrations.add(createSdkIntegration(native));
+      if (platform.isAndroid || platform.isIOS || platform.isMacOS) {
+        integrations.add(NativeSessionIntegration(native));
+      }
       if (native.supportsTraceSync) {
         integrations.add(NativeTraceSyncIntegration(native));
       }

--- a/packages/flutter/lib/src/web/sentry_web.dart
+++ b/packages/flutter/lib/src/web/sentry_web.dart
@@ -70,6 +70,11 @@ class SentryWeb with SentryNativeSafeInvoker implements SentryNativeBinding {
   }
 
   @override
+  FutureOr<void> updateSessionForDroppedEventNonTerminating(bool unhandled) {
+    _logNotSupported('update session for dropped non-terminating event');
+  }
+
+  @override
   FutureOr<void> captureStructuredEnvelope(SentryEnvelope envelope) =>
       tryCatchAsync('captureStructuredEnvelope', () async {
         final List<dynamic> envelopeItems = [];

--- a/packages/flutter/test/integrations/native_session_integration_test.dart
+++ b/packages/flutter/test/integrations/native_session_integration_test.dart
@@ -1,0 +1,121 @@
+// ignore_for_file: invalid_use_of_internal_member
+
+@TestOn('vm')
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sentry/src/platform/mock_platform.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+import 'package:sentry_flutter/src/integrations/native_session_integration.dart';
+import 'package:sentry_flutter/src/native/sentry_native_binding.dart';
+
+import '../mocks.dart';
+
+void main() {
+  group('$NativeSessionIntegration', () {
+    late Fixture fixture;
+
+    setUp(() {
+      fixture = Fixture();
+    });
+
+    test('adds integration', () {
+      fixture.registerIntegration();
+
+      expect(
+        fixture.options.sdk.integrations,
+        contains(NativeSessionIntegration.integrationName),
+      );
+    });
+
+    test('updates native session for sampled out unhandled event', () async {
+      fixture.registerIntegration();
+
+      await fixture.dispatchSampledOut(_event(handled: false));
+
+      expect(fixture.binding.unhandledUpdates, [true]);
+    });
+
+    test('ignores sampled out handled event', () async {
+      fixture.registerIntegration();
+
+      await fixture.dispatchSampledOut(_event(handled: true));
+
+      expect(fixture.binding.unhandledUpdates, isEmpty);
+    });
+
+    test('does not register when auto session tracking is disabled', () async {
+      fixture.options.enableAutoSessionTracking = false;
+      fixture.registerIntegration();
+
+      await fixture.dispatchSampledOut(_event(handled: false));
+
+      expect(fixture.binding.unhandledUpdates, isEmpty);
+      expect(
+        fixture.options.sdk.integrations,
+        isNot(contains(NativeSessionIntegration.integrationName)),
+      );
+    });
+
+    test('unregisters callback on close', () async {
+      fixture.registerIntegration();
+      fixture.sut.close();
+
+      await fixture.dispatchSampledOut(_event(handled: false));
+
+      expect(fixture.binding.unhandledUpdates, isEmpty);
+    });
+
+    test('does not surface native update errors', () async {
+      fixture.binding.throwOnUpdate = true;
+      fixture.registerIntegration();
+
+      await expectLater(
+        fixture.dispatchSampledOut(_event(handled: false)),
+        completes,
+      );
+    });
+  });
+}
+
+SentryEvent _event({required bool handled}) => SentryEvent(
+  exceptions: [
+    SentryException(
+      type: 'StateError',
+      value: 'failure',
+      mechanism: Mechanism(type: 'FlutterError', handled: handled),
+    ),
+  ],
+);
+
+class Fixture {
+  final options = defaultTestOptions(platform: MockPlatform.iOS());
+  final binding = _FakeNativeBinding();
+  late final hub = Hub(options);
+  late final sut = NativeSessionIntegration(binding);
+
+  void registerIntegration() {
+    sut.call(hub, options);
+  }
+
+  Future<void> dispatchSampledOut(SentryEvent event) async {
+    await options.lifecycleRegistry.dispatchCallback(
+      OnEventSampledOut(event, Hint()),
+    );
+  }
+}
+
+class _FakeNativeBinding extends Fake implements SentryNativeBinding {
+  final unhandledUpdates = <bool>[];
+  bool throwOnUpdate = false;
+
+  @override
+  Future<void> updateSessionForDroppedEventNonTerminating(
+    bool unhandled,
+  ) async {
+    unhandledUpdates.add(unhandled);
+    if (throwOnUpdate) {
+      throw Exception('native session update failed');
+    }
+  }
+}

--- a/packages/flutter/test/mocks.mocks.dart
+++ b/packages/flutter/test/mocks.mocks.dart
@@ -1332,6 +1332,17 @@ class MockSentryNativeBinding extends _i1.Mock
           as _i12.FutureOr<void>);
 
   @override
+  _i12.FutureOr<void> updateSessionForDroppedEventNonTerminating(
+    bool? unhandled,
+  ) =>
+      (super.noSuchMethod(
+            Invocation.method(#updateSessionForDroppedEventNonTerminating, [
+              unhandled,
+            ]),
+          )
+          as _i12.FutureOr<void>);
+
+  @override
   _i12.FutureOr<void> captureStructuredEnvelope(_i2.SentryEnvelope? envelope) =>
       (super.noSuchMethod(
             Invocation.method(#captureStructuredEnvelope, [envelope]),

--- a/packages/flutter/test/native/android_core_worker_test_real.dart
+++ b/packages/flutter/test/native/android_core_worker_test_real.dart
@@ -238,6 +238,18 @@ void main() {
       worker.close();
     });
 
+    test('awaits sampled out session update', () async {
+      final fixture = _Fixture();
+      final worker = fixture.getSut();
+      await worker.start();
+
+      final payload = await fixture.expectPendingRequest(
+        worker.updateSessionForDroppedEventNonTerminating(true),
+      );
+
+      expect((payload as dynamic).unhandled, true);
+    });
+
     test('requests debug images by instruction addresses', () async {
       final fixture = _Fixture();
       final worker = fixture.getSut();

--- a/packages/flutter/test/native/sentry_native_java_test_real.dart
+++ b/packages/flutter/test/native/sentry_native_java_test_real.dart
@@ -115,6 +115,11 @@ class _FakeCoreWorker implements AndroidCoreWorker {
   }
 
   @override
+  FutureOr<void> updateSessionForDroppedEventNonTerminating(bool unhandled) {
+    // No-op for testing
+  }
+
+  @override
   FutureOr<List<DebugImage>?> loadDebugImages(SentryStackTrace stackTrace) {
     return null;
   }

--- a/packages/flutter/test/sentry_flutter_test.dart
+++ b/packages/flutter/test/sentry_flutter_test.dart
@@ -12,6 +12,7 @@ import 'package:sentry_flutter/src/flutter_exception_type_identifier.dart';
 import 'package:sentry_flutter/src/app_start/standalone/standalone_app_start_integration.dart';
 import 'package:sentry_flutter/src/integrations/connectivity/connectivity_integration.dart';
 import 'package:sentry_flutter/src/integrations/integrations.dart';
+import 'package:sentry_flutter/src/integrations/native_session_integration.dart';
 import 'package:sentry_flutter/src/integrations/screenshot_integration.dart';
 import 'package:sentry_flutter/src/app_start/generic_app_start_integration.dart';
 import 'package:sentry_flutter/src/integrations/web_session_integration.dart';
@@ -42,6 +43,8 @@ final webIntegrations = [ConnectivityIntegration, WebSessionIntegration];
 final genericAppStartIntegrations = [GenericAppStartIntegration];
 
 final nonWebIntegrations = [OnErrorIntegration];
+
+final nativeSessionIntegrations = [NativeSessionIntegration];
 
 // These should be added to iOS and macOS
 final iOsAndMacOsIntegrations = [LoadContextsIntegration];
@@ -92,6 +95,7 @@ void main() {
         integrations: options.integrations,
         shouldHaveIntegrations: [
           ...iOsAndMacOsIntegrations,
+          ...nativeSessionIntegrations,
           ...platformAgnosticIntegrations,
           ...nonWebIntegrations,
           ReplayIntegration,
@@ -108,6 +112,10 @@ void main() {
       expect(SentryFlutter.native, isNotNull);
       expect(
         options.integrations.whereType<StandaloneAppStartIntegration>(),
+        hasLength(1),
+      );
+      expect(
+        options.integrations.whereType<NativeSessionIntegration>(),
         hasLength(1),
       );
 
@@ -214,6 +222,7 @@ void main() {
         integrations: integrations,
         shouldHaveIntegrations: [
           ...iOsAndMacOsIntegrations,
+          ...nativeSessionIntegrations,
           ...platformAgnosticIntegrations,
           ...nonWebIntegrations,
           ...genericAppStartIntegrations,

--- a/packages/flutter/test/sentry_native/sentry_native_test_ffi.dart
+++ b/packages/flutter/test/sentry_native/sentry_native_test_ffi.dart
@@ -269,6 +269,13 @@ void main() {
         expect(() => sut.captureEnvelope(data), throwsUnsupportedError);
       });
 
+      test('updateSessionForDroppedEventNonTerminating', () async {
+        expect(
+          () => sut.updateSessionForDroppedEventNonTerminating(true),
+          throwsUnsupportedError,
+        );
+      });
+
       test('loadContexts', () async {
         expect(await sut.loadContexts(), isNull);
       });

--- a/packages/flutter/test/sentry_native_channel_test.dart
+++ b/packages/flutter/test/sentry_native_channel_test.dart
@@ -320,6 +320,27 @@ void main() {
         }
       });
 
+      test('updates session for sampled out unhandled event', () async {
+        if (mockPlatform.isAndroid) {
+          return;
+        }
+        when(
+          channel.invokeMethod(
+            'updateSessionForDroppedEventNonTerminating',
+            true,
+          ),
+        ).thenAnswer((_) => Future.value());
+
+        await sut.updateSessionForDroppedEventNonTerminating(true);
+
+        verify(
+          channel.invokeMethod(
+            'updateSessionForDroppedEventNonTerminating',
+            true,
+          ),
+        );
+      });
+
       test('loadContexts', () async {
         if (mockPlatform.isAndroid) {
           final matcher = _nativeUnavailableMatcher();


### PR DESCRIPTION
## :scroll: Description

Add an internal sampled-out event lifecycle hook and use it to keep native session state accurate when an unhandled Dart or Flutter event is dropped by sampling.

The native session integration:
- receives only final events accepted by processors and `beforeSend`
- updates Android or Cocoa with `unhandled: true` when `mechanism.handled == false`
- awaits Android worker persistence before capture returns
- unregisters on close and contains native failures
- remains disabled when automatic session tracking is disabled

Stacked on [#4007](https://github.com/getsentry/sentry-dart/pull/4007), which adopts the non-terminating envelope APIs. That PR is itself stacked on [#4006](https://github.com/getsentry/sentry-dart/pull/4006).

Fixes #3786

## :bulb: Motivation and Context

A sampled-out unhandled error has no envelope, so the native SDK cannot infer its session side effects from capture. Without a separate update, a gracefully ending session is incorrectly reported as exited instead of unhandled.

## :green_heart: How did you test it?

- Core `SentryClient` sampling suite: 10 tests passed
- Native session integration, channel, and Android worker suite: 104 tests passed
- Platform registration suite: 22 tests passed
- Android release APK build passed
- Dart and Flutter analysis passed with fatal warnings
- Dart 3.13 formatting verified
- Confirmed the Cocoa 9.27.0 private API signatures against the tagged source

The local macOS example build was blocked before compilation by Flutter's experimental Swift Package Manager override identity mismatch (`flutter` vs `sentry_flutter`); CI provides the platform build lane.

## :pencil: Checklist

- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [ ] I updated the docs if needed
- [x] All focused tests passing
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec
- [x] No breaking changes

Made with [Cursor](https://cursor.com)