### PR TITLE
feat(flutter): Add manual replay APIs

### DIFF
--- a/packages/flutter/android/src/main/kotlin/io/sentry/flutter/ReplayRecorderCallbacks.kt
+++ b/packages/flutter/android/src/main/kotlin/io/sentry/flutter/ReplayRecorderCallbacks.kt
@@ -8,6 +8,11 @@ interface ReplayRecorderCallbacks {
 
   fun replayResumed()
 
+  fun replayStateChanged(
+    replayId: String,
+    replayIsBuffering: Boolean,
+  )
+
   fun replayPaused()
 
   fun replayStopped()

--- a/packages/flutter/android/src/main/kotlin/io/sentry/flutter/SafeReplayRecorderCallbacks.kt
+++ b/packages/flutter/android/src/main/kotlin/io/sentry/flutter/SafeReplayRecorderCallbacks.kt
@@ -43,6 +43,13 @@ internal class SafeReplayRecorderCallbacks(
       delegate.replayResumed()
     }
 
+  override fun replayStateChanged(
+    replayId: String,
+    replayIsBuffering: Boolean,
+  ) = guard {
+    delegate.replayStateChanged(replayId, replayIsBuffering)
+  }
+
   override fun replayPaused() =
     guard {
       delegate.replayPaused()

--- a/packages/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/packages/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -97,8 +97,11 @@ class SentryFlutterPlugin :
     // Stub
   }
   private fun closeNativeSdk(result: Result) {
-    tearDownReplayIntegration()
+    // Let the SDK shut the ReplayIntegration down as part of its own teardown,
+    // then drop our reference so a closed integration can't be reached through
+    // privateSentryGetReplayIntegration().
     ScopesAdapter.getInstance().close()
+    tearDownReplayIntegration()
 
     result.success("")
   }

--- a/packages/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/packages/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -97,6 +97,7 @@ class SentryFlutterPlugin :
     // Stub
   }
   private fun closeNativeSdk(result: Result) {
+    tearDownReplayIntegration()
     ScopesAdapter.getInstance().close()
 
     result.success("")
@@ -241,8 +242,7 @@ class SentryFlutterPlugin :
 
       // Replace the default ReplayIntegration with a Flutter-specific recorder.
       options.integrations.removeAll { it is ReplayIntegration }
-      val replayOptions = options.sessionReplay
-      if ((replayOptions.isSessionReplayEnabled || replayOptions.isSessionReplayForErrorsEnabled) && replayCallbacks != null) {
+      if (replayCallbacks != null) {
         val ctx = applicationContext
         if (ctx == null) {
           Log.w("Sentry", "setupReplay called before applicationContext initialized")

--- a/packages/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
+++ b/packages/flutter/android/src/main/kotlin/io/sentry/flutter/SentryFlutterPlugin.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import android.os.Build
+import android.os.Handler
 import android.os.Looper
 import android.util.Log
 import io.flutter.embedding.engine.plugins.FlutterPlugin
@@ -111,6 +112,8 @@ class SentryFlutterPlugin :
     @SuppressLint("StaticFieldLeak")
     private var replay: ReplayIntegration? = null
 
+    private var replayCallbacks: SafeReplayRecorderCallbacks? = null
+
     @SuppressLint("StaticFieldLeak")
     private var applicationContext: Context? = null
 
@@ -145,12 +148,32 @@ class SentryFlutterPlugin :
         Log.w("Sentry", "Failed to close existing ReplayIntegration", e)
       } finally {
         replay = null
+        replayCallbacks = null
       }
     }
 
     @Suppress("unused") // Used by native/jni bindings
     @JvmStatic
     fun privateSentryGetReplayIntegration(): ReplayIntegration? = replay
+
+    @Suppress("unused") // Used by native/jni bindings
+    @JvmStatic
+    fun privateSentryFlushReplay() {
+      val integration = replay ?: return
+      val callbacks = replayCallbacks ?: return
+      integration.flush()
+      // flush() queues the transition on this looper. Read the resulting state
+      // afterwards; buffer promotion does not restart the Flutter recorder.
+      Handler(Looper.getMainLooper()).post {
+        if (integration !== replay) return@post
+        val replayId = integration.getReplayId()
+        var isBuffering = true
+        Sentry.configureScope { scope ->
+          isBuffering = scope.replayId != replayId
+        }
+        callbacks.replayStateChanged(replayId.toString(), isBuffering)
+      }
+    }
 
     @Suppress("unused") // Used by native/jni bindings
     @JvmStatic
@@ -253,6 +276,7 @@ class SentryFlutterPlugin :
         }
 
         val safeCallbacks = SafeReplayRecorderCallbacks(replayCallbacks)
+        this.replayCallbacks = safeCallbacks
 
         replay =
           ReplayIntegration(

--- a/packages/flutter/darwin/sentry_flutter/Sources/sentry_flutter/SentryFlutterPlugin.swift
+++ b/packages/flutter/darwin/sentry_flutter/Sources/sentry_flutter/SentryFlutterPlugin.swift
@@ -155,6 +155,42 @@ public class SentryFlutterPlugin: NSObject, FlutterPlugin {
             result(nil)
 #endif
 
+        case "startReplay":
+#if canImport(UIKit) && !SENTRY_NO_UIKIT && (os(iOS) || os(tvOS))
+            SentrySDK.internal.replay.start()
+#endif
+            result("")
+
+        case "startReplayBuffering":
+#if canImport(UIKit) && !SENTRY_NO_UIKIT && (os(iOS) || os(tvOS))
+            SentrySDK.internal.replay.startBuffering()
+#endif
+            result("")
+
+        case "pauseReplay":
+#if canImport(UIKit) && !SENTRY_NO_UIKIT && (os(iOS) || os(tvOS))
+            SentrySDK.internal.replay.pause()
+#endif
+            result("")
+
+        case "resumeReplay":
+#if canImport(UIKit) && !SENTRY_NO_UIKIT && (os(iOS) || os(tvOS))
+            SentrySDK.internal.replay.resume()
+#endif
+            result("")
+
+        case "stopReplay":
+#if canImport(UIKit) && !SENTRY_NO_UIKIT && (os(iOS) || os(tvOS))
+            SentrySDK.internal.replay.stop()
+#endif
+            result("")
+
+        case "flushReplay":
+#if canImport(UIKit) && !SENTRY_NO_UIKIT && (os(iOS) || os(tvOS))
+            SentrySDK.internal.replay.flush()
+#endif
+            result("")
+
         case "setTrace":
             let arguments = call.arguments as? [String: Any?]
             let traceId = arguments?["traceId"] as? String

--- a/packages/flutter/darwin/sentry_flutter/Sources/sentry_flutter/SentryFlutterPlugin.swift
+++ b/packages/flutter/darwin/sentry_flutter/Sources/sentry_flutter/SentryFlutterPlugin.swift
@@ -155,41 +155,8 @@ public class SentryFlutterPlugin: NSObject, FlutterPlugin {
             result(nil)
 #endif
 
-        case "startReplay":
-#if canImport(UIKit) && !SENTRY_NO_UIKIT && (os(iOS) || os(tvOS))
-            SentrySDK.internal.replay.start()
-#endif
-            result("")
-
-        case "startReplayBuffering":
-#if canImport(UIKit) && !SENTRY_NO_UIKIT && (os(iOS) || os(tvOS))
-            SentrySDK.internal.replay.startBuffering()
-#endif
-            result("")
-
-        case "pauseReplay":
-#if canImport(UIKit) && !SENTRY_NO_UIKIT && (os(iOS) || os(tvOS))
-            SentrySDK.internal.replay.pause()
-#endif
-            result("")
-
-        case "resumeReplay":
-#if canImport(UIKit) && !SENTRY_NO_UIKIT && (os(iOS) || os(tvOS))
-            SentrySDK.internal.replay.resume()
-#endif
-            result("")
-
-        case "stopReplay":
-#if canImport(UIKit) && !SENTRY_NO_UIKIT && (os(iOS) || os(tvOS))
-            SentrySDK.internal.replay.stop()
-#endif
-            result("")
-
-        case "flushReplay":
-#if canImport(UIKit) && !SENTRY_NO_UIKIT && (os(iOS) || os(tvOS))
-            SentrySDK.internal.replay.flush()
-#endif
-            result("")
+        case "startReplay", "startReplayBuffering", "pauseReplay", "resumeReplay", "stopReplay", "flushReplay":
+            controlReplay(call.method, result: result)
 
         case "setTrace":
             let arguments = call.arguments as? [String: Any?]
@@ -200,6 +167,29 @@ public class SentryFlutterPlugin: NSObject, FlutterPlugin {
         default:
             result(FlutterMethodNotImplemented)
         }
+    }
+
+    private func controlReplay(_ method: String, result: @escaping FlutterResult) {
+#if canImport(UIKit) && !SENTRY_NO_UIKIT && (os(iOS) || os(tvOS))
+        let replay = SentrySDK.internal.replay
+        switch method {
+        case "startReplay":
+            replay.start()
+        case "startReplayBuffering":
+            replay.startBuffering()
+        case "pauseReplay":
+            replay.pause()
+        case "resumeReplay":
+            replay.resume()
+        case "stopReplay":
+            replay.stop()
+        case "flushReplay":
+            replay.flush()
+        default:
+            break
+        }
+#endif
+        result("")
     }
 
     // swiftlint:disable:next cyclomatic_complexity

--- a/packages/flutter/example/integration_test/manual_replay_test.dart
+++ b/packages/flutter/example/integration_test/manual_replay_test.dart
@@ -1,0 +1,246 @@
+// ignore_for_file: invalid_use_of_internal_member
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+import 'package:sentry_flutter/src/native/java/android_replay_recorder.dart';
+import 'package:sentry_flutter/src/native/java/sentry_native_java.dart';
+
+void main() {
+  final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  binding.framePolicy = LiveTestWidgetsFlutterBindingFramePolicy.fullyLive;
+
+  group('$SentryReplay', () {
+    late Fixture fixture;
+
+    setUp(() {
+      fixture = Fixture();
+    });
+
+    tearDown(() async {
+      await Sentry.close();
+    });
+
+    testWidgets('captures frames when started after the widget builds', (
+      tester,
+    ) async {
+      final replay = await fixture.getSut(tester);
+
+      await replay.start();
+
+      await fixture.expectFrame(tester);
+    }, skip: !Platform.isAndroid);
+
+    testWidgets('captures frames after stop and restart without resizing', (
+      tester,
+    ) async {
+      final replay = await fixture.getSut(tester);
+      await replay.start();
+      final firstRecorder = await fixture.expectFrame(tester);
+      final firstId = fixture.native.replayId;
+
+      await replay.stop();
+      await fixture.waitFor(
+        () => fixture.native.testRecorder == null,
+        'Replay recorder did not stop',
+      );
+      await replay.start();
+
+      final secondRecorder = await fixture.expectFrame(tester);
+      expect(secondRecorder, isNot(same(firstRecorder)));
+      expect(fixture.native.replayId, isNot(firstId));
+    }, skip: !Platform.isAndroid);
+
+    testWidgets('captures frames when flushing without an active replay', (
+      tester,
+    ) async {
+      final replay = await fixture.getSut(tester);
+
+      await replay.flush();
+
+      await fixture.expectFrame(tester);
+      await fixture.expectTelemetry(
+        fixture.native.replayId!,
+        isBuffering: false,
+      );
+    }, skip: !Platform.isAndroid);
+
+    testWidgets('links telemetry after flushing a manual buffer', (
+      tester,
+    ) async {
+      final replay = await fixture.getSut(tester);
+      await replay.startBuffering();
+      await fixture.expectFrame(tester);
+      final replayId = fixture.native.replayId!;
+      expect(Sentry.currentHub.scope.replayId, isNull);
+      await fixture.expectTelemetry(replayId, isBuffering: true);
+
+      await replay.flush();
+
+      await fixture.waitFor(
+        () => Sentry.currentHub.scope.replayId == replayId,
+        'Dart scope was not updated after flushing the replay buffer',
+      );
+      await fixture.expectTelemetry(replayId, isBuffering: false);
+    }, skip: !Platform.isAndroid);
+
+    testWidgets(
+      'keeps the new buffer state when flush is followed by stop and restart',
+      (tester) async {
+        final replay = await fixture.getSut(tester);
+        await replay.startBuffering();
+        await fixture.expectFrame(tester);
+        final oldId = fixture.native.replayId;
+
+        await replay.flush();
+        await replay.stop();
+        await replay.startBuffering();
+
+        await fixture.waitFor(
+          () =>
+              fixture.native.replayId != null &&
+              fixture.native.replayId != oldId,
+          'Restart did not create a new replay',
+        );
+        await fixture.expectFrame(tester);
+        expect(Sentry.currentHub.scope.replayId, isNull);
+        await fixture.expectTelemetry(
+          fixture.native.replayId!,
+          isBuffering: true,
+        );
+      },
+      skip: !Platform.isAndroid,
+    );
+
+    testWidgets('links telemetry after error sampling rejects a buffer', (
+      tester,
+    ) async {
+      final replay = await fixture.getSut(tester);
+      await replay.startBuffering();
+      await fixture.expectFrame(tester);
+      final replayId = fixture.native.replayId!;
+      // Zero error sampling deterministically exercises the native rejection
+      // path also taken by an unsampled error with a fractional sample rate.
+      expect(fixture.native.captureReplay(), const SentryId.empty());
+
+      await replay.flush();
+
+      await fixture.waitFor(
+        () => Sentry.currentHub.scope.replayId == replayId,
+        'Rejected error capture prevented manual buffer promotion',
+      );
+      await fixture.expectTelemetry(replayId, isBuffering: false);
+    }, skip: !Platform.isAndroid);
+  });
+}
+
+class Fixture {
+  late SentryFlutterOptions options;
+  SentryNativeJava get native => SentryFlutter.native as SentryNativeJava;
+
+  Future<SentryReplay> getSut(WidgetTester tester) async {
+    await SentryFlutter.init((options) {
+      this.options = options;
+      options
+        ..dsn = 'https://abc@def.ingest.sentry.io/1234567'
+        ..automatedTestMode = true;
+      options.replay
+        ..sessionSampleRate = 0
+        ..onErrorSampleRate = 0;
+    });
+    await tester.pumpWidget(
+      SentryWidget(
+        child: const MaterialApp(home: Scaffold(body: Text('Replay test'))),
+      ),
+    );
+    await tester.pump();
+    return SentryFlutter.replay;
+  }
+
+  Future<void> waitFor(bool Function() condition, String failure) async {
+    final deadline = DateTime.now().add(const Duration(seconds: 10));
+    while (!condition()) {
+      if (DateTime.now().isAfter(deadline)) fail(failure);
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+    }
+  }
+
+  Future<void> expectTelemetry(
+    SentryId replayId, {
+    required bool isBuffering,
+  }) async {
+    final log = SentryLog(
+      timestamp: DateTime.now(),
+      traceId: SentryId.newId(),
+      level: SentryLogLevel.info,
+      body: 'Manual replay',
+      attributes: {},
+    );
+    final metric = SentryCounterMetric(
+      timestamp: DateTime.now(),
+      name: 'manual-replay',
+      value: 1,
+      traceId: SentryId.newId(),
+      attributes: {},
+    );
+    final span = RecordingSentrySpanV2.root(
+      name: 'manual-replay',
+      traceId: SentryId.newId(),
+      onSpanEnd: (_) async {},
+      clock: options.clock,
+      dscCreator: (span) => SentryTraceContextHeader(span.traceId, 'publicKey'),
+      samplingDecision: SentryTracesSamplingDecision(true),
+    );
+    await options.lifecycleRegistry.dispatchCallback(OnProcessLog(log, Hint()));
+    await options.lifecycleRegistry.dispatchCallback(
+      OnProcessMetric(metric, Hint()),
+    );
+    await options.lifecycleRegistry.dispatchCallback(
+      OnProcessSpan(span, Hint()),
+    );
+    for (final attributes in [
+      log.attributes,
+      metric.attributes,
+      span.attributes,
+    ]) {
+      expect(
+        attributes[SemanticAttributesConstants.sentryReplayId]?.value,
+        replayId.toString(),
+      );
+      expect(
+        attributes[SemanticAttributesConstants.sentryInternalReplayIsBuffering]
+            ?.value,
+        isBuffering ? true : null,
+      );
+    }
+  }
+
+  Future<AndroidReplayRecorder> expectFrame(WidgetTester tester) async {
+    final deadline = DateTime.now().add(const Duration(seconds: 10));
+    while (native.testRecorder == null) {
+      if (DateTime.now().isAfter(deadline)) {
+        fail('The Android replay recorder was not created');
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+    }
+    final recorder = native.testRecorder!;
+    final frame = Completer<void>();
+    recorder.onScreenshotAddedForTest = () {
+      if (!frame.isCompleted) frame.complete();
+    };
+    try {
+      await tester.pump();
+      await frame.future.timeout(
+        const Duration(seconds: 10),
+        onTimeout: () => fail('Manual replay did not capture a frame'),
+      );
+    } finally {
+      recorder.onScreenshotAddedForTest = null;
+    }
+    return recorder;
+  }
+}

--- a/packages/flutter/example/integration_test/replay_test.dart
+++ b/packages/flutter/example/integration_test/replay_test.dart
@@ -33,7 +33,11 @@ Future<void> _waitUntilReplayId({SentryId? differentFrom}) async {
   while (SentryFlutter.native?.replayId == null ||
       SentryFlutter.native?.replayId == differentFrom) {
     if (!DateTime.now().isBefore(deadline)) {
-      fail('Replay ID was not set after 10s');
+      fail(
+        differentFrom == null
+            ? 'Replay ID was not set after 10s'
+            : 'Replay ID stayed at $differentFrom for 10s',
+      );
     }
     await Future<void>.delayed(const Duration(milliseconds: 50));
   }
@@ -203,9 +207,8 @@ void main() {
 
       final replay =
           native.SentryFlutterPlugin.privateSentryGetReplayIntegration();
-      if (replay != null) {
-        addTearDown(replay.release);
-      }
+      // Release the reference so a failing assertion doesn't leak it.
+      addTearDown(() => replay?.release());
       expect(replay, isNull);
     }, skip: !Platform.isAndroid);
 

--- a/packages/flutter/example/integration_test/replay_test.dart
+++ b/packages/flutter/example/integration_test/replay_test.dart
@@ -28,6 +28,17 @@ Future<void> _waitUntilRecording(
   }
 }
 
+Future<void> _waitUntilReplayId({SentryId? differentFrom}) async {
+  final deadline = DateTime.now().add(const Duration(seconds: 10));
+  while (SentryFlutter.native?.replayId == null ||
+      SentryFlutter.native?.replayId == differentFrom) {
+    if (!DateTime.now().isBefore(deadline)) {
+      fail('Replay ID was not set after 10s');
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+  }
+}
+
 /// Returns the native replay integration, registering its release.
 native.ReplayIntegration _replayIntegration() {
   final replay = native.SentryFlutterPlugin.privateSentryGetReplayIntegration();
@@ -47,21 +58,34 @@ void main() {
     await Sentry.close();
   });
 
-  Future<void> setupSentryAndApp(WidgetTester tester, {String? dsn}) async {
-    await setupSentry(
-      () async {
-        await tester.pumpWidget(
-          SentryScreenshotWidget(
-            child: DefaultAssetBundle(
-              bundle: SentryAssetBundle(enableStructuredDataTracing: true),
-              child: const MyApp(),
-            ),
+  Future<void> setupSentryAndApp(
+    WidgetTester tester, {
+    String? dsn,
+    bool enableAutomaticReplay = true,
+  }) async {
+    Future<void> appRunner() async {
+      await tester.pumpWidget(
+        SentryScreenshotWidget(
+          child: DefaultAssetBundle(
+            bundle: SentryAssetBundle(enableStructuredDataTracing: true),
+            child: const MyApp(),
           ),
-        );
-      },
-      dsn ?? fakeDsn,
-      isIntegrationTest: true,
-    );
+        ),
+      );
+    }
+
+    if (enableAutomaticReplay) {
+      await setupSentry(appRunner, dsn ?? fakeDsn, isIntegrationTest: true);
+    } else {
+      await SentryFlutter.init((options) {
+        options
+          ..dsn = dsn ?? fakeDsn
+          ..automatedTestMode = true;
+        options.replay
+          ..sessionSampleRate = 0
+          ..onErrorSampleRate = 0;
+      }, appRunner: appRunner);
+    }
   }
 
   group('Replay recording', () {
@@ -113,19 +137,76 @@ void main() {
       // an allowed transition, so it would no-op and then start underneath us.
       await _waitUntilRecording(replay, true);
 
-      replay.stop();
+      await SentryFlutter.replay.stop();
       await _waitUntilRecording(replay, false);
       expect(
         await SentryFlutter.native?.captureReplay(),
         const SentryId.empty(),
       );
 
-      replay.start();
+      await SentryFlutter.replay.start();
       await _waitUntilRecording(replay, true);
       expect(
         await SentryFlutter.native?.captureReplay(),
         isNot(const SentryId.empty()),
       );
+    }, skip: !Platform.isAndroid);
+
+    testWidgets('manual replay controls complete on mobile', (tester) async {
+      if (!(Platform.isAndroid || Platform.isIOS)) return;
+      await setupSentryAndApp(tester);
+
+      await SentryFlutter.replay.pause();
+      await SentryFlutter.replay.resume();
+      await SentryFlutter.replay.flush();
+      await SentryFlutter.replay.stop();
+      await SentryFlutter.replay.startBuffering();
+      await SentryFlutter.replay.flush();
+      await SentryFlutter.replay.stop();
+      await SentryFlutter.replay.start();
+    });
+
+    testWidgets('manual start records when automatic sampling is disabled', (
+      tester,
+    ) async {
+      if (!(Platform.isAndroid || Platform.isIOS)) return;
+      await setupSentryAndApp(tester, enableAutomaticReplay: false);
+
+      await SentryFlutter.replay.start();
+
+      if (Platform.isAndroid) {
+        await _waitUntilRecording(_replayIntegration(), true);
+      } else {
+        await _waitUntilReplayId();
+      }
+
+      final firstReplayId = SentryFlutter.native?.replayId;
+      await SentryFlutter.replay.stop();
+      if (Platform.isAndroid) {
+        await _waitUntilRecording(_replayIntegration(), false);
+      }
+
+      await SentryFlutter.replay.startBuffering();
+      if (Platform.isAndroid) {
+        await _waitUntilRecording(_replayIntegration(), true);
+      }
+      await SentryFlutter.replay.flush();
+      await _waitUntilReplayId(differentFrom: firstReplayId);
+    });
+
+    testWidgets('close tears down the native replay integration on Android', (
+      tester,
+    ) async {
+      await setupSentryAndApp(tester);
+
+      await Sentry.close();
+
+      final replay =
+          native.SentryFlutterPlugin.privateSentryGetReplayIntegration();
+      if (replay != null) {
+        addTearDown(replay.release);
+      }
+      expect(replay, isNull);
     }, skip: !Platform.isAndroid);
 
     // We would like to add a test that ensures a native-initiated replay stop

--- a/packages/flutter/example/integration_test/replay_test.dart
+++ b/packages/flutter/example/integration_test/replay_test.dart
@@ -62,35 +62,33 @@ void main() {
     await Sentry.close();
   });
 
-  Future<void> setupSentryAndApp(
-    WidgetTester tester, {
-    String? dsn,
-    bool enableAutomaticReplay = true,
-  }) async {
-    Future<void> appRunner() async {
-      await tester.pumpWidget(
-        SentryScreenshotWidget(
-          child: DefaultAssetBundle(
-            bundle: SentryAssetBundle(enableStructuredDataTracing: true),
-            child: const MyApp(),
-          ),
-        ),
-      );
-    }
+  Future<void> pumpApp(WidgetTester tester) => tester.pumpWidget(
+    SentryScreenshotWidget(
+      child: DefaultAssetBundle(
+        bundle: SentryAssetBundle(enableStructuredDataTracing: true),
+        child: const MyApp(),
+      ),
+    ),
+  );
 
-    if (enableAutomaticReplay) {
-      await setupSentry(appRunner, dsn ?? fakeDsn, isIntegrationTest: true);
-    } else {
-      await SentryFlutter.init((options) {
+  Future<void> setupSentryAndApp(WidgetTester tester, {String? dsn}) =>
+      setupSentry(
+        () => pumpApp(tester),
+        dsn ?? fakeDsn,
+        isIntegrationTest: true,
+      );
+
+  /// Installs Session Replay but never samples it, so a recording can only be
+  /// started through `SentryFlutter.replay`.
+  Future<void> setupWithoutAutomaticReplay(WidgetTester tester) =>
+      SentryFlutter.init((options) {
         options
-          ..dsn = dsn ?? fakeDsn
+          ..dsn = fakeDsn
           ..automatedTestMode = true;
         options.replay
           ..sessionSampleRate = 0
           ..onErrorSampleRate = 0;
-      }, appRunner: appRunner);
-    }
-  }
+      }, appRunner: () => pumpApp(tester));
 
   group('Replay recording', () {
     testWidgets('native binding is initialized', (tester) async {
@@ -157,7 +155,6 @@ void main() {
     }, skip: !Platform.isAndroid);
 
     testWidgets('manual replay controls complete on mobile', (tester) async {
-      if (!(Platform.isAndroid || Platform.isIOS)) return;
       await setupSentryAndApp(tester);
 
       await SentryFlutter.replay.pause();
@@ -168,13 +165,12 @@ void main() {
       await SentryFlutter.replay.flush();
       await SentryFlutter.replay.stop();
       await SentryFlutter.replay.start();
-    });
+    }, skip: !(Platform.isAndroid || Platform.isIOS));
 
     testWidgets('manual start records when automatic sampling is disabled', (
       tester,
     ) async {
-      if (!(Platform.isAndroid || Platform.isIOS)) return;
-      await setupSentryAndApp(tester, enableAutomaticReplay: false);
+      await setupWithoutAutomaticReplay(tester);
 
       await SentryFlutter.replay.start();
 
@@ -196,7 +192,7 @@ void main() {
       }
       await SentryFlutter.replay.flush();
       await _waitUntilReplayId(differentFrom: firstReplayId);
-    });
+    }, skip: !(Platform.isAndroid || Platform.isIOS));
 
     testWidgets('close tears down the native replay integration on Android', (
       tester,

--- a/packages/flutter/example/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/packages/flutter/example/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -13,8 +13,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa",
       "state" : {
-        "revision" : "53eb9bd5da18e208cfd80e86863d3f4c7ba21b1d",
-        "version" : "9.21.0"
+        "revision" : "aaf96c4a417d30208b3c25d90910d6156ddc973d",
+        "version" : "9.27.0"
       }
     }
   ],

--- a/packages/flutter/example/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/packages/flutter/example/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -13,8 +13,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa",
       "state" : {
-        "revision" : "53eb9bd5da18e208cfd80e86863d3f4c7ba21b1d",
-        "version" : "9.21.0"
+        "revision" : "aaf96c4a417d30208b3c25d90910d6156ddc973d",
+        "version" : "9.27.0"
       }
     }
   ],

--- a/packages/flutter/lib/sentry_flutter.dart
+++ b/packages/flutter/lib/sentry_flutter.dart
@@ -12,6 +12,7 @@ export 'src/integrations/on_error_integration.dart';
 export 'src/navigation/sentry_navigator_observer.dart';
 export 'src/navigation/sentry_display.dart';
 export 'src/navigation/sentry_display_widget.dart';
+export 'src/replay/replay_api.dart' show SentryReplay;
 export 'src/replay/replay_quality.dart';
 export 'src/screenshot/masking_config.dart' show SentryMaskingDecision;
 export 'src/screenshot/sentry_mask_widget.dart';

--- a/packages/flutter/lib/src/integrations/replay_telemetry_integration.dart
+++ b/packages/flutter/lib/src/integrations/replay_telemetry_integration.dart
@@ -22,10 +22,9 @@ class ReplayTelemetryIntegration implements Integration<SentryFlutterOptions> {
 
   @override
   Future<void> call(Hub hub, SentryFlutterOptions options) async {
-    // Deliberately not gated on `options.replay.isEnabled`: with both sample
-    // rates at zero a replay can still be started through `SentryFlutter.replay`.
-    // Registering unconditionally is safe because `_replayAttributes` keys off
-    // whether a replay is actually recording, not off the configuration.
+    // Deliberately not gated on `options.replay.isEnabled`: a replay can also
+    // be started manually while both sample rates are zero. See
+    // [_replayAttributes] for what decides whether anything is attached.
     _options = options;
 
     _onProcessLog = (OnProcessLog event) {
@@ -72,11 +71,9 @@ class ReplayTelemetryIntegration implements Integration<SentryFlutterOptions> {
     options.sdk.addIntegration(integrationName);
   }
 
-  /// Attributes describing the replay that is currently recording, or `null`
-  /// when none is.
-  ///
-  /// Derived from live SDK state rather than from the sample rates, so replays
-  /// started manually through `SentryFlutter.replay` are covered too.
+  /// Attributes for the currently recording replay, keyed off live SDK state
+  /// rather than the sample rates so that manually started replays are covered
+  /// too. Null when nothing is recording.
   Map<String, SentryAttribute>? _replayAttributes(SentryId? scopeReplayId) {
     final replayId = scopeReplayId ?? _native?.replayId;
     if (replayId == null || replayId == SentryId.empty()) {

--- a/packages/flutter/lib/src/integrations/replay_telemetry_integration.dart
+++ b/packages/flutter/lib/src/integrations/replay_telemetry_integration.dart
@@ -22,42 +22,26 @@ class ReplayTelemetryIntegration implements Integration<SentryFlutterOptions> {
 
   @override
   Future<void> call(Hub hub, SentryFlutterOptions options) async {
-    if (!options.replay.isEnabled) {
-      return;
-    }
-    final sessionSampleRate = options.replay.sessionSampleRate ?? 0;
-    final onErrorSampleRate = options.replay.onErrorSampleRate ?? 0;
-
+    // Not gated on `options.replay.isEnabled`: a replay can also be started
+    // manually through `SentryFlutter.replay` while both sample rates are zero.
     _options = options;
 
     _onProcessLog = (OnProcessLog event) {
-      final attributes = _replayAttributes(
-        hub.scope.replayId,
-        sessionSampleRate: sessionSampleRate,
-        onErrorSampleRate: onErrorSampleRate,
-      );
+      final attributes = _replayAttributes(hub.scope.replayId);
       if (attributes != null) {
         event.log.attributes.addAll(attributes);
       }
     };
 
     _onProcessMetric = (OnProcessMetric event) {
-      final attributes = _replayAttributes(
-        hub.scope.replayId,
-        sessionSampleRate: sessionSampleRate,
-        onErrorSampleRate: onErrorSampleRate,
-      );
+      final attributes = _replayAttributes(hub.scope.replayId);
       if (attributes != null) {
         event.metric.attributes.addAll(attributes);
       }
     };
 
     _onProcessSpan = (OnProcessSpan event) {
-      final attributes = _replayAttributes(
-        hub.scope.replayId,
-        sessionSampleRate: sessionSampleRate,
-        onErrorSampleRate: onErrorSampleRate,
-      );
+      final attributes = _replayAttributes(hub.scope.replayId);
       if (attributes != null) {
         event.span.setAttributes(attributes);
       }
@@ -86,32 +70,24 @@ class ReplayTelemetryIntegration implements Integration<SentryFlutterOptions> {
     options.sdk.addIntegration(integrationName);
   }
 
+  /// Resolves the running replay from SDK state rather than from the sample
+  /// rates, so manually started replays are covered too.
+  ///
+  /// The native layer puts the replay ID on the scope only while recording in
+  /// session mode, so a replay the binding knows about but the scope doesn't is
+  /// buffering.
   ({SentryId replayId, bool replayIsBuffering})? _replayContext(
-    SentryId? scopeReplayId, {
-    required double sessionSampleRate,
-    required double onErrorSampleRate,
-  }) {
+    SentryId? scopeReplayId,
+  ) {
     final replayId = scopeReplayId ?? _native?.replayId;
-    final replayIsBuffering = replayId != null && scopeReplayId == null;
-
-    if (sessionSampleRate > 0 && replayId != null && !replayIsBuffering) {
-      return (replayId: replayId, replayIsBuffering: replayIsBuffering);
-    } else if (onErrorSampleRate > 0 && replayId != null && replayIsBuffering) {
-      return (replayId: replayId, replayIsBuffering: replayIsBuffering);
+    if (replayId == null || replayId == SentryId.empty()) {
+      return null;
     }
-    return null;
+    return (replayId: replayId, replayIsBuffering: scopeReplayId == null);
   }
 
-  Map<String, SentryAttribute>? _replayAttributes(
-    SentryId? scopeReplayId, {
-    required double sessionSampleRate,
-    required double onErrorSampleRate,
-  }) {
-    final replayContext = _replayContext(
-      scopeReplayId,
-      sessionSampleRate: sessionSampleRate,
-      onErrorSampleRate: onErrorSampleRate,
-    );
+  Map<String, SentryAttribute>? _replayAttributes(SentryId? scopeReplayId) {
+    final replayContext = _replayContext(scopeReplayId);
     if (replayContext == null) {
       return null;
     }

--- a/packages/flutter/lib/src/integrations/replay_telemetry_integration.dart
+++ b/packages/flutter/lib/src/integrations/replay_telemetry_integration.dart
@@ -22,8 +22,10 @@ class ReplayTelemetryIntegration implements Integration<SentryFlutterOptions> {
 
   @override
   Future<void> call(Hub hub, SentryFlutterOptions options) async {
-    // Not gated on `options.replay.isEnabled`: a replay can also be started
-    // manually through `SentryFlutter.replay` while both sample rates are zero.
+    // Deliberately not gated on `options.replay.isEnabled`: with both sample
+    // rates at zero a replay can still be started through `SentryFlutter.replay`.
+    // Registering unconditionally is safe because `_replayAttributes` keys off
+    // whether a replay is actually recording, not off the configuration.
     _options = options;
 
     _onProcessLog = (OnProcessLog event) {
@@ -70,33 +72,27 @@ class ReplayTelemetryIntegration implements Integration<SentryFlutterOptions> {
     options.sdk.addIntegration(integrationName);
   }
 
-  /// Resolves the running replay from SDK state rather than from the sample
-  /// rates, so manually started replays are covered too.
+  /// Attributes describing the replay that is currently recording, or `null`
+  /// when none is.
   ///
-  /// The native layer puts the replay ID on the scope only while recording in
-  /// session mode, so a replay the binding knows about but the scope doesn't is
-  /// buffering.
-  ({SentryId replayId, bool replayIsBuffering})? _replayContext(
-    SentryId? scopeReplayId,
-  ) {
+  /// Derived from live SDK state rather than from the sample rates, so replays
+  /// started manually through `SentryFlutter.replay` are covered too.
+  Map<String, SentryAttribute>? _replayAttributes(SentryId? scopeReplayId) {
     final replayId = scopeReplayId ?? _native?.replayId;
     if (replayId == null || replayId == SentryId.empty()) {
       return null;
     }
-    return (replayId: replayId, replayIsBuffering: scopeReplayId == null);
-  }
 
-  Map<String, SentryAttribute>? _replayAttributes(SentryId? scopeReplayId) {
-    final replayContext = _replayContext(scopeReplayId);
-    if (replayContext == null) {
-      return null;
-    }
+    // Both native layers put the replay ID on the scope only while recording in
+    // session mode, so an ID the binding knows about but the scope doesn't
+    // belongs to a replay that is still buffering.
+    final isBuffering = scopeReplayId == null;
 
     return {
       SemanticAttributesConstants.sentryReplayId: SentryAttribute.string(
-        replayContext.replayId.toString(),
+        replayId.toString(),
       ),
-      if (replayContext.replayIsBuffering)
+      if (isBuffering)
         SemanticAttributesConstants.sentryInternalReplayIsBuffering:
             SentryAttribute.bool(true),
     };

--- a/packages/flutter/lib/src/native/c/sentry_native.dart
+++ b/packages/flutter/lib/src/native/c/sentry_native.dart
@@ -304,6 +304,36 @@ class SentryNative with SentryNativeSafeInvoker implements SentryNativeBinding {
   }
 
   @override
+  FutureOr<void> startReplay() {
+    _logNotSupported('starting replay');
+  }
+
+  @override
+  FutureOr<void> startReplayBuffering() {
+    _logNotSupported('starting replay buffering');
+  }
+
+  @override
+  FutureOr<void> pauseReplay() {
+    _logNotSupported('pausing replay');
+  }
+
+  @override
+  FutureOr<void> resumeReplay() {
+    _logNotSupported('resuming replay');
+  }
+
+  @override
+  FutureOr<void> stopReplay() {
+    _logNotSupported('stopping replay');
+  }
+
+  @override
+  FutureOr<void> flushReplay() {
+    _logNotSupported('flushing replay');
+  }
+
+  @override
   FutureOr<void> startSession({bool ignoreDuration = false}) {
     _logNotSupported('starting session');
   }

--- a/packages/flutter/lib/src/native/cocoa/sentry_native_cocoa.dart
+++ b/packages/flutter/lib/src/native/cocoa/sentry_native_cocoa.dart
@@ -22,9 +22,7 @@ class SentryNativeCocoa extends SentryNativeChannel {
 
   @override
   Future<void> init(Hub hub) async {
-    // We only need these when replay is enabled (session or error capture)
-    // so let's set it up conditionally. This allows Dart to trim the code.
-    if (options.replay.isEnabled) {
+    if (supportsReplay) {
       channel.setMethodCallHandler((call) async {
         switch (call.method) {
           case 'captureReplayScreenshot':

--- a/packages/flutter/lib/src/native/cocoa/sentry_native_cocoa.dart
+++ b/packages/flutter/lib/src/native/cocoa/sentry_native_cocoa.dart
@@ -66,14 +66,17 @@ class SentryNativeCocoa extends SentryNativeChannel {
 
   @override
   Future<void> stopReplay() async {
-    await super.stopReplay();
-    // iOS reports replay IDs only through the screenshot provider, which goes
-    // quiet once recording stops. Android has `replayStopped` for this.
-    _replayId = null;
-    _hub?.configureScope((s) {
-      // ignore: invalid_use_of_internal_member
-      s.replayId = null;
-    });
+    try {
+      await super.stopReplay();
+    } finally {
+      // iOS reports replay IDs only through the screenshot provider, which goes
+      // quiet once recording stops. Android has `replayStopped` for this.
+      _replayId = null;
+      _hub?.configureScope((s) {
+        // ignore: invalid_use_of_internal_member
+        s.replayId = null;
+      });
+    }
   }
 
   @override

--- a/packages/flutter/lib/src/native/cocoa/sentry_native_cocoa.dart
+++ b/packages/flutter/lib/src/native/cocoa/sentry_native_cocoa.dart
@@ -63,6 +63,14 @@ class SentryNativeCocoa extends SentryNativeChannel {
   }
 
   @override
+  Future<void> stopReplay() async {
+    await super.stopReplay();
+    // iOS has no "replay stopped" callback, so without this the last known ID
+    // would keep being attached to telemetry.
+    _replayId = null;
+  }
+
+  @override
   FutureOr<void> setReplayConfig(ReplayConfig config) {
     // Note: unused on iOS.
   }

--- a/packages/flutter/lib/src/native/cocoa/sentry_native_cocoa.dart
+++ b/packages/flutter/lib/src/native/cocoa/sentry_native_cocoa.dart
@@ -11,6 +11,7 @@ import 'cocoa_replay_recorder.dart';
 class SentryNativeCocoa extends SentryNativeChannel {
   CocoaReplayRecorder? _replayRecorder;
   SentryId? _replayId;
+  Hub? _hub;
 
   SentryNativeCocoa(super.options);
 
@@ -22,6 +23,7 @@ class SentryNativeCocoa extends SentryNativeChannel {
 
   @override
   Future<void> init(Hub hub) async {
+    _hub = hub;
     if (supportsReplay) {
       channel.setMethodCallHandler((call) async {
         switch (call.method) {
@@ -65,9 +67,13 @@ class SentryNativeCocoa extends SentryNativeChannel {
   @override
   Future<void> stopReplay() async {
     await super.stopReplay();
-    // iOS has no "replay stopped" callback, so without this the last known ID
-    // would keep being attached to telemetry.
+    // iOS reports replay IDs only through the screenshot provider, which goes
+    // quiet once recording stops. Android has `replayStopped` for this.
     _replayId = null;
+    _hub?.configureScope((s) {
+      // ignore: invalid_use_of_internal_member
+      s.replayId = null;
+    });
   }
 
   @override

--- a/packages/flutter/lib/src/native/java/binding.dart
+++ b/packages/flutter/lib/src/native/java/binding.dart
@@ -5242,6 +5242,35 @@ extension SentryFlutterPlugin$Companion$$Methods
     ).object<ReplayIntegration?>();
   }
 
+  static final _id_privateSentryFlushReplay = SentryFlutterPlugin$Companion
+      ._class
+      .instanceMethodId(r'privateSentryFlushReplay', r'()V');
+
+  static final _privateSentryFlushReplay =
+      jni$_.ProtectedJniExtensions.lookup<
+            jni$_.NativeFunction<
+              jni$_.JThrowablePtr Function(
+                jni$_.Pointer<jni$_.Void>,
+                jni$_.JMethodIDPtr,
+              )
+            >
+          >('globalEnv_CallVoidMethod')
+          .asFunction<
+            jni$_.JThrowablePtr Function(
+              jni$_.Pointer<jni$_.Void>,
+              jni$_.JMethodIDPtr,
+            )
+          >();
+
+  /// from: `public fun privateSentryFlushReplay(): kotlin.Unit`
+  void privateSentryFlushReplay() {
+    final _$$selfRef = reference;
+    _privateSentryFlushReplay(
+      _$$selfRef.pointer,
+      _id_privateSentryFlushReplay.pointer,
+    ).check();
+  }
+
   static final _id_setupBeforeSend = SentryFlutterPlugin$Companion._class
       .instanceMethodId(
         r'setupBeforeSend',
@@ -5727,6 +5756,36 @@ extension type SentryFlutterPlugin._(jni$_.JObject _$this)
       _$$classRef.pointer,
       _id_privateSentryGetReplayIntegration.pointer,
     ).object<ReplayIntegration?>();
+  }
+
+  static final _id_privateSentryFlushReplay = _class.staticMethodId(
+    r'privateSentryFlushReplay',
+    r'()V',
+  );
+
+  static final _privateSentryFlushReplay =
+      jni$_.ProtectedJniExtensions.lookup<
+            jni$_.NativeFunction<
+              jni$_.JThrowablePtr Function(
+                jni$_.Pointer<jni$_.Void>,
+                jni$_.JMethodIDPtr,
+              )
+            >
+          >('globalEnv_CallStaticVoidMethod')
+          .asFunction<
+            jni$_.JThrowablePtr Function(
+              jni$_.Pointer<jni$_.Void>,
+              jni$_.JMethodIDPtr,
+            )
+          >();
+
+  /// from: `static public final void privateSentryFlushReplay()`
+  static void privateSentryFlushReplay() {
+    final _$$classRef = _class.reference;
+    _privateSentryFlushReplay(
+      _$$classRef.pointer,
+      _id_privateSentryFlushReplay.pointer,
+    ).check();
   }
 
   static final _id_setupBeforeSend = _class.staticMethodId(
@@ -6439,6 +6498,13 @@ extension type ReplayRecorderCallbacks._(jni$_.JObject _$this)
         _$impls[$p]!.replayResumed();
         return jni$_.nullptr;
       }
+      if ($d == r'replayStateChanged(Ljava/lang/String;Z)V') {
+        _$impls[$p]!.replayStateChanged(
+          ($a![0] as jni$_.JString),
+          ($a![1] as jni$_.JBoolean).toDartBool(releaseOriginal: true),
+        );
+        return jni$_.nullptr;
+      }
       if ($d == r'replayPaused()V') {
         _$impls[$p]!.replayPaused();
         return jni$_.nullptr;
@@ -6488,6 +6554,8 @@ extension type ReplayRecorderCallbacks._(jni$_.JObject _$this)
       [
         if ($impl.replayStarted$async) r'replayStarted(Ljava/lang/String;Z)V',
         if ($impl.replayResumed$async) r'replayResumed()V',
+        if ($impl.replayStateChanged$async)
+          r'replayStateChanged(Ljava/lang/String;Z)V',
         if ($impl.replayPaused$async) r'replayPaused()V',
         if ($impl.replayStopped$async) r'replayStopped()V',
         if ($impl.replayReset$async) r'replayReset()V',
@@ -6563,6 +6631,40 @@ extension ReplayRecorderCallbacks$$Methods on ReplayRecorderCallbacks {
   void replayResumed() {
     final _$$selfRef = reference;
     _replayResumed(_$$selfRef.pointer, _id_replayResumed.pointer).check();
+  }
+
+  static final _id_replayStateChanged = ReplayRecorderCallbacks._class
+      .instanceMethodId(r'replayStateChanged', r'(Ljava/lang/String;Z)V');
+
+  static final _replayStateChanged =
+      jni$_.ProtectedJniExtensions.lookup<
+            jni$_.NativeFunction<
+              jni$_.JThrowablePtr Function(
+                jni$_.Pointer<jni$_.Void>,
+                jni$_.JMethodIDPtr,
+                jni$_.VarArgs<(jni$_.Pointer<jni$_.Void>, jni$_.Int32)>,
+              )
+            >
+          >('globalEnv_CallVoidMethod')
+          .asFunction<
+            jni$_.JThrowablePtr Function(
+              jni$_.Pointer<jni$_.Void>,
+              jni$_.JMethodIDPtr,
+              jni$_.Pointer<jni$_.Void>,
+              core$_.int,
+            )
+          >();
+
+  /// from: `public fun replayStateChanged(replayId: kotlin.String, replayIsBuffering: kotlin.Boolean): kotlin.Unit`
+  void replayStateChanged(jni$_.JString string, core$_.bool z) {
+    final _$$selfRef = reference;
+    final _$string = string.reference;
+    _replayStateChanged(
+      _$$selfRef.pointer,
+      _id_replayStateChanged.pointer,
+      _$string.pointer,
+      z ? 1 : 0,
+    ).check();
   }
 
   static final _id_replayPaused = ReplayRecorderCallbacks._class
@@ -6682,6 +6784,9 @@ abstract base mixin class $ReplayRecorderCallbacks {
     core$_.bool replayStarted$async,
     required void Function() replayResumed,
     core$_.bool replayResumed$async,
+    required void Function(jni$_.JString string, core$_.bool z)
+    replayStateChanged,
+    core$_.bool replayStateChanged$async,
     required void Function() replayPaused,
     core$_.bool replayPaused$async,
     required void Function() replayStopped,
@@ -6697,6 +6802,8 @@ abstract base mixin class $ReplayRecorderCallbacks {
   core$_.bool get replayStarted$async => false;
   void replayResumed();
   core$_.bool get replayResumed$async => false;
+  void replayStateChanged(jni$_.JString string, core$_.bool z);
+  core$_.bool get replayStateChanged$async => false;
   void replayPaused();
   core$_.bool get replayPaused$async => false;
   void replayStopped();
@@ -6713,6 +6820,9 @@ final class _$ReplayRecorderCallbacks with $ReplayRecorderCallbacks {
     this.replayStarted$async = false,
     required void Function() replayResumed,
     this.replayResumed$async = false,
+    required void Function(jni$_.JString string, core$_.bool z)
+    replayStateChanged,
+    this.replayStateChanged$async = false,
     required void Function() replayPaused,
     this.replayPaused$async = false,
     required void Function() replayStopped,
@@ -6724,6 +6834,7 @@ final class _$ReplayRecorderCallbacks with $ReplayRecorderCallbacks {
     this.replayConfigChanged$async = false,
   }) : _replayStarted = replayStarted,
        _replayResumed = replayResumed,
+       _replayStateChanged = replayStateChanged,
        _replayPaused = replayPaused,
        _replayStopped = replayStopped,
        _replayReset = replayReset,
@@ -6733,6 +6844,8 @@ final class _$ReplayRecorderCallbacks with $ReplayRecorderCallbacks {
   final core$_.bool replayStarted$async;
   final void Function() _replayResumed;
   final core$_.bool replayResumed$async;
+  final void Function(jni$_.JString string, core$_.bool z) _replayStateChanged;
+  final core$_.bool replayStateChanged$async;
   final void Function() _replayPaused;
   final core$_.bool replayPaused$async;
   final void Function() _replayStopped;
@@ -6749,6 +6862,10 @@ final class _$ReplayRecorderCallbacks with $ReplayRecorderCallbacks {
 
   void replayResumed() {
     return _replayResumed();
+  }
+
+  void replayStateChanged(jni$_.JString string, core$_.bool z) {
+    return _replayStateChanged(string, z);
   }
 
   void replayPaused() {

--- a/packages/flutter/lib/src/native/java/sentry_native_java.dart
+++ b/packages/flutter/lib/src/native/java/sentry_native_java.dart
@@ -277,18 +277,18 @@ class SentryNativeJava extends SentryNativeChannel {
       adjWidth = newWidth;
     }
 
-    final replayConfig = native.ScreenshotRecorderConfig(
-      adjWidth.round(),
-      adjHeight.round(),
-      adjWidth / config.windowWidth,
-      adjHeight / config.windowHeight,
-      config.frameRate,
-      0, // bitRate is currently not used
-    );
+    using((arena) {
+      final replayConfig = native.ScreenshotRecorderConfig(
+        adjWidth.round(),
+        adjHeight.round(),
+        adjWidth / config.windowWidth,
+        adjHeight / config.windowHeight,
+        config.frameRate,
+        0, // bitRate is currently not used
+      )..releasedBy(arena);
 
-    _replay?.onConfigurationChanged(replayConfig);
-
-    replayConfig.release();
+      _replay?.onConfigurationChanged(replayConfig);
+    });
   });
 
   @override

--- a/packages/flutter/lib/src/native/java/sentry_native_java.dart
+++ b/packages/flutter/lib/src/native/java/sentry_native_java.dart
@@ -48,6 +48,11 @@ class SentryNativeJava extends SentryNativeChannel {
     _nativeReplay = nativeReplay;
   }
 
+  /// The native replay integration, looked up on first use and cached until
+  /// [_setNativeReplay] drops it. Null while no replay integration is set up.
+  native.ReplayIntegration? get _replay => _nativeReplay ??=
+      native.SentryFlutterPlugin.privateSentryGetReplayIntegration();
+
   @override
   void init(Hub hub) {
     initSentryAndroid(hub: hub, options: options, owner: this);
@@ -188,10 +193,8 @@ class SentryNativeJava extends SentryNativeChannel {
   SentryId captureReplay() {
     final id = tryCatchSync<SentryId>('captureReplay', () {
       return using((arena) {
-        _nativeReplay ??=
-            native.SentryFlutterPlugin.privateSentryGetReplayIntegration();
         // The passed parameter is `isTerminating`
-        final nativeReplayId = _nativeReplay?.captureReplay(
+        final nativeReplayId = _replay?.captureReplay(
           false.toJBoolean()..releasedBy(arena),
         );
         nativeReplayId?.releasedBy(arena);
@@ -214,44 +217,24 @@ class SentryNativeJava extends SentryNativeChannel {
     return id ?? SentryId.empty();
   }
 
-  void _controlReplay(
-    String operation,
-    void Function(native.ReplayIntegration replay) callback,
-  ) {
-    tryCatchSync(operation, () {
-      _nativeReplay ??=
-          native.SentryFlutterPlugin.privateSentryGetReplayIntegration();
-      final replay = _nativeReplay;
-      if (replay != null) {
-        callback(replay);
-      }
-    });
-  }
+  @override
+  void startReplay() => tryCatchSync('startReplay', () => _replay?.start());
 
   @override
-  void startReplay() =>
-      _controlReplay('startReplay', (replay) => replay.start());
+  void startReplayBuffering() =>
+      tryCatchSync('startReplayBuffering', () => _replay?.startBuffering());
 
   @override
-  void startReplayBuffering() => _controlReplay(
-    'startReplayBuffering',
-    (replay) => replay.startBuffering(),
-  );
+  void pauseReplay() => tryCatchSync('pauseReplay', () => _replay?.pause());
 
   @override
-  void pauseReplay() =>
-      _controlReplay('pauseReplay', (replay) => replay.pause());
+  void resumeReplay() => tryCatchSync('resumeReplay', () => _replay?.resume());
 
   @override
-  void resumeReplay() =>
-      _controlReplay('resumeReplay', (replay) => replay.resume());
+  void stopReplay() => tryCatchSync('stopReplay', () => _replay?.stop());
 
   @override
-  void stopReplay() => _controlReplay('stopReplay', (replay) => replay.stop());
-
-  @override
-  void flushReplay() =>
-      _controlReplay('flushReplay', (replay) => replay.flush());
+  void flushReplay() => tryCatchSync('flushReplay', () => _replay?.flush());
 
   @override
   void setReplayConfig(
@@ -303,9 +286,7 @@ class SentryNativeJava extends SentryNativeChannel {
       0, // bitRate is currently not used
     );
 
-    _nativeReplay ??=
-        native.SentryFlutterPlugin.privateSentryGetReplayIntegration();
-    _nativeReplay?.onConfigurationChanged(replayConfig);
+    _replay?.onConfigurationChanged(replayConfig);
 
     replayConfig.release();
   });
@@ -340,9 +321,7 @@ class SentryNativeJava extends SentryNativeChannel {
       using((arena) {
         final jTraceId = traceId.toString().toJString()..releasedBy(arena);
         final sentryId = native.SentryId.new$2(jTraceId)..releasedBy(arena);
-        _nativeReplay ??=
-            native.SentryFlutterPlugin.privateSentryGetReplayIntegration();
-        _nativeReplay?.registerTraceId(sentryId);
+        _replay?.registerTraceId(sentryId);
       });
     });
   }
@@ -356,9 +335,7 @@ class SentryNativeJava extends SentryNativeChannel {
     tryCatchSync('registerSegmentName', () {
       using((arena) {
         final jSegmentName = segmentName.toJString()..releasedBy(arena);
-        _nativeReplay ??=
-            native.SentryFlutterPlugin.privateSentryGetReplayIntegration();
-        _nativeReplay?.registerSegmentName(jSegmentName);
+        _replay?.registerSegmentName(jSegmentName);
       });
     });
   }

--- a/packages/flutter/lib/src/native/java/sentry_native_java.dart
+++ b/packages/flutter/lib/src/native/java/sentry_native_java.dart
@@ -214,6 +214,45 @@ class SentryNativeJava extends SentryNativeChannel {
     return id ?? SentryId.empty();
   }
 
+  void _controlReplay(
+    String operation,
+    void Function(native.ReplayIntegration replay) callback,
+  ) {
+    tryCatchSync(operation, () {
+      _nativeReplay ??=
+          native.SentryFlutterPlugin.privateSentryGetReplayIntegration();
+      final replay = _nativeReplay;
+      if (replay != null) {
+        callback(replay);
+      }
+    });
+  }
+
+  @override
+  void startReplay() =>
+      _controlReplay('startReplay', (replay) => replay.start());
+
+  @override
+  void startReplayBuffering() => _controlReplay(
+    'startReplayBuffering',
+    (replay) => replay.startBuffering(),
+  );
+
+  @override
+  void pauseReplay() =>
+      _controlReplay('pauseReplay', (replay) => replay.pause());
+
+  @override
+  void resumeReplay() =>
+      _controlReplay('resumeReplay', (replay) => replay.resume());
+
+  @override
+  void stopReplay() => _controlReplay('stopReplay', (replay) => replay.stop());
+
+  @override
+  void flushReplay() =>
+      _controlReplay('flushReplay', (replay) => replay.flush());
+
   @override
   void setReplayConfig(
     ReplayConfig config,

--- a/packages/flutter/lib/src/native/java/sentry_native_java.dart
+++ b/packages/flutter/lib/src/native/java/sentry_native_java.dart
@@ -48,8 +48,8 @@ class SentryNativeJava extends SentryNativeChannel {
     _nativeReplay = nativeReplay;
   }
 
-  /// The native replay integration, looked up on first use and cached until
-  /// [_setNativeReplay] drops it. Null while no replay integration is set up.
+  /// Cached JNI reference to the native replay integration. Only
+  /// [_setNativeReplay] may drop it, which releases the previous reference.
   native.ReplayIntegration? get _replay => _nativeReplay ??=
       native.SentryFlutterPlugin.privateSentryGetReplayIntegration();
 

--- a/packages/flutter/lib/src/native/java/sentry_native_java.dart
+++ b/packages/flutter/lib/src/native/java/sentry_native_java.dart
@@ -25,6 +25,7 @@ class SentryNativeJava extends SentryNativeChannel {
   AndroidReplayRecorder? _replayRecorder;
   AndroidCoreWorker? _coreWorker;
   native.ReplayIntegration? _nativeReplay;
+  ReplayConfig? _replayConfig;
 
   SentryNativeJava(super.options) {
     // Initialize core worker here in the ctor instead of init().
@@ -131,6 +132,7 @@ class SentryNativeJava extends SentryNativeChannel {
 
   @override
   Future<void> close() async {
+    _replayConfig = null;
     await _replayRecorder?.stop();
     await _coreWorker?.close();
     _setNativeReplay(null);
@@ -209,7 +211,11 @@ class SentryNativeJava extends SentryNativeChannel {
             ? SentryId.empty()
             : SentryId.fromId(jString.toDartString());
 
-        _replayId = result;
+        // A rejected error capture does not end the active buffered replay.
+        // Keep its lifecycle ID so a later manual flush can promote it.
+        if (result != SentryId.empty()) {
+          _replayId = result;
+        }
         return result;
       });
     });
@@ -234,10 +240,20 @@ class SentryNativeJava extends SentryNativeChannel {
   void stopReplay() => tryCatchSync('stopReplay', () => _replay?.stop());
 
   @override
-  void flushReplay() => tryCatchSync('flushReplay', () => _replay?.flush());
+  void flushReplay() => tryCatchSync(
+    'flushReplay',
+    native.SentryFlutterPlugin.privateSentryFlushReplay,
+  );
 
   @override
-  void setReplayConfig(
+  void setReplayConfig(ReplayConfig config) {
+    // Native discards configuration while replay is inactive. Keep it for the
+    // next start, which need not coincide with a widget size change.
+    _replayConfig = config;
+    _applyReplayConfig(config);
+  }
+
+  void _applyReplayConfig(
     ReplayConfig config,
   ) => tryCatchSync('setReplayConfig', () {
     // Since codec block size is 16, so we have to adjust the width and height to it,

--- a/packages/flutter/lib/src/native/java/sentry_native_java_init.dart
+++ b/packages/flutter/lib/src/native/java/sentry_native_java_init.dart
@@ -135,6 +135,7 @@ native.ReplayRecorderCallbacks? createReplayRecorderCallbacks({
         await owner._replayRecorder?.pause();
       },
       replayStopped: () async {
+        owner._replayId = null;
         hub.configureScope((s) {
           // ignore: invalid_use_of_internal_member
           s.replayId = null;

--- a/packages/flutter/lib/src/native/java/sentry_native_java_init.dart
+++ b/packages/flutter/lib/src/native/java/sentry_native_java_init.dart
@@ -110,8 +110,6 @@ native.ReplayRecorderCallbacks? createReplayRecorderCallbacks({
   required Hub hub,
   required SentryNativeJava owner,
 }) {
-  if (!options.replay.isEnabled) return null;
-
   return native.ReplayRecorderCallbacks.implement(
     native.$ReplayRecorderCallbacks(
       replayStarted: (JString replayIdString, bool replayIsBuffering) async {

--- a/packages/flutter/lib/src/native/java/sentry_native_java_init.dart
+++ b/packages/flutter/lib/src/native/java/sentry_native_java_init.dart
@@ -118,11 +118,27 @@ native.ReplayRecorderCallbacks? createReplayRecorderCallbacks({
         );
 
         owner._replayId = replayId;
+        hub.configureScope((s) {
+          // ignore: invalid_use_of_internal_member
+          s.replayId = !replayIsBuffering ? replayId : null;
+        });
         owner._setNativeReplay(
           native.SentryFlutterPlugin.privateSentryGetReplayIntegration(),
         );
         owner._replayRecorder = AndroidReplayRecorder.factory(options);
+        final config = owner._replayConfig;
+        if (config != null) {
+          owner._applyReplayConfig(config);
+        }
         await owner._replayRecorder!.start();
+      },
+      replayStateChanged: (JString replayIdString, bool replayIsBuffering) {
+        final replayId = SentryId.fromId(
+          replayIdString.toDartString(releaseOriginal: true),
+        );
+        if (replayId == SentryId.empty() || owner._replayId != replayId) {
+          return;
+        }
         hub.configureScope((s) {
           // ignore: invalid_use_of_internal_member
           s.replayId = !replayIsBuffering ? replayId : null;

--- a/packages/flutter/lib/src/native/sentry_native_binding.dart
+++ b/packages/flutter/lib/src/native/sentry_native_binding.dart
@@ -64,6 +64,18 @@ abstract class SentryNativeBinding {
 
   FutureOr<SentryId> captureReplay();
 
+  FutureOr<void> startReplay();
+
+  FutureOr<void> startReplayBuffering();
+
+  FutureOr<void> pauseReplay();
+
+  FutureOr<void> resumeReplay();
+
+  FutureOr<void> stopReplay();
+
+  FutureOr<void> flushReplay();
+
   /// Starts a new session.
   ///
   /// Note: This is used on web platforms. Android and iOS handle sessions

--- a/packages/flutter/lib/src/native/sentry_native_channel.dart
+++ b/packages/flutter/lib/src/native/sentry_native_channel.dart
@@ -426,6 +426,25 @@ class SentryNativeChannel
   }
 
   @override
+  FutureOr<void> startReplay() => channel.invokeMethod('startReplay');
+
+  @override
+  FutureOr<void> startReplayBuffering() =>
+      channel.invokeMethod('startReplayBuffering');
+
+  @override
+  FutureOr<void> pauseReplay() => channel.invokeMethod('pauseReplay');
+
+  @override
+  FutureOr<void> resumeReplay() => channel.invokeMethod('resumeReplay');
+
+  @override
+  FutureOr<void> stopReplay() => channel.invokeMethod('stopReplay');
+
+  @override
+  FutureOr<void> flushReplay() => channel.invokeMethod('flushReplay');
+
+  @override
   FutureOr<void> captureSession() {
     _logNotSupported('capturing session');
   }

--- a/packages/flutter/lib/src/replay/integration.dart
+++ b/packages/flutter/lib/src/replay/integration.dart
@@ -20,7 +20,7 @@ class ReplayIntegration extends Integration<SentryFlutterOptions> {
   Hub? _hub;
   SentryFlutterOptions? _options;
   SdkLifecycleCallback<OnBeforeSendEvent>? _onBeforeSendEventCallback;
-  void Function()? _removeOnBuildCallback;
+  void Function()? _removeOnBuildListener;
 
   @override
   FutureOr<void> call(Hub hub, SentryFlutterOptions options) {
@@ -43,8 +43,8 @@ class ReplayIntegration extends Integration<SentryFlutterOptions> {
       _onBeforeSendEventCallback = callback;
     }
 
-    _removeOnBuildCallback?.call();
-    _removeOnBuildCallback = SentryScreenshotWidget.onBuild((
+    _removeOnBuildListener?.call();
+    _removeOnBuildListener = SentryScreenshotWidget.onBuild((
       status,
       prevStatus,
     ) {
@@ -73,8 +73,8 @@ class ReplayIntegration extends Integration<SentryFlutterOptions> {
 
   @override
   void close() {
-    _removeOnBuildCallback?.call();
-    _removeOnBuildCallback = null;
+    _removeOnBuildListener?.call();
+    _removeOnBuildListener = null;
 
     final callback = _onBeforeSendEventCallback;
     if (callback != null) {

--- a/packages/flutter/lib/src/replay/integration.dart
+++ b/packages/flutter/lib/src/replay/integration.dart
@@ -20,12 +20,18 @@ class ReplayIntegration extends Integration<SentryFlutterOptions> {
   Hub? _hub;
   SentryFlutterOptions? _options;
   SdkLifecycleCallback<OnBeforeSendEvent>? _onBeforeSendEventCallback;
+  void Function()? _removeOnBuildCallback;
 
   @override
   FutureOr<void> call(Hub hub, SentryFlutterOptions options) {
     final replayOptions = options.replay;
-    if (_native.supportsReplay && replayOptions.isEnabled) {
-      options.sdk.addIntegration(replayIntegrationName);
+    if (!_native.supportsReplay) {
+      return null;
+    }
+
+    options.sdk.addIntegration(replayIntegrationName);
+
+    if (replayOptions.isEnabled) {
       _hub = hub;
       _options = options;
 
@@ -37,34 +43,41 @@ class ReplayIntegration extends Integration<SentryFlutterOptions> {
         options.lifecycleRegistry.registerCallback<OnBeforeSendEvent>(callback);
         _onBeforeSendEventCallback = callback;
       }
-
-      SentryScreenshotWidget.onBuild((status, prevStatus) {
-        // Skip config update if the difference is negligible (e.g., due to floating-point precision)
-        // e.g a size.height of 200.00001 and 200.001 could be treated as equals
-        if (prevStatus != null && status.matches(prevStatus)) {
-          return true;
-        }
-
-        _native.setReplayConfig(
-          ReplayConfig(
-            windowWidth: status.size?.width ?? 0.0,
-            windowHeight: status.size?.height ?? 0.0,
-            width:
-                replayOptions.quality.resolutionScalingFactor *
-                (status.size?.width ?? 0.0),
-            height:
-                replayOptions.quality.resolutionScalingFactor *
-                (status.size?.height ?? 0.0),
-          ),
-        );
-
-        return true;
-      });
     }
+
+    _removeOnBuildCallback?.call();
+    _removeOnBuildCallback = SentryScreenshotWidget.onBuild((
+      status,
+      prevStatus,
+    ) {
+      // Skip config update if the difference is negligible (e.g., due to floating-point precision)
+      // e.g a size.height of 200.00001 and 200.001 could be treated as equals
+      if (prevStatus != null && status.matches(prevStatus)) {
+        return true;
+      }
+
+      _native.setReplayConfig(
+        ReplayConfig(
+          windowWidth: status.size?.width ?? 0.0,
+          windowHeight: status.size?.height ?? 0.0,
+          width:
+              replayOptions.quality.resolutionScalingFactor *
+              (status.size?.width ?? 0.0),
+          height:
+              replayOptions.quality.resolutionScalingFactor *
+              (status.size?.height ?? 0.0),
+        ),
+      );
+
+      return true;
+    });
   }
 
   @override
   void close() {
+    _removeOnBuildCallback?.call();
+    _removeOnBuildCallback = null;
+
     final callback = _onBeforeSendEventCallback;
     if (callback != null) {
       _options?.lifecycleRegistry.removeCallback<OnBeforeSendEvent>(callback);

--- a/packages/flutter/lib/src/replay/integration.dart
+++ b/packages/flutter/lib/src/replay/integration.dart
@@ -31,18 +31,16 @@ class ReplayIntegration extends Integration<SentryFlutterOptions> {
 
     options.sdk.addIntegration(replayIntegrationName);
 
-    if (replayOptions.isEnabled) {
-      _hub = hub;
-      _options = options;
+    _hub = hub;
+    _options = options;
 
-      // We only need the hook when error-replay capture is enabled. It runs in
-      // the send phase rather than as an event processor so that an event
-      // dropped by sampling or `beforeSend` cannot flush the buffered replay.
-      if ((replayOptions.onErrorSampleRate ?? 0) > 0) {
-        final callback = _onEventAboutToBeSent;
-        options.lifecycleRegistry.registerCallback<OnBeforeSendEvent>(callback);
-        _onBeforeSendEventCallback = callback;
-      }
+    // We only need the hook when error-replay capture is enabled. It runs in
+    // the send phase rather than as an event processor so that an event
+    // dropped by sampling or `beforeSend` cannot flush the buffered replay.
+    if ((replayOptions.onErrorSampleRate ?? 0) > 0) {
+      final callback = _onEventAboutToBeSent;
+      options.lifecycleRegistry.registerCallback<OnBeforeSendEvent>(callback);
+      _onBeforeSendEventCallback = callback;
     }
 
     _removeOnBuildCallback?.call();
@@ -83,6 +81,9 @@ class ReplayIntegration extends Integration<SentryFlutterOptions> {
       _options?.lifecycleRegistry.removeCallback<OnBeforeSendEvent>(callback);
       _onBeforeSendEventCallback = null;
     }
+
+    _hub = null;
+    _options = null;
   }
 
   Future<void> _onEventAboutToBeSent(OnBeforeSendEvent lifecycleEvent) async {
@@ -100,6 +101,9 @@ class ReplayIntegration extends Integration<SentryFlutterOptions> {
   }
 
   Future<void> captureReplay() async {
+    // A replay started through `SentryFlutter.replay` is only sent by
+    // `SentryFlutter.replay.flush()`; error and feedback events send the buffer
+    // only for the configured sample rates.
     if (_native.supportsReplay && _options?.replay.isEnabled == true) {
       final replayId = await _native.captureReplay();
       _hub?.configureScope((scope) {

--- a/packages/flutter/lib/src/replay/replay_api.dart
+++ b/packages/flutter/lib/src/replay/replay_api.dart
@@ -7,6 +7,8 @@ import '../utils/internal_logger.dart';
 
 /// Controls Session Replay recording.
 ///
+/// Access via `SentryFlutter.replay`.
+///
 /// Only Android and iOS support Session Replay. On every other platform these
 /// methods are no-ops.
 abstract interface class SentryReplay {
@@ -41,53 +43,44 @@ abstract interface class SentryReplay {
 }
 
 @internal
-SentryReplay createSentryReplay(
-  SentryNativeBinding? Function() nativeProvider,
-) => _SentryReplay(nativeProvider);
-
-final class _SentryReplay implements SentryReplay {
-  _SentryReplay(this._nativeProvider);
+final class DefaultSentryReplay implements SentryReplay {
+  DefaultSentryReplay(this._nativeProvider);
 
   final SentryNativeBinding? Function() _nativeProvider;
 
-  Future<void> _invoke(
-    String operation,
-    FutureOr<void> Function(SentryNativeBinding native) callback,
-  ) async {
+  /// The binding to control, or null when there is nothing to control because
+  /// the SDK isn't initialized or the platform has no Session Replay.
+  SentryNativeBinding? get _native {
     final native = _nativeProvider();
     if (native == null) {
       internalLogger.debug(
-        'SentryFlutter.replay.$operation() was ignored because the native '
-        'integration is unavailable. Make sure SentryFlutter.init() ran first.',
+        'SentryFlutter.replay was used before SentryFlutter.init(), so the '
+        'native integration is unavailable.',
       );
-      return;
+      return null;
     }
     if (!native.supportsReplay) {
-      internalLogger.debug(
-        'SentryFlutter.replay.$operation() was ignored because Session Replay '
-        'is not supported on this platform.',
-      );
-      return;
+      internalLogger.debug('Session Replay is not supported on this platform.');
+      return null;
     }
-    await callback(native);
+    return native;
   }
 
   @override
-  Future<void> start() => _invoke('start', (native) => native.startReplay());
+  Future<void> start() async => _native?.startReplay();
 
   @override
-  Future<void> startBuffering() =>
-      _invoke('startBuffering', (native) => native.startReplayBuffering());
+  Future<void> startBuffering() async => _native?.startReplayBuffering();
 
   @override
-  Future<void> pause() => _invoke('pause', (native) => native.pauseReplay());
+  Future<void> pause() async => _native?.pauseReplay();
 
   @override
-  Future<void> resume() => _invoke('resume', (native) => native.resumeReplay());
+  Future<void> resume() async => _native?.resumeReplay();
 
   @override
-  Future<void> stop() => _invoke('stop', (native) => native.stopReplay());
+  Future<void> stop() async => _native?.stopReplay();
 
   @override
-  Future<void> flush() => _invoke('flush', (native) => native.flushReplay());
+  Future<void> flush() async => _native?.flushReplay();
 }

--- a/packages/flutter/lib/src/replay/replay_api.dart
+++ b/packages/flutter/lib/src/replay/replay_api.dart
@@ -5,7 +5,10 @@ import 'package:meta/meta.dart';
 import '../native/sentry_native_binding.dart';
 import '../utils/internal_logger.dart';
 
-/// Controls Session Replay recording on supported native platforms.
+/// Controls Session Replay recording.
+///
+/// Only Android and iOS support Session Replay. On every other platform these
+/// methods are no-ops.
 abstract interface class SentryReplay {
   /// Starts a new replay session.
   ///
@@ -54,13 +57,16 @@ final class _SentryReplay implements SentryReplay {
     final native = _nativeProvider();
     if (native == null) {
       internalLogger.debug(
-        'Native integration is not available. Make sure SentryFlutter is '
-        'initialized before accessing the SentryFlutter.replay.$operation API.',
+        'SentryFlutter.replay.$operation() was ignored because the native '
+        'integration is unavailable. Make sure SentryFlutter.init() ran first.',
       );
       return;
     }
     if (!native.supportsReplay) {
-      internalLogger.debug('Session Replay is not supported on this platform.');
+      internalLogger.debug(
+        'SentryFlutter.replay.$operation() was ignored because Session Replay '
+        'is not supported on this platform.',
+      );
       return;
     }
     await callback(native);

--- a/packages/flutter/lib/src/replay/replay_api.dart
+++ b/packages/flutter/lib/src/replay/replay_api.dart
@@ -1,0 +1,87 @@
+import 'dart:async';
+
+import 'package:meta/meta.dart';
+
+import '../native/sentry_native_binding.dart';
+import '../utils/internal_logger.dart';
+
+/// Controls Session Replay recording on supported native platforms.
+abstract interface class SentryReplay {
+  /// Starts a new replay session.
+  ///
+  /// This explicit start bypasses session sampling. It does nothing when a
+  /// replay is already active.
+  Future<void> start();
+
+  /// Starts Replay in buffer mode.
+  ///
+  /// This explicit start bypasses session sampling. The rolling buffer is sent
+  /// by [flush] or when an error is selected by the configured error sample
+  /// rate, then recording continues in session mode.
+  Future<void> startBuffering();
+
+  /// Pauses the active replay until [resume] is called.
+  Future<void> pause();
+
+  /// Resumes a replay paused with [pause].
+  Future<void> resume();
+
+  /// Stops the active replay.
+  ///
+  /// A subsequent [start] or [startBuffering] creates a new replay.
+  Future<void> stop();
+
+  /// Sends the current replay data and continues in session mode.
+  ///
+  /// If Replay is inactive, this starts a new replay session.
+  Future<void> flush();
+}
+
+@internal
+SentryReplay createSentryReplay(
+  SentryNativeBinding? Function() nativeProvider,
+) => _SentryReplay(nativeProvider);
+
+final class _SentryReplay implements SentryReplay {
+  _SentryReplay(this._nativeProvider);
+
+  final SentryNativeBinding? Function() _nativeProvider;
+
+  Future<void> _invoke(
+    String operation,
+    FutureOr<void> Function(SentryNativeBinding native) callback,
+  ) async {
+    final native = _nativeProvider();
+    if (native == null) {
+      internalLogger.debug(
+        'Native integration is not available. Make sure SentryFlutter is '
+        'initialized before accessing the SentryFlutter.replay.$operation API.',
+      );
+      return;
+    }
+    if (!native.supportsReplay) {
+      internalLogger.debug('Session Replay is not supported on this platform.');
+      return;
+    }
+    await callback(native);
+  }
+
+  @override
+  Future<void> start() => _invoke('start', (native) => native.startReplay());
+
+  @override
+  Future<void> startBuffering() =>
+      _invoke('startBuffering', (native) => native.startReplayBuffering());
+
+  @override
+  Future<void> pause() => _invoke('pause', (native) => native.pauseReplay());
+
+  @override
+  Future<void> resume() => _invoke('resume', (native) => native.resumeReplay());
+
+  @override
+  Future<void> stop() => _invoke('stop', (native) => native.stopReplay());
+
+  @override
+  Future<void> flush() => _invoke('flush', (native) => native.flushReplay());
+}

--- a/packages/flutter/lib/src/screenshot/sentry_screenshot_widget.dart
+++ b/packages/flutter/lib/src/screenshot/sentry_screenshot_widget.dart
@@ -66,11 +66,13 @@ class SentryScreenshotWidget extends StatefulWidget {
 
   /// Registers a persistent callback that is called whenever the widget is
   /// built. The callback is called with the current and previous widget status.
-  /// To unregister, return false;
+  /// To unregister, return false or call the returned function.
   /// If the widget is already built, the callback is called immediately.
   /// Note: the callback must not throw and it must not call onBuild().
   @internal
-  static void onBuild(SentryScreenshotWidgetOnBuildCallback callback) {
+  static void Function() onBuild(
+    SentryScreenshotWidgetOnBuildCallback callback,
+  ) {
     bool register = true;
     final currentStatus = _status;
     if (currentStatus != null) {
@@ -79,6 +81,7 @@ class SentryScreenshotWidget extends StatefulWidget {
     if (register) {
       _onBuild.add(callback);
     }
+    return () => _onBuild.remove(callback);
   }
 }
 

--- a/packages/flutter/lib/src/sentry_flutter.dart
+++ b/packages/flutter/lib/src/sentry_flutter.dart
@@ -562,7 +562,7 @@ mixin SentryFlutter {
   ///
   /// Only Android and iOS support Session Replay. On every other platform the
   /// methods on the returned [SentryReplay] are no-ops.
-  static final SentryReplay replay = createSentryReplay(() => _native);
+  static final SentryReplay replay = DefaultSentryReplay(() => _native);
 
   /// Use `nativeCrash()` to crash the native implementation and test/debug the crash reporting for native code.
   /// This should not be used in production code.

--- a/packages/flutter/lib/src/sentry_flutter.dart
+++ b/packages/flutter/lib/src/sentry_flutter.dart
@@ -558,10 +558,11 @@ mixin SentryFlutter {
 
   static SentryNativeBinding? _native;
 
-  /// Controls Session Replay recording on supported native platforms.
-  static SentryReplay get replay => _replay;
-
-  static final SentryReplay _replay = createSentryReplay(() => _native);
+  /// Controls Session Replay recording.
+  ///
+  /// Only Android and iOS support Session Replay. On every other platform the
+  /// methods on the returned [SentryReplay] are no-ops.
+  static final SentryReplay replay = createSentryReplay(() => _native);
 
   /// Use `nativeCrash()` to crash the native implementation and test/debug the crash reporting for native code.
   /// This should not be used in production code.

--- a/packages/flutter/lib/src/sentry_flutter.dart
+++ b/packages/flutter/lib/src/sentry_flutter.dart
@@ -36,6 +36,7 @@ import 'native/native_scope_observer.dart';
 import 'native/sentry_native_binding.dart';
 import 'replay/integration.dart';
 import 'replay/network_details_capture.dart';
+import 'replay/replay_api.dart';
 import 'screenshot/screenshot_support.dart';
 import 'utils/internal_logger.dart';
 import 'utils/platform_dispatcher_wrapper.dart';
@@ -556,6 +557,11 @@ mixin SentryFlutter {
   static set native(SentryNativeBinding? value) => _native = value;
 
   static SentryNativeBinding? _native;
+
+  /// Controls Session Replay recording on supported native platforms.
+  static SentryReplay get replay => _replay;
+
+  static final SentryReplay _replay = createSentryReplay(() => _native);
 
   /// Use `nativeCrash()` to crash the native implementation and test/debug the crash reporting for native code.
   /// This should not be used in production code.

--- a/packages/flutter/lib/src/web/sentry_web.dart
+++ b/packages/flutter/lib/src/web/sentry_web.dart
@@ -141,6 +141,36 @@ class SentryWeb with SentryNativeSafeInvoker implements SentryNativeBinding {
   }
 
   @override
+  FutureOr<void> startReplay() {
+    _logNotSupported('starting replay');
+  }
+
+  @override
+  FutureOr<void> startReplayBuffering() {
+    _logNotSupported('starting replay buffering');
+  }
+
+  @override
+  FutureOr<void> pauseReplay() {
+    _logNotSupported('pausing replay');
+  }
+
+  @override
+  FutureOr<void> resumeReplay() {
+    _logNotSupported('resuming replay');
+  }
+
+  @override
+  FutureOr<void> stopReplay() {
+    _logNotSupported('stopping replay');
+  }
+
+  @override
+  FutureOr<void> flushReplay() {
+    _logNotSupported('flushing replay');
+  }
+
+  @override
   FutureOr<void> clearBreadcrumbs() {
     _logNotSupported('clear breadcrumbs');
   }

--- a/packages/flutter/test/integrations/replay_telemetry_integration_test.dart
+++ b/packages/flutter/test/integrations/replay_telemetry_integration_test.dart
@@ -21,17 +21,42 @@ void main() {
   });
 
   group('$ReplayTelemetryIntegration', () {
-    group('when replay is disabled', () {
-      test('does not register', () async {
+    group('when automatic sampling is disabled', () {
+      setUp(() {
         fixture.options.replay.sessionSampleRate = 0.0;
         fixture.options.replay.onErrorSampleRate = 0.0;
+      });
+
+      test('registers so manually started replays are covered', () async {
+        await fixture.getSut().call(fixture.hub, fixture.options);
+
+        expect(fixture.options.sdk.integrations, contains('ReplayTelemetry'));
+      });
+
+      test('adds replay_id for a manually started session replay', () async {
+        fixture.scope.replayId = SentryId.fromId('test-replay-id');
 
         await fixture.getSut().call(fixture.hub, fixture.options);
 
-        expect(
-          fixture.options.sdk.integrations,
-          isNot(contains('ReplayTelemetry')),
-        );
+        final log = fixture.createTestLog();
+        await fixture.hub.captureLog(log);
+
+        expect(log.attributes[_replayId]?.value, 'testreplayid');
+        expect(log.attributes.containsKey(_replayIsBuffering), false);
+      });
+
+      test('adds replay_id for a manually buffered replay', () async {
+        when(
+          fixture.nativeBinding.replayId,
+        ).thenReturn(SentryId.fromId('test-replay-id'));
+
+        await fixture.getSut().call(fixture.hub, fixture.options);
+
+        final log = fixture.createTestLog();
+        await fixture.hub.captureLog(log);
+
+        expect(log.attributes[_replayId]?.value, 'testreplayid');
+        expect(log.attributes[_replayIsBuffering]?.value, true);
       });
     });
 
@@ -271,80 +296,55 @@ void main() {
       });
     });
 
-    group('with zero or null sample rates', () {
-      for (final rate in [0.0, null]) {
-        test(
-          'ignores scope replayId when sessionSampleRate is $rate',
-          () async {
-            fixture.options.replay.sessionSampleRate = rate;
-            fixture.options.replay.onErrorSampleRate = 0.5;
-            fixture.scope.replayId = SentryId.fromId('test-replay-id');
+    group('when no replay is running', () {
+      setUp(() {
+        fixture.options.replay.sessionSampleRate = 0.5;
+        fixture.options.replay.onErrorSampleRate = 0.5;
+      });
 
-            await fixture.getSut().call(fixture.hub, fixture.options);
+      test('adds no replay_id to logs without a replay ID', () async {
+        await fixture.getSut().call(fixture.hub, fixture.options);
 
-            final log = fixture.createTestLog();
-            await fixture.hub.captureLog(log);
+        final log = fixture.createTestLog();
+        await fixture.hub.captureLog(log);
 
-            expect(log.attributes.containsKey(_replayId), false);
-          },
+        expect(log.attributes.containsKey(_replayId), false);
+      });
+
+      test('adds no replay_id to spans without a replay ID', () async {
+        await fixture.getSut().call(fixture.hub, fixture.options);
+
+        final span = fixture.createTestSpan();
+        await fixture.options.lifecycleRegistry.dispatchCallback(
+          OnProcessSpan(span, Hint()),
         );
 
-        test(
-          'ignores scope replayId for spans when sessionSampleRate is $rate',
-          () async {
-            fixture.options.replay.sessionSampleRate = rate;
-            fixture.options.replay.onErrorSampleRate = 0.5;
-            fixture.scope.replayId = SentryId.fromId('test-replay-id');
+        expect(span.attributes.containsKey(_replayId), false);
+      });
 
-            await fixture.getSut().call(fixture.hub, fixture.options);
+      test('ignores an empty native replay ID for logs', () async {
+        when(fixture.nativeBinding.replayId).thenReturn(SentryId.empty());
 
-            final span = fixture.createTestSpan();
-            await fixture.options.lifecycleRegistry.dispatchCallback(
-              OnProcessSpan(span, Hint()),
-            );
+        await fixture.getSut().call(fixture.hub, fixture.options);
 
-            expect(span.attributes.containsKey(_replayId), false);
-          },
+        final log = fixture.createTestLog();
+        await fixture.hub.captureLog(log);
+
+        expect(log.attributes.containsKey(_replayId), false);
+      });
+
+      test('ignores an empty native replay ID for spans', () async {
+        when(fixture.nativeBinding.replayId).thenReturn(SentryId.empty());
+
+        await fixture.getSut().call(fixture.hub, fixture.options);
+
+        final span = fixture.createTestSpan();
+        await fixture.options.lifecycleRegistry.dispatchCallback(
+          OnProcessSpan(span, Hint()),
         );
 
-        test(
-          'ignores native replayId when onErrorSampleRate is $rate',
-          () async {
-            fixture.options.replay.sessionSampleRate = 0.5;
-            fixture.options.replay.onErrorSampleRate = rate;
-            when(
-              fixture.nativeBinding.replayId,
-            ).thenReturn(SentryId.fromId('test-replay-id'));
-
-            await fixture.getSut().call(fixture.hub, fixture.options);
-
-            final log = fixture.createTestLog();
-            await fixture.hub.captureLog(log);
-
-            expect(log.attributes.containsKey(_replayId), false);
-          },
-        );
-
-        test(
-          'ignores native replayId for spans when onErrorSampleRate is $rate',
-          () async {
-            fixture.options.replay.sessionSampleRate = 0.5;
-            fixture.options.replay.onErrorSampleRate = rate;
-            when(
-              fixture.nativeBinding.replayId,
-            ).thenReturn(SentryId.fromId('test-replay-id'));
-
-            await fixture.getSut().call(fixture.hub, fixture.options);
-
-            final span = fixture.createTestSpan();
-            await fixture.options.lifecycleRegistry.dispatchCallback(
-              OnProcessSpan(span, Hint()),
-            );
-
-            expect(span.attributes.containsKey(_replayId), false);
-          },
-        );
-      }
+        expect(span.attributes.containsKey(_replayId), false);
+      });
     });
 
     group('when closed', () {

--- a/packages/flutter/test/replay/replay_api_test.dart
+++ b/packages/flutter/test/replay/replay_api_test.dart
@@ -10,18 +10,10 @@ import '../mocks.mocks.dart';
 
 void main() {
   group('$SentryReplay', () {
-    late MockSentryNativeBinding native;
+    late Fixture fixture;
 
     setUp(() {
-      native = MockSentryNativeBinding();
-      when(native.supportsReplay).thenReturn(true);
-      when(native.startReplay()).thenReturn(null);
-      when(native.startReplayBuffering()).thenReturn(null);
-      when(native.pauseReplay()).thenReturn(null);
-      when(native.resumeReplay()).thenReturn(null);
-      when(native.stopReplay()).thenReturn(null);
-      when(native.flushReplay()).thenReturn(null);
-      SentryFlutter.native = native;
+      fixture = Fixture();
     });
 
     tearDown(() {
@@ -29,53 +21,53 @@ void main() {
     });
 
     test('start forwards to the native binding', () async {
-      await SentryFlutter.replay.start();
+      await fixture.getSut().start();
 
-      verify(native.startReplay()).called(1);
+      verify(fixture.native.startReplay()).called(1);
     });
 
     test('startBuffering forwards to the native binding', () async {
-      await SentryFlutter.replay.startBuffering();
+      await fixture.getSut().startBuffering();
 
-      verify(native.startReplayBuffering()).called(1);
+      verify(fixture.native.startReplayBuffering()).called(1);
     });
 
     test('pause forwards to the native binding', () async {
-      await SentryFlutter.replay.pause();
+      await fixture.getSut().pause();
 
-      verify(native.pauseReplay()).called(1);
+      verify(fixture.native.pauseReplay()).called(1);
     });
 
     test('resume forwards to the native binding', () async {
-      await SentryFlutter.replay.resume();
+      await fixture.getSut().resume();
 
-      verify(native.resumeReplay()).called(1);
+      verify(fixture.native.resumeReplay()).called(1);
     });
 
     test('stop forwards to the native binding', () async {
-      await SentryFlutter.replay.stop();
+      await fixture.getSut().stop();
 
-      verify(native.stopReplay()).called(1);
+      verify(fixture.native.stopReplay()).called(1);
     });
 
     test('flush forwards to the native binding', () async {
-      await SentryFlutter.replay.flush();
+      await fixture.getSut().flush();
 
-      verify(native.flushReplay()).called(1);
+      verify(fixture.native.flushReplay()).called(1);
     });
 
     test('waits for an asynchronous native call', () async {
       final nativeCall = Completer<void>();
-      when(native.startReplay()).thenAnswer((_) => nativeCall.future);
+      when(fixture.native.startReplay()).thenAnswer((_) => nativeCall.future);
       var completed = false;
 
-      unawaited(SentryFlutter.replay.start().then((_) => completed = true));
-      await Future<void>.delayed(Duration.zero);
+      final start = fixture.getSut().start().then((_) => completed = true);
+      await Future<void>.value();
 
       expect(completed, false);
 
       nativeCall.complete();
-      await Future<void>.delayed(Duration.zero);
+      await start;
 
       expect(completed, true);
     });
@@ -83,15 +75,32 @@ void main() {
     test('completes when native integration is unavailable', () async {
       SentryFlutter.native = null;
 
-      await expectLater(SentryFlutter.replay.start(), completes);
+      await expectLater(fixture.getSut().start(), completes);
     });
 
     test('does not invoke replay when the platform is unsupported', () async {
-      when(native.supportsReplay).thenReturn(false);
+      when(fixture.native.supportsReplay).thenReturn(false);
 
-      await SentryFlutter.replay.start();
+      await fixture.getSut().start();
 
-      verifyNever(native.startReplay());
+      verifyNever(fixture.native.startReplay());
     });
   });
+}
+
+class Fixture {
+  final native = MockSentryNativeBinding();
+
+  Fixture() {
+    when(native.supportsReplay).thenReturn(true);
+    when(native.startReplay()).thenReturn(null);
+    when(native.startReplayBuffering()).thenReturn(null);
+    when(native.pauseReplay()).thenReturn(null);
+    when(native.resumeReplay()).thenReturn(null);
+    when(native.stopReplay()).thenReturn(null);
+    when(native.flushReplay()).thenReturn(null);
+    SentryFlutter.native = native;
+  }
+
+  SentryReplay getSut() => SentryFlutter.replay;
 }

--- a/packages/flutter/test/replay/replay_api_test.dart
+++ b/packages/flutter/test/replay/replay_api_test.dart
@@ -1,5 +1,7 @@
 // ignore_for_file: invalid_use_of_internal_member
 
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
@@ -60,6 +62,22 @@ void main() {
       await SentryFlutter.replay.flush();
 
       verify(native.flushReplay()).called(1);
+    });
+
+    test('waits for an asynchronous native call', () async {
+      final nativeCall = Completer<void>();
+      when(native.startReplay()).thenAnswer((_) => nativeCall.future);
+      var completed = false;
+
+      unawaited(SentryFlutter.replay.start().then((_) => completed = true));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(completed, false);
+
+      nativeCall.complete();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(completed, true);
     });
 
     test('completes when native integration is unavailable', () async {

--- a/packages/flutter/test/replay/replay_api_test.dart
+++ b/packages/flutter/test/replay/replay_api_test.dart
@@ -1,0 +1,79 @@
+// ignore_for_file: invalid_use_of_internal_member
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+import '../mocks.mocks.dart';
+
+void main() {
+  group('$SentryReplay', () {
+    late MockSentryNativeBinding native;
+
+    setUp(() {
+      native = MockSentryNativeBinding();
+      when(native.supportsReplay).thenReturn(true);
+      when(native.startReplay()).thenReturn(null);
+      when(native.startReplayBuffering()).thenReturn(null);
+      when(native.pauseReplay()).thenReturn(null);
+      when(native.resumeReplay()).thenReturn(null);
+      when(native.stopReplay()).thenReturn(null);
+      when(native.flushReplay()).thenReturn(null);
+      SentryFlutter.native = native;
+    });
+
+    tearDown(() {
+      SentryFlutter.native = null;
+    });
+
+    test('start forwards to the native binding', () async {
+      await SentryFlutter.replay.start();
+
+      verify(native.startReplay()).called(1);
+    });
+
+    test('startBuffering forwards to the native binding', () async {
+      await SentryFlutter.replay.startBuffering();
+
+      verify(native.startReplayBuffering()).called(1);
+    });
+
+    test('pause forwards to the native binding', () async {
+      await SentryFlutter.replay.pause();
+
+      verify(native.pauseReplay()).called(1);
+    });
+
+    test('resume forwards to the native binding', () async {
+      await SentryFlutter.replay.resume();
+
+      verify(native.resumeReplay()).called(1);
+    });
+
+    test('stop forwards to the native binding', () async {
+      await SentryFlutter.replay.stop();
+
+      verify(native.stopReplay()).called(1);
+    });
+
+    test('flush forwards to the native binding', () async {
+      await SentryFlutter.replay.flush();
+
+      verify(native.flushReplay()).called(1);
+    });
+
+    test('completes when native integration is unavailable', () async {
+      SentryFlutter.native = null;
+
+      await expectLater(SentryFlutter.replay.start(), completes);
+    });
+
+    test('does not invoke replay when the platform is unsupported', () async {
+      when(native.supportsReplay).thenReturn(false);
+
+      await SentryFlutter.replay.start();
+
+      verifyNever(native.startReplay());
+    });
+  });
+}

--- a/packages/flutter/test/replay/replay_integration_test.dart
+++ b/packages/flutter/test/replay/replay_integration_test.dart
@@ -58,9 +58,7 @@ void main() {
       () {
         options.replay.sessionSampleRate = sampleRate;
         sut.call(hub, options);
-        var matcher = contains(replayIntegrationName);
-        matcher = sampleRate > 0 ? matcher : isNot(matcher);
-        expect(options.sdk.integrations, matcher);
+        expect(options.sdk.integrations, contains(replayIntegrationName));
       },
     );
   }
@@ -172,6 +170,31 @@ void main() {
     expect(config.frameRate, 1);
     expect(config.width, 800);
     expect(config.height, 600);
+  });
+
+  testWidgets('configures replay when automatic sampling is disabled', (
+    tester,
+  ) async {
+    when(native.setReplayConfig(any)).thenReturn(null);
+    sut.call(hub, options);
+
+    TestWidgetsFlutterBinding.ensureInitialized();
+    await pumpTestElement(tester);
+    await tester.pumpAndSettle(const Duration(seconds: 1));
+
+    verify(native.setReplayConfig(any)).called(1);
+  });
+
+  testWidgets('does not configure replay after close', (tester) async {
+    when(native.setReplayConfig(any)).thenReturn(null);
+    sut.call(hub, options);
+    sut.close();
+
+    TestWidgetsFlutterBinding.ensureInitialized();
+    await pumpTestElement(tester);
+    await tester.pumpAndSettle(const Duration(seconds: 1));
+
+    verifyNever(native.setReplayConfig(any));
   });
 
   testWidgets('Adjusts resolution based on quality', (tester) async {

--- a/packages/flutter/test/sentry_flutter_test.dart
+++ b/packages/flutter/test/sentry_flutter_test.dart
@@ -705,16 +705,30 @@ void main() {
     await expectLater(SentryFlutter.pauseAppHangTracking(), completes);
   });
 
-  test(
-    'replay screenshot handler is available when automatic sampling is disabled',
-    () async {
-      final options = defaultTestOptions(checker: MockRuntimeChecker())
-        ..platform = MockPlatform.iOS()
-        ..methodChannel = native.channel;
+  // Only the Cocoa binding tracks a replay ID, and it is never built for the
+  // browser, so these run on the VM with a mocked iOS platform.
+  group('replay', () {
+    setUp(() async {
+      loadTestPackage();
+    });
+
+    tearDown(() async {
+      await Sentry.close();
+    });
+
+    test('screenshot handler is set up when sampling is disabled', () async {
+      final sentryFlutterOptions =
+          defaultTestOptions(checker: MockRuntimeChecker())
+            ..platform = MockPlatform.iOS()
+            ..methodChannel = native.channel;
       await SentryFlutter.init(
-        (options) {},
+        (options) {
+          options.replay
+            ..sessionSampleRate = 0
+            ..onErrorSampleRate = 0;
+        },
         appRunner: appRunner,
-        options: options,
+        options: sentryFlutterOptions,
       );
       final replayId = SentryId.newId();
 
@@ -724,9 +738,8 @@ void main() {
       });
 
       expect(SentryFlutter.native?.replayId, replayId);
-      await Sentry.close();
-    },
-  );
+    }, testOn: 'vm');
+  });
 
   group('extended app start', () {
     late _ExtendedAppStartFixture fixture;

--- a/packages/flutter/test/sentry_flutter_test.dart
+++ b/packages/flutter/test/sentry_flutter_test.dart
@@ -739,6 +739,29 @@ void main() {
 
       expect(SentryFlutter.native?.replayId, replayId);
     }, testOn: 'vm');
+
+    test('stop clears the finished replay ID off the scope', () async {
+      final sentryFlutterOptions =
+          defaultTestOptions(checker: MockRuntimeChecker())
+            ..platform = MockPlatform.iOS()
+            ..methodChannel = native.channel;
+      when(native.handler('stopReplay', any)).thenAnswer((_) => Future.value());
+      await SentryFlutter.init(
+        (options) {},
+        appRunner: appRunner,
+        options: sentryFlutterOptions,
+      );
+      await native.invokeFromNative('captureReplayScreenshot', {
+        'replayId': SentryId.newId().toString(),
+        'replayIsBuffering': false,
+      });
+      expect(Sentry.currentHub.scope.replayId, isNotNull);
+
+      await SentryFlutter.replay.stop();
+
+      expect(SentryFlutter.native?.replayId, isNull);
+      expect(Sentry.currentHub.scope.replayId, isNull);
+    }, testOn: 'vm');
   });
 
   group('extended app start', () {

--- a/packages/flutter/test/sentry_flutter_test.dart
+++ b/packages/flutter/test/sentry_flutter_test.dart
@@ -705,6 +705,29 @@ void main() {
     await expectLater(SentryFlutter.pauseAppHangTracking(), completes);
   });
 
+  test(
+    'replay screenshot handler is available when automatic sampling is disabled',
+    () async {
+      final options = defaultTestOptions(checker: MockRuntimeChecker())
+        ..platform = MockPlatform.iOS()
+        ..methodChannel = native.channel;
+      await SentryFlutter.init(
+        (options) {},
+        appRunner: appRunner,
+        options: options,
+      );
+      final replayId = SentryId.newId();
+
+      await native.invokeFromNative('captureReplayScreenshot', {
+        'replayId': replayId.toString(),
+        'replayIsBuffering': false,
+      });
+
+      expect(SentryFlutter.native?.replayId, replayId);
+      await Sentry.close();
+    },
+  );
+
   group('extended app start', () {
     late _ExtendedAppStartFixture fixture;
 

--- a/packages/flutter/test/sentry_flutter_test.dart
+++ b/packages/flutter/test/sentry_flutter_test.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: invalid_use_of_internal_member
 
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -758,6 +759,34 @@ void main() {
       expect(Sentry.currentHub.scope.replayId, isNotNull);
 
       await SentryFlutter.replay.stop();
+
+      expect(SentryFlutter.native?.replayId, isNull);
+      expect(Sentry.currentHub.scope.replayId, isNull);
+    }, testOn: 'vm');
+
+    test('stop clears the replay ID when the native call fails', () async {
+      final sentryFlutterOptions =
+          defaultTestOptions(checker: MockRuntimeChecker())
+            ..platform = MockPlatform.iOS()
+            ..methodChannel = native.channel;
+      when(
+        native.handler('stopReplay', any),
+      ).thenAnswer((_) => Future.error(PlatformException(code: 'stop-failed')));
+      await SentryFlutter.init(
+        (options) {},
+        appRunner: appRunner,
+        options: sentryFlutterOptions,
+      );
+      await native.invokeFromNative('captureReplayScreenshot', {
+        'replayId': SentryId.newId().toString(),
+        'replayIsBuffering': false,
+      });
+      expect(Sentry.currentHub.scope.replayId, isNotNull);
+
+      await expectLater(
+        SentryFlutter.replay.stop(),
+        throwsA(isA<PlatformException>()),
+      );
 
       expect(SentryFlutter.native?.replayId, isNull);
       expect(Sentry.currentHub.scope.replayId, isNull);

--- a/packages/flutter/test/sentry_native_channel_test.dart
+++ b/packages/flutter/test/sentry_native_channel_test.dart
@@ -484,6 +484,42 @@ void main() {
         }
       });
 
+      test('manual replay controls invoke native methods', () async {
+        if (mockPlatform.isAndroid) {
+          return;
+        }
+        for (final method in [
+          'startReplay',
+          'startReplayBuffering',
+          'pauseReplay',
+          'resumeReplay',
+          'stopReplay',
+          'flushReplay',
+        ]) {
+          when(
+            channel.invokeMethod<void>(method),
+          ).thenAnswer((_) => Future.value());
+        }
+
+        await sut.startReplay();
+        await sut.startReplayBuffering();
+        await sut.pauseReplay();
+        await sut.resumeReplay();
+        await sut.stopReplay();
+        await sut.flushReplay();
+
+        for (final method in [
+          'startReplay',
+          'startReplayBuffering',
+          'pauseReplay',
+          'resumeReplay',
+          'stopReplay',
+          'flushReplay',
+        ]) {
+          verify(channel.invokeMethod<void>(method)).called(1);
+        }
+      });
+
       test(
         'captureReplay returns empty ID when native result is null',
         () async {

--- a/packages/flutter/test/sentry_native_channel_test.dart
+++ b/packages/flutter/test/sentry_native_channel_test.dart
@@ -3,6 +3,7 @@
 @TestOn('vm')
 library;
 
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -488,36 +489,43 @@ void main() {
         if (mockPlatform.isAndroid) {
           return;
         }
-        for (final method in [
-          'startReplay',
-          'startReplayBuffering',
-          'pauseReplay',
-          'resumeReplay',
-          'stopReplay',
-          'flushReplay',
-        ]) {
+        final controls = <String, FutureOr<void> Function()>{
+          'startReplay': sut.startReplay,
+          'startReplayBuffering': sut.startReplayBuffering,
+          'pauseReplay': sut.pauseReplay,
+          'resumeReplay': sut.resumeReplay,
+          'stopReplay': sut.stopReplay,
+          'flushReplay': sut.flushReplay,
+        };
+
+        for (final entry in controls.entries) {
           when(
-            channel.invokeMethod<void>(method),
+            channel.invokeMethod<void>(entry.key),
           ).thenAnswer((_) => Future.value());
-        }
 
-        await sut.startReplay();
-        await sut.startReplayBuffering();
-        await sut.pauseReplay();
-        await sut.resumeReplay();
+          await entry.value();
+
+          verify(channel.invokeMethod<void>(entry.key)).called(1);
+        }
+      });
+
+      test('stopReplay clears the last known replay ID', () async {
+        if (!mockPlatform.isIOS) {
+          return;
+        }
+        when(
+          channel.invokeMethod<String>('captureReplay', any),
+        ).thenAnswer((_) => Future.value(SentryId.newId().toString()));
+        when(
+          channel.invokeMethod<void>('stopReplay'),
+        ).thenAnswer((_) => Future.value());
+
+        await sut.captureReplay();
+        expect(sut.replayId, isNotNull);
+
         await sut.stopReplay();
-        await sut.flushReplay();
 
-        for (final method in [
-          'startReplay',
-          'startReplayBuffering',
-          'pauseReplay',
-          'resumeReplay',
-          'stopReplay',
-          'flushReplay',
-        ]) {
-          verify(channel.invokeMethod<void>(method)).called(1);
-        }
+        expect(sut.replayId, isNull);
       });
 
       test(


### PR DESCRIPTION
## :scroll: Description

Adds `SentryFlutter.replay` with `start`, `startBuffering`, `pause`, `resume`, `stop`, and `flush`, routed through JNI on Android and the method channel on iOS. The replay recorder now stays available when automatic sampling is off, and native and Dart callbacks are cleaned up on close.

Two changes worth a closer look in review:

**`ReplayTelemetryIntegration` no longer checks the sample rates.** A manually started replay records while both rates are `0`, and the old gates would have dropped its `replay_id` from logs, spans, and metrics. Attributes are now derived from whether a replay is actually recording, which is safe because:

- The session gate was redundant — native writes the replay ID to the scope *only* in session mode, so the scope already answers the question. It also suppressed a legitimate case: a buffered replay flushed by an error keeps recording in session mode.
- The buffering gate guarded a state only real buffering produces — "the binding has an ID but the scope doesn't". iOS can't produce that split at all (the screenshot provider hardcodes `replayIsBuffering = NO`), leaving Android's `replayStarted(id, isBuffering: true)` as its only source.

**iOS now clears the replay ID on stop.** iOS has no `replayStopped` callback, so after `stop()` a finished replay's ID stayed on `scope.replayId` and kept riding along on events and the trace context. `SentryNativeCocoa.stopReplay()` now clears both the binding cache and the scope. Pre-existing and still open: a native-initiated stop (session max duration) has no callback, and it can't be covered by a test because FFI/JNI can't be mocked.

## :bulb: Motivation and Context

Applications need explicit Session Replay control for opt-in flows and sensitive screens, independent of the automatic sample rates.

Fixes #2558

## :green_heart: How did you test it?

- Full `sentry_flutter` unit suite, plus new coverage for manual starts with sampling disabled, the "no replay running" cases, and `stopReplay()` clearing both the binding cache and the scope (verified to fail before the fix).
- Replay integration tests on an iOS simulator; Android integration test target builds.
- `flutter analyze` and formatting with the Flutter-bundled Dart that CI uses.

## :pencil: Checklist

- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled
- [x] I updated the docs if needed
- [x] All tests passing
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec
- [x] No breaking changes

## :crystal_ball: Next steps

None.

Made with [Cursor](https://cursor.com)
